### PR TITLE
feat: OpenRouter audit passthrough + model_config hotfix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,13 @@ DATABASE_URL=postgres://postgres:<password>@<host>:5432/postgres
 # OpenRouter (chat completions). Same key works for both apps.
 OPENROUTER_API_KEY=sk-or-...
 
+# OpenRouter app attribution (optional). When set, the engine adds
+# these headers to every outbound OpenRouter call so the deployment
+# shows up on OpenRouter's app analytics dashboard. Leave unset to
+# remain anonymous.
+# OPENROUTER_APP_REFERER=https://eros.example
+# OPENROUTER_APP_TITLE=Eros
+
 # Supabase project — same as eros-gateway.
 # Setting SUPABASE_URL is enough on modern projects: the engine derives the
 # JWKS URL (${SUPABASE_URL}/auth/v1/.well-known/jwks.json) and validates

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,6 +290,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,6 +394,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+ "wiremock",
 ]
 
 [[package]]
@@ -470,6 +499,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,6 +517,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
 ]
 
 [[package]]
@@ -529,6 +579,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,8 +607,10 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -593,6 +656,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,6 +699,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -706,6 +794,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1159,6 +1248,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -2192,6 +2291,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2922,6 +3034,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/crates/eros-engine-core/src/pde.rs
+++ b/crates/eros-engine-core/src/pde.rs
@@ -207,6 +207,7 @@ mod tests {
             content: content.into(),
             message_id: Uuid::new_v4(),
             prompt_traits: Vec::new(),
+            audit: None,
         }
     }
 

--- a/crates/eros-engine-core/src/types.rs
+++ b/crates/eros-engine-core/src/types.rs
@@ -17,6 +17,21 @@ pub struct PromptTrait {
     pub text: String,
 }
 
+/// Caller-supplied OpenRouter passthrough for per-request audit /
+/// analytics. Engine never inspects these fields; they ride straight to
+/// `openrouter.ai/api/v1/chat/completions` as wire-level `user`,
+/// `session_id`, `metadata`. The HTTP layer applies size/shape caps;
+/// content remains opaque to the engine.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct LlmAudit {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Map<String, serde_json::Value>>,
+}
+
 /// Events that drive the engine pipeline.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Event {
@@ -28,6 +43,12 @@ pub enum Event {
         /// byte-for-byte.
         #[serde(default)]
         prompt_traits: Vec<PromptTrait>,
+        /// Optional caller-supplied OpenRouter audit passthrough.
+        /// `None` for clients that don't send the field. Engine carries it
+        /// opaquely from request → handler → ChatRequest; content is never
+        /// inspected.
+        #[serde(default)]
+        audit: Option<LlmAudit>,
     },
     Gift {
         gift_id: Uuid,
@@ -75,10 +96,16 @@ pub struct ConversationSignals {
     pub hours_since_last_ghost: Option<f64>,
 }
 
-/// Response from the chat engine — pure text reply.
-#[derive(Debug, Clone)]
+/// Response from the chat engine — text reply plus opaque OpenRouter
+/// wire echoes (`generation_id`, `model`, `usage`). The three echo
+/// fields are `None` when no LLM call was made (handler returned None)
+/// or when upstream omitted them.
+#[derive(Debug, Clone, Default)]
 pub struct ChatResponse {
     pub reply: String,
+    pub generation_id: Option<String>,
+    pub model: Option<String>,
+    pub usage: Option<serde_json::Value>,
 }
 
 /// Input bundle consumed by the PDE.
@@ -115,5 +142,47 @@ mod tests {
         let json = serde_json::to_string(&t).unwrap();
         let back: PromptTrait = serde_json::from_str(&json).unwrap();
         assert_eq!(back, t);
+    }
+
+    #[test]
+    fn llm_audit_serde_roundtrip_full() {
+        let mut metadata = serde_json::Map::new();
+        metadata.insert("plan".into(), serde_json::Value::String("pro".into()));
+        let a = LlmAudit {
+            user: Some("u_abc".into()),
+            session_id: Some("conv_xyz".into()),
+            metadata: Some(metadata),
+        };
+        let json = serde_json::to_string(&a).unwrap();
+        let back: LlmAudit = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, a);
+    }
+
+    #[test]
+    fn llm_audit_serde_roundtrip_empty_yields_all_none() {
+        let a: LlmAudit = serde_json::from_str("{}").unwrap();
+        assert!(a.user.is_none());
+        assert!(a.session_id.is_none());
+        assert!(a.metadata.is_none());
+    }
+
+    #[test]
+    fn event_user_message_defaults_audit_to_none() {
+        let raw = r#"{"UserMessage":{"content":"hi","message_id":"00000000-0000-0000-0000-000000000001"}}"#;
+        let ev: Event = serde_json::from_str(raw).expect("legacy body deserialises");
+        match ev {
+            Event::UserMessage { audit, .. } => {
+                assert!(audit.is_none(), "missing audit field must default to None");
+            }
+            _ => panic!("expected UserMessage"),
+        }
+    }
+
+    #[test]
+    fn chat_response_defaults_audit_fields_to_none() {
+        let r = ChatResponse { reply: "hi".into(), ..Default::default() };
+        assert!(r.usage.is_none());
+        assert!(r.generation_id.is_none());
+        assert!(r.model.is_none());
     }
 }

--- a/crates/eros-engine-llm/Cargo.toml
+++ b/crates/eros-engine-llm/Cargo.toml
@@ -21,3 +21,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
 toml = "0.8"
+
+[dev-dependencies]
+wiremock = "0.6"
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -10,6 +10,14 @@ use crate::error::LlmError;
 
 const BASE_URL: &str = "https://openrouter.ai/api/v1/chat/completions";
 
