### PR TITLE
chore(ci): restore strict CLA gating now that CLA_BOT_TOKEN is set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,12 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      # Non-blocking until CLA_BOT_TOKEN is configured in repo secrets.
-      # Without the PAT the bot can't create/update cla-signatures.json, so
-      # every PR currently fails on a 404 read. Flip continue-on-error back
-      # to false once the secret is set and signatures.json is seeded.
       - uses: contributor-assistant/github-action@v2.4.0
-        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_BOT_TOKEN }}

--- a/cla-signatures.json
+++ b/cla-signatures.json
@@ -1,0 +1,3 @@
+{
+  "signedContributors": []
+}


### PR DESCRIPTION
## Summary

Follow-up to #9. `CLA_BOT_TOKEN` is now configured in repo secrets, so flip the CLA gate back to strict.

- Seed `cla-signatures.json` on `main` with an empty `signedContributors` array so the bot's initial read no longer 404s.
- Drop `continue-on-error: true` on the cla step.
- Maintainer (`enriquephl`) stays on the allowlist; external PRs go through the normal "I have read the CLA Document" flow.

## Test plan

- [ ] CI green on this PR — the maintainer-author path should pass via allowlist (file read should also succeed now that signatures.json exists)
- [ ] (Manual, later) confirm an external PR triggers the CLA comment flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)