### PR TITLE
style: cargo fmt --all to satisfy CI fmt check

### DIFF
--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -243,7 +243,12 @@ description  = "reserved — Voyage hard-codes its own model"
         assert_eq!(cfg.defaults.fallback_max_tokens, Some(200));
 
         // All four committed task names are present.
-        for name in ["chat_companion", "insight_extraction", "pde_decision", "embedding"] {
+        for name in [
+            "chat_companion",
+            "insight_extraction",
+            "pde_decision",
+            "embedding",
+        ] {
             assert!(
                 cfg.tasks.contains_key(name),
                 "compat fixture missing task `{name}`"
@@ -253,7 +258,10 @@ description  = "reserved — Voyage hard-codes its own model"
         // chat_companion — every field round-trips.
         let chat = cfg.tasks.get("chat_companion").unwrap();
         assert_eq!(chat.model, "x-ai/grok-4-fast");
-        assert_eq!(chat.fallback.as_deref(), Some("deepseek/deepseek-chat-v3.2"));
+        assert_eq!(
+            chat.fallback.as_deref(),
+            Some("deepseek/deepseek-chat-v3.2")
+        );
         assert_eq!(chat.temperature, Some(0.85));
         assert_eq!(chat.max_tokens, Some(600));
         assert_eq!(chat.description, "AI companion chat");
@@ -282,7 +290,10 @@ description  = "reserved — Voyage hard-codes its own model"
         // Resolution behaviour on the live tasks.
         let r = cfg.resolve("chat_companion", None);
         assert_eq!(r.model, "x-ai/grok-4-fast");
-        assert_eq!(r.fallback_model.as_deref(), Some("deepseek/deepseek-chat-v3.2"));
+        assert_eq!(
+            r.fallback_model.as_deref(),
+            Some("deepseek/deepseek-chat-v3.2")
+        );
         assert_eq!(r.temperature, 0.85);
         assert_eq!(r.max_tokens, 600);
 

--- a/crates/eros-engine-server/src/main.rs
+++ b/crates/eros-engine-server/src/main.rs
@@ -82,8 +82,7 @@ async fn run_seed_personas(dir: &str) -> Result<()> {
         .context("failed to connect to DATABASE_URL")?;
     let repo = eros_engine_store::persona::PersonaRepo { pool: &pool };
 
-    let entries = std::fs::read_dir(dir)
-        .with_context(|| format!("read_dir({dir}) failed"))?;
+    let entries = std::fs::read_dir(dir).with_context(|| format!("read_dir({dir}) failed"))?;
     let mut inserted = 0u32;
     let mut skipped = 0u32;
     for entry in entries {
@@ -92,10 +91,8 @@ async fn run_seed_personas(dir: &str) -> Result<()> {
         if path.extension().and_then(|s| s.to_str()) != Some("toml") {
             continue;
         }
-        let text = std::fs::read_to_string(&path)
-            .with_context(|| format!("read {path:?}"))?;
-        let f: PersonaFile = toml::from_str(&text)
-            .with_context(|| format!("parse {path:?}"))?;
+        let text = std::fs::read_to_string(&path).with_context(|| format!("read {path:?}"))?;
+        let f: PersonaFile = toml::from_str(&text).with_context(|| format!("parse {path:?}"))?;
 
         let (id, created) = repo
             .upsert_genome(

--- a/crates/eros-engine-store/src/persona.rs
+++ b/crates/eros-engine-store/src/persona.rs
@@ -160,12 +160,11 @@ impl<'a> PersonaRepo<'a> {
         art_metadata: serde_json::Value,
         is_active: bool,
     ) -> Result<(Uuid, bool), sqlx::Error> {
-        if let Some(id) = sqlx::query_scalar::<_, Uuid>(
-            "SELECT id FROM engine.persona_genomes WHERE name = $1",
-        )
-        .bind(name)
-        .fetch_optional(self.pool)
-        .await?
+        if let Some(id) =
+            sqlx::query_scalar::<_, Uuid>("SELECT id FROM engine.persona_genomes WHERE name = $1")
+                .bind(name)
+                .fetch_optional(self.pool)
+                .await?
         {
             sqlx::query(
                 "UPDATE engine.persona_genomes SET \


### PR DESCRIPTION
## Summary
- Last 5 CI runs on main were red on the `fmt` job — rustfmt 1.88 wanted three blocks reformatted that recent edits had left over the width budget.
- Ran `cargo fmt --all` and committed the diff. No behavior changes.

## Files
- `crates/eros-engine-llm/src/model_config.rs` — fixture test array literals + multi-arg `assert_eq!`s.
- `crates/eros-engine-server/src/main.rs` — persona seeder `read_dir` / `read_to_string` chains.
- `crates/eros-engine-store/src/persona.rs` — `upsert_genome` `if let Some(...)` guard.

## Test plan
- [x] `cargo fmt --all -- --check` clean locally
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean locally
- [ ] CI fmt + clippy + test green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)