+/// OpenRouter app-attribution header names. Pinned to the current
+/// `https://openrouter.ai/docs/app-attribution` spec. If OpenRouter
+/// renames either header in the future, update the value here; today's
+/// names become legacy and (if a transition window applies) get added as
+/// a parallel alias below.
+const HEADER_REFERER: &str = "HTTP-Referer";
+const HEADER_TITLE: &str = "X-Title";
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChatMessage {
     pub role: String,
@@ -54,17 +62,71 @@ struct WireResponse {
     choices: Vec<WireChoice>,
 }
 
+/// App-Attribution headers sent on every outbound OpenRouter call.
+/// Skipping `None` fields avoids emitting blank-but-set headers, which
+/// OpenRouter would record as a real attribution. Both `None` reverts
+/// to today's no-header behaviour.
+#[derive(Debug, Clone, Default)]
+pub struct AppAttribution {
+    /// Sent as `HTTP-Referer`. Identifies the deploying app to OpenRouter.
+    pub referer: Option<String>,
+    /// Sent as `X-Title`. Display name in OpenRouter's app analytics.
+    pub title: Option<String>,
+}
+
 #[derive(Clone)]
 pub struct OpenRouterClient {
     http: reqwest::Client,
     api_key: String,
+    base_url: String,
 }
 
 impl OpenRouterClient {
-    pub fn new(api_key: String) -> Self {
+    /// Production constructor. Pins to OpenRouter's canonical URL and
+    /// bakes attribution headers into the shared reqwest client at boot.
+    pub fn new(api_key: String, attribution: AppAttribution) -> Self {
+        Self::with_base_url(api_key, attribution, BASE_URL.to_string())
+    }
+
+    /// Low-level constructor that lets callers override the OpenRouter
+    /// endpoint. Intended for integration tests (workspace-internal and
+    /// downstream) that wire a wiremock or fake server in front of the
+    /// client. Production code should use `new`, which pins to OpenRouter's
+    /// canonical URL.
+    pub fn with_base_url(api_key: String, attribution: AppAttribution, base_url: String) -> Self {
+        let mut headers = reqwest::header::HeaderMap::new();
+        if let Some(ref referer) = attribution.referer {
+            match reqwest::header::HeaderValue::from_str(referer) {
+                Ok(v) => {
+                    headers.insert(HEADER_REFERER, v);
+                }
+                Err(e) => tracing::warn!(
+                    error = %e,
+                    header = HEADER_REFERER,
+                    "openrouter: dropping invalid attribution value"
+                ),
+            }
+        }
+        if let Some(ref title) = attribution.title {
+            match reqwest::header::HeaderValue::from_str(title) {
+                Ok(v) => {
+                    headers.insert(HEADER_TITLE, v);
+                }
+                Err(e) => tracing::warn!(
+                    error = %e,
+                    header = HEADER_TITLE,
+                    "openrouter: dropping invalid attribution value"
+                ),
+            }
+        }
+        let http = reqwest::Client::builder()
+            .default_headers(headers)
+            .build()
+            .expect("reqwest client build never fails with empty config");
         Self {
-            http: reqwest::Client::new(),
+            http,
             api_key,
+            base_url,
         }
     }
 
@@ -116,7 +178,7 @@ impl OpenRouterClient {
 
         let resp = self
             .http
-            .post(BASE_URL)
+            .post(&self.base_url)
             .bearer_auth(&self.api_key)
             .json(&wire)
             .send()
@@ -165,6 +227,126 @@ pub fn clean_response(raw: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use wiremock::matchers::{header, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn ok_response() -> serde_json::Value {
+        serde_json::json!({
+            "choices": [{ "message": { "content": "ok" } }]
+        })
+    }
+
+    #[tokio::test]
+    async fn client_sends_app_attribution_headers_when_set() {
+        let server = MockServer::start().await;
+        Mock::given(path("/api/v1/chat/completions"))
+            .and(header("HTTP-Referer", "https://eros.example"))
+            .and(header("X-Title", "Eros"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ok_response()))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = OpenRouterClient::with_base_url(
+            "test-key".into(),
+            AppAttribution {
+                referer: Some("https://eros.example".into()),
+                title: Some("Eros".into()),
+            },
+            format!("{}/api/v1/chat/completions", server.uri()),
+        );
+        let _ = client
+            .execute(ChatRequest {
+                model: "test/model".into(),
+                fallback_model: None,
+                messages: vec![ChatMessage {
+                    role: "user".into(),
+                    content: "hi".into(),
+                }],
+                temperature: 0.0,
+                max_tokens: 16,
+            })
+            .await
+            .expect("call succeeds");
+    }
+
+    #[tokio::test]
+    async fn client_omits_app_attribution_headers_when_default() {
+        let server = MockServer::start().await;
+        Mock::given(path("/api/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ok_response()))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = OpenRouterClient::with_base_url(
+            "test-key".into(),
+            AppAttribution::default(),
+            format!("{}/api/v1/chat/completions", server.uri()),
+        );
+        let _ = client
+            .execute(ChatRequest {
+                model: "test/model".into(),
+                fallback_model: None,
+                messages: vec![ChatMessage {
+                    role: "user".into(),
+                    content: "hi".into(),
+                }],
+                temperature: 0.0,
+                max_tokens: 16,
+            })
+            .await
+            .expect("call succeeds");
+
+        for req in server.received_requests().await.unwrap_or_default() {
+            assert!(
+                req.headers.get("http-referer").is_none(),
+                "HTTP-Referer must be absent when unset"
+            );
+            assert!(
+                req.headers.get("x-title").is_none(),
+                "X-Title must be absent when unset"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn client_drops_invalid_attribution_value() {
+        let server = MockServer::start().await;
+        Mock::given(path("/api/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ok_response()))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = OpenRouterClient::with_base_url(
+            "test-key".into(),
+            AppAttribution {
+                referer: Some("bad\nvalue".into()),
+                title: Some("also\rbad".into()),
+            },
+            format!("{}/api/v1/chat/completions", server.uri()),
+        );
+        let _ = client
+            .execute(ChatRequest {
+                model: "test/model".into(),
+                fallback_model: None,
+                messages: vec![ChatMessage {
+                    role: "user".into(),
+                    content: "hi".into(),
+                }],
+                temperature: 0.0,
+                max_tokens: 16,
+            })
+            .await
+            .expect("call succeeds despite dropped header");
+
+        for req in server.received_requests().await.unwrap_or_default() {
+            assert!(req.headers.get("http-referer").is_none(), "HTTP-Referer must be dropped");
+            assert!(req.headers.get("x-title").is_none(), "X-Title must be dropped");
+        }
+    }
 
     #[test]
     fn test_clean_response_strips_code_fence() {

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -82,6 +82,12 @@ struct WireChoice {
 
 #[derive(Debug, Deserialize)]
 struct WireResponse {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    model: Option<String>,
+    #[serde(default)]
+    usage: Option<serde_json::Value>,
     choices: Vec<WireChoice>,
 }
 
@@ -234,8 +240,6 @@ impl OpenRouterClient {
         }
 
         let parsed: WireResponse = resp.json().await?;
-        // .iter() (not into_iter()) so `parsed` stays available for Task 4
-        // to read id / model / usage off the same value below.
         let raw = parsed
             .choices
             .iter()
@@ -244,9 +248,9 @@ impl OpenRouterClient {
             .unwrap_or_default();
         Ok(ChatResponse {
             reply: clean_response(raw.trim()),
-            generation_id: None,
-            model: None,
-            usage: None,
+            generation_id: parsed.id,
+            model: parsed.model,
+            usage: parsed.usage,
         })
     }
 }
@@ -475,5 +479,79 @@ mod tests {
         assert!(s.contains("\"user\":\"u_abc\""), "{s}");
         assert!(s.contains("\"session_id\":\"conv_xyz\""), "{s}");
         assert!(s.contains("\"metadata\":{\"feature\":\"chat\"}"), "{s}");
+    }
+
+    #[tokio::test]
+    async fn wire_response_parses_id_model_usage() {
+        let server = MockServer::start().await;
+        Mock::given(path("/api/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "gen-abc123",
+                "model": "openai/gpt-5.2",
+                "usage": {
+                    "prompt_tokens": 12,
+                    "completion_tokens": 8,
+                    "total_tokens": 20,
+                    "cost": 0.0004
+                },
+                "choices": [{ "message": { "content": "ok" } }]
+            })))
+            .mount(&server)
+            .await;
+
+        let client = OpenRouterClient::with_base_url(
+            "test-key".into(),
+            AppAttribution::default(),
+            format!("{}/api/v1/chat/completions", server.uri()),
+        );
+        let resp = client
+            .execute(ChatRequest {
+                model: "openai/gpt-5.2".into(),
+                messages: vec![ChatMessage { role: "user".into(), content: "hi".into() }],
+                temperature: 0.0,
+                max_tokens: 16,
+                ..Default::default()
+            })
+            .await
+            .expect("call succeeds");
+
+        assert_eq!(resp.reply, "ok");
+        assert_eq!(resp.generation_id.as_deref(), Some("gen-abc123"));
+        assert_eq!(resp.model.as_deref(), Some("openai/gpt-5.2"));
+        let usage = resp.usage.expect("usage present");
+        assert_eq!(usage.get("prompt_tokens").and_then(|v| v.as_u64()), Some(12));
+        assert_eq!(usage.get("total_tokens").and_then(|v| v.as_u64()), Some(20));
+    }
+
+    #[tokio::test]
+    async fn wire_response_handles_missing_id_model_usage() {
+        let server = MockServer::start().await;
+        Mock::given(path("/api/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "choices": [{ "message": { "content": "ok" } }]
+            })))
+            .mount(&server)
+            .await;
+
+        let client = OpenRouterClient::with_base_url(
+            "test-key".into(),
+            AppAttribution::default(),
+            format!("{}/api/v1/chat/completions", server.uri()),
+        );
+        let resp = client
+            .execute(ChatRequest {
+                model: "openai/gpt-5.2".into(),
+                messages: vec![ChatMessage { role: "user".into(), content: "hi".into() }],
+                temperature: 0.0,
+                max_tokens: 16,
+                ..Default::default()
+            })
+            .await
+            .expect("call succeeds");
+
+        assert_eq!(resp.reply, "ok");
+        assert!(resp.generation_id.is_none());
+        assert!(resp.model.is_none());
+        assert!(resp.usage.is_none());
     }
 }

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -24,18 +24,35 @@ pub struct ChatMessage {
     pub content: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ChatRequest {
     pub model: String,
     pub fallback_model: Option<String>,
     pub messages: Vec<ChatMessage>,
     pub temperature: f32,
     pub max_tokens: u32,
+    /// Opaque OpenRouter wire passthrough — `user` field. Engine never
+    /// inspects this; callers are responsible for hashing PII out.
+    pub user: Option<String>,
+    /// Opaque OpenRouter wire passthrough — caller's session/conversation
+    /// grouping id. Distinct from the engine's URL-path `session_id`.
+    pub session_id: Option<String>,
+    /// Opaque OpenRouter wire passthrough — analytics dimensions. Caps
+    /// (≤16 keys, key ≤64 chars, value ≤512 chars) are enforced at the
+    /// HTTP boundary, not here.
+    pub metadata: Option<serde_json::Map<String, serde_json::Value>>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize)]
 pub struct ChatResponse {
     pub reply: String,
+    /// OpenRouter response `id` — opaque generation handle.
+    pub generation_id: Option<String>,
+    /// Model actually served (may differ from request when fallback hit).
+    pub model: Option<String>,
+    /// OpenRouter `usage` block — tokens / cost. Opaque to engine;
+    /// caller deserialises as needed.
+    pub usage: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Serialize)]
@@ -44,6 +61,12 @@ struct WireRequest<'a> {
     messages: &'a [ChatMessage],
     temperature: f32,
     max_tokens: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    user: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    session_id: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    metadata: Option<&'a serde_json::Map<String, serde_json::Value>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -132,13 +155,21 @@ impl OpenRouterClient {
 
     /// Execute a chat completion. If `fallback_model` is set and the primary
     /// call fails (transport error or non-2xx status), retry once with the
-    /// fallback model.
+    /// fallback model. Audit passthrough fields ride along on both attempts.
     pub async fn execute(&self, req: ChatRequest) -> Result<ChatResponse, LlmError> {
         match self
-            .call_once(&req.model, &req.messages, req.temperature, req.max_tokens)
+            .call_once(
+                &req.model,
+                &req.messages,
+                req.temperature,
+                req.max_tokens,
+                req.user.as_deref(),
+                req.session_id.as_deref(),
+                req.metadata.as_ref(),
+            )
             .await
         {
-            Ok(reply) => Ok(ChatResponse { reply }),
+            Ok(resp) => Ok(resp),
             Err(primary_err) => {
                 if let Some(fallback) = req.fallback_model.as_deref() {
                     tracing::warn!(
@@ -147,10 +178,16 @@ impl OpenRouterClient {
                         error = %primary_err,
                         "openrouter: primary failed, retrying with fallback"
                     );
-                    let reply = self
-                        .call_once(fallback, &req.messages, req.temperature, req.max_tokens)
-                        .await?;
-                    Ok(ChatResponse { reply })
+                    self.call_once(
+                        fallback,
+                        &req.messages,
+                        req.temperature,
+                        req.max_tokens,
+                        req.user.as_deref(),
+                        req.session_id.as_deref(),
+                        req.metadata.as_ref(),
+                    )
+                    .await
                 } else {
                     Err(primary_err)
                 }
@@ -164,7 +201,10 @@ impl OpenRouterClient {
         messages: &[ChatMessage],
         temperature: f32,
         max_tokens: u32,
-    ) -> Result<String, LlmError> {
+        req_user: Option<&str>,
+        req_session_id: Option<&str>,
+        req_metadata: Option<&serde_json::Map<String, serde_json::Value>>,
+    ) -> Result<ChatResponse, LlmError> {
         if self.api_key.is_empty() {
             return Err(LlmError::Config("openrouter: api key not set".into()));
         }
@@ -174,6 +214,9 @@ impl OpenRouterClient {
             messages,
             temperature,
             max_tokens,
+            user: req_user,
+            session_id: req_session_id,
+            metadata: req_metadata,
         };
 
         let resp = self
@@ -191,13 +234,20 @@ impl OpenRouterClient {
         }
 
         let parsed: WireResponse = resp.json().await?;
+        // .iter() (not into_iter()) so `parsed` stays available for Task 4
+        // to read id / model / usage off the same value below.
         let raw = parsed
             .choices
-            .into_iter()
+            .iter()
             .next()
-            .and_then(|c| c.message.content)
+            .and_then(|c| c.message.content.clone())
             .unwrap_or_default();
-        Ok(clean_response(raw.trim()))
+        Ok(ChatResponse {
+            reply: clean_response(raw.trim()),
+            generation_id: None,
+            model: None,
+            usage: None,
+        })
     }
 }
 
@@ -266,6 +316,7 @@ mod tests {
                 }],
                 temperature: 0.0,
                 max_tokens: 16,
+                ..Default::default()
             })
             .await
             .expect("call succeeds");
@@ -295,6 +346,7 @@ mod tests {
                 }],
                 temperature: 0.0,
                 max_tokens: 16,
+                ..Default::default()
             })
             .await
             .expect("call succeeds");
@@ -338,6 +390,7 @@ mod tests {
                 }],
                 temperature: 0.0,
                 max_tokens: 16,
+                ..Default::default()
             })
             .await
             .expect("call succeeds despite dropped header");
