### PR TITLE
feat(memory): dreaming-lite session-end classifier

### DIFF
--- a/crates/eros-engine-server/src/main.rs
+++ b/crates/eros-engine-server/src/main.rs
@@ -221,6 +221,12 @@ async fn run_server() -> Result<()> {
         .merge(routes::router(state.clone()))
         .split_for_parts();
 
+    // Spawn the dreaming-lite sweeper alongside the HTTP service. Returns
+    // immediately when DREAMING_DISABLED=1 (or tick=0) is set, so unit
+    // tests and self-hosters who want only synchronous behaviour can opt out.
+    // Cloned because the next line moves `state` into the router.
+    tokio::spawn(crate::pipeline::dreaming::sweeper(state.clone()));
+
     let app: Router = open_router
         .with_state(state)
         .merge(Scalar::with_url("/docs", api))

--- a/crates/eros-engine-server/src/pipeline/dreaming.rs
+++ b/crates/eros-engine-server/src/pipeline/dreaming.rs
@@ -1,0 +1,342 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! Dreaming-lite: session-end memory extraction sweeper.
+//!
+//! Background tokio task that scans `engine.chat_sessions` for idle,
+//! unclassified sessions and runs the `memory_extraction` LLM task on
+//! their `chat_messages`. Extracted candidates with category tags are
+//! written to `engine.companion_memories` as profile-layer rows; the
+//! session's `classified_at` is then stamped to suppress re-sweeps.
+//!
+//! Single-instance assumption: with multiple replicas the picker query
+//! would need `FOR UPDATE SKIP LOCKED` to avoid double-classifying the
+//! same session. OSS v1 ships single-instance.
+//!
+//! Failure handling:
+//! - Network/DB error during pick or stamp → propagate, retry next tick.
+//! - LLM call error → propagate (no stamp), retry next tick.
+//! - LLM returns garbage / empty parse → stamp anyway so a poison-pill
+//!   session can't loop the sweeper forever.
+
+use std::time::Duration;
+
+use chrono::Utc;
+use serde::Deserialize;
+use uuid::Uuid;
+
+use eros_engine_llm::openrouter::{ChatMessage, ChatRequest};
+use eros_engine_store::memory::{MemoryLayer, MemoryRepo};
+
+use crate::state::AppState;
+
+const MEMORY_TASK: &str = "memory_extraction";
+const PICK_BATCH: i64 = 10;
+
+#[derive(Debug, Deserialize)]
+struct MemoryCandidate {
+    content: String,
+    category: String,
+}
+
+/// Run forever. Spawn this once at server startup. Returns immediately
+/// (and never spawns the loop) if `state.config.dreaming_tick` is zero.
+pub async fn sweeper(state: AppState) {
+    let interval = state.config.dreaming_tick;
+    let idle = state.config.dreaming_idle_threshold;
+    if interval.is_zero() {
+        tracing::info!("dreaming sweeper disabled (DREAMING_DISABLED=1 or tick=0)");
+        return;
+    }
+    tracing::info!(?interval, ?idle, "dreaming sweeper starting");
+
+    let mut tick = tokio::time::interval(interval);
+    tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    loop {
+        tick.tick().await;
+        match scan_and_classify(&state, idle).await {
+            Ok(0) => {} // quiet — common case on a low-traffic instance
+            Ok(n) => tracing::info!(processed = n, "dreaming: sessions classified"),
+            Err(e) => tracing::warn!("dreaming scan failed: {e}"),
+        }
+    }
+}
+
+/// One sweep tick: pick eligible sessions, classify each in turn.
+async fn scan_and_classify(state: &AppState, idle: Duration) -> Result<usize, sqlx::Error> {
+    let cutoff = Utc::now() - chrono::Duration::from_std(idle).unwrap_or_default();
+    let sessions: Vec<(Uuid, Uuid, Option<Uuid>)> = sqlx::query_as(
+        "SELECT id, user_id, instance_id FROM engine.chat_sessions \
+         WHERE classified_at IS NULL AND last_active_at < $1 \
+         ORDER BY last_active_at \
+         LIMIT $2",
+    )
+    .bind(cutoff)
+    .bind(PICK_BATCH)
+    .fetch_all(&state.pool)
+    .await?;
+
+    let mut count = 0;
+    for (session_id, user_id, instance_id) in sessions {
+        match classify_session(state, session_id, user_id, instance_id).await {
+            Ok(written) => {
+                tracing::info!(%session_id, written, "dreaming: session classified");
+                count += 1;
+            }
+            Err(e) => tracing::warn!(%session_id, "dreaming: classify failed: {e}"),
+        }
+    }
+    Ok(count)
+}
+
+/// Classify one session. Returns the number of memory rows written.
+/// Stamps `classified_at` on a graceful pass (including empty extraction)
+/// so the picker doesn't see this session again. Network-level errors
+/// propagate and skip the stamp so they retry next tick.
+async fn classify_session(
+    state: &AppState,
+    session_id: Uuid,
+    user_id: Uuid,
+    instance_id: Option<Uuid>,
+) -> Result<usize, String> {
+    // 1. Pull the conversation log. We use chat_messages (the canonical
+    // turn record) rather than the formatted companion_memories rows so
+    // the LLM doesn't see the "用户：X\nAI：Y" wrapper twice.
+    let rows: Vec<(String, String)> = sqlx::query_as(
+        "SELECT role, content FROM engine.chat_messages \
+         WHERE session_id = $1 AND role IN ('user', 'assistant') \
+         ORDER BY sent_at",
+    )
+    .bind(session_id)
+    .fetch_all(&state.pool)
+    .await
+    .map_err(|e| format!("load chat_messages failed: {e}"))?;
+
+    if rows.is_empty() {
+        mark_classified(&state.pool, session_id)
+            .await
+            .map_err(|e| format!("mark classified (empty session): {e}"))?;
+        return Ok(0);
+    }
+
+    let turns: Vec<String> = rows
+        .into_iter()
+        .map(|(role, content)| {
+            let label = if role == "user" { "用户" } else { "AI" };
+            format!("{label}：{content}")
+        })
+        .collect();
+
+    // 2. Single LLM call, structured-JSON output.
+    let prompt = crate::prompt::extract_memories_prompt(&turns);
+    let resolved = state.model_config.resolve(MEMORY_TASK, None);
+    let req = ChatRequest {
+        model: resolved.model,
+        fallback_model: resolved.fallback_model,
+        messages: vec![ChatMessage {
+            role: "user".into(),
+            content: prompt,
+        }],
+        temperature: resolved.temperature as f32,
+        max_tokens: resolved.max_tokens,
+    };
+    let raw = state
+        .openrouter
+        .execute(req)
+        .await
+        .map_err(|e| format!("memory_extraction LLM call failed: {e}"))?;
+
+    let candidates = parse_memory_candidates(&raw.reply);
+
+    // 3. Embed + insert each candidate as a profile-layer row.
+    // Profile layer is the right home for these — they're stable facts
+    // about the user that should be visible across persona instances.
+    let repo = MemoryRepo { pool: &state.pool };
+    let mut written = 0;
+    for cand in &candidates {
+        let trimmed = cand.content.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let category = normalise_category(&cand.category);
+        match state.voyage.embed_document(trimmed).await {
+            Ok(embedding) => {
+                if let Err(e) = repo
+                    .upsert(
+                        MemoryLayer::Profile,
+                        session_id,
+                        user_id,
+                        instance_id,
+                        trimmed,
+                        &embedding,
+                        Some(&category),
+                    )
+                    .await
+                {
+                    tracing::warn!(%session_id, "dreaming: insert failed: {e}");
+                } else {
+                    written += 1;
+                }
+            }
+            Err(e) => {
+                tracing::warn!(%session_id, "dreaming: voyage embed failed: {e}");
+            }
+        }
+    }
+
+    // 4. Stamp on graceful completion. Even when `written == 0` we stamp,
+    // because either the session genuinely had nothing memorable or the
+    // model returned junk — both cases should not loop the sweeper.
+    mark_classified(&state.pool, session_id)
+        .await
+        .map_err(|e| format!("mark classified (post-success): {e}"))?;
+    Ok(written)
+}
+
+async fn mark_classified(pool: &sqlx::PgPool, session_id: Uuid) -> Result<(), sqlx::Error> {
+    sqlx::query("UPDATE engine.chat_sessions SET classified_at = now() WHERE id = $1")
+        .bind(session_id)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+/// Walk forward from the first `{` and return the substring up to its
+/// balanced `}`, ignoring braces inside string literals. Mirrors the
+/// helper in `post_process.rs`; kept private to this module so the
+/// extraction-vs-classification parsing stays decoupled.
+fn find_json_block(raw: &str) -> Option<&str> {
+    let bytes = raw.as_bytes();
+    let start = bytes.iter().position(|&b| b == b'{')?;
+    let mut depth = 0_i32;
+    let mut in_string = false;
+    let mut escape = false;
+    for (i, &b) in bytes.iter().enumerate().skip(start) {
+        if in_string {
+            if escape {
+                escape = false;
+            } else if b == b'\\' {
+                escape = true;
+            } else if b == b'"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match b {
+            b'"' => in_string = true,
+            b'{' => depth += 1,
+            b'}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(&raw[start..=i]);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn parse_memory_candidates(raw: &str) -> Vec<MemoryCandidate> {
+    if let Ok(v) = serde_json::from_str::<serde_json::Value>(raw) {
+        return extract_memory_array(&v);
+    }
+    if let Some(block) = find_json_block(raw) {
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(block) {
+            return extract_memory_array(&v);
+        }
+    }
+    vec![]
+}
+
+fn extract_memory_array(v: &serde_json::Value) -> Vec<MemoryCandidate> {
+    v.get("memories")
+        .and_then(|a| a.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|x| serde_json::from_value::<MemoryCandidate>(x.clone()).ok())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Restrict to the documented vocabulary. Anything else collapses to "fact" —
+/// the prompt asks for one of these five but the model occasionally
+/// invents new categories; we'd rather have a coarse but valid tag than
+/// a high-cardinality mess.
+fn normalise_category(raw: &str) -> String {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        s @ ("fact" | "preference" | "event" | "emotion" | "relation") => s.into(),
+        _ => "fact".into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_memory_candidates_handles_clean_json() {
+        let raw = r#"{"memories":[{"content":"住在上海","category":"fact"},
+                                  {"content":"喜欢咖啡","category":"preference"}]}"#;
+        let cands = parse_memory_candidates(raw);
+        assert_eq!(cands.len(), 2);
+        assert_eq!(cands[0].content, "住在上海");
+        assert_eq!(cands[0].category, "fact");
+        assert_eq!(cands[1].content, "喜欢咖啡");
+        assert_eq!(cands[1].category, "preference");
+    }
+
+    #[test]
+    fn parse_memory_candidates_handles_fenced_block() {
+        let raw = "Sure, here you go:\n```json\n\
+                   {\"memories\":[{\"content\":\"养了一只猫\",\"category\":\"fact\"}]}\n\
+                   ```";
+        let cands = parse_memory_candidates(raw);
+        assert_eq!(cands.len(), 1);
+        assert_eq!(cands[0].content, "养了一只猫");
+    }
+
+    #[test]
+    fn parse_memory_candidates_returns_empty_on_garbage() {
+        assert!(parse_memory_candidates("nope, no json").is_empty());
+        assert!(parse_memory_candidates(r#"{"facts":[]}"#).is_empty());
+    }
+
+    #[test]
+    fn parse_memory_candidates_skips_malformed_items() {
+        // Missing `category` on second item — should drop just that one.
+        let raw = r#"{"memories":[
+            {"content":"a","category":"fact"},
+            {"content":"b"},
+            {"content":"c","category":"event"}
+        ]}"#;
+        let cands = parse_memory_candidates(raw);
+        assert_eq!(cands.len(), 2);
+        assert_eq!(cands[0].content, "a");
+        assert_eq!(cands[1].content, "c");
+    }
+
+    #[test]
+    fn normalise_category_passes_known_values() {
+        assert_eq!(normalise_category("fact"), "fact");
+        assert_eq!(normalise_category("PREFERENCE"), "preference");
+        assert_eq!(normalise_category("  Event  "), "event");
+        assert_eq!(normalise_category("emotion"), "emotion");
+        assert_eq!(normalise_category("relation"), "relation");
+    }
+
+    #[test]
+    fn normalise_category_collapses_unknowns_to_fact() {
+        assert_eq!(normalise_category("opinion"), "fact");
+        assert_eq!(normalise_category(""), "fact");
+        assert_eq!(normalise_category("分类"), "fact");
+    }
+
+    #[test]
+    fn find_json_block_balanced_with_string_braces() {
+        let raw = r#"prefix {"a": "b}c", "d": 1} trailing"#;
+        let block = find_json_block(raw).unwrap();
+        let v: serde_json::Value = serde_json::from_str(block).unwrap();
+        assert_eq!(v["a"], "b}c");
+        assert_eq!(v["d"], 1);
+    }
+}

--- a/crates/eros-engine-server/src/pipeline/mod.rs
+++ b/crates/eros-engine-server/src/pipeline/mod.rs
@@ -12,6 +12,7 @@
 //!   through `persist_with_event`.
 //! - `state.chat_engine` → `state.openrouter`.
 
+pub mod dreaming;
 pub mod handlers;
 pub mod post_process;
 

--- a/crates/eros-engine-server/src/prompt.rs
+++ b/crates/eros-engine-server/src/prompt.rs
@@ -355,6 +355,39 @@ pub fn extract_facts_prompt(user_msg: &str, assistant_msg: &str) -> String {
     )
 }
 
+/// Session-end memory extraction prompt: feed the LLM all turns from a
+/// finished (idle) session and ask it to emit 0-N memory candidates with
+/// a category tag. Output expected as
+/// `{"memories": [{"content": "...", "category": "fact"}, ...]}` —
+/// `parse_memory_candidates` in `pipeline::dreaming` handles the
+/// fenced-JSON fallback the same way `parse_facts` does.
+///
+/// `turns` is the chronologically ordered list of `用户：X / AI：Y` lines
+/// (or whatever pre-format the caller chose); the prompt does not assume
+/// a specific shape beyond "this is the conversation".
+pub fn extract_memories_prompt(turns: &[String]) -> String {
+    let convo = turns.join("\n");
+    format!(
+        "下面是一段已经结束的对话。提取 0-10 条值得长期记住的关于「用户」的记忆条目，\
+         每条带一个 category 标签。\n\n\
+         category 取值（只能用这五种之一）：\n\
+         - fact: 客观事实，如住在哪、做什么工作、家庭状况\n\
+         - preference: 偏好/喜好，如喜欢什么、讨厌什么、口味、品味\n\
+         - event: 发生的事件，如最近发生了什么、经历过什么\n\
+         - emotion: 情绪/心理状态，如对某事的感受、长期心理倾向\n\
+         - relation: 与他人的关系，如朋友、家人、同事\n\n\
+         过滤规则：\n\
+         - 只记关于用户的，不记关于 AI 的\n\
+         - 不记 AI 单方面的回复内容\n\
+         - 不记一次性的寒暄、玩笑\n\
+         - 同一事实合并成一条，不要重复\n\
+         - 没有任何值得记的就返回空数组\n\n\
+         对话：\n{convo}\n\n\
+         严格输出 JSON，格式：\
+         {{\"memories\": [{{\"content\": \"...\", \"category\": \"fact\"}}]}}",
+    )
+}
+
 /// Stage-2 insight extraction prompt: take the bullet list of facts mined
 /// in stage 1 plus the user's existing `companion_insights` JSONB, and
 /// fill in whatever fields the LLM is confident about. Output expected

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -929,6 +929,10 @@ mod tests {
                 ema_inertia: 0.0, // no smoothing → deltas applied 1:1 in tests
                 demo_ema_inertia: 0.0,
                 bind_addr: "127.0.0.1:0".into(),
+                // Sweeper disabled in tests — unit tests don't spawn it
+                // and the field is just for AppState completeness.
+                dreaming_tick: std::time::Duration::ZERO,
+                dreaming_idle_threshold: std::time::Duration::from_secs(1800),
             },
             openrouter: Arc::new(eros_engine_llm::openrouter::OpenRouterClient::new(
                 "stub".into(),

--- a/crates/eros-engine-server/src/state.rs
+++ b/crates/eros-engine-server/src/state.rs
@@ -2,6 +2,7 @@
 
 use sqlx::PgPool;
 use std::sync::Arc;
+use std::time::Duration;
 
 #[derive(Clone)]
 pub struct AppState {
@@ -22,6 +23,13 @@ pub struct ServerConfig {
     /// visibly across an 8-turn demo. Falls back to `ema_inertia` if unset.
     pub demo_ema_inertia: f64,
     pub bind_addr: String,
+    /// How often the dreaming-lite sweeper wakes up to look for idle
+    /// sessions. Set to `Duration::ZERO` (env `DREAMING_DISABLED=1`) to
+    /// skip spawning the sweeper entirely — useful for unit-test runs.
+    pub dreaming_tick: Duration,
+    /// Minimum idle time on `chat_sessions.last_active_at` before a
+    /// session becomes eligible for classification.
+    pub dreaming_idle_threshold: Duration,
 }
 
 impl ServerConfig {
@@ -30,6 +38,25 @@ impl ServerConfig {
             .ok()
             .and_then(|v| v.parse().ok())
             .unwrap_or(0.8);
+        let dreaming_disabled = std::env::var("DREAMING_DISABLED")
+            .map(|v| v == "1" || v == "true")
+            .unwrap_or(false);
+        let dreaming_tick = if dreaming_disabled {
+            Duration::ZERO
+        } else {
+            Duration::from_secs(
+                std::env::var("DREAMING_TICK_SECS")
+                    .ok()
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(300),
+            )
+        };
+        let dreaming_idle_threshold = Duration::from_secs(
+            std::env::var("DREAMING_IDLE_SECS")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(1800),
+        );
         Self {
             expose_affinity_debug: std::env::var("EXPOSE_AFFINITY_DEBUG")
                 .map(|v| v == "true" || v == "1")
@@ -40,6 +67,8 @@ impl ServerConfig {
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(0.3),
             bind_addr: std::env::var("BIND_ADDR").unwrap_or_else(|_| "0.0.0.0:8080".into()),
+            dreaming_tick,
+            dreaming_idle_threshold,
         }
     }
 }

--- a/crates/eros-engine-store/migrations/0007_session_classified_at.sql
+++ b/crates/eros-engine-store/migrations/0007_session_classified_at.sql
@@ -1,0 +1,15 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Marker for the dreaming-lite classifier sweep.
+--
+-- A background sweeper in eros-engine-server picks idle sessions
+-- (last_active_at older than idle_threshold AND classified_at IS NULL),
+-- runs the memory_extraction LLM task on their chat_messages, and writes
+-- categorised profile-layer rows back to engine.companion_memories.
+--
+-- Setting classified_at = now() at the end of the sweep makes the run
+-- idempotent — the next tick won't re-process a session that's already
+-- been classified, even if more turns arrive afterwards. (OSS v1
+-- treats post-classification activity as a separate session lifecycle;
+-- incremental re-classification is a future iteration.)
+ALTER TABLE engine.chat_sessions
+    ADD COLUMN classified_at TIMESTAMPTZ;

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -15,6 +15,9 @@ pub struct ChatSession {
     pub is_converted: bool,
     pub last_active_at: DateTime<Utc>,
     pub metadata: serde_json::Value,
+    /// Set by the dreaming-lite sweeper after a classification pass.
+    /// `None` means the session is still eligible for the next sweep tick.
+    pub classified_at: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
 }
 

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -20,7 +20,7 @@ max_tokens = 400
 # Haiku 4.5 is the cheapest model with reliable structured-JSON output;
 # grok-4-mini fallback keeps the no-OpenAI invariant if Anthropic is down.
 [tasks.memory_extraction]
-model = "anthropic/claude-haiku-4-5"
+model = "anthropic/claude-haiku-4.5"
 fallback = "x-ai/grok-4-mini"
 temperature = 0.2
 max_tokens = 800

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -14,6 +14,17 @@ fallback = "deepseek/deepseek-chat-v3.2"
 temperature = 0.3
 max_tokens = 400
 
+# Session-end memory extraction (dreaming-lite). Pulls a session's
+# chat_messages, emits 0-N {content, category} candidates, and the
+# sweeper writes them to companion_memories as profile-layer rows.
+# Haiku 4.5 is the cheapest model with reliable structured-JSON output;
+# grok-4-mini fallback keeps the no-OpenAI invariant if Anthropic is down.
+[tasks.memory_extraction]
+model = "anthropic/claude-haiku-4-5"
+fallback = "x-ai/grok-4-mini"
+temperature = 0.2
+max_tokens = 800
+
 # Reserved — not consumed by current code. The PDE in
 # `eros-engine-core/src/pde.rs` is purely rule-based; this entry is a
 # placeholder for a future optional LLM decision layer.


### PR DESCRIPTION
## Summary

Implements the classifier follow-up to #5 (which added the \`category\` schema). Background tokio sweeper picks idle, unclassified \`chat_sessions\` and runs a new \`memory_extraction\` LLM task (Haiku 4.5, grok-4-mini fallback) on their messages. Extracted candidates land in \`companion_memories\` as profile-layer rows with \`category\` populated.

### Architecture
- **Trigger**: in-process tokio task spawned in \`main.rs\`. Picks at most 10 sessions per tick where \`classified_at IS NULL AND last_active_at < now() - idle_threshold\`.
- **Model**: Anthropic Haiku 4.5 primary, xAI grok-4-mini fallback. Configured under \`[tasks.memory_extraction]\` in \`examples/model_config.toml\`.
- **Output layer**: profile (cross-persona) — these are stable user facts and should be visible regardless of which persona instance answers next.
- **Categories**: \`fact\` | \`preference\` | \`event\` | \`emotion\` | \`relation\`. Anything outside this vocabulary collapses to \`fact\` (\`normalise_category\`).
- **Idempotency**: \`classified_at\` is stamped on a graceful pass — even when extraction returns 0 rows or LLM output is garbage — so a poison-pill session can't loop the sweeper. Network errors propagate without stamping so they retry next tick.
- **Single-instance assumption**: documented in \`dreaming.rs\` module doc; multi-replica needs \`FOR UPDATE SKIP LOCKED\` on the picker.

### Knobs (env)
| Var | Default | Purpose |
| --- | --- | --- |
| \`DREAMING_TICK_SECS\` | 300 | Sweeper interval |
| \`DREAMING_IDLE_SECS\` | 1800 | Min idle before a session is eligible |
| \`DREAMING_DISABLED\` | unset | \`=1\` skips spawning the sweeper |

### Schema
\`0007_session_classified_at.sql\` adds \`engine.chat_sessions.classified_at TIMESTAMPTZ\` (nullable).

## Test plan

- [x] \`cargo fmt --all\` clean
- [x] \`cargo clippy --workspace --tests --all-features -- -D warnings\` clean
- [x] 7 new unit tests in \`pipeline::dreaming\` pass locally (parse / fenced-block / normalise) — verified with \`DATABASE_URL= cargo test -p eros-engine-server pipeline::dreaming::tests\`
- [ ] CI runs the existing sqlx integration suite — should still pass since the new column is nullable and \`ChatSession\` field is \`Option<DateTime<Utc>>\`
- [ ] Live smoke test: run server with \`DREAMING_TICK_SECS=10 DREAMING_IDLE_SECS=30\`, chat for a turn or two, idle 30s, observe \`engine.companion_memories\` for new rows with \`category\` set
- [ ] Track per-call cost on the OpenRouter dashboard for the first week to validate the \`~$0.30/user/month\` estimate

## Notes
- This is the first introduction of an Anthropic model into the engine's runtime path. \`grok-4-mini\` fallback keeps the system functional if Anthropic is down.
- \`SELECT *\` on \`chat_sessions\` requires the new \`classified_at\` field on \`ChatSession\`; existing repos already use \`SELECT *\` so no other code paths needed updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)