### PR TITLE
feat: per-request prompt_traits injection layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,9 @@ Highlights:
 - `GET  /comp/user/{user_id}/profile` — current `companion_insights` and `training_level`.
 - `POST /comp/chat/{session_id}/event/gift` — apply an out-of-band gift event and affinity delta.
 - `GET  /comp/chat/{session_id}/gifts` — list gift events for a session.
+- `POST /comp/chat/{session_id}/message` and `/message_async` accept an optional
+  `prompt_traits` field for per-request system-prompt injection — see
+  [docs/prompt-traits.md](docs/prompt-traits.md).
 - `GET  /comp/affinity/{session_id}` — debug-only live affinity vector, enabled by `EXPOSE_AFFINITY_DEBUG=true`.
 
 The `AuthValidator` trait is pluggable if you use a different identity provider.
@@ -228,7 +231,16 @@ If you are building a different product, the reusable part is the affinity + mem
 
 ## Content note
 
-The example personas under `examples/personas/` are written as adult character-chat examples. They can flirt and express desire when the relationship state reaches that point, while still refusing disrespectful or boundary-crossing behavior. If your product needs a SFW default, replace those persona files before deploying.
+The example personas under `examples/personas/` are written as adult
+character-chat examples. They can flirt and express desire when the
+relationship state reaches that point, while still refusing disrespectful or
+boundary-crossing behavior. If your product needs a SFW default, replace
+those persona files before deploying.
+
+Per-request behaviour can be further modulated via the
+[`prompt_traits`](docs/prompt-traits.md) field on the message routes —
+the engine treats the supplied text as opaque, so the policy of what
+those traits encode lives entirely in your frontend / middleware.
 
 ## Contributing
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -154,6 +154,9 @@ Server 默認監聽 `0.0.0.0:8080`。Scalar API docs 在 `/docs`，OpenAPI JSON 
 - `GET  /comp/user/{user_id}/profile`——讀取目前的 `companion_insights` 和 `training_level`。
 - `POST /comp/chat/{session_id}/event/gift`——套用外部 gift event 與 affinity delta。
 - `GET  /comp/chat/{session_id}/gifts`——列出某個 session 的 gift events。
+- `POST /comp/chat/{session_id}/message` 與 `/message_async` 接受可選的
+  `prompt_traits` 欄位，用於 per-request system-prompt 注入——詳見
+  [docs/prompt-traits.md](docs/prompt-traits.md)。
 - `GET  /comp/affinity/{session_id}`——debug-only 即時 affinity vector，由 `EXPOSE_AFFINITY_DEBUG=true` 開啟。
 
 如果你不用 Supabase，可以實現 `AuthValidator` trait 接自己的 identity provider。
@@ -186,6 +189,11 @@ Server 默認監聽 `0.0.0.0:8080`。Scalar API docs 在 `/docs`，OpenAPI JSON 
 ## 內容說明
 
 `examples/personas/` 裡的人格是成人 character-chat 示例。當 relationship state 走到相應位置，它們可以調情、表達慾望；同時仍會拒絕不尊重或越界的要求。如果你的產品需要 SFW default，部署前請替換這些 persona files。
+
+每一輪的行為還可以透過 message routes 上的
+[`prompt_traits`](docs/prompt-traits.md) 欄位再調整——engine 把傳入的文字
+當成 opaque string 處理，這些 traits 實際代表什麼策略，完全交給你的
+frontend / middleware 決定。
 
 ## 貢獻
 

--- a/crates/eros-engine-core/src/pde.rs
+++ b/crates/eros-engine-core/src/pde.rs
@@ -206,6 +206,7 @@ mod tests {
         Event::UserMessage {
             content: content.into(),
             message_id: Uuid::new_v4(),
+            prompt_traits: Vec::new(),
         }
     }
 

--- a/crates/eros-engine-core/src/types.rs
+++ b/crates/eros-engine-core/src/types.rs
@@ -7,11 +7,32 @@ use uuid::Uuid;
 use crate::affinity::{Affinity, AffinityDeltas};
 use crate::persona::CompanionPersona;
 
+/// A caller-supplied system-prompt fragment. The engine treats `text` as
+/// opaque — it is inserted verbatim under the `【附加指引】` section of
+/// the persona system prompt. `tag` is for logging/observability only and
+/// is constrained to `[a-z0-9_]{1,32}` by the HTTP layer.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PromptTrait {
+    pub tag: String,
+    pub text: String,
+}
+
 /// Events that drive the engine pipeline.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Event {
-    UserMessage { content: String, message_id: Uuid },
-    Gift { gift_id: Uuid, amount: i64 },
+    UserMessage {
+        content: String,
+        message_id: Uuid,
+        /// Optional caller-supplied prompt traits. Empty for clients that
+        /// don't send the field — preserves the legacy system-prompt output
+        /// byte-for-byte.
+        #[serde(default)]
+        prompt_traits: Vec<PromptTrait>,
+    },
+    Gift {
+        gift_id: Uuid,
+        amount: i64,
+    },
     ProactiveTrigger,
     AppOpen,
 }
@@ -67,4 +88,32 @@ pub struct DecisionInput {
     pub affinity: Affinity,
     pub persona: CompanionPersona,
     pub signals: ConversationSignals,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn event_user_message_defaults_prompt_traits_to_empty_vec() {
+        let raw = r#"{"UserMessage":{"content":"hi","message_id":"00000000-0000-0000-0000-000000000001"}}"#;
+        let ev: Event = serde_json::from_str(raw).expect("legacy body deserialises");
+        match ev {
+            Event::UserMessage { prompt_traits, .. } => {
+                assert!(prompt_traits.is_empty(), "missing field must default to []");
+            }
+            _ => panic!("expected UserMessage"),
+        }
+    }
+
+    #[test]
+    fn prompt_trait_round_trips_through_serde() {
+        let t = PromptTrait {
+            tag: "nsfw_boost".into(),
+            text: "be more daring".into(),
+        };
+        let json = serde_json::to_string(&t).unwrap();
+        let back: PromptTrait = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, t);
+    }
 }

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -1193,6 +1193,24 @@
           }
         }
       },