@@ -369,5 +422,58 @@ mod tests {
     #[test]
     fn test_clean_response_passthrough_plain() {
         assert_eq!(clean_response("hello"), "hello");
+    }
+
+    #[test]
+    fn wire_request_omits_audit_fields_when_none() {
+        let req = ChatRequest {
+            model: "openai/gpt-5.2".into(),
+            messages: vec![ChatMessage { role: "user".into(), content: "hi".into() }],
+            temperature: 0.0,
+            max_tokens: 16,
+            ..Default::default()
+        };
+        let wire = WireRequest {
+            model: &req.model,
+            messages: &req.messages,
+            temperature: req.temperature,
+            max_tokens: req.max_tokens,
+            user: req.user.as_deref(),
+            session_id: req.session_id.as_deref(),
+            metadata: req.metadata.as_ref(),
+        };
+        let s = serde_json::to_string(&wire).unwrap();
+        assert!(!s.contains("\"user\":"), "user key must be absent: {s}");
+        assert!(!s.contains("\"session_id\":"), "session_id key must be absent: {s}");
+        assert!(!s.contains("\"metadata\":"), "metadata key must be absent: {s}");
+    }
+
+    #[test]
+    fn wire_request_includes_audit_fields_when_set() {
+        let mut metadata = serde_json::Map::new();
+        metadata.insert("feature".into(), serde_json::Value::String("chat".into()));
+        let req = ChatRequest {
+            model: "openai/gpt-5.2".into(),
+            messages: vec![ChatMessage { role: "user".into(), content: "hi".into() }],
+            temperature: 0.0,
+            max_tokens: 16,
+            user: Some("u_abc".into()),
+            session_id: Some("conv_xyz".into()),
+            metadata: Some(metadata),
+            ..Default::default()
+        };
+        let wire = WireRequest {
+            model: &req.model,
+            messages: &req.messages,
+            temperature: req.temperature,
+            max_tokens: req.max_tokens,
+            user: req.user.as_deref(),
+            session_id: req.session_id.as_deref(),
+            metadata: req.metadata.as_ref(),
+        };
+        let s = serde_json::to_string(&wire).unwrap();
+        assert!(s.contains("\"user\":\"u_abc\""), "{s}");
+        assert!(s.contains("\"session_id\":\"conv_xyz\""), "{s}");
+        assert!(s.contains("\"metadata\":{\"feature\":\"chat\"}"), "{s}");
     }
 }

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -1,3 +1,5 @@
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.96s
+     Running `target/debug/eros-engine print-openapi`
 {
   "openapi": "3.1.0",
   "info": {
@@ -7,7 +9,7 @@
       "name": "AGPL-3.0-only",
       "identifier": "AGPL-3.0-only"
     },
-    "version": "0.1.0"
+    "version": "0.1.1"
   },
   "servers": [
     {
@@ -915,9 +917,23 @@
             "type": "number",
             "format": "double"
           },
+          "generation_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "OpenRouter `response.id`. Omitted when not returned."
+          },
           "lead_score": {
             "type": "number",
             "format": "double"
+          },
+          "model": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Model actually served (may differ from request when fallback hit).\nOmitted when not returned."
           },
           "reply": {
             "type": "string"
@@ -933,6 +949,9 @@
             "type": "integer",
             "format": "int64",
             "minimum": 0
+          },
+          "usage": {
+            "description": "OpenRouter `usage` block (tokens / cost). Omitted when upstream\ndidn't return one or no LLM call was made for this turn."
           }
         }
       },
@@ -1059,6 +1078,37 @@
           "user_id": {
             "type": "string",
             "format": "uuid"
+          }
+        }
+      },
+      "LlmAuditDto": {
+        "type": "object",
+        "description": "Caller-supplied OpenRouter audit passthrough. All three fields are\noptional; engine never inspects content. See `docs/llm-audit.md`.",
+        "properties": {
+          "metadata": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "description": "Up to 16 string-valued key/value pairs. Key regex\n`^[A-Za-z0-9_.-]{1,64}$`, value `chars ≤ 512`.",
+            "additionalProperties": {},
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "session_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Caller-defined session / conversation grouping. Distinct from the\nURL path's `session_id`. `chars ≤ 256`. Forwarded as wire\n`session_id`."
+          },
+          "user": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Free-form caller identifier (recommended: hash of internal user id).\n`chars ≤ 256`. Forwarded as OpenRouter wire `user`."
           }
         }
       },
@@ -1217,6 +1267,17 @@
           "message"
         ],
         "properties": {
+          "audit": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/LlmAuditDto",
+                "description": "Optional OpenRouter audit passthrough. See `docs/llm-audit.md`."
+              }
+            ]
+          },
           "message": {
             "type": "string"
           },

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -1,5 +1,3 @@
-    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.96s
-     Running `target/debug/eros-engine print-openapi`
 {
   "openapi": "3.1.0",
   "info": {

--- a/crates/eros-engine-server/src/main.rs
+++ b/crates/eros-engine-server/src/main.rs
@@ -165,8 +165,17 @@ async fn run_server() -> Result<()> {
 
     let openrouter_key =
         std::env::var("OPENROUTER_API_KEY").context("OPENROUTER_API_KEY is required")?;
+    let attribution = eros_engine_llm::openrouter::AppAttribution {
+        referer: std::env::var("OPENROUTER_APP_REFERER")
+            .ok()
+            .filter(|s| !s.is_empty()),
+        title: std::env::var("OPENROUTER_APP_TITLE")
+            .ok()
+            .filter(|s| !s.is_empty()),
+    };
     let openrouter = Arc::new(eros_engine_llm::openrouter::OpenRouterClient::new(
         openrouter_key,
+        attribution,
     ));
 
     let voyage_key = std::env::var("VOYAGE_API_KEY").context("VOYAGE_API_KEY is required")?;

--- a/crates/eros-engine-server/src/pipeline/dreaming.rs
+++ b/crates/eros-engine-server/src/pipeline/dreaming.rs
@@ -170,6 +170,7 @@ async fn classify_session(
         }],
         temperature: resolved.temperature as f32,
         max_tokens: resolved.max_tokens,
+        ..Default::default()
     };
     let raw = state
         .openrouter

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -22,7 +22,7 @@ use sqlx::PgPool;
 use uuid::Uuid;
 
 use eros_engine_core::affinity::AffinityDeltas;
-use eros_engine_core::types::{ActionPlan, DecisionInput, Event, PromptTrait};
+use eros_engine_core::types::{ActionPlan, DecisionInput, Event, LlmAudit, PromptTrait};
 use eros_engine_llm::openrouter::{ChatMessage, ChatRequest};
 use eros_engine_store::chat::ChatRepo;
 use eros_engine_store::insight::InsightRepo;
@@ -67,12 +67,26 @@ fn persona_model_override(input: &DecisionInput) -> Option<String> {
         .map(String::from)
 }
 
+/// Extract the caller-supplied OpenRouter audit passthrough off the
+/// `Event` driving this turn. Returns `None` for non-`UserMessage` events
+/// (gift / proactive paths cannot supply audit today — out of scope for
+/// the v1 audit feature).
+fn audit_from_event(event: &Event) -> Option<&LlmAudit> {
+    match event {
+        Event::UserMessage { audit, .. } => audit.as_ref(),
+        _ => None,
+    }
+}
+
 /// Materialise a ChatRequest from a system prompt + chronological history.
+/// `audit` carries the caller's OpenRouter passthrough fields when the
+/// driving event was a `UserMessage`; gift / proactive paths pass `None`.
 fn assemble_chat_request(
     state: &AppState,
     input: &DecisionInput,
     system_prompt: String,
     history: Vec<eros_engine_store::chat::ChatMessage>,
+    audit: Option<&LlmAudit>,
 ) -> ChatRequest {
     let mut messages = Vec::with_capacity(history.len() + 1);
     messages.push(ChatMessage {
@@ -95,13 +109,19 @@ fn assemble_chat_request(
         .model_config
         .resolve(CHAT_TASK, persona_model_override(input).as_deref());
 
+    let (audit_user, audit_session, audit_metadata) = audit
+        .map(|a| (a.user.clone(), a.session_id.clone(), a.metadata.clone()))
+        .unwrap_or_default();
+
     ChatRequest {
         model: resolved.model,
         fallback_model: resolved.fallback_model,
         messages,
         temperature: resolved.temperature as f32,
         max_tokens: resolved.max_tokens,
-        ..Default::default()
+        user: audit_user,
+        session_id: audit_session,
+        metadata: audit_metadata,
     }
 }
 
@@ -378,6 +398,7 @@ impl<'a> ActionHandler for ReplyHandler<'a> {
             input,
             system_prompt,
             history,
+            audit_from_event(&input.event),
         )))
     }
 }
