### PR TITLE
fix(auth): validate Supabase JWTs via JWKS (ES256/RS256), keep HS256 fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,10 +8,16 @@ DATABASE_URL=postgres://postgres:<password>@<host>:5432/postgres
 OPENROUTER_API_KEY=sk-or-...
 
 # Supabase project — same as eros-gateway.
+# Setting SUPABASE_URL is enough on modern projects: the engine derives the
+# JWKS URL (${SUPABASE_URL}/auth/v1/.well-known/jwks.json) and validates
+# JWTs asymmetrically (ES256/RS256/EdDSA). Override with SUPABASE_JWKS_URL
+# if your project sits behind a non-standard path.
 SUPABASE_URL=https://<project-ref>.supabase.co
-# JWT secret from Supabase Dashboard → Project Settings → API → JWT Secret.
-# eros-gateway does not currently verify JWTs; eros-engine does, so this
-# secret must match what Supabase signs tokens with.
+# SUPABASE_JWKS_URL=  # optional override for the JWKS endpoint
+
+# Optional. Legacy HS256 shared secret, for projects that haven't migrated
+# to JWT signing keys. If set alongside SUPABASE_URL, both validators are
+# wired and the engine dispatches by the token's `alg` header.
 SUPABASE_JWT_SECRET=
 
 # Voyage embeddings (voyage-3-lite, 512-dim).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,6 +372,7 @@ dependencies = [
  "eros-engine-llm",
  "eros-engine-store",
  "jsonwebtoken",
+ "reqwest",
  "serde",
  "serde_json",
  "sqlx",

--- a/crates/eros-engine-server/Cargo.toml
+++ b/crates/eros-engine-server/Cargo.toml
@@ -28,6 +28,9 @@ tracing-subscriber = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true }
 jsonwebtoken = { workspace = true }
+# JWKS fetch for Supabase asymmetric JWT validation. Workspace pins
+# rustls-tls so this stays fly.io / scratch-image friendly.
+reqwest = { workspace = true }
 utoipa = { workspace = true }
 utoipa-axum = { workspace = true }
 utoipa-scalar = { workspace = true }

--- a/crates/eros-engine-server/src/auth/supabase.rs
+++ b/crates/eros-engine-server/src/auth/supabase.rs
@@ -1,19 +1,23 @@
 // SPDX-License-Identifier: AGPL-3.0-only
+//! Supabase JWT validator.
+//!
+//! Supports two signing modes:
+//! * Asymmetric (ES256/RS256/EdDSA) via the project's JWKS endpoint, which
+//!   is the default for Supabase projects since the 2025 "JWT Signing
+//!   Keys" rollout.
+//! * Legacy HS256 with a shared secret, kept around so OSS deployments
+//!   that haven't migrated still work.
+//!
+//! At validation time we look at the token's `alg` header and dispatch
+//! to whichever validator can handle it. Tokens minted before a key
+//! rotation continue to verify against the JWKS until they expire (the
+//! previous key remains in `keys` until revoked).
 use super::{AuthError, AuthValidator};
 use async_trait::async_trait;
-use jsonwebtoken::{decode, errors::ErrorKind, DecodingKey, Validation};
+use jsonwebtoken::{decode, decode_header, jwk::JwkSet, Algorithm, DecodingKey, Validation};
 use serde::Deserialize;