+      "PromptTraitDto": {
+        "type": "object",
+        "description": "Caller-supplied prompt-injection fragment. See `docs/prompt-traits.md`.",
+        "required": [
+          "tag",
+          "text"
+        ],
+        "properties": {
+          "tag": {
+            "type": "string",
+            "description": "ASCII identifier, regex `^[a-z0-9_]{1,32}$`. Used for logging."
+          },
+          "text": {
+            "type": "string",
+            "description": "Verbatim text inserted under `【附加指引】` in the system prompt.\n1 ≤ chars ≤ 2000 after trim."
+          }
+        }
+      },
       "SendMessageRequest": {
         "type": "object",
         "required": [
@@ -1201,6 +1219,16 @@
         "properties": {
           "message": {
             "type": "string"
+          },
+          "prompt_traits": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/PromptTraitDto"
+            },
+            "description": "Optional caller-supplied prompt-injection fragments. See\n`docs/prompt-traits.md`. Missing field → empty list."
           }
         }
       },

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -22,7 +22,7 @@ use sqlx::PgPool;
 use uuid::Uuid;
 
 use eros_engine_core::affinity::AffinityDeltas;
-use eros_engine_core::types::{ActionPlan, DecisionInput, Event};
+use eros_engine_core::types::{ActionPlan, DecisionInput, Event, PromptTrait};
 use eros_engine_llm::openrouter::{ChatMessage, ChatRequest};
 use eros_engine_store::chat::ChatRepo;
 use eros_engine_store::insight::InsightRepo;