@@ -486,6 +507,7 @@ impl<'a> ActionHandler for GiftHandler<'a> {
             input,
             system_prompt,
             history,
+            None,
         )))
     }
 }
@@ -924,5 +946,32 @@ mod tests {
                 "兴趣：登山、精酿".to_string(),
             ]
         );
+    }
+
+    // ─── audit_from_event ───────────────────────────────────────────────
+
+    #[test]
+    fn extract_audit_from_user_message() {
+        let mut metadata = serde_json::Map::new();
+        metadata.insert("feature".into(), serde_json::Value::String("chat".into()));
+        let audit = LlmAudit {
+            user: Some("u_abc".into()),
+            session_id: Some("conv_xyz".into()),
+            metadata: Some(metadata.clone()),
+        };
+        let ev = Event::UserMessage {
+            content: "hi".into(),
+            message_id: Uuid::new_v4(),
+            prompt_traits: vec![],
+            audit: Some(audit.clone()),
+        };
+        let extracted = audit_from_event(&ev);
+        assert_eq!(extracted, Some(&audit));
+    }
+
+    #[test]
+    fn extract_audit_from_non_user_message_is_none() {
+        let ev = Event::ProactiveTrigger;
+        assert!(audit_from_event(&ev).is_none());
     }
 }

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -101,6 +101,7 @@ fn assemble_chat_request(
         messages,
         temperature: resolved.temperature as f32,
         max_tokens: resolved.max_tokens,
+        ..Default::default()
     }
 }
 

--- a/crates/eros-engine-server/src/pipeline/mod.rs
+++ b/crates/eros-engine-server/src/pipeline/mod.rs
@@ -24,7 +24,6 @@ use eros_engine_core::types::{
     ActionType, ChatResponse, ConversationSignals, DecisionInput, Event,
 };
 use eros_engine_core::{pde, persona::CompanionPersona};
-use eros_engine_llm::openrouter::ChatResponse as LlmChatResponse;
 use eros_engine_store::affinity::AffinityRepo;
 use eros_engine_store::chat::ChatRepo;
 use eros_engine_store::persona::PersonaRepo;
@@ -129,16 +128,21 @@ pub async fn run(
     // engine's public API stays decoupled from the openrouter wire shape.
     let response: Option<ChatResponse> = match chat_req {
         Some(req) => {
-            let LlmChatResponse { reply } = state
+            let llm_resp = state
                 .openrouter
                 .execute(req)
                 .await
                 .map_err(|e| AppError::Internal(format!("openrouter: {e}")))?;
             let chat_repo = ChatRepo { pool: &state.pool };
             chat_repo
-                .append_message(session_id, "assistant", &reply)
+                .append_message(session_id, "assistant", &llm_resp.reply)
                 .await?;
-            Some(ChatResponse { reply })
+            Some(ChatResponse {
+                reply: llm_resp.reply,
+                generation_id: None,
+                model: None,
+                usage: None,
+            })
         }
         None => None,
     };

--- a/crates/eros-engine-server/src/pipeline/mod.rs
+++ b/crates/eros-engine-server/src/pipeline/mod.rs
@@ -72,7 +72,12 @@ pub async fn run(
         plan.reply_style,
     );
 
-    if let Event::UserMessage { prompt_traits, .. } = &event {
+    if let Event::UserMessage {
+        prompt_traits,
+        audit,
+        ..
+    } = &event
+    {
         if !prompt_traits.is_empty() {
             let tags: Vec<&str> = prompt_traits.iter().map(|t| t.tag.as_str()).collect();
             tracing::info!(
@@ -80,6 +85,20 @@ pub async fn run(
                 traits_count = prompt_traits.len(),
                 trait_tags = ?tags,
                 "engine: prompt_traits applied"
+            );
+        }
+        if let Some(a) = audit {
+            let metadata_keys: Vec<&str> = a
+                .metadata
+                .as_ref()
+                .map(|m| m.keys().map(String::as_str).collect())
+                .unwrap_or_default();
+            tracing::info!(
+                session = %session_id,
+                audit_user_present = a.user.is_some(),
+                audit_session_present = a.session_id.is_some(),
+                audit_metadata_keys = ?metadata_keys,
+                "engine: llm audit applied"
             );
         }
     }
@@ -133,15 +152,41 @@ pub async fn run(
                 .execute(req)
                 .await
                 .map_err(|e| AppError::Internal(format!("openrouter: {e}")))?;
+
+            // Tracing-only usage line. Covers sync, async (background
+            // tokio::spawn calls pipeline::run too), dreaming, post_process
+            // — every codepath that reaches this point in the orchestrator.
+            // Token / cost fields are best-effort parses off the opaque
+            // usage JSON; missing fields silently drop out of the log line.
+            let usage_ref = llm_resp.usage.as_ref();
+            let prompt_tokens =
+                usage_ref.and_then(|u| u.get("prompt_tokens")).and_then(|v| v.as_u64());
+            let completion_tokens = usage_ref
+                .and_then(|u| u.get("completion_tokens"))
+                .and_then(|v| v.as_u64());
+            let total_tokens =
+                usage_ref.and_then(|u| u.get("total_tokens")).and_then(|v| v.as_u64());
+            let cost = usage_ref.and_then(|u| u.get("cost")).and_then(|v| v.as_f64());
+            tracing::info!(
+                session = %session_id,
+                generation_id = ?llm_resp.generation_id,
+                model = ?llm_resp.model,
+                prompt_tokens = ?prompt_tokens,
+                completion_tokens = ?completion_tokens,
+                total_tokens = ?total_tokens,
+                cost = ?cost,
+                "openrouter: call completed"
+            );
+
             let chat_repo = ChatRepo { pool: &state.pool };
             chat_repo
                 .append_message(session_id, "assistant", &llm_resp.reply)
                 .await?;
             Some(ChatResponse {
                 reply: llm_resp.reply,
-                generation_id: None,
-                model: None,
-                usage: None,
+                generation_id: llm_resp.generation_id,
+                model: llm_resp.model,
+                usage: llm_resp.usage,
             })
         }
         None => None,

--- a/crates/eros-engine-server/src/pipeline/post_process.rs
+++ b/crates/eros-engine-server/src/pipeline/post_process.rs
@@ -340,6 +340,7 @@ async fn extract_facts(
         }],
         temperature: resolved.temperature as f32,
         max_tokens: resolved.max_tokens,
+        ..Default::default()
     };
 
     let raw = match llm.execute(req).await {
@@ -398,6 +399,7 @@ async fn extract_structured_insights(
         }],
         temperature: resolved.temperature as f32,
         max_tokens: resolved.max_tokens,
+        ..Default::default()
     };
 
     let raw = match llm.execute(req).await {

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -638,6 +638,7 @@ async fn send_message(
         content: req.message.clone(),
         message_id: user_message_id,
         prompt_traits,
+        audit: None,
     };
     let response = pipeline::run(&state, session_id, event).await?;
 
@@ -725,6 +726,7 @@ async fn send_message_async(
             content: msg_copy,
             message_id: user_message_id,
             prompt_traits: traits_copy,
+            audit: None,
         };
         if let Err(e) = pipeline::run(&state_bg, session_id, event).await {
             tracing::error!("engine pipeline failed for session {session_id}: {e}");

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -42,6 +42,7 @@ use uuid::Uuid;
 
 use eros_engine_core::affinity::AffinityDeltas;
 use eros_engine_core::types::Event;
+use eros_engine_core::types::LlmAudit;
 use eros_engine_core::types::PromptTrait;
 use eros_engine_store::affinity::AffinityRepo;
 use eros_engine_store::chat::{ChatMessage as StoreChatMessage, ChatRepo, ChatSession};
@@ -60,6 +61,17 @@ use crate::state::AppState;
 const MAX_PROMPT_TRAITS: usize = 8;
 const MAX_PROMPT_TRAIT_TEXT_CHARS: usize = 2000;
 const MAX_PROMPT_TRAIT_TAG_LEN: usize = 32;
+
+/// Audit-string caps. Conservative: holds any reasonable hash without
+/// inviting raw PII in `user`. No OpenRouter doc requirement; engine-side
+/// guard.
+const MAX_LLM_AUDIT_STRING_CHARS: usize = 256;
+/// OpenRouter documented cap.
+const MAX_LLM_AUDIT_METADATA_KEYS: usize = 16;
+/// OpenRouter documented cap.
+const MAX_LLM_AUDIT_METADATA_KEY_CHARS: usize = 64;
+/// OpenRouter documented cap.
+const MAX_LLM_AUDIT_METADATA_VALUE_CHARS: usize = 512;
 
 /// NFT-ownership gate. Returns `Ok(())` immediately if `asset_id` is `None`
 /// (legacy seed-persona genome). Otherwise joins persona_ownership with
@@ -139,6 +151,9 @@ pub struct SendMessageRequest {
     /// `docs/prompt-traits.md`. Missing field → empty list.
     #[serde(default)]
     pub prompt_traits: Option<Vec<PromptTraitDto>>,
+    /// Optional OpenRouter audit passthrough. See `docs/llm-audit.md`.
+    #[serde(default)]
+    pub audit: Option<LlmAuditDto>,
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
@@ -149,6 +164,17 @@ pub struct CompanionReplyResponse {
     pub should_show_cta: bool,
     pub typing_delay_ms: u64,
     pub agent_training_level: f64,
+    /// OpenRouter `usage` block (tokens / cost). Omitted when upstream
+    /// didn't return one or no LLM call was made for this turn.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub usage: Option<serde_json::Value>,
+    /// OpenRouter `response.id`. Omitted when not returned.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub generation_id: Option<String>,
+    /// Model actually served (may differ from request when fallback hit).
+    /// Omitted when not returned.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
@@ -287,6 +313,25 @@ pub struct PromptTraitDto {
     pub text: String,
 }
 
+/// Caller-supplied OpenRouter audit passthrough. All three fields are
+/// optional; engine never inspects content. See `docs/llm-audit.md`.
+#[derive(Debug, Clone, Deserialize, utoipa::ToSchema)]
+pub struct LlmAuditDto {
+    /// Free-form caller identifier (recommended: hash of internal user id).
+    /// `chars ≤ 256`. Forwarded as OpenRouter wire `user`.
+    #[serde(default)]
+    pub user: Option<String>,
+    /// Caller-defined session / conversation grouping. Distinct from the
+    /// URL path's `session_id`. `chars ≤ 256`. Forwarded as wire
+    /// `session_id`.
+    #[serde(default)]
+    pub session_id: Option<String>,
+    /// Up to 16 string-valued key/value pairs. Key regex
+    /// `^[A-Za-z0-9_.-]{1,64}$`, value `chars ≤ 512`.
+    #[serde(default)]
+    pub metadata: Option<serde_json::Map<String, serde_json::Value>>,
+}
+
 #[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct GiftEventResponse {
     pub reply: Option<String>,
@@ -418,6 +463,66 @@ fn validate_prompt_traits(dtos: &[PromptTraitDto]) -> Result<Vec<PromptTrait>, A
         });
     }
     Ok(out)
+}
+
+/// Validate a caller-supplied `audit` object against the documented caps.
+/// Returns `Ok(None)` when the field is absent. `Err(BadRequest)` for any
+/// cap violation — first failure wins so the message points at one cause.
+fn validate_llm_audit(dto: Option<LlmAuditDto>) -> Result<Option<LlmAudit>, AppError> {
+    let Some(dto) = dto else { return Ok(None) };
+
+    if let Some(ref u) = dto.user {
+        if u.chars().count() > MAX_LLM_AUDIT_STRING_CHARS {
+            return Err(AppError::BadRequest(format!(
+                "audit.user exceeds {MAX_LLM_AUDIT_STRING_CHARS} chars"
+            )));
+        }
+    }
+    if let Some(ref s) = dto.session_id {
+        if s.chars().count() > MAX_LLM_AUDIT_STRING_CHARS {
+            return Err(AppError::BadRequest(format!(
+                "audit.session_id exceeds {MAX_LLM_AUDIT_STRING_CHARS} chars"
+            )));
+        }
+    }
+    if let Some(ref m) = dto.metadata {
+        if m.len() > MAX_LLM_AUDIT_METADATA_KEYS {
+            return Err(AppError::BadRequest(format!(
+                "audit.metadata exceeds {MAX_LLM_AUDIT_METADATA_KEYS} keys"
+            )));
+        }
+        for (k, v) in m.iter() {
+            if k.is_empty() || k.chars().count() > MAX_LLM_AUDIT_METADATA_KEY_CHARS {
+                return Err(AppError::BadRequest(format!(
+                    "audit.metadata key length must be 1..={MAX_LLM_AUDIT_METADATA_KEY_CHARS}"
+                )));
+            }
+            if !k
+                .bytes()
+                .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'.' | b'-'))
+            {
+                return Err(AppError::BadRequest(format!(
+                    "audit.metadata key '{k}' must match [A-Za-z0-9_.-]"
+                )));
+            }
+            let s = v.as_str().ok_or_else(|| {
+                AppError::BadRequest(format!(
+                    "audit.metadata['{k}'] must be a string value"
+                ))
+            })?;
+            if s.chars().count() > MAX_LLM_AUDIT_METADATA_VALUE_CHARS {
+                return Err(AppError::BadRequest(format!(
+                    "audit.metadata['{k}'] exceeds {MAX_LLM_AUDIT_METADATA_VALUE_CHARS} chars"
+                )));
+            }
+        }
+    }
+
+    Ok(Some(LlmAudit {
+        user: dto.user,
+        session_id: dto.session_id,
+        metadata: dto.metadata,
+    }))
 }
 
 // ─── Handlers ───────────────────────────────────────────────────────