+use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
-
-pub struct SupabaseJwtValidator {
-    secret: String,
-}
-
-impl SupabaseJwtValidator {
-    pub fn new(secret: String) -> Self {
-        Self { secret }
-    }
-}
 
 #[derive(Debug, Deserialize)]
 struct Claims {
@@ -21,25 +25,111 @@ struct Claims {
     exp: Option<i64>,
 }
 
+/// Decoding-key bundle: the JWT's `alg` header determines which one we use.
+struct AsymKey {
+    alg: Algorithm,
+    key: DecodingKey,
+}
+
+pub struct SupabaseJwtValidator {
+    /// kid → asymmetric public key (ES256 / RS256 / EdDSA).
+    asymmetric: HashMap<String, AsymKey>,
+    /// Optional HS256 shared secret for legacy projects.
+    legacy_hs256: Option<DecodingKey>,
+}
+
+impl SupabaseJwtValidator {
+    /// Build a validator with neither source wired. Call `with_jwks_url` and/or
+    /// `with_legacy_secret` afterwards. A validator with neither configured
+    /// rejects every token, which is the correct fail-closed behavior.
+    pub fn new() -> Self {
+        Self {
+            asymmetric: HashMap::new(),
+            legacy_hs256: None,
+        }
+    }
+
+    /// Add an HS256 shared secret. Used for legacy Supabase projects that
+    /// haven't migrated to JWT signing keys.
+    pub fn with_legacy_secret(mut self, secret: String) -> Self {
+        self.legacy_hs256 = Some(DecodingKey::from_secret(secret.as_ref()));
+        self
+    }
+
+    /// Fetch the JWKS document and load every key into the asymmetric map.
+    /// `url` is typically `https://<project>.supabase.co/auth/v1/.well-known/jwks.json`.
+    pub async fn with_jwks_url(mut self, url: &str) -> anyhow::Result<Self> {
+        let jwks: JwkSet = reqwest::get(url)
+            .await
+            .map_err(|e| anyhow::anyhow!("fetch jwks {url}: {e}"))?
+            .error_for_status()
+            .map_err(|e| anyhow::anyhow!("fetch jwks {url}: {e}"))?
+            .json()
+            .await
+            .map_err(|e| anyhow::anyhow!("parse jwks {url}: {e}"))?;
+
+        for jwk in &jwks.keys {
+            let Some(kid) = jwk.common.key_id.as_ref() else {
+                tracing::warn!("jwks key missing kid, skipping");
+                continue;
+            };
+            let alg = match jwk.common.key_algorithm {
+                Some(jsonwebtoken::jwk::KeyAlgorithm::ES256) => Algorithm::ES256,
+                Some(jsonwebtoken::jwk::KeyAlgorithm::RS256) => Algorithm::RS256,
+                Some(jsonwebtoken::jwk::KeyAlgorithm::EdDSA) => Algorithm::EdDSA,
+                Some(other) => {
+                    tracing::warn!("jwks kid={kid} has unsupported alg {other:?}, skipping");
+                    continue;
+                }
+                None => {
+                    tracing::warn!("jwks kid={kid} has no alg, skipping");
+                    continue;
+                }
+            };
+            let key = DecodingKey::from_jwk(jwk)
+                .map_err(|e| anyhow::anyhow!("decode jwk kid={kid}: {e}"))?;
+            self.asymmetric.insert(kid.clone(), AsymKey { alg, key });
+        }
+        tracing::info!(
+            "loaded {} asymmetric jwt key(s) from {url}",
+            self.asymmetric.len()
+        );
+        Ok(self)
+    }
+}
+
+impl Default for SupabaseJwtValidator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[async_trait]
 impl AuthValidator for SupabaseJwtValidator {
     async fn validate(&self, bearer: &str) -> Result<Uuid, AuthError> {
-        let mut validation = Validation::new(jsonwebtoken::Algorithm::HS256);
+        let header = decode_header(bearer).map_err(|_| AuthError::Malformed)?;
+
+        let (alg, key) = if header.alg == Algorithm::HS256 {
+            let key = self.legacy_hs256.as_ref().ok_or(AuthError::BadSignature)?;
+            (Algorithm::HS256, key)
+        } else {
+            // Asymmetric: dispatch by kid.
+            let kid = header.kid.as_deref().ok_or(AuthError::Malformed)?;
+            let entry = self.asymmetric.get(kid).ok_or(AuthError::BadSignature)?;
+            (entry.alg, &entry.key)
+        };
+
+        let mut validation = Validation::new(alg);
         // We check exp ourselves so we can return our own error variants and
         // avoid jsonwebtoken's required-claims behaviour.
-        validation.required_spec_claims = std::collections::HashSet::new();
+        validation.required_spec_claims = HashSet::new();
         // Supabase tokens have aud = "authenticated"; relaxing aud match keeps
         // the validator usable with self-issued test JWTs that omit it.
         validation.validate_aud = false;
 
-        let data = decode::<Claims>(
-            bearer,
-            &DecodingKey::from_secret(self.secret.as_ref()),
-            &validation,
-        )
-        .map_err(|e| match e.kind() {
-            ErrorKind::ExpiredSignature => AuthError::Expired,
-            ErrorKind::InvalidSignature => AuthError::BadSignature,
+        let data = decode::<Claims>(bearer, key, &validation).map_err(|e| match e.kind() {
+            jsonwebtoken::errors::ErrorKind::ExpiredSignature => AuthError::Expired,
+            jsonwebtoken::errors::ErrorKind::InvalidSignature => AuthError::BadSignature,
             _ => AuthError::Malformed,
         })?;
 
@@ -59,7 +149,7 @@ mod tests {
     use jsonwebtoken::{encode, EncodingKey, Header};
     use serde_json::json;
 
-    fn mint(secret: &str, payload: serde_json::Value) -> String {
+    fn mint_hs256(secret: &str, payload: serde_json::Value) -> String {
         encode(
             &Header::default(),
             &payload,
@@ -69,41 +159,51 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn valid_token_returns_user_id() {
-        let v = SupabaseJwtValidator::new("test-secret".into());
+    async fn legacy_hs256_valid_token_returns_user_id() {
+        let v = SupabaseJwtValidator::new().with_legacy_secret("test-secret".into());
         let uid = "00000000-0000-0000-0000-000000000001";
         let exp = (chrono::Utc::now() + chrono::Duration::hours(1)).timestamp();
-        let token = mint("test-secret", json!({ "sub": uid, "exp": exp }));
+        let token = mint_hs256("test-secret", json!({ "sub": uid, "exp": exp }));
         let result = v.validate(&token).await.expect("valid");
         assert_eq!(result.to_string(), uid);
     }
 
     #[tokio::test]
-    async fn expired_token_rejected() {
-        let v = SupabaseJwtValidator::new("test-secret".into());
+    async fn legacy_hs256_expired_token_rejected() {
+        let v = SupabaseJwtValidator::new().with_legacy_secret("test-secret".into());
         let exp = (chrono::Utc::now() - chrono::Duration::hours(1)).timestamp();
         let uid = "00000000-0000-0000-0000-000000000001";
-        let token = mint("test-secret", json!({ "sub": uid, "exp": exp }));
+        let token = mint_hs256("test-secret", json!({ "sub": uid, "exp": exp }));
         let err = v.validate(&token).await.unwrap_err();
         assert!(matches!(err, AuthError::Expired), "got {err:?}");
     }
 
     #[tokio::test]
-    async fn wrong_signature_rejected() {
-        let v = SupabaseJwtValidator::new("real-secret".into());
+    async fn legacy_hs256_wrong_signature_rejected() {
+        let v = SupabaseJwtValidator::new().with_legacy_secret("real-secret".into());
         let exp = (chrono::Utc::now() + chrono::Duration::hours(1)).timestamp();
         let uid = "00000000-0000-0000-0000-000000000001";
-        let token = mint("WRONG", json!({ "sub": uid, "exp": exp }));
+        let token = mint_hs256("WRONG", json!({ "sub": uid, "exp": exp }));
         let err = v.validate(&token).await.unwrap_err();
         assert!(matches!(err, AuthError::BadSignature), "got {err:?}");
     }
 
     #[tokio::test]
     async fn missing_sub_rejected() {
-        let v = SupabaseJwtValidator::new("test-secret".into());
+        let v = SupabaseJwtValidator::new().with_legacy_secret("test-secret".into());
         let exp = (chrono::Utc::now() + chrono::Duration::hours(1)).timestamp();
-        let token = mint("test-secret", json!({ "exp": exp }));
+        let token = mint_hs256("test-secret", json!({ "exp": exp }));
         let err = v.validate(&token).await.unwrap_err();
         assert!(matches!(err, AuthError::MissingSub), "got {err:?}");
+    }
+
+    #[tokio::test]
+    async fn hs256_token_rejected_when_no_legacy_secret_configured() {
+        let v = SupabaseJwtValidator::new();
+        let exp = (chrono::Utc::now() + chrono::Duration::hours(1)).timestamp();
+        let uid = "00000000-0000-0000-0000-000000000001";
+        let token = mint_hs256("any", json!({ "sub": uid, "exp": exp }));
+        let err = v.validate(&token).await.unwrap_err();
+        assert!(matches!(err, AuthError::BadSignature), "got {err:?}");
     }
 }

--- a/crates/eros-engine-server/src/main.rs
+++ b/crates/eros-engine-server/src/main.rs
@@ -158,9 +158,39 @@ async fn run_server() -> Result<()> {
     }
     let voyage = Arc::new(eros_engine_llm::voyage::VoyageClient::new(voyage_key));
 
-    let jwt_secret =
-        std::env::var("SUPABASE_JWT_SECRET").context("SUPABASE_JWT_SECRET is required")?;
-    let auth: Arc<dyn AuthValidator> = Arc::new(SupabaseJwtValidator::new(jwt_secret));
+    // Auth: prefer JWKS (asymmetric, the post-2025 Supabase default) and
+    // fall back to a legacy HS256 shared secret if one is configured. At
+    // least one source must be wired or the server boots with a validator
+    // that rejects every token (fail-closed).
+    //
+    // - SUPABASE_JWKS_URL: explicit override.
+    // - SUPABASE_URL: derive `${SUPABASE_URL}/auth/v1/.well-known/jwks.json`.
+    // - SUPABASE_JWT_SECRET: legacy HS256 shared secret (optional).
+    let mut validator = SupabaseJwtValidator::new();
+    let jwks_url = std::env::var("SUPABASE_JWKS_URL").ok().or_else(|| {
+        std::env::var("SUPABASE_URL")
+            .ok()
+            .map(|u| format!("{}/auth/v1/.well-known/jwks.json", u.trim_end_matches('/')))
+    });
+    if let Some(url) = jwks_url.as_deref() {
+        validator = validator
+            .with_jwks_url(url)
+            .await
+            .with_context(|| format!("failed to load Supabase JWKS from {url}"))?;
+    }
+    if let Ok(secret) = std::env::var("SUPABASE_JWT_SECRET") {
+        if !secret.is_empty() {
+            validator = validator.with_legacy_secret(secret);
+        }
+    }
+    if jwks_url.is_none() && std::env::var("SUPABASE_JWT_SECRET").ok().is_none() {
+        anyhow::bail!(
+            "no JWT validation source configured: set SUPABASE_URL (preferred) \
+             or SUPABASE_JWKS_URL for asymmetric JWT validation, and/or \
+             SUPABASE_JWT_SECRET for the legacy HS256 path"
+        );
+    }
+    let auth: Arc<dyn AuthValidator> = Arc::new(validator);
 
     // model_config: env override > examples/model_config.toml dev default.
     // T14's Dockerfile sets MODEL_CONFIG_PATH=/etc/eros-engine/model_config.toml

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -906,7 +906,8 @@ mod tests {
     }
 
     fn test_state(pool: PgPool) -> AppState {
-        let auth: Arc<dyn AuthValidator> = Arc::new(SupabaseJwtValidator::new(TEST_SECRET.into()));
+        let auth: Arc<dyn AuthValidator> =
+            Arc::new(SupabaseJwtValidator::new().with_legacy_secret(TEST_SECRET.into()));
         AppState {
             pool,
             auth,


### PR DESCRIPTION
## Summary
- Replace HS256-only `SupabaseJwtValidator` with a dual-mode validator: asymmetric (ES256/RS256/EdDSA) keys loaded from the project's JWKS, plus optional legacy HS256 shared secret.
- Dispatch by the token's `alg` header at validation time. `kid` selects the right key for asymmetric.
- Wire JWKS via `SUPABASE_JWKS_URL` (explicit) or derive from `SUPABASE_URL`. `SUPABASE_JWT_SECRET` is now optional.

## Why
Supabase rolled out "JWT Signing Keys" (ES256 by default, ECDSA P-256) in 2025. Projects that have rotated — including new projects — sign user tokens asymmetrically and serve the public key at `<project>/auth/v1/.well-known/jwks.json`. Our validator only knew HS256, so every modern Supabase project's tokens hit `Validation::new(HS256)` and bounced as InvalidSignature → 401, even with the right legacy secret configured (the *algorithm* was wrong, not the secret value).

Verified by inspecting a real production token: header decoded to `{"alg":"ES256","typ":"JWT","kid":"<uuid>"}`, JWKS endpoint returns the matching EC P-256 public key.

## Test plan
- [x] `cargo build -p eros-engine-server`
- [x] `cargo test -p eros-engine-server auth::supabase` — 5/5 (legacy HS256 happy path, expired, wrong sig, missing sub, no-source fail-closed)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] Existing `routes::companion` integration tests still pass (they mint HS256 tokens against `TEST_SECRET`, routed through the legacy path)
- [ ] Reviewer: deploy to staging, point at a project with JWKS, confirm a real ES256 token validates

## Migration
Existing deployments using only `SUPABASE_JWT_SECRET` keep working unchanged. To enable JWKS validation, set `SUPABASE_URL` (which most deployments already have for other reasons) — the engine derives the JWKS URL automatically. Both sources can coexist; the per-token `alg` decides which path runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)