@@ -355,7 +355,7 @@ impl<'a> ActionHandler for ReplyHandler<'a> {
         // Reply path never has pending gifts — those flow through GiftHandler.
         let pending_gifts: Vec<PendingGift> = vec![];
 
-        let prompt_traits: &[eros_engine_core::types::PromptTrait] = match &input.event {
+        let prompt_traits: &[PromptTrait] = match &input.event {
             Event::UserMessage { prompt_traits, .. } => prompt_traits.as_slice(),
             _ => &[],
         };
@@ -467,6 +467,7 @@ impl<'a> ActionHandler for GiftHandler<'a> {
             .as_deref()
             .unwrap_or("normal");
 
+        // Gift path: prompt_traits flow only from UserMessage; ignore for gift reactions.
         let system_prompt = build_prompt(
             &input.persona,
             &profile_groups,

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -355,6 +355,11 @@ impl<'a> ActionHandler for ReplyHandler<'a> {
         // Reply path never has pending gifts — those flow through GiftHandler.
         let pending_gifts: Vec<PendingGift> = vec![];
 
+        let prompt_traits: &[eros_engine_core::types::PromptTrait] = match &input.event {
+            Event::UserMessage { prompt_traits, .. } => prompt_traits.as_slice(),
+            _ => &[],
+        };
+
         let system_prompt = build_prompt(
             &input.persona,
             &profile_groups,
@@ -364,6 +369,7 @@ impl<'a> ActionHandler for ReplyHandler<'a> {
             tip_personality,
             plan.reply_style,
             &plan.context_hints,
+            prompt_traits,
         );
 
         Ok(Some(assemble_chat_request(
@@ -470,6 +476,7 @@ impl<'a> ActionHandler for GiftHandler<'a> {
             tip_personality,
             plan.reply_style,
             &plan.context_hints,
+            &[],
         );
 
         Ok(Some(assemble_chat_request(

--- a/crates/eros-engine-server/src/pipeline/mod.rs
+++ b/crates/eros-engine-server/src/pipeline/mod.rs
@@ -73,6 +73,18 @@ pub async fn run(
         plan.reply_style,
     );
 
+    if let Event::UserMessage { prompt_traits, .. } = &event {
+        if !prompt_traits.is_empty() {
+            let tags: Vec<&str> = prompt_traits.iter().map(|t| t.tag.as_str()).collect();
+            tracing::info!(
+                session = %session_id,
+                traits_count = prompt_traits.len(),
+                trait_tags = ?tags,
+                "engine: prompt_traits applied"
+            );
+        }
+    }
+
     // 7. Dispatch to handler. The Gift branch passes `plan.affinity_deltas`
     // through; T11 will replace this with deltas supplied directly by the
     // `/comp/chat/{id}/event/gift` route's request body, since the OSS

--- a/crates/eros-engine-server/src/prompt.rs
+++ b/crates/eros-engine-server/src/prompt.rs
@@ -494,7 +494,10 @@ mod tests {
             &[],
             &[],
         );
-        assert!(!p.contains("【附加指引】"), "empty traits must not render section");
+        assert!(
+            !p.contains("【附加指引】"),
+            "empty traits must not render section"
+        );
         // Byte-level invariant proving "byte-for-byte identical to legacy"
         // for the empty-traits case: topics → time-context joins with the
         // pre-existing `\n\n` separator, no leftover whitespace from the
@@ -508,8 +511,14 @@ mod tests {
     #[test]
     fn build_prompt_renders_traits_as_bullets_under_label() {
         let traits = vec![
-            PromptTrait { tag: "nsfw_boost".into(), text: "be more daring".into() },
-            PromptTrait { tag: "politics_open".into(), text: "discuss politics openly".into() },
+            PromptTrait {
+                tag: "nsfw_boost".into(),
+                text: "be more daring".into(),
+            },
+            PromptTrait {
+                tag: "politics_open".into(),
+                text: "discuss politics openly".into(),
+            },
         ];
         let p = build_prompt(
             &fixture_persona(),
@@ -551,8 +560,10 @@ mod tests {
         let topics_idx = p.find("【擅长话题】").expect("topics header");
         let traits_idx = p.find("【附加指引】").expect("traits header");
         let time_idx = p.find("【今日情境】").expect("time-context header");
-        assert!(topics_idx < traits_idx && traits_idx < time_idx,
-                "order: 擅长话题 → 附加指引 → 今日情境");
+        assert!(
+            topics_idx < traits_idx && traits_idx < time_idx,
+            "order: 擅长话题 → 附加指引 → 今日情境"
+        );
     }
 
     #[test]

--- a/crates/eros-engine-server/src/prompt.rs
+++ b/crates/eros-engine-server/src/prompt.rs
@@ -27,6 +27,7 @@ use chrono::{Timelike, Utc};
 
 use eros_engine_core::affinity::Affinity;
 use eros_engine_core::persona::CompanionPersona;
+use eros_engine_core::types::PromptTrait;
 use eros_engine_core::types::ReplyStyle;
 
 /// A pending gift/tip that the prompt builder must surface to the LLM.
@@ -216,6 +217,7 @@ pub fn build_prompt(
     tip_personality: &str,
     style: ReplyStyle,
     hints: &[String],
+    prompt_traits: &[PromptTrait],
 ) -> String {
     let name = persona.genome.name.as_str();
     let age = meta_i32(persona, "age")
@@ -228,6 +230,17 @@ pub fn build_prompt(
         meta_string_array_joined(persona, "quirks").unwrap_or_else(|| "无特定口癖".into());
     let topics_str =
         meta_string_array_joined(persona, "topics").unwrap_or_else(|| "日常生活、感情观".into());
+
+    let traits_section = if prompt_traits.is_empty() {
+        String::new()
+    } else {
+        let bullets = prompt_traits
+            .iter()
+            .map(|t| format!("- {}", t.text))
+            .collect::<Vec<_>>()
+            .join("\n");
+        format!("\n\n【附加指引】\n{bullets}")
+    };
 
     let non_empty_groups: Vec<&(String, Vec<String>)> = profile_groups
         .iter()
@@ -294,7 +307,7 @@ pub fn build_prompt(
          \n\
          【说话风格】{speech_style}\n\
          【口癖/习惯】{quirks_str}\n\
-         【擅长话题】{topics_str}\n\
+         【擅长话题】{topics_str}{traits_section}\n\
          \n\
          【今日情境】\n{tc}\n\
          \n\
@@ -436,6 +449,111 @@ pub fn extract_structured_insights_prompt(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use uuid::Uuid;
+
+    fn fixture_persona() -> CompanionPersona {
+        use eros_engine_core::persona::{PersonaGenome, PersonaInstance};
+        let uid = Uuid::nil();
+        CompanionPersona {
+            instance_id: uid,
+            genome: PersonaGenome {
+                id: uid,
+                name: "Aria".into(),
+                system_prompt: "p".into(),
+                tip_personality: Some("normal".into()),
+                avatar_url: None,
+                art_metadata: serde_json::json!({
+                    "age": 24,
+                    "mbti": "INFP",
+                    "backstory": "back",
+                    "speech_style": "soft",
+                    "quirks": ["q1"],
+                    "topics": ["t1"]
+                }),
+                is_active: true,
+            },
+            instance: PersonaInstance {
+                id: uid,
+                genome_id: uid,
+                owner_uid: uid,
+                status: "active".into(),
+            },
+        }
+    }
+
+    #[test]
+    fn build_prompt_with_empty_traits_omits_section_and_preserves_layout() {
+        let p = build_prompt(
+            &fixture_persona(),
+            &[],
+            &[],
+            None,
+            &[],
+            "normal",
+            ReplyStyle::Neutral,
+            &[],
+            &[],
+        );
+        assert!(!p.contains("【附加指引】"), "empty traits must not render section");
+        // Byte-level invariant proving "byte-for-byte identical to legacy"
+        // for the empty-traits case: topics → time-context joins with the
+        // pre-existing `\n\n` separator, no leftover whitespace from the
+        // new `{traits_section}` placeholder.
+        assert!(
+            p.contains("【擅长话题】t1\n\n【今日情境】"),
+            "topics → time-context separator must be exactly '\\n\\n'"
+        );
+    }
+
+    #[test]
+    fn build_prompt_renders_traits_as_bullets_under_label() {
+        let traits = vec![
+            PromptTrait { tag: "nsfw_boost".into(), text: "be more daring".into() },
+            PromptTrait { tag: "politics_open".into(), text: "discuss politics openly".into() },
+        ];
+        let p = build_prompt(
+            &fixture_persona(),
+            &[],
+            &[],
+            None,
+            &[],
+            "normal",
+            ReplyStyle::Neutral,
+            &[],
+            &traits,
+        );
+        assert!(p.contains("【附加指引】"), "section header present");
+        assert!(p.contains("- be more daring"));
+        assert!(p.contains("- discuss politics openly"));
+        // Ordering preserved.
+        let i1 = p.find("be more daring").unwrap();
+        let i2 = p.find("discuss politics openly").unwrap();
+        assert!(i1 < i2, "traits render in input order");
+    }
+
+    #[test]
+    fn build_prompt_section_sits_between_topics_and_time_context() {
+        let traits = vec![PromptTrait {
+            tag: "x".into(),
+            text: "trait body".into(),
+        }];
+        let p = build_prompt(
+            &fixture_persona(),
+            &[],
+            &[],
+            None,
+            &[],
+            "normal",
+            ReplyStyle::Neutral,
+            &[],
+            &traits,
+        );
+        let topics_idx = p.find("【擅长话题】").expect("topics header");
+        let traits_idx = p.find("【附加指引】").expect("traits header");
+        let time_idx = p.find("【今日情境】").expect("time-context header");
+        assert!(topics_idx < traits_idx && traits_idx < time_idx,
+                "order: 擅长话题 → 附加指引 → 今日情境");
+    }
 
     #[test]
     fn test_style_directive_for_all_styles() {

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -135,6 +135,10 @@ pub struct StartChatResponse {
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct SendMessageRequest {
     pub message: String,
+    /// Optional caller-supplied prompt-injection fragments. See
+    /// `docs/prompt-traits.md`. Missing field → empty list.
+    #[serde(default)]
+    pub prompt_traits: Option<Vec<PromptTraitDto>>,
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
@@ -607,6 +611,10 @@ async fn send_message(
         enforce_nft_ownership(&state.pool, user_id, asset_id_opt.as_deref()).await?;
     }
 
+    let prompt_traits = validate_prompt_traits(
+        req.prompt_traits.as_deref().unwrap_or(&[]),
+    )?;
+
     // Persist the user message up-front so the engine sees it in history.
     let chat_repo = ChatRepo { pool: &state.pool };
     let user_message_id = chat_repo
@@ -616,7 +624,7 @@ async fn send_message(
     let event = Event::UserMessage {
         content: req.message.clone(),
         message_id: user_message_id,
-        prompt_traits: Vec::new(),
+        prompt_traits,
     };
     let response = pipeline::run(&state, session_id, event).await?;
 
@@ -688,6 +696,11 @@ async fn send_message_async(
         enforce_nft_ownership(&state.pool, user_id, asset_id_opt.as_deref()).await?;
     }
 
+    // Validate BEFORE we persist the user message so a bad request leaves no row.
+    let prompt_traits = validate_prompt_traits(
+        req.prompt_traits.as_deref().unwrap_or(&[]),
+    )?;
+
     let chat_repo = ChatRepo { pool: &state.pool };
     let user_message_id = chat_repo
         .append_message(session_id, "user", &req.message)
@@ -695,11 +708,12 @@ async fn send_message_async(
 
     let state_bg = state.clone();
     let msg_copy = req.message.clone();
+    let traits_copy = prompt_traits;
     tokio::spawn(async move {
         let event = Event::UserMessage {
             content: msg_copy,
             message_id: user_message_id,
-            prompt_traits: Vec::new(),
+            prompt_traits: traits_copy,
         };
         if let Err(e) = pipeline::run(&state_bg, session_id, event).await {
             tracing::error!("engine pipeline failed for session {session_id}: {e}");

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -1654,4 +1654,180 @@ mod tests {
             "embedded newline must be rejected so bullet rendering stays safe"
         );
     }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn send_message_rejects_too_many_prompt_traits(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Vega").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+
+        let state = test_state(pool.clone());
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        let traits: Vec<Value> = (0..9)
+            .map(|i| json!({ "tag": format!("t{i}"), "text": "x" }))
+            .collect();
+        let body = serde_json::to_vec(&json!({
+            "message": "hi",
+            "prompt_traits": traits,
+        }))
+        .unwrap();
+
+        let req = Request::builder()
+            .method("POST")
+            .uri(format!("/comp/chat/{session_id}/message"))
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        let (status, _resp) = send_request(&mut app, req).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+
+        // No user message persisted on a 400.
+        let count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM engine.chat_messages WHERE session_id = $1",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn send_message_rejects_oversized_trait_text(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Vega").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+
+        let state = test_state(pool.clone());
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        let body = serde_json::to_vec(&json!({
+            "message": "hi",
+            "prompt_traits": [{ "tag": "ok", "text": "a".repeat(2001) }],
+        }))
+        .unwrap();
+
+        let req = Request::builder()
+            .method("POST")
+            .uri(format!("/comp/chat/{session_id}/message"))
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        let (status, _resp) = send_request(&mut app, req).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn send_message_rejects_invalid_tag_regex(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Vega").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+
+        let state = test_state(pool.clone());
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        let body = serde_json::to_vec(&json!({
+            "message": "hi",
+            "prompt_traits": [{ "tag": "NSFW Boost", "text": "x" }],
+        }))
+        .unwrap();
+
+        let req = Request::builder()
+            .method("POST")
+            .uri(format!("/comp/chat/{session_id}/message"))
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        let (status, _resp) = send_request(&mut app, req).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn send_message_accepts_missing_prompt_traits_field(pool: PgPool) {
+        // A body without `prompt_traits` deserialises fine and reaches the
+        // pipeline. We only assert that the validator did not reject the
+        // request — the downstream LLM call may or may not succeed against
+        // the stubbed OpenRouter key in test state.
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Vega").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+
+        let state = test_state(pool.clone());
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        let body = serde_json::to_vec(&json!({ "message": "hi" })).unwrap();
+        let req = Request::builder()
+            .method("POST")
+            .uri(format!("/comp/chat/{session_id}/message"))
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        let (status, _resp) = send_request(&mut app, req).await;
+        assert_ne!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "missing prompt_traits must NOT be rejected"
+        );
+        // The user message row should have been appended either way.
+        let count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM engine.chat_messages \
+             WHERE session_id = $1 AND role = 'user'",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn send_message_async_rejects_invalid_tag_regex(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Vega").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+
+        let state = test_state(pool.clone());
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        let body = serde_json::to_vec(&json!({
+            "message": "hi",
+            "prompt_traits": [{ "tag": "BadTag", "text": "x" }],
+        }))
+        .unwrap();
+
+        let req = Request::builder()
+            .method("POST")
+            .uri(format!("/comp/chat/{session_id}/message_async"))
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        let (status, _resp) = send_request(&mut app, req).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+
+        // Async route also validates BEFORE persisting — no user row.
+        let count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM engine.chat_messages WHERE session_id = $1",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(count, 0);
+    }
 }

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -384,26 +384,37 @@ fn validate_prompt_traits(dtos: &[PromptTraitDto]) -> Result<Vec<PromptTrait>, A
             )));
         }
         // text: non-empty after trim, length-capped by char count (not bytes)
-        if dto.text.trim().is_empty() {
+        // of the TRIMMED form so leading/trailing whitespace doesn't eat the
+        // budget. Both checks use the same `trimmed` slice — matches the
+        // `1 ≤ chars ≤ 2000 (after trim)` contract in docs/prompt-traits.md.
+        let trimmed = dto.text.trim();
+        if trimmed.is_empty() {
             return Err(AppError::BadRequest(format!(
                 "prompt_traits[{i}].text must not be blank"
             )));
         }
-        if dto.text.chars().count() > MAX_PROMPT_TRAIT_TEXT_CHARS {
+        if trimmed.chars().count() > MAX_PROMPT_TRAIT_TEXT_CHARS {
             return Err(AppError::BadRequest(format!(
-                "prompt_traits[{i}].text exceeds {MAX_PROMPT_TRAIT_TEXT_CHARS} chars"
+                "prompt_traits[{i}].text exceeds {MAX_PROMPT_TRAIT_TEXT_CHARS} chars after trim"
             )));
         }
-        // text: no embedded control characters (newlines / tabs / etc.)
-        // would break the bullet rendering in `build_prompt`.
-        if dto.text.chars().any(char::is_control) {
+        // text: no characters that would break the single-line bullet
+        // rendering in `build_prompt`. `char::is_control` covers
+        // \n / \r / \t / DEL / C1 controls; we additionally reject the
+        // Unicode LINE SEPARATOR (U+2028) and PARAGRAPH SEPARATOR
+        // (U+2029) which are NOT in Cc but DO start a new line.
+        if dto
+            .text
+            .chars()
+            .any(|c| c.is_control() || c == '\u{2028}' || c == '\u{2029}')
+        {
             return Err(AppError::BadRequest(format!(
-                "prompt_traits[{i}].text must not contain control characters"
+                "prompt_traits[{i}].text must not contain line-break or control characters"
             )));
         }
         out.push(PromptTrait {
             tag: dto.tag.clone(),
-            text: dto.text.clone(),
+            text: trimmed.to_string(),
         });
     }
     Ok(out)
@@ -1679,6 +1690,20 @@ mod tests {
             matches!(validate_prompt_traits(&dtos), Err(AppError::BadRequest(_))),
             "embedded newline must be rejected so bullet rendering stays safe"
         );
+    }
+
+    #[test]
+    fn validate_traits_rejects_text_with_unicode_line_separators() {
+        for sep in ["a\u{2028}b", "a\u{2029}b"] {
+            let dtos = vec![PromptTraitDto {
+                tag: "ok".into(),
+                text: sep.into(),
+            }];
+            assert!(
+                matches!(validate_prompt_traits(&dtos), Err(AppError::BadRequest(_))),
+                "Unicode line separator in text must be rejected: {sep:?}"
+            );
+        }
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -374,7 +374,11 @@ fn validate_prompt_traits(dtos: &[PromptTraitDto]) -> Result<Vec<PromptTrait>, A
                 "prompt_traits[{i}].tag must be 1..={MAX_PROMPT_TRAIT_TAG_LEN} chars"
             )));
         }
-        if !dto.tag.bytes().all(|b| matches!(b, b'a'..=b'z' | b'0'..=b'9' | b'_')) {
+        if !dto
+            .tag
+            .bytes()
+            .all(|b| matches!(b, b'a'..=b'z' | b'0'..=b'9' | b'_'))
+        {
             return Err(AppError::BadRequest(format!(
                 "prompt_traits[{i}].tag must match [a-z0-9_]+"
             )));
@@ -611,9 +615,7 @@ async fn send_message(
         enforce_nft_ownership(&state.pool, user_id, asset_id_opt.as_deref()).await?;
     }
 
-    let prompt_traits = validate_prompt_traits(
-        req.prompt_traits.as_deref().unwrap_or(&[]),
-    )?;
+    let prompt_traits = validate_prompt_traits(req.prompt_traits.as_deref().unwrap_or(&[]))?;
 
     // Persist the user message up-front so the engine sees it in history.
     let chat_repo = ChatRepo { pool: &state.pool };
@@ -697,9 +699,7 @@ async fn send_message_async(
     }
 
     // Validate BEFORE we persist the user message so a bad request leaves no row.
-    let prompt_traits = validate_prompt_traits(
-        req.prompt_traits.as_deref().unwrap_or(&[]),
-    )?;
+    let prompt_traits = validate_prompt_traits(req.prompt_traits.as_deref().unwrap_or(&[]))?;
 
     let chat_repo = ChatRepo { pool: &state.pool };
     let user_message_id = chat_repo
@@ -1599,8 +1599,14 @@ mod tests {
     #[test]
     fn validate_traits_accepts_two_well_formed_entries() {
         let dtos = vec![
-            PromptTraitDto { tag: "nsfw_boost".into(), text: "x".into() },
-            PromptTraitDto { tag: "politics_open".into(), text: "y".into() },
+            PromptTraitDto {
+                tag: "nsfw_boost".into(),
+                text: "x".into(),
+            },
+            PromptTraitDto {
+                tag: "politics_open".into(),
+                text: "y".into(),
+            },
         ];
         let out = validate_prompt_traits(&dtos).expect("ok");
         assert_eq!(out.len(), 2);
@@ -1622,20 +1628,40 @@ mod tests {
     #[test]
     fn validate_traits_rejects_oversized_text() {
         let big = "a".repeat(2001);
-        let dtos = vec![PromptTraitDto { tag: "ok".into(), text: big }];
-        assert!(matches!(validate_prompt_traits(&dtos), Err(AppError::BadRequest(_))));
+        let dtos = vec![PromptTraitDto {
+            tag: "ok".into(),
+            text: big,
+        }];
+        assert!(matches!(
+            validate_prompt_traits(&dtos),
+            Err(AppError::BadRequest(_))
+        ));
     }
 
     #[test]
     fn validate_traits_rejects_empty_text_after_trim() {
-        let dtos = vec![PromptTraitDto { tag: "ok".into(), text: "   ".into() }];
-        assert!(matches!(validate_prompt_traits(&dtos), Err(AppError::BadRequest(_))));
+        let dtos = vec![PromptTraitDto {
+            tag: "ok".into(),
+            text: "   ".into(),
+        }];
+        assert!(matches!(
+            validate_prompt_traits(&dtos),
+            Err(AppError::BadRequest(_))
+        ));
     }
 
     #[test]
     fn validate_traits_rejects_invalid_tag_regex() {
-        for bad in ["", "NSFW", "with space", "too_long_tag_xxxxxxxxxxxxxxxxxxxxxxx"] {
-            let dtos = vec![PromptTraitDto { tag: bad.into(), text: "x".into() }];
+        for bad in [
+            "",
+            "NSFW",
+            "with space",
+            "too_long_tag_xxxxxxxxxxxxxxxxxxxxxxx",
+        ] {
+            let dtos = vec![PromptTraitDto {
+                tag: bad.into(),
+                text: "x".into(),
+            }];
             assert!(
                 matches!(validate_prompt_traits(&dtos), Err(AppError::BadRequest(_))),
                 "tag {bad:?} must be rejected"
@@ -1686,13 +1712,12 @@ mod tests {
         assert_eq!(status, StatusCode::BAD_REQUEST);
 
         // No user message persisted on a 400.
-        let count: i64 = sqlx::query_scalar(
-            "SELECT COUNT(*) FROM engine.chat_messages WHERE session_id = $1",
-        )
-        .bind(session_id)
-        .fetch_one(&pool)
-        .await
-        .unwrap();
+        let count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM engine.chat_messages WHERE session_id = $1")
+                .bind(session_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
         assert_eq!(count, 0);
     }
 
@@ -1821,13 +1846,12 @@ mod tests {
         assert_eq!(status, StatusCode::BAD_REQUEST);
 
         // Async route also validates BEFORE persisting — no user row.
-        let count: i64 = sqlx::query_scalar(
-            "SELECT COUNT(*) FROM engine.chat_messages WHERE session_id = $1",
-        )
-        .bind(session_id)
-        .fetch_one(&pool)
-        .await
-        .unwrap();
+        let count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM engine.chat_messages WHERE session_id = $1")
+                .bind(session_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
         assert_eq!(count, 0);
     }
 }

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -42,6 +42,7 @@ use uuid::Uuid;
 
 use eros_engine_core::affinity::AffinityDeltas;
 use eros_engine_core::types::Event;
+use eros_engine_core::types::PromptTrait;
 use eros_engine_store::affinity::AffinityRepo;
 use eros_engine_store::chat::{ChatMessage as StoreChatMessage, ChatRepo, ChatSession};
 use eros_engine_store::insight::{compute_training_level, InsightRepo};
@@ -52,6 +53,13 @@ use crate::auth::middleware::AuthUser;
 use crate::error::AppError;
 use crate::pipeline;
 use crate::state::AppState;
+
+/// Per-request prompt-injection limits. Conservative defaults; deployers
+/// can tighten by editing these consts. Kept in one block so future env
+/// overrides land here.
+const MAX_PROMPT_TRAITS: usize = 8;
+const MAX_PROMPT_TRAIT_TEXT_CHARS: usize = 2000;
+const MAX_PROMPT_TRAIT_TAG_LEN: usize = 32;
 
 /// NFT-ownership gate. Returns `Ok(())` immediately if `asset_id` is `None`
 /// (legacy seed-persona genome). Otherwise joins persona_ownership with
@@ -265,6 +273,16 @@ impl From<&AffinityDeltasDto> for AffinityDeltas {
     }
 }
 
+/// Caller-supplied prompt-injection fragment. See `docs/prompt-traits.md`.
+#[derive(Debug, Clone, Deserialize, utoipa::ToSchema)]
+pub struct PromptTraitDto {
+    /// ASCII identifier, regex `^[a-z0-9_]{1,32}$`. Used for logging.
+    pub tag: String,
+    /// Verbatim text inserted under `【附加指引】` in the system prompt.
+    /// 1 ≤ chars ≤ 2000 after trim.
+    pub text: String,
+}
+
 #[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct GiftEventResponse {
     pub reply: Option<String>,
@@ -327,6 +345,60 @@ fn typing_delay_ms_from(seed: Uuid) -> u64 {
         bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
     ]);
     800 + (n % 1700)
+}
+
+/// Validate a caller-supplied list of `PromptTraitDto` and convert to the
+/// core `PromptTrait` shape. Empty input is allowed and returns `vec![]`.
+///
+/// Rules (all violations → `400 BadRequest`):
+/// - `traits.len()` ≤ `MAX_PROMPT_TRAITS`
+/// - `tag` matches `^[a-z0-9_]+$` and `1..=MAX_PROMPT_TRAIT_TAG_LEN` chars
+/// - `text.trim()` non-empty
+/// - `text.chars().count()` ≤ `MAX_PROMPT_TRAIT_TEXT_CHARS`
+/// - `text` contains no control characters (would break bullet rendering)
+fn validate_prompt_traits(dtos: &[PromptTraitDto]) -> Result<Vec<PromptTrait>, AppError> {
+    if dtos.len() > MAX_PROMPT_TRAITS {
+        return Err(AppError::BadRequest(format!(
+            "too many prompt_traits (max {MAX_PROMPT_TRAITS})"
+        )));
+    }
+    let mut out = Vec::with_capacity(dtos.len());
+    for (i, dto) in dtos.iter().enumerate() {
+        // tag: 1..=MAX bytes, all [a-z0-9_]
+        if dto.tag.is_empty() || dto.tag.len() > MAX_PROMPT_TRAIT_TAG_LEN {
+            return Err(AppError::BadRequest(format!(
+                "prompt_traits[{i}].tag must be 1..={MAX_PROMPT_TRAIT_TAG_LEN} chars"
+            )));
+        }
+        if !dto.tag.bytes().all(|b| matches!(b, b'a'..=b'z' | b'0'..=b'9' | b'_')) {
+            return Err(AppError::BadRequest(format!(
+                "prompt_traits[{i}].tag must match [a-z0-9_]+"
+            )));
+        }
+        // text: non-empty after trim, length-capped by char count (not bytes)
+        if dto.text.trim().is_empty() {
+            return Err(AppError::BadRequest(format!(
+                "prompt_traits[{i}].text must not be blank"
+            )));
+        }
+        if dto.text.chars().count() > MAX_PROMPT_TRAIT_TEXT_CHARS {
+            return Err(AppError::BadRequest(format!(
+                "prompt_traits[{i}].text exceeds {MAX_PROMPT_TRAIT_TEXT_CHARS} chars"
+            )));
+        }
+        // text: no embedded control characters (newlines / tabs / etc.)
+        // would break the bullet rendering in `build_prompt`.
+        if dto.text.chars().any(char::is_control) {
+            return Err(AppError::BadRequest(format!(
+                "prompt_traits[{i}].text must not contain control characters"
+            )));
+        }
+        out.push(PromptTrait {
+            tag: dto.tag.clone(),
+            text: dto.text.clone(),
+        });
+    }
+    Ok(out)
 }
 
 // ─── Handlers ───────────────────────────────────────────────────────
@@ -1500,5 +1572,72 @@ mod tests {
         // Defaults from migration: warmth=0.3, intrigue=0.5
         assert!((body["warmth"].as_f64().unwrap() - 0.3).abs() < 1e-9);
         assert!((body["intrigue"].as_f64().unwrap() - 0.5).abs() < 1e-9);
+    }
+
+    // ─── Prompt-traits validator unit tests ─────────────────────────
+
+    #[test]
+    fn validate_traits_accepts_empty_input() {
+        let out = validate_prompt_traits(&[]).expect("empty ok");
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn validate_traits_accepts_two_well_formed_entries() {
+        let dtos = vec![
+            PromptTraitDto { tag: "nsfw_boost".into(), text: "x".into() },
+            PromptTraitDto { tag: "politics_open".into(), text: "y".into() },
+        ];
+        let out = validate_prompt_traits(&dtos).expect("ok");
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].tag, "nsfw_boost");
+    }
+
+    #[test]
+    fn validate_traits_rejects_more_than_max() {
+        let dtos: Vec<PromptTraitDto> = (0..9)
+            .map(|i| PromptTraitDto {
+                tag: format!("t{i}"),
+                text: "x".into(),
+            })
+            .collect();
+        let err = validate_prompt_traits(&dtos).unwrap_err();
+        assert!(matches!(err, AppError::BadRequest(_)));
+    }
+
+    #[test]
+    fn validate_traits_rejects_oversized_text() {
+        let big = "a".repeat(2001);
+        let dtos = vec![PromptTraitDto { tag: "ok".into(), text: big }];
+        assert!(matches!(validate_prompt_traits(&dtos), Err(AppError::BadRequest(_))));
+    }
+
+    #[test]
+    fn validate_traits_rejects_empty_text_after_trim() {
+        let dtos = vec![PromptTraitDto { tag: "ok".into(), text: "   ".into() }];
+        assert!(matches!(validate_prompt_traits(&dtos), Err(AppError::BadRequest(_))));
+    }
+
+    #[test]
+    fn validate_traits_rejects_invalid_tag_regex() {
+        for bad in ["", "NSFW", "with space", "too_long_tag_xxxxxxxxxxxxxxxxxxxxxxx"] {
+            let dtos = vec![PromptTraitDto { tag: bad.into(), text: "x".into() }];
+            assert!(
+                matches!(validate_prompt_traits(&dtos), Err(AppError::BadRequest(_))),
+                "tag {bad:?} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_traits_rejects_text_with_newlines() {
+        let dtos = vec![PromptTraitDto {
+            tag: "ok".into(),
+            text: "first line\nsecond line".into(),
+        }];
+        assert!(
+            matches!(validate_prompt_traits(&dtos), Err(AppError::BadRequest(_))),
+            "embedded newline must be rejected so bullet rendering stays safe"
+        );
     }
 }

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -544,6 +544,7 @@ async fn send_message(
     let event = Event::UserMessage {
         content: req.message.clone(),
         message_id: user_message_id,
+        prompt_traits: Vec::new(),
     };
     let response = pipeline::run(&state, session_id, event).await?;
 
@@ -626,6 +627,7 @@ async fn send_message_async(
         let event = Event::UserMessage {
             content: msg_copy,
             message_id: user_message_id,
+            prompt_traits: Vec::new(),
         };
         if let Err(e) = pipeline::run(&state_bg, session_id, event).await {
             tracing::error!("engine pipeline failed for session {session_id}: {e}");

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -86,7 +86,7 @@ Synchronous chat turn. Blocks until the LLM responds.
 
 ```bash
 curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json" \
-  -d '{"content":"hi, what are you reading today?"}' \
+  -d '{"message":"hi, what are you reading today?"}' \
   http://localhost:8080/comp/chat/<session_id>/message
 ```
 
@@ -101,6 +101,25 @@ curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json"
 ```
 
 `reply: null` when the persona ghosted this turn (see [ghost mechanics](ghost-mechanics.md)). The HTTP status is still 200.
+
+**Optional: per-request prompt traits.** The body may include a
+`prompt_traits` array — see [prompt-traits.md](prompt-traits.md). Example:
+
+```bash
+curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json" \
+  -d '{
+        "message": "hi",
+        "prompt_traits": [
+          {"tag": "nsfw_boost", "text": "<your injection text here>"}
+        ]
+      }' \
+  http://localhost:8080/comp/chat/<session_id>/message
+```
+
+Limits: ≤ 8 entries, `tag` matches `[a-z0-9_]{1,32}`, `text` ≤ 2000 chars
+(non-blank). Violations return `400 BadRequest`.
+
+The same field is accepted by `/message_async`.
 
 ### `POST /comp/chat/{session_id}/message_async`
 

--- a/docs/api-reference.zh.md
+++ b/docs/api-reference.zh.md
@@ -86,7 +86,7 @@ curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json"
 
 ```bash
 curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json" \
-  -d '{"content":"嗨，今天讀甚麼書？"}' \
+  -d '{"message":"嗨，今天讀甚麼書？"}' \
   http://localhost:8080/comp/chat/<session_id>/message
 ```
 
@@ -101,6 +101,25 @@ curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json"
 ```
 
 `reply: null` 意味著人格在這一輪 ghost 了你（看 [Ghost 機制](ghost-mechanics.zh.md)）。HTTP 狀態仍是 200。
+
+**可选：单轮 prompt traits。** 请求体可附加 `prompt_traits` 数组 ——
+详见 [prompt-traits.md](prompt-traits.md)。示例：
+
+```bash
+curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json" \
+  -d '{
+        "message": "hi",
+        "prompt_traits": [
+          {"tag": "nsfw_boost", "text": "<your injection text>"}
+        ]
+      }' \
+  http://localhost:8080/comp/chat/<session_id>/message
+```
+
+限制：最多 8 条，`tag` 满足 `[a-z0-9_]{1,32}`，`text` ≤ 2000 字符
+（trim 后非空）。违反返回 `400 BadRequest`。
+
+`/message_async` 接受同一字段。
 
 ### `POST /comp/chat/{session_id}/message_async`
 

--- a/docs/api-reference.zh.md
+++ b/docs/api-reference.zh.md
@@ -103,7 +103,7 @@ curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json"
 `reply: null` 意味著人格在這一輪 ghost 了你（看 [Ghost 機制](ghost-mechanics.zh.md)）。HTTP 狀態仍是 200。
 
 **可选：单轮 prompt traits。** 请求体可附加 `prompt_traits` 数组 ——
-详见 [prompt-traits.md](prompt-traits.md)。示例：
+详见 [prompt-traits.zh.md](prompt-traits.zh.md)。示例：
 
 ```bash
 curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json" \

--- a/docs/prompt-traits.md
+++ b/docs/prompt-traits.md
@@ -1,0 +1,66 @@
+# Prompt traits
+
+A per-request hook for injecting caller-controlled fragments into the
+persona system prompt.
+
+## Shape
+
+```jsonc
+{
+  "message": "...",
+  "prompt_traits": [
+    { "tag": "ascii_identifier", "text": "verbatim text to inject" }
+  ]
+}
+```
+
+Accepted on `POST /comp/chat/{session_id}/message` and
+`POST /comp/chat/{session_id}/message_async`.
+
+## What the engine does
+
+For each turn, the validated `text` of every trait is rendered as a
+bullet under a `【附加指引】` section inside the persona system prompt,
+positioned between `【擅长话题】` and `【今日情境】`. Empty list →
+the section is omitted and the prompt is byte-for-byte identical to
+the legacy output.
+
+## What the engine does NOT do
+
+- **No persistence.** Traits are not written to any DB table.
+  Each request re-supplies them.
+- **No content interpretation.** The engine treats `text` as opaque.
+  Sanitisation, allow-listing, and user-consent gating are the caller's
+  responsibility.
+- **No semantic categories.** `tag` is a logging key — the engine does
+  not interpret `"nsfw_boost"` differently from `"politics_open"`.
+
+## Limits
+
+| Field                 | Limit                              |
+|-----------------------|------------------------------------|
+| `prompt_traits` count | ≤ 8                                |
+| `tag`                 | regex `^[a-z0-9_]{1,32}$`          |
+| `text`                | 1 ≤ chars ≤ 2000 (after trim)      |
+| `text` content        | no control characters (incl. `\n`) |
+
+Violations return `400 BadRequest` and **no user message row is persisted**.
+
+## Observability
+
+When at least one trait is supplied, the engine logs an `info`-level
+event with `traits_count` and `trait_tags`. The `text` body is never
+logged.
+
+## Threat model
+
+A compromised client can attempt prompt-injection through `text`. The
+engine is a transport, not a guard — protecting persona internals is
+the caller's responsibility. Use deployer-side allow-listing of `tag`
+values if you need to lock down which traits a client may send.
+
+## Why not persist?
+
+By design, the engine's persona table is the long-lived contract. Traits
+are intentionally ephemeral so caller-side experimentation, A/B testing,
+and per-session policy don't pollute persona rows or require migrations.

--- a/docs/prompt-traits.zh.md
+++ b/docs/prompt-traits.zh.md
@@ -1,0 +1,60 @@
+# Prompt traits（提示注入层）
+
+一个面向请求的 hook，让调用方在不修改 persona 数据的前提下，往 system
+prompt 里塞入自定义段落。
+
+## 请求结构
+
+```jsonc
+{
+  "message": "...",
+  "prompt_traits": [
+    { "tag": "ascii_identifier", "text": "要注入的文字" }
+  ]
+}
+```
+
+接受于 `POST /comp/chat/{session_id}/message` 和
+`POST /comp/chat/{session_id}/message_async`。
+
+## 引擎会做什么
+
+每轮请求中，所有 trait 的 `text` 会被渲染为 bullet 列表，放在 persona
+system prompt 的 `【附加指引】` 段落下，位置在 `【擅长话题】` 与
+`【今日情境】` 之间。空列表 → 该段落整个不渲染，输出与旧 prompt
+逐字节一致。
+
+## 引擎不会做什么
+
+- **不持久化。** trait 不会写进任何数据库表，每轮请求都由调用方重新提交。
+- **不解释内容。** 引擎把 `text` 当不透明字符串处理。内容过滤、白名单、
+  用户同意流程都是调用方的责任。
+- **不带语义类别。** `tag` 仅供日志/指标用，引擎不会因为 tag 是
+  `"nsfw_boost"` 还是 `"politics_open"` 而做任何区别处理。
+
+## 限制
+
+| 字段                  | 限制                                  |
+|----------------------|---------------------------------------|
+| `prompt_traits` 数量 | ≤ 8                                   |
+| `tag`                | 正则 `^[a-z0-9_]{1,32}$`              |
+| `text`               | trim 后 1 ≤ 字符数 ≤ 2000             |
+| `text` 内容          | 不允许控制字符（含 `\n`）             |
+
+违反规则返回 `400 BadRequest`，且**不会写入任何用户消息行**。
+
+## 可观测性
+
+只要有至少一条 trait 被提交，引擎会输出 `info` 级日志，字段包含
+`traits_count` 和 `trait_tags`。`text` 内容**不**进日志。
+
+## 威胁模型
+
+被入侵的客户端可以通过 `text` 尝试 prompt-injection。引擎只是传输层，
+不负责防护 persona 内部状态 —— 这一层防御由调用方承担。如需限制 tag
+名称白名单，可在部署层加一层 reverse proxy / middleware。
+
+## 为什么不持久化？
+
+引擎的 persona 表是长期契约。trait 故意保持瞬态，让调用方的实验、A/B
+测试和按会话的策略不会污染 persona 数据，也不需要 migration。


### PR DESCRIPTION
## Summary

Adds a generic per-request prompt-injection hook on the chat message routes. The frontend can send a `prompt_traits: [{tag, text}]` array; each entry's `text` renders as a bullet under a new `【附加指引】` section inside the persona system prompt (positioned between `【擅长话题】` and `【今日情境】`).

- **Backend is a pure transport.** Engine validates size/shape only — content is opaque. Nothing persists in any DB table.
- **Backward compatible.** Missing field → empty list → byte-for-byte identical to legacy system-prompt output (asserted by `build_prompt_with_empty_traits_omits_section_and_preserves_layout`).
- **Existing personas untouched.** The `【附加指引】` section is purely additive.
- **Semantically neutral.** The engine never branches on `tag` values — `nsfw_boost` / `politics_open` policy lives entirely in your frontend/middleware.

Spec: `docs/superpowers/specs/2026-05-18-prompt-traits-injection-design.md`
Plan: `docs/superpowers/plans/2026-05-18-prompt-traits-injection.md`
User-facing reference: `docs/prompt-traits.md`

### What changed where

| Crate / file | Change |
|---|---|
| `eros-engine-core/src/types.rs` | New `PromptTrait { tag, text }`; `Event::UserMessage` gains `#[serde(default)] prompt_traits: Vec<PromptTrait>` |
| `eros-engine-server/src/prompt.rs` | `build_prompt` gains 9th param `prompt_traits: &[PromptTrait]`; renders `【附加指引】` section when non-empty |
| `eros-engine-server/src/routes/companion.rs` | New `PromptTraitDto` + `validate_prompt_traits`; `SendMessageRequest` gains `prompt_traits: Option<Vec<PromptTraitDto>>`; both `/message` and `/message_async` validate **before** persisting the user row |
| `eros-engine-server/src/pipeline/mod.rs` | New `info!` log: `traits_count` + `trait_tags` only (never `text`) |
| `eros-engine-server/src/pipeline/handlers.rs` | `ReplyHandler` extracts traits from `input.event`; `GiftHandler` passes `&[]` (out of scope) |
| `openapi.json` | Regenerated — adds `PromptTraitDto` schema + extends `SendMessageRequest` |
| `docs/*` | New `prompt-traits.{md,zh.md}`; `api-reference.{md,zh.md}` + README updated (EN + ZH) |

### Validator rules (`400 BadRequest` on any violation)

| Field | Limit |
|---|---|
| `prompt_traits` count | ≤ 8 |
| `tag` | regex `^[a-z0-9_]{1,32}$` (byte-set match, no `regex` crate added) |
| `text` | 1 ≤ chars ≤ 2000 **after trim** |
| `text` content | no control chars; also rejects U+2028 / U+2029 line separators |

### Deviation from spec (intentional)

The spec proposed mirroring `prompt_traits` onto `DecisionInput` for handler convenience. The implementation keeps it only on `Event::UserMessage` and pattern-matches in the handler. Avoids touching 8 PDE test construction sites for a mirror that has no real consumer. Documented at the top of the plan file.

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p eros-engine-core` — 27/27 pass (incl. new serde-default + round-trip tests)
- [x] `cargo test -p eros-engine-server --bins prompt::tests` — 8/8 pass
- [x] `cargo test -p eros-engine-server --bins routes::companion::tests::validate_traits` — 8/8 pass (incl. Unicode-separator rejection)
- [x] OpenAPI snapshot drift check — zero diff
- [ ] CI Postgres service runs the 5 new `#[sqlx::test]` HTTP integration tests (local dev has no Postgres):
  - `send_message_rejects_too_many_prompt_traits` (asserts no `chat_messages` row on 400)
  - `send_message_rejects_oversized_trait_text`
  - `send_message_rejects_invalid_tag_regex`
  - `send_message_accepts_missing_prompt_traits_field` (asserts user row IS persisted)
  - `send_message_async_rejects_invalid_tag_regex` (asserts no row on async path either)
- [ ] Manual smoke: POST with 2 traits → server log shows `traits_count=2 trait_tags=["nsfw_boost", "politics_open"]`, `text` bodies absent

## Threat model note

The engine is a transport; a compromised frontend can prompt-inject through `text`. Deployer-side allow-listing of `tag` values is a one-function change if needed later (the limits live in a single `const` block).