@@ -604,7 +709,7 @@ async fn send_message(
     State(state): State<AppState>,
     Path(session_id): Path<Uuid>,
     Extension(AuthUser(user_id)): Extension<AuthUser>,
-    Json(req): Json<SendMessageRequest>,
+    Json(mut req): Json<SendMessageRequest>,
 ) -> Result<Json<CompanionReplyResponse>, AppError> {
     let session = require_session_for_user(&state, session_id, user_id).await?;
 
@@ -627,6 +732,7 @@ async fn send_message(
     }
 
     let prompt_traits = validate_prompt_traits(req.prompt_traits.as_deref().unwrap_or(&[]))?;
+    let audit = validate_llm_audit(req.audit.take())?;
 
     // Persist the user message up-front so the engine sees it in history.
     let chat_repo = ChatRepo { pool: &state.pool };
@@ -638,7 +744,7 @@ async fn send_message(
         content: req.message.clone(),
         message_id: user_message_id,
         prompt_traits,
-        audit: None,
+        audit,
     };
     let response = pipeline::run(&state, session_id, event).await?;
 
@@ -659,6 +765,11 @@ async fn send_message(
     let training_level = read_training_level(&state, user_id).await;
     let should_show_cta = lead_score >= 7.0 && training_level >= 0.4;
 
+    let (usage, generation_id, model) = response
+        .as_ref()
+        .map(|r| (r.usage.clone(), r.generation_id.clone(), r.model.clone()))
+        .unwrap_or((None, None, None));
+
     Ok(Json(CompanionReplyResponse {
         reply: reply_text,
         session_id,
@@ -666,6 +777,9 @@ async fn send_message(
         should_show_cta,
         typing_delay_ms: typing_delay_ms_from(user_message_id),
         agent_training_level: training_level,
+        usage,
+        generation_id,
+        model,
     }))
 }
 
@@ -689,7 +803,7 @@ async fn send_message_async(
     State(state): State<AppState>,
     Path(session_id): Path<Uuid>,
     Extension(AuthUser(user_id)): Extension<AuthUser>,
-    Json(req): Json<SendMessageRequest>,
+    Json(mut req): Json<SendMessageRequest>,
 ) -> Result<(axum::http::StatusCode, Json<AsyncSendResponse>), AppError> {
     let session = require_session_for_user(&state, session_id, user_id).await?;
 
@@ -712,6 +826,7 @@ async fn send_message_async(
 
     // Validate BEFORE we persist the user message so a bad request leaves no row.
     let prompt_traits = validate_prompt_traits(req.prompt_traits.as_deref().unwrap_or(&[]))?;
+    let audit = validate_llm_audit(req.audit.take())?;
 
     let chat_repo = ChatRepo { pool: &state.pool };
     let user_message_id = chat_repo
@@ -721,12 +836,13 @@ async fn send_message_async(
     let state_bg = state.clone();
     let msg_copy = req.message.clone();
     let traits_copy = prompt_traits;
+    let audit_copy = audit;
     tokio::spawn(async move {
         let event = Event::UserMessage {
             content: msg_copy,
             message_id: user_message_id,
             prompt_traits: traits_copy,
-            audit: None,
+            audit: audit_copy,
         };
         if let Err(e) = pipeline::run(&state_bg, session_id, event).await {
             tracing::error!("engine pipeline failed for session {session_id}: {e}");
@@ -1709,6 +1825,103 @@ mod tests {
         }
     }
 
+    // ─── LlmAudit validator unit tests ──────────────────────────────
+
+    #[test]
+    fn validate_llm_audit_none_returns_none() {
+        let out = validate_llm_audit(None).expect("None input ok");
+        assert!(out.is_none());
+    }
+
+    #[test]
+    fn validate_llm_audit_full_passes() {
+        let mut metadata = serde_json::Map::new();
+        metadata.insert("feature".into(), serde_json::Value::String("chat".into()));
+        let dto = LlmAuditDto {
+            user: Some("u_abc".into()),
+            session_id: Some("conv_xyz".into()),
+            metadata: Some(metadata),
+        };
+        let out = validate_llm_audit(Some(dto)).expect("ok").expect("Some");
+        assert_eq!(out.user.as_deref(), Some("u_abc"));
+        assert_eq!(out.session_id.as_deref(), Some("conv_xyz"));
+        assert_eq!(
+            out.metadata
+                .as_ref()
+                .and_then(|m| m.get("feature"))
+                .and_then(|v| v.as_str()),
+            Some("chat")
+        );
+    }
+
+    #[test]
+    fn validate_llm_audit_rejects_oversized_user() {
+        let dto = LlmAuditDto {
+            user: Some("x".repeat(MAX_LLM_AUDIT_STRING_CHARS + 1)),
+            session_id: None,
+            metadata: None,
+        };
+        assert!(matches!(validate_llm_audit(Some(dto)), Err(AppError::BadRequest(_))));
+    }
+
+    #[test]
+    fn validate_llm_audit_rejects_oversized_session_id() {
+        let dto = LlmAuditDto {
+            user: None,
+            session_id: Some("x".repeat(MAX_LLM_AUDIT_STRING_CHARS + 1)),
+            metadata: None,
+        };
+        assert!(matches!(validate_llm_audit(Some(dto)), Err(AppError::BadRequest(_))));
+    }
+
+    #[test]
+    fn validate_llm_audit_rejects_too_many_metadata_keys() {
+        let mut metadata = serde_json::Map::new();
+        for i in 0..(MAX_LLM_AUDIT_METADATA_KEYS + 1) {
+            metadata.insert(format!("k{i}"), serde_json::Value::String("v".into()));
+        }
+        let dto = LlmAuditDto { user: None, session_id: None, metadata: Some(metadata) };
+        assert!(matches!(validate_llm_audit(Some(dto)), Err(AppError::BadRequest(_))));
+    }
+
+    #[test]
+    fn validate_llm_audit_rejects_invalid_metadata_key_regex() {
+        let mut metadata = serde_json::Map::new();
+        metadata.insert("Bad Key!".into(), serde_json::Value::String("v".into()));
+        let dto = LlmAuditDto { user: None, session_id: None, metadata: Some(metadata) };
+        assert!(matches!(validate_llm_audit(Some(dto)), Err(AppError::BadRequest(_))));
+    }
+
+    #[test]
+    fn validate_llm_audit_rejects_oversized_metadata_key() {
+        let mut metadata = serde_json::Map::new();
+        metadata.insert(
+            "x".repeat(MAX_LLM_AUDIT_METADATA_KEY_CHARS + 1),
+            serde_json::Value::String("v".into()),
+        );
+        let dto = LlmAuditDto { user: None, session_id: None, metadata: Some(metadata) };
+        assert!(matches!(validate_llm_audit(Some(dto)), Err(AppError::BadRequest(_))));
+    }
+
+    #[test]
+    fn validate_llm_audit_rejects_non_string_metadata_value() {
+        let mut metadata = serde_json::Map::new();
+        metadata.insert("feature".into(), serde_json::Value::Number(serde_json::Number::from(123)));
+        let dto = LlmAuditDto { user: None, session_id: None, metadata: Some(metadata) };
+        assert!(matches!(validate_llm_audit(Some(dto)), Err(AppError::BadRequest(_))));
+    }
+
+    #[test]
+    fn validate_llm_audit_rejects_oversized_metadata_value() {
+        let mut metadata = serde_json::Map::new();
+        metadata.insert(
+            "feature".into(),
+            serde_json::Value::String("v".repeat(MAX_LLM_AUDIT_METADATA_VALUE_CHARS + 1)),
+        );
+        let dto = LlmAuditDto { user: None, session_id: None, metadata: Some(metadata) };
+        assert!(matches!(validate_llm_audit(Some(dto)), Err(AppError::BadRequest(_))));
+    }
+
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
     async fn send_message_rejects_too_many_prompt_traits(pool: PgPool) {
         let user_id = Uuid::new_v4();
@@ -1881,5 +2094,154 @@ mod tests {
                 .await
                 .unwrap();
         assert_eq!(count, 0);
+    }
+
+    // ─── LlmAudit HTTP integration tests ────────────────────────────
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn send_message_async_rejects_oversized_audit_user(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Vega").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+
+        let state = test_state(pool.clone());
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        let body = serde_json::to_vec(&json!({
+            "message": "hi",
+            "audit": { "user": "x".repeat(MAX_LLM_AUDIT_STRING_CHARS + 1) },
+        }))
+        .unwrap();
+
+        let req = Request::builder()
+            .method("POST")
+            .uri(format!("/comp/chat/{session_id}/message_async"))
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        let (status, _resp) = send_request(&mut app, req).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+
+        let count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM engine.chat_messages WHERE session_id = $1")
+                .bind(session_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(count, 0, "validation must fire before persistence");
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn send_message_async_rejects_too_many_metadata_keys(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Vega").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+
+        let state = test_state(pool.clone());
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        let mut metadata = serde_json::Map::new();
+        for i in 0..(MAX_LLM_AUDIT_METADATA_KEYS + 1) {
+            metadata.insert(format!("k{i}"), Value::String("v".into()));
+        }
+        let body = serde_json::to_vec(&json!({
+            "message": "hi",
+            "audit": { "metadata": metadata },
+        }))
+        .unwrap();
+
+        let req = Request::builder()
+            .method("POST")
+            .uri(format!("/comp/chat/{session_id}/message_async"))
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        let (status, _resp) = send_request(&mut app, req).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn send_message_async_rejects_non_string_metadata_value(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Vega").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+
+        let state = test_state(pool.clone());
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        let body = serde_json::to_vec(&json!({
+            "message": "hi",
+            "audit": { "metadata": { "feature": 123 } },
+        }))
+        .unwrap();
+
+        let req = Request::builder()
+            .method("POST")
+            .uri(format!("/comp/chat/{session_id}/message_async"))
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        let (status, _resp) = send_request(&mut app, req).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn send_message_async_accepts_valid_audit(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Vega").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+
+        let state = test_state(pool.clone());
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        let body = serde_json::to_vec(&json!({
+            "message": "hi",
+            "audit": {
+                "user": "u_abc",
+                "session_id": "conv_xyz",
+                "metadata": { "feature": "chat", "plan": "pro" }
+            },
+        }))
+        .unwrap();
+
+        let req = Request::builder()
+            .method("POST")
+            .uri(format!("/comp/chat/{session_id}/message_async"))
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        let (status, _resp) = send_request(&mut app, req).await;
+        assert_eq!(status, StatusCode::ACCEPTED);
+
+        let user_msg_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM engine.chat_messages WHERE session_id = $1 AND role = 'user'",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(user_msg_count, 1);
+
+        let leak_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM engine.chat_messages \
+             WHERE session_id = $1 AND (content LIKE '%u_abc%' OR content LIKE '%conv_xyz%')",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(leak_count, 0, "audit strings must never appear in chat_messages.content");
     }
 }

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -1072,6 +1072,7 @@ pub(crate) fn test_state(pool: sqlx::PgPool) -> AppState {
         },
         openrouter: Arc::new(eros_engine_llm::openrouter::OpenRouterClient::new(
             "stub".into(),
+            eros_engine_llm::openrouter::AppAttribution::default(),
         )),
         voyage: Arc::new(eros_engine_llm::voyage::VoyageClient::new("stub".into())),
         model_config: Arc::new(eros_engine_llm::model_config::ModelConfig::default()),

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -96,11 +96,21 @@ curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json"
   "lead_score": 4.2,
   "should_show_cta": false,
   "typing_delay_ms": 1340,
-  "agent_training_level": 0.18
+  "agent_training_level": 0.18,
+  "usage": { "prompt_tokens": 12, "completion_tokens": 8, "total_tokens": 20, "cost": 0.0004 },
+  "generation_id": "gen-abc123",
+  "model": "openai/gpt-5.2"
 }
 ```
 
 `reply: null` when the persona ghosted this turn (see [ghost mechanics](ghost-mechanics.md)). The HTTP status is still 200.
+
+`usage` / `generation_id` / `model` are optional echoes of OpenRouter's
+response. They are omitted when upstream didn't return them or when no
+LLM call was made for this turn. The engine treats `usage` as an opaque
+JSON object — callers deserialize as needed. Only on `/message`; the
+`/message_async` route does not surface these fields (see
+[llm-audit.md](llm-audit.md)).
 
 **Optional: per-request prompt traits.** The body may include a
 `prompt_traits` array — see [prompt-traits.md](prompt-traits.md). Example:
@@ -119,7 +129,31 @@ curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json"
 Limits: ≤ 8 entries, `tag` matches `[a-z0-9_]{1,32}`, `text` ≤ 2000 chars
 (non-blank). Violations return `400 BadRequest`.
 
-The same field is accepted by `/message_async`.
+**Optional: OpenRouter audit passthrough.** The body may include an
+`audit` object that rides directly to OpenRouter as wire-level `user` /
+`session_id` / `metadata` — see [llm-audit.md](llm-audit.md). Example:
+
+```bash
+curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json" \
+  -d '{
+        "message": "hi",
+        "audit": {
+          "user": "u_<hash>",
+          "session_id": "conv_xyz",
+          "metadata": { "feature": "chat", "plan": "pro" }
+        }
+      }' \
+  http://localhost:8080/comp/chat/<session_id>/message
+```
+
+Caps: `audit.user` and `audit.session_id` ≤ 256 chars; `audit.metadata`
+≤ 16 keys, key matches `[A-Za-z0-9_.-]{1,64}`, value is a string ≤ 512
+chars. Violations return `400 BadRequest`.
+
+Both `prompt_traits` and `audit` are accepted by `/message_async` as
+well — the async route does not surface `usage` / `generation_id` /
+`model` on its response, but the audit fields still ride through to
+OpenRouter.
 
 ### `POST /comp/chat/{session_id}/message_async`
 

--- a/docs/api-reference.zh.md
+++ b/docs/api-reference.zh.md
@@ -96,11 +96,19 @@ curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json"
   "lead_score": 4.2,
   "should_show_cta": false,
   "typing_delay_ms": 1340,
-  "agent_training_level": 0.18
+  "agent_training_level": 0.18,
+  "usage": { "prompt_tokens": 12, "completion_tokens": 8, "total_tokens": 20, "cost": 0.0004 },
+  "generation_id": "gen-abc123",
+  "model": "openai/gpt-5.2"
 }
 ```
 
 `reply: null` 意味著人格在這一輪 ghost 了你（看 [Ghost 機制](ghost-mechanics.zh.md)）。HTTP 狀態仍是 200。
+
+`usage` / `generation_id` / `model` 是 OpenRouter 响应的可选回显。
+上游未返回或本轮没有 LLM 调用时省略。引擎把 `usage` 当作不透明 JSON
+对象，调用方按需反序列化。只有 `/message` 会带，`/message_async`
+不在响应里暴露这三个字段（详见 [llm-audit.zh.md](llm-audit.zh.md)）。
 
 **可选：单轮 prompt traits。** 请求体可附加 `prompt_traits` 数组 ——
 详见 [prompt-traits.zh.md](prompt-traits.zh.md)。示例：
@@ -119,7 +127,30 @@ curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json"
 限制：最多 8 条，`tag` 满足 `[a-z0-9_]{1,32}`，`text` ≤ 2000 字符
 （trim 后非空）。违反返回 `400 BadRequest`。
 
-`/message_async` 接受同一字段。
+**可选：OpenRouter audit 透传。** 请求体可附加 `audit` 对象，
+原样作为 wire 级别的 `user` / `session_id` / `metadata` 发送给
+OpenRouter —— 详见 [llm-audit.zh.md](llm-audit.zh.md)。示例：
+
+```bash
+curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json" \
+  -d '{
+        "message": "hi",
+        "audit": {
+          "user": "u_<hash>",
+          "session_id": "conv_xyz",
+          "metadata": { "feature": "chat", "plan": "pro" }
+        }
+      }' \
+  http://localhost:8080/comp/chat/<session_id>/message
+```
+
+限制：`audit.user` 与 `audit.session_id` ≤ 256 字符；`audit.metadata`
+≤ 16 个 key，key 满足 `[A-Za-z0-9_.-]{1,64}`，value 必须是 string
+且 ≤ 512 字符。违反返回 `400 BadRequest`。
+
+`prompt_traits` 与 `audit` 同样被 `/message_async` 接受 —— 异步路由
+的响应里不带 `usage` / `generation_id` / `model`，但 audit 字段仍会
+透传到 OpenRouter。
 
 ### `POST /comp/chat/{session_id}/message_async`
 

--- a/docs/llm-audit.md
+++ b/docs/llm-audit.md
@@ -1,0 +1,112 @@
+# LLM audit passthrough
+
+eros-engine exposes an opaque OpenRouter passthrough on the chat
+message endpoints. Three caller-supplied fields ride to
+`openrouter.ai/api/v1/chat/completions` unchanged, three OpenRouter wire
+echoes come back on the sync response, and two deployer-set env vars
+add app-attribution headers to every outbound call.
+
+The engine never inspects content. PII scrubbing, hashing, and
+metadata semantics are the caller's responsibility.
+
+## Inbound: the `audit` request field
+
+Both `POST /comp/chat/{session_id}/message` and
+`POST /comp/chat/{session_id}/message_async` accept an optional `audit`
+object:
+
+```jsonc
+{
+  "message": "...",
+  "audit": {
+    "user": "u_<hash-of-internal-id>",     // optional
+    "session_id": "conv_xyz",               // optional, ≠ URL session UUID
+    "metadata": {                           // optional
+      "feature": "chat",
+      "plan": "pro"
+    }
+  }
+}
+```
+
+Caps enforced at the engine before forwarding:
+
+| Field                  | Cap                                              |
+|------------------------|--------------------------------------------------|
+| `audit.user`           | `chars ≤ 256`                                    |
+| `audit.session_id`     | `chars ≤ 256`                                    |
+| `audit.metadata` keys  | `≤ 16`                                           |
+| `audit.metadata` key   | regex `^[A-Za-z0-9_.-]{1,64}$`                   |
+| `audit.metadata` value | JSON string, `chars ≤ 512`                       |
+
+Violations return `400 BadRequest`, and no user message row is persisted.
+
+**Privacy:** do not put raw email / wallet address / real name in
+`user` — send a hash. OpenRouter retains request metadata (token
+counts, latency) but not prompts / responses by default.
+
+## Outbound: the `usage` echo on the sync response
+
+`POST /comp/chat/{session_id}/message` adds three optional fields to
+its 200 body:
+
+| Field           | Type      | Meaning                                                                                       |
+|-----------------|-----------|-----------------------------------------------------------------------------------------------|
+| `usage`         | `object?` | OpenRouter `usage` block verbatim (tokens / cost / cached / reasoning). Engine does not flatten. |
+| `generation_id` | `string?` | OpenRouter `response.id`. Query `/api/v1/generation` with it for full request metadata later. |
+| `model`         | `string?` | Model OpenRouter actually served. When `fallback_model` was hit, this is the fallback.        |
+
+The async route (`/message_async`) and the polling route
+(`/pending/{message_id}`) do **not** carry these fields. Use the sync
+route if you need per-turn audit data.
+
+Background paths (`pipeline::dreaming`, `pipeline::post_process`) emit
+usage only as `tracing::info!` fields:
+
+```
+openrouter: call completed session=… generation_id=… model=…
+prompt_tokens=… completion_tokens=… total_tokens=… cost=…
+```
+
+## App-attribution headers
+
+Two optional env vars add headers to every outbound OpenRouter call:
+
+| Env                       | Header         | Purpose                                          |
+|---------------------------|----------------|--------------------------------------------------|
+| `OPENROUTER_APP_REFERER`  | `HTTP-Referer` | App identifier on OpenRouter dashboards          |
+| `OPENROUTER_APP_TITLE`    | `X-Title`      | Display name in OpenRouter app analytics         |
+
+Both unset → today's behaviour (no attribution headers). They are set
+per deployment, not per request — App-Attribution is intended for
+app-level aggregation. Per-user attribution belongs in `audit.user`.
+
+Invalid values (control characters, non-ASCII outside header rules)
+are dropped at construction time with a `tracing::warn!`; the client
+still works.
+
+## What the engine does NOT do
+
+- **Persist.** No DB column stores `audit`, `usage`, or attribution.
+  Surface fields only.
+- **Hash.** The engine does not transform `user` — callers are
+  responsible for sending a hash.
+- **Sanitise.** `metadata` keys and values are size / shape-checked,
+  not content-checked.
+- **Interpret.** The engine does not group, aggregate, or alert on
+  any audit field. Callers wire that themselves.
+
+## Observability
+
+When `audit` is supplied, the engine logs an `info`-level event with
+`audit_user_present`, `audit_session_present`, and `audit_metadata_keys`
+(keys only — never values). On every successful OpenRouter call the
+engine also logs `generation_id`, `model`, and best-effort parsed
+token/cost fields from `usage`.
+
+## Why not persist?
+
+The engine's persona / chat / affinity tables are the long-lived
+contract. Audit context is intentionally ephemeral so callers can
+experiment with `user` hashing, metadata schemas, and per-deployment
+analytics without engine-side migrations or business logic.

--- a/docs/llm-audit.zh.md
+++ b/docs/llm-audit.zh.md
@@ -1,0 +1,104 @@
+# LLM audit 透传
+
+eros-engine 在 chat 消息路由上暴露一个不透明的 OpenRouter 透传层。
+三个 caller 提供的字段原样发给
+`openrouter.ai/api/v1/chat/completions`，三个 OpenRouter 的 wire 回显
+在 sync 响应里带回来，两个 deployer 设的环境变量会给每次出站调用都
+带上 app-attribution headers。
+
+引擎不解读内容。PII 脱敏、hash、metadata 语义都是 caller 的责任。
+
+## Inbound：请求体的 `audit` 字段
+
+`POST /comp/chat/{session_id}/message` 和
+`POST /comp/chat/{session_id}/message_async` 都接受可选的 `audit`
+对象：
+
+```jsonc
+{
+  "message": "...",
+  "audit": {
+    "user": "u_<hash-of-internal-id>",     // 可选
+    "session_id": "conv_xyz",               // 可选，与 URL 上的 session UUID 不同
+    "metadata": {                           // 可选
+      "feature": "chat",
+      "plan": "pro"
+    }
+  }
+}
+```
+
+引擎在转发前强制的上限：
+
+| 字段                    | 上限                                                  |
+|-------------------------|-------------------------------------------------------|
+| `audit.user`            | `chars ≤ 256`                                         |
+| `audit.session_id`      | `chars ≤ 256`                                         |
+| `audit.metadata` key 数 | `≤ 16`                                                |
+| `audit.metadata` key    | 正则 `^[A-Za-z0-9_.-]{1,64}$`                         |
+| `audit.metadata` value  | JSON string，`chars ≤ 512`                            |
+
+违反返回 `400 BadRequest`，且不会写任何 user message 行。
+
+**隐私：**不要把原始 email / 钱包地址 / 真实姓名放进 `user` ——
+要送 hash。OpenRouter 默认保留 request metadata（token 数、延迟），
+但不保留 prompt / response 内容。
+
+## Outbound：sync 响应里的 `usage` 回显
+
+`POST /comp/chat/{session_id}/message` 在 200 响应体里增加三个可选
+字段：
+
+| 字段            | 类型      | 含义                                                                                       |
+|-----------------|-----------|--------------------------------------------------------------------------------------------|
+| `usage`         | `object?` | OpenRouter 的 `usage` 块原样（tokens / cost / cached / reasoning）。引擎不展平。           |
+| `generation_id` | `string?` | OpenRouter `response.id`。之后可以用它查 `/api/v1/generation` 拿完整 metadata。          |
+| `model`         | `string?` | OpenRouter 实际服务的模型。`fallback_model` 命中时，这里是 fallback。                    |
+
+异步路由（`/message_async`）和轮询路由（`/pending/{message_id}`）
+**不带**这三个字段。需要 per-turn audit 数据请走 sync。
+
+后台路径（`pipeline::dreaming`、`pipeline::post_process`）的 usage
+只通过 `tracing::info!` 字段输出：
+
+```
+openrouter: call completed session=… generation_id=… model=…
+prompt_tokens=… completion_tokens=… total_tokens=… cost=…
+```
+
+## App-attribution headers
+
+两个可选环境变量给每次出站 OpenRouter 调用加 header：
+
+| Env                       | Header         | 用途                                          |
+|---------------------------|----------------|-----------------------------------------------|
+| `OPENROUTER_APP_REFERER`  | `HTTP-Referer` | OpenRouter 仪表盘上的 app 标识                |
+| `OPENROUTER_APP_TITLE`    | `X-Title`      | OpenRouter app analytics 里显示的名字         |
+
+两个都不设 → 维持现状（不发任何 attribution header）。它们是
+deployment 级别的设置，不是 per-request —— App-Attribution 的目的是
+app-level 聚合。Per-user 维度走 `audit.user`。
+
+非法值（控制字符、非 ASCII 之类）在构造时被丢弃并打一条
+`tracing::warn!`，client 仍然可用。
+
+## 引擎不做的事
+
+- **不持久化。**没有任何 DB 列保存 `audit` / `usage` / attribution。
+  只有 surface 字段。
+- **不 hash。**引擎不会变换 `user` —— caller 负责送 hash。
+- **不消毒。**`metadata` 的 key / value 只检查 size / shape，不查内容。
+- **不解读。**引擎不会按 audit 字段分组、聚合、报警。Caller 自己接。
+
+## 可观测性
+
+收到 `audit` 时，引擎会打 info 级别日志，带
+`audit_user_present` / `audit_session_present` / `audit_metadata_keys`
+（只有 key，永远不带 value）。每次成功的 OpenRouter 调用也会日志
+`generation_id` / `model` 以及 best-effort 解析出来的 token / cost。
+
+## 为什么不持久化？
+
+引擎的 persona / chat / affinity 表是长期契约。Audit 上下文有意做成
+短暂的，让 caller 可以自由实验 `user` hash、metadata schema、不同
+deployment 的 analytics，不污染引擎表也不需要 migration。

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -3,14 +3,15 @@
 # explicitly avoids over-refusal on intimate adult dialogue.
 # DeepSeek fallback covers multilingual depth (esp. zh) and is cheap enough
 # to absorb traffic spikes.
-model = "x-ai/grok-4-fast"
-fallback = "deepseek/deepseek-chat-v3.2"
+model = "x-ai/grok-4.20"
+# fallback will be a list like ["x-ai/grok-4.1-fast", "deepseek/deepseek-v4-flash"] in a future iteration, with orders of preference. For now we only have one fallback per task.
+fallback = "x-ai/grok-4.1-fast"
 temperature = 0.85
 max_tokens = 600
 
 [tasks.insight_extraction]
-model = "x-ai/grok-4-mini"
-fallback = "deepseek/deepseek-chat-v3.2"
+model = "x-ai/grok-4.1-fast"
+fallback = "deepseek/deepseek-v4-flash"
 temperature = 0.3
 max_tokens = 400
 
@@ -18,10 +19,10 @@ max_tokens = 400
 # chat_messages, emits 0-N {content, category} candidates, and the
 # sweeper writes them to companion_memories as profile-layer rows.
 # Haiku 4.5 is the cheapest model with reliable structured-JSON output;
-# grok-4-mini fallback keeps the no-OpenAI invariant if Anthropic is down.
+# grok-4.1-fast fallback keeps the no-OpenAI invariant if Anthropic is down.
 [tasks.memory_extraction]
 model = "anthropic/claude-haiku-4.5"
-fallback = "x-ai/grok-4-mini"
+fallback = "x-ai/grok-4.1-fast"
 temperature = 0.2
 max_tokens = 800
 
@@ -29,7 +30,7 @@ max_tokens = 800
 # `eros-engine-core/src/pde.rs` is purely rule-based; this entry is a
 # placeholder for a future optional LLM decision layer.
 [tasks.pde_decision]
-model = "x-ai/grok-4-mini"
+model = "x-ai/grok-4.1-fast"
 temperature = 0.5
 max_tokens = 200
 


### PR DESCRIPTION
## Summary

OpenRouter audit / usage passthrough — a transport-only HTTP surface
that lets callers attribute requests on OpenRouter dashboards and
record their own usage without engine-side business logic. Bundled
with a small hotfix for issue #19 (retired model IDs in the example
config).

### Audit feature (Tasks 1-12 from the implementation plan)

- **Inbound:** `audit: { user?, session_id?, metadata? }` on
  `POST /comp/chat/{id}/message[_async]`. Engine validates caps
  (`user`/`session_id` ≤ 256 chars, `metadata` ≤ 16 keys with regex
  + value ≤ 512 chars), forwards verbatim as OpenRouter wire fields,
  never persists or interprets content.
- **Outbound:** sync `/message` response gains optional
  `usage` (opaque JSON), `generation_id`, `model`. Async + polling
  routes are unchanged.
- **App-Attribution:** two optional env vars
  (`OPENROUTER_APP_REFERER` → `HTTP-Referer`,
  `OPENROUTER_APP_TITLE` → `X-Title`) attach attribution headers to
  every outbound call. Header names pinned via `const` so a future
  OpenRouter rename is a one-line change.
- **Observability:** `pipeline::run` logs `audit_user_present`,
  `audit_session_present`, `audit_metadata_keys` (keys only — never
  values), plus best-effort parsed `prompt_tokens` /
  `completion_tokens` / `total_tokens` / `cost` from the opaque
  `usage` JSON.
- **No persistence**, **no PII hashing**, **no content
  interpretation** — by design. Audit-string leak detection
  enforced by an integration test asserting raw audit values never
  appear in `chat_messages.content`.

Spec: `docs/superpowers/specs/2026-05-19-openrouter-audit-design.md`
Plan: `docs/superpowers/plans/2026-05-19-openrouter-audit.md`
Docs: new `docs/llm-audit.md` + `.zh.md`, extended `api-reference*.md`
.env.example: `OPENROUTER_APP_REFERER` / `OPENROUTER_APP_TITLE` documented

### Hotfix: retired OpenRouter model IDs (closes #19)

`examples/model_config.toml` updated to current model IDs:
- `x-ai/grok-4-fast` → `x-ai/grok-4.20`
- `x-ai/grok-4-mini` → `x-ai/grok-4.1-fast`
- `deepseek/deepseek-chat-v3.2` → `x-ai/grok-4.1-fast` /
  `deepseek/deepseek-v4-flash`

Hardcoded Rust defaults in `model_config.rs` still reference the
retired IDs — explicitly out of scope; separate follow-up.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test -p eros-engine-core` — 31/31 green (incl. 4 new
      `LlmAudit` / `Event` / `ChatResponse` tests)
- [x] `cargo test -p eros-engine-llm` — 20/20 green (incl. 5 new
      wiremock tests: App-Attribution headers + audit wire
      passthrough + usage response parsing)
- [x] 9 new `validate_llm_audit_*` unit tests pass (all cap paths
      + happy path)
- [x] 4 new `send_message_async_*` sqlx integration tests
      (validation-failure paths + positive happy path with
      leak-detection SQL)
- [x] OpenAPI snapshot regenerated; CI drift check clean
- [ ] **Manual deploy smoke** (after merge): POST with
      `audit.user = "u_smoke"` against staging; confirm 200 carries
      non-null `usage`/`generation_id`/`model`; confirm OpenRouter
      dashboard shows the request attributed to the configured
      title and grouped by `u_smoke`; confirm `tracing` output
      contains the `openrouter: call completed` line with
      `total_tokens` populated.
- [ ] **Hotfix smoke** (after merge to staging): `POST /comp/chat/...`
      with the deployed `examples/model_config.toml` no longer
      returns 400 "is not a valid model ID".

🤖 Generated with [Claude Code](https://claude.com/claude-code)