### PR TITLE
ci(release): publish multi-arch docker image to ghcr on tag

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,0 +1,62 @@
+name: Release Docker image
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build (e.g. v0.1.0). Required for manual runs.'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve ref
+        id: ref
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            ref="${{ github.event.inputs.tag }}"
+          else
+            ref="${{ github.ref_name }}"
+          fi
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+          echo "version=${ref#v}" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.ref.outputs.ref }}
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/etherfunlab/eros-engine:${{ steps.ref.outputs.version }}
+            ghcr.io/etherfunlab/eros-engine:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          labels: |
+            org.opencontainers.image.source=https://github.com/etherfunlab/eros-engine
+            org.opencontainers.image.version=${{ steps.ref.outputs.version }}
+            org.opencontainers.image.licenses=AGPL-3.0-only


### PR DESCRIPTION
## Summary

Add a release workflow that builds and pushes `eros-engine-server` as a multi-arch Docker image to GitHub Container Registry whenever a `v*` tag is pushed.

**Image**: `ghcr.io/etherfunlab/eros-engine:{version,latest}`
**Platforms**: `linux/amd64`, `linux/arm64`
**Triggers**:
- `push` of any `v*` tag (future releases auto-publish)
- `workflow_dispatch` with explicit tag input (for **v0.1.0**, which is already tagged)

No new secrets needed — uses `GITHUB_TOKEN` for GHCR push (`packages: write` permission scoped to this workflow only). Build cache uses GHA backend so subsequent tag builds reuse the Rust compile cache.

## Followups after merge

1. Trigger this workflow manually for `v0.1.0` (workflow_dispatch with `tag=v0.1.0`).
2. Verify image at `ghcr.io/etherfunlab/eros-engine:0.1.0` pulls and runs.
3. Possibly: add a `docker pull` snippet to README under "Use as a library" / new "Run as a service" section.

## Test plan

- [ ] CI green on this PR (workflow itself doesn't run on PR — only on tags / dispatch)
- [ ] Post-merge: manually dispatch with `tag=v0.1.0`, watch the build, confirm image lands at ghcr.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)