### PR TITLE
feat(memory): multi-instance safe dreaming sweeper picker

### DIFF
--- a/crates/eros-engine-server/src/pipeline/dreaming.rs
+++ b/crates/eros-engine-server/src/pipeline/dreaming.rs
@@ -7,9 +7,14 @@
 //! written to `engine.companion_memories` as profile-layer rows; the
 //! session's `classified_at` is then stamped to suppress re-sweeps.
 //!
-//! Single-instance assumption: with multiple replicas the picker query
-//! would need `FOR UPDATE SKIP LOCKED` to avoid double-classifying the
-//! same session. OSS v1 ships single-instance.
+//! Multi-instance safety: the picker uses an atomic
+//! `UPDATE ... WHERE id IN (SELECT ... FOR UPDATE SKIP LOCKED)
+//! RETURNING ...` to claim rows in one statement. Concurrent sweepers
+//! see disjoint sets and don't race on the same session. A separate
+//! `classification_claimed_at` column carries the claim sentinel; if a
+//! worker crashes after claiming but before stamping `classified_at`,
+//! the row is re-eligible after `DREAMING_CLAIM_STALE_SECS` (default
+//! 600s).
 //!
 //! Failure handling:
 //! - Network/DB error during pick or stamp → propagate, retry next tick.
@@ -42,17 +47,18 @@ struct MemoryCandidate {
 pub async fn sweeper(state: AppState) {
     let interval = state.config.dreaming_tick;
     let idle = state.config.dreaming_idle_threshold;
+    let claim_stale = state.config.dreaming_claim_stale_threshold;
     if interval.is_zero() {
         tracing::info!("dreaming sweeper disabled (DREAMING_DISABLED=1 or tick=0)");
         return;
     }
-    tracing::info!(?interval, ?idle, "dreaming sweeper starting");
+    tracing::info!(?interval, ?idle, ?claim_stale, "dreaming sweeper starting");
 
     let mut tick = tokio::time::interval(interval);
     tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     loop {
         tick.tick().await;
-        match scan_and_classify(&state, idle).await {
+        match scan_and_classify(&state, idle, claim_stale).await {
             Ok(0) => {} // quiet — common case on a low-traffic instance
             Ok(n) => tracing::info!(processed = n, "dreaming: sessions classified"),
             Err(e) => tracing::warn!("dreaming scan failed: {e}"),
@@ -60,16 +66,43 @@ pub async fn sweeper(state: AppState) {
     }
 }
 
-/// One sweep tick: pick eligible sessions, classify each in turn.
-async fn scan_and_classify(state: &AppState, idle: Duration) -> Result<usize, sqlx::Error> {
-    let cutoff = Utc::now() - chrono::Duration::from_std(idle).unwrap_or_default();
+/// Atomically claim eligible sessions and classify each in turn.
+///
+/// The picker fuses "find idle sessions" and "stamp them as claimed" into
+/// a single `UPDATE ... WHERE id IN (SELECT ... FOR UPDATE SKIP LOCKED)
+/// RETURNING ...` statement so concurrent sweeper instances can't both
+/// pick the same row. The claim is set in this one quick statement — no
+/// transaction stays open across the LLM / Voyage HTTP calls that follow.
+///
+/// Stale claim recovery: rows with `classification_claimed_at < now() -
+/// claim_stale` are eligible again, so a worker that crashed mid-pass
+/// gets re-tried automatically.
+async fn scan_and_classify(
+    state: &AppState,
+    idle: Duration,
+    claim_stale: Duration,
+) -> Result<usize, sqlx::Error> {
+    let now = Utc::now();
+    let cutoff = now - chrono::Duration::from_std(idle).unwrap_or_default();
+    let stale_cutoff = now - chrono::Duration::from_std(claim_stale).unwrap_or_default();
+
     let sessions: Vec<(Uuid, Uuid, Option<Uuid>)> = sqlx::query_as(
-        "SELECT id, user_id, instance_id FROM engine.chat_sessions \
-         WHERE classified_at IS NULL AND last_active_at < $1 \
-         ORDER BY last_active_at \
-         LIMIT $2",
+        "UPDATE engine.chat_sessions \
+         SET classification_claimed_at = now() \
+         WHERE id IN ( \
+             SELECT id FROM engine.chat_sessions \
+             WHERE classified_at IS NULL \
+               AND last_active_at < $1 \
+               AND (classification_claimed_at IS NULL \
+                    OR classification_claimed_at < $2) \
+             ORDER BY last_active_at \
+             LIMIT $3 \
+             FOR UPDATE SKIP LOCKED \
+         ) \
+         RETURNING id, user_id, instance_id",
     )
     .bind(cutoff)
+    .bind(stale_cutoff)
     .bind(PICK_BATCH)
     .fetch_all(&state.pool)
     .await?;

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -930,9 +930,10 @@ mod tests {
                 demo_ema_inertia: 0.0,
                 bind_addr: "127.0.0.1:0".into(),
                 // Sweeper disabled in tests — unit tests don't spawn it
-                // and the field is just for AppState completeness.
+                // and the fields are just for AppState completeness.
                 dreaming_tick: std::time::Duration::ZERO,
                 dreaming_idle_threshold: std::time::Duration::from_secs(1800),
+                dreaming_claim_stale_threshold: std::time::Duration::from_secs(600),
             },
             openrouter: Arc::new(eros_engine_llm::openrouter::OpenRouterClient::new(
                 "stub".into(),

--- a/crates/eros-engine-server/src/state.rs
+++ b/crates/eros-engine-server/src/state.rs
@@ -30,6 +30,11 @@ pub struct ServerConfig {
     /// Minimum idle time on `chat_sessions.last_active_at` before a
     /// session becomes eligible for classification.
     pub dreaming_idle_threshold: Duration,
+    /// How long a `classification_claimed_at` claim is considered fresh.
+    /// Older than this and the picker treats it as a crashed worker and
+    /// re-claims the row. Should comfortably exceed the worst-case
+    /// processing time (one LLM call + N voyage embeddings).
+    pub dreaming_claim_stale_threshold: Duration,
 }
 
 impl ServerConfig {
@@ -57,6 +62,12 @@ impl ServerConfig {
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(1800),
         );
+        let dreaming_claim_stale_threshold = Duration::from_secs(
+            std::env::var("DREAMING_CLAIM_STALE_SECS")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(600),
+        );
         Self {
             expose_affinity_debug: std::env::var("EXPOSE_AFFINITY_DEBUG")
                 .map(|v| v == "true" || v == "1")
@@ -69,6 +80,7 @@ impl ServerConfig {
             bind_addr: std::env::var("BIND_ADDR").unwrap_or_else(|_| "0.0.0.0:8080".into()),
             dreaming_tick,
             dreaming_idle_threshold,
+            dreaming_claim_stale_threshold,
         }
     }
 }

--- a/crates/eros-engine-store/migrations/0008_session_classification_claim.sql
+++ b/crates/eros-engine-store/migrations/0008_session_classification_claim.sql
@@ -1,0 +1,26 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Multi-instance safe claim sentinel for the dreaming-lite sweeper.
+--
+-- The picker now runs as
+--   UPDATE chat_sessions SET classification_claimed_at = now()
+--   WHERE id IN (
+--     SELECT id FROM chat_sessions
+--     WHERE classified_at IS NULL
+--       AND last_active_at < $cutoff
+--       AND (classification_claimed_at IS NULL
+--            OR classification_claimed_at < $stale_cutoff)
+--     ORDER BY last_active_at LIMIT $batch
+--     FOR UPDATE SKIP LOCKED)
+--   RETURNING id, user_id, instance_id;
+--
+-- so two sweeper instances racing on the same row see one of them get
+-- the SKIP LOCKED brush-off rather than both processing the same session.
+-- The claim is set in a single atomic statement — no transaction stays
+-- open across the subsequent LLM / Voyage HTTP calls.
+--
+-- Recovery: if a worker crashes after claiming but before stamping
+-- classified_at, the row sits with a non-NULL classification_claimed_at
+-- and NULL classified_at. After DREAMING_CLAIM_STALE_SECS (default 600)
+-- the next tick will treat the claim as stale and re-pick it.
+ALTER TABLE engine.chat_sessions
+    ADD COLUMN classification_claimed_at TIMESTAMPTZ;

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -18,6 +18,13 @@ pub struct ChatSession {
     /// Set by the dreaming-lite sweeper after a classification pass.
     /// `None` means the session is still eligible for the next sweep tick.
     pub classified_at: Option<DateTime<Utc>>,
+    /// Set by the dreaming-lite picker when it claims a session for
+    /// processing — the claim sentinel that makes multi-instance
+    /// sweepers safe via `FOR UPDATE SKIP LOCKED`. A non-NULL value
+    /// older than `DREAMING_CLAIM_STALE_SECS` is treated as a crashed
+    /// worker and re-claimable. Cleared implicitly by `classified_at`
+    /// being set on a successful pass.
+    pub classification_claimed_at: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
 }
 


### PR DESCRIPTION
## Summary

Removes the single-instance assumption from the dreaming-lite sweeper. Self-hosters can now run >1 server replica without two sweepers racing on the same \`chat_sessions\` row.

### Mechanism
Picker fuses \"find idle sessions\" and \"stamp them as claimed\" into one atomic statement:
\`\`\`sql
UPDATE engine.chat_sessions
SET classification_claimed_at = now()
WHERE id IN (
    SELECT id FROM engine.chat_sessions
    WHERE classified_at IS NULL
      AND last_active_at < $idle_cutoff
      AND (classification_claimed_at IS NULL
           OR classification_claimed_at < $stale_cutoff)
    ORDER BY last_active_at LIMIT $batch
    FOR UPDATE SKIP LOCKED
)
RETURNING id, user_id, instance_id;
\`\`\`
Concurrent sweepers see disjoint sets — \`SKIP LOCKED\` quietly excludes rows another worker is already mid-pick on. The claim lives in its own column so no DB transaction stays open across the subsequent LLM / Voyage HTTP work.

### Crash recovery
A worker that grabs a row but dies before stamping \`classified_at\` leaves the row with \`classification_claimed_at != NULL\` and \`classified_at IS NULL\`. After \`DREAMING_CLAIM_STALE_SECS\` (default 600s) the picker treats the claim as stale and re-eligible. No manual intervention needed.

### New knob
| Var | Default | Purpose |
| --- | --- | --- |
| \`DREAMING_CLAIM_STALE_SECS\` | 600 | How long a claim is fresh before another worker can re-pick it |

### Schema
\`0008_session_classification_claim.sql\` adds \`engine.chat_sessions.classification_claimed_at TIMESTAMPTZ\` (nullable). \`ChatSession\` picks up the matching \`Option<DateTime<Utc>>\` field so \`SELECT *\` callers don't break.

## Test plan

- [x] \`cargo fmt --all\` clean
- [x] \`cargo clippy --workspace --tests --all-features -- -D warnings\` clean
- [x] 7 dreaming unit tests still pass (parsing/normalisation, unaffected by the picker change)
- [ ] CI runs the full sqlx integration suite (existing tests construct sessions; the new column is nullable and doesn't affect their queries)
- [ ] Concurrency invariant is asserted by the SQL semantics (\`FOR UPDATE SKIP LOCKED\` is a Postgres primitive); a multi-tokio-task race test would need a custom pool setup not worth the maintenance for OSS v1

## Notes
- This is roadmap item #2 from PR #7's notes. Items #3 (incremental re-classification) and #4 (true dreaming — merge/generalise/dedupe) remain.
- Migration is purely additive; rolling back the deploy without rolling back the migration is safe (the new column just sits unused).

🤖 Generated with [Claude Code](https://claude.com/claude-code)