### PR TITLE
feat: v0.2.0 — SSE streaming chat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,7 +395,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "eros-engine-core"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "serde",
@@ -383,15 +405,19 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-llm"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
+ "async-stream",
  "async-trait",
  "eros-engine-core",
+ "eventsource-stream",
+ "futures-util",
  "reqwest",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-stream",
  "toml",
  "tracing",
  "wiremock",
@@ -399,9 +425,10 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-server"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "anyhow",
+ "async-stream",
  "async-trait",
  "axum",
  "chrono",
@@ -409,6 +436,7 @@ dependencies = [
  "eros-engine-core",
  "eros-engine-llm",
  "eros-engine-store",
+ "futures-util",
  "hex",
  "hmac",
  "jsonwebtoken",
@@ -420,11 +448,13 @@ dependencies = [
  "subtle",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-stream",
  "toml",
  "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "ulid",
  "urlencoding",
  "utoipa",
  "utoipa-axum",
@@ -434,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-store"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "bs58",
@@ -478,6 +508,17 @@ checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
  "concurrent-queue",
  "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "eventsource-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
+dependencies = [
+ "futures-core",
+ "nom",
  "pin-project-lite",
 ]
 
@@ -1169,6 +1210,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1177,6 +1224,16 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -2460,6 +2517,18 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "ulid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+dependencies = [
+ "rand 0.9.4",
+ "serde",
+ "uuid",
+ "web-time",
+]
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,6 +460,7 @@ dependencies = [
  "utoipa-axum",
  "utoipa-scalar",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]
@@ -1631,6 +1632,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -1650,12 +1652,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.7",
 ]
@@ -2756,6 +2760,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serde_json = "1"
 sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls", "postgres", "uuid", "chrono", "json"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 thiserror = "1"
 anyhow = "1"
 tracing = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 license = "AGPL-3.0-only"
 repository = "https://github.com/etherfunlab/eros-engine"
@@ -35,3 +35,8 @@ hmac = "0.12"
 sha2 = "0.10"
 subtle = "2.5"
 hex = "0.4"
+eventsource-stream = "0.2"
+futures-util       = "0.3"
+tokio-stream       = "0.1"
+async-stream       = "0.3"
+ulid               = { version = "1", features = ["serde", "uuid"] }

--- a/README.md
+++ b/README.md
@@ -186,25 +186,36 @@ Highlights:
 
 - `GET  /comp/personas` — list active persona genomes.
 - `POST /comp/chat/start` — open a chat session against a persona.
-- `POST /comp/chat/{session_id}/message` — synchronous chat turn.
-- `POST /comp/chat/{session_id}/message_async` — async chat turn with pending-status polling.
-- `GET  /comp/chat/{session_id}/pending/{message_id}` — poll async completion.
+- `POST /comp/chat/{session_id}/message/stream` — streaming chat turn (SSE, recommended).
+- `POST /comp/chat/{session_id}/message` — synchronous chat turn (deprecated in 0.2, removed in 0.3).
 - `GET  /comp/chat/{session_id}/history` — paginated chat history.
 - `GET  /comp/chat/{user_id}/sessions` — list a user's sessions.
 - `GET  /comp/user/{user_id}/profile` — current `companion_insights` and `training_level`.
 - `POST /comp/chat/{session_id}/event/gift` — apply an out-of-band gift event and affinity delta.
 - `GET  /comp/chat/{session_id}/gifts` — list gift events for a session.
-- `POST /comp/chat/{session_id}/message` and `/message_async` accept two
-  optional caller-supplied fields:
+- `/message/stream` and `/message` accept two optional caller-supplied fields:
   - `prompt_traits` — per-request system-prompt injection, see
     [docs/prompt-traits.md](docs/prompt-traits.md).
   - `audit` — opaque OpenRouter passthrough (`user` / `session_id` /
     `metadata`) for per-user / per-session attribution on OpenRouter
-    dashboards. Sync `/message` also echoes `usage` / `generation_id` /
-    `model` on its response. See [docs/llm-audit.md](docs/llm-audit.md).
+    dashboards. See [docs/llm-audit.md](docs/llm-audit.md).
 - `GET  /comp/affinity/{session_id}` — debug-only live affinity vector, enabled by `EXPOSE_AFFINITY_DEBUG=true`.
 
 The `AuthValidator` trait is pluggable if you use a different identity provider.
+
+### Streaming chat
+
+```bash
+curl -N -X POST \
+  -H "Authorization: Bearer $JWT" \
+  -H "Content-Type: application/json" \
+  -H "Accept: text/event-stream" \
+  -d '{"content":"hi","client_msg_id":"01J3333333333333333333333A"}' \
+  http://localhost:8080/comp/chat/<session_id>/message/stream
+```
+
+See [docs/api-reference.md](docs/api-reference.md#post-compchatsession_idmessagestream)
+for frame layout and error semantics.
 
 ## Configuration
 

--- a/crates/eros-engine-llm/Cargo.toml
+++ b/crates/eros-engine-llm/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "openrouter", "voyage", "embeddings", "llm"]
 categories = ["api-bindings"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "0.1.3" }
+eros-engine-core = { path = "../eros-engine-core", version = "0.2.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true }
@@ -21,6 +21,10 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
 toml = "0.8"
+eventsource-stream = { workspace = true }
+futures-util       = { workspace = true }
+tokio-stream       = { workspace = true }
+async-stream       = { workspace = true }
 
 [dev-dependencies]
 wiremock = "0.6"

--- a/crates/eros-engine-llm/src/error.rs
+++ b/crates/eros-engine-llm/src/error.rs
@@ -25,4 +25,26 @@ pub enum LlmError {
 
     #[error("provider error: {0}")]
     Provider(String),
+
+    /// Wraps a mid-stream parse failure (`data:` line that did not decode as
+    /// an OpenRouter-compatible delta envelope). The string is the raw
+    /// payload trimmed to a reasonable size for logs.
+    #[error("openrouter stream parse error: {0}")]
+    StreamParse(String),
+
+    /// Wraps a transport-level interruption while reading the SSE body
+    /// (connection reset, TLS error after the response headers arrived).
+    #[error("openrouter stream transport error: {0}")]
+    Stream(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stream_parse_variant_renders_message() {
+        let e = LlmError::StreamParse("bad delta envelope".into());
+        assert_eq!(e.to_string(), "openrouter stream parse error: bad delta envelope");
+    }
 }

--- a/crates/eros-engine-llm/src/error.rs
+++ b/crates/eros-engine-llm/src/error.rs
@@ -45,6 +45,9 @@ mod tests {
     #[test]
     fn stream_parse_variant_renders_message() {
         let e = LlmError::StreamParse("bad delta envelope".into());
-        assert_eq!(e.to_string(), "openrouter stream parse error: bad delta envelope");
+        assert_eq!(
+            e.to_string(),
+            "openrouter stream parse error: bad delta envelope"
+        );
     }
 }

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -359,10 +359,7 @@ impl OpenRouterClient {
 
     /// Open a streaming chat completion against a single model. Fallback
     /// chain handling is the caller's responsibility (pipeline layer).
-    pub async fn execute_stream(
-        &self,
-        req: ChatRequest,
-    ) -> Result<DeltaStream, LlmError> {
+    pub async fn execute_stream(&self, req: ChatRequest) -> Result<DeltaStream, LlmError> {
         use eventsource_stream::Eventsource;
         use futures_util::StreamExt;
 
@@ -402,35 +399,34 @@ impl OpenRouterClient {
             return Err(LlmError::Status(status, text));
         }
 
-        let stream = resp.bytes_stream().eventsource().filter_map(|ev| async move {
-            match ev {
-                Ok(e) => {
-                    if e.data == "[DONE]" {
-                        return None;
-                    }
-                    match serde_json::from_str::<WireStreamFrame>(&e.data) {
-                        Ok(frame) => {
-                            let choice = frame
-                                .choices
-                                .into_iter()
-                                .next()
-                                .unwrap_or_default();
-                            Some(Ok(DeltaChunk {
-                                content: choice.delta.content.filter(|s| !s.is_empty()),
-                                finish_reason: choice.finish_reason,
-                                usage: frame.usage,
-                                generation_id: frame.id,
-                                model: frame.model,
-                            }))
+        let stream = resp
+            .bytes_stream()
+            .eventsource()
+            .filter_map(|ev| async move {
+                match ev {
+                    Ok(e) => {
+                        if e.data == "[DONE]" {
+                            return None;
                         }
-                        Err(_) => Some(Err(LlmError::StreamParse(
-                            e.data.chars().take(256).collect(),
-                        ))),
+                        match serde_json::from_str::<WireStreamFrame>(&e.data) {
+                            Ok(frame) => {
+                                let choice = frame.choices.into_iter().next().unwrap_or_default();
+                                Some(Ok(DeltaChunk {
+                                    content: choice.delta.content.filter(|s| !s.is_empty()),
+                                    finish_reason: choice.finish_reason,
+                                    usage: frame.usage,
+                                    generation_id: frame.id,
+                                    model: frame.model,
+                                }))
+                            }
+                            Err(_) => Some(Err(LlmError::StreamParse(
+                                e.data.chars().take(256).collect(),
+                            ))),
+                        }
                     }
+                    Err(e) => Some(Err(LlmError::Stream(e.to_string()))),
                 }
-                Err(e) => Some(Err(LlmError::Stream(e.to_string()))),
-            }
-        });
+            });
 
         Ok(DeltaStream(stream.boxed()))
     }
@@ -1003,7 +999,10 @@ data: [DONE]\n\n";
             .execute_stream(ChatRequest {
                 model: "x-ai/grok-4-fast".into(),
                 fallback_model: Vec::new(),
-                messages: vec![ChatMessage { role: "user".into(), content: "hi".into() }],
+                messages: vec![ChatMessage {
+                    role: "user".into(),
+                    content: "hi".into(),
+                }],
                 temperature: 0.0,
                 max_tokens: 16,
                 ..Default::default()
@@ -1017,10 +1016,18 @@ data: [DONE]\n\n";
         let mut last_model: Option<String> = None;
         while let Some(item) = stream.next().await {
             let chunk = item.expect("delta chunk parses");
-            if let Some(c) = chunk.content { contents.push(c); }
-            if chunk.usage.is_some()         { last_usage = chunk.usage; }
-            if chunk.generation_id.is_some() { last_gen_id = chunk.generation_id; }
-            if chunk.model.is_some()         { last_model = chunk.model; }
+            if let Some(c) = chunk.content {
+                contents.push(c);
+            }
+            if chunk.usage.is_some() {
+                last_usage = chunk.usage;
+            }
+            if chunk.generation_id.is_some() {
+                last_gen_id = chunk.generation_id;
+            }
+            if chunk.model.is_some() {
+                last_model = chunk.model;
+            }
         }
         assert_eq!(contents, vec!["你".to_string(), "好".to_string()]);
         let u = last_usage.expect("usage present on terminal chunk");
@@ -1048,7 +1055,10 @@ data: [DONE]\n\n";
         let err = client
             .execute_stream(ChatRequest {
                 model: "x-ai/grok-4-fast".into(),
-                messages: vec![ChatMessage { role: "user".into(), content: "hi".into() }],
+                messages: vec![ChatMessage {
+                    role: "user".into(),
+                    content: "hi".into(),
+                }],
                 temperature: 0.0,
                 max_tokens: 16,
                 ..Default::default()
@@ -1084,7 +1094,10 @@ data: [DONE]\n\n";
         let mut stream = client
             .execute_stream(ChatRequest {
                 model: "x-ai/grok-4-fast".into(),
-                messages: vec![ChatMessage { role: "user".into(), content: "hi".into() }],
+                messages: vec![ChatMessage {
+                    role: "user".into(),
+                    content: "hi".into(),
+                }],
                 temperature: 0.0,
                 max_tokens: 16,
                 ..Default::default()

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -95,6 +95,80 @@ struct WireResponse {
     choices: Vec<WireChoice>,
 }
 
+// ── SSE streaming types ──────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq)]
+pub struct UsageBlock {
+    #[serde(default)]
+    pub prompt_tokens: u64,
+    #[serde(default)]
+    pub completion_tokens: u64,
+    #[serde(default)]
+    pub total_tokens: u64,
+    /// OpenRouter sometimes includes a `cost` field (USD). Kept here so
+    /// callers that want to log it have access; the spec's `done.usage`
+    /// schema only requires the three token counts.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cost: Option<f64>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct DeltaChunk {
+    pub content: Option<String>,
+    pub finish_reason: Option<String>,
+    pub usage: Option<UsageBlock>,
+    pub generation_id: Option<String>,
+    pub model: Option<String>,
+}
+
+/// Opaque wrapper around a boxed SSE delta stream. Implements [`Debug`] so
+/// callers can use `.expect_err()` / `.unwrap()` in tests without the
+/// underlying `dyn Stream` trait-object imposing a `Debug` bound.
+pub struct DeltaStream(pub futures_util::stream::BoxStream<'static, Result<DeltaChunk, LlmError>>);
+
+impl std::fmt::Debug for DeltaStream {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DeltaStream").finish_non_exhaustive()
+    }
+}
+
+impl futures_util::Stream for DeltaStream {
+    type Item = Result<DeltaChunk, LlmError>;
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        use std::pin::Pin;
+        Pin::new(&mut self.0).poll_next(cx)
+    }
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct WireStreamDelta {
+    #[serde(default)]
+    content: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct WireStreamChoice {
+    #[serde(default)]
+    delta: WireStreamDelta,
+    #[serde(default)]
+    finish_reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct WireStreamFrame {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    model: Option<String>,
+    #[serde(default)]
+    usage: Option<UsageBlock>,
+    #[serde(default)]
+    choices: Vec<WireStreamChoice>,
+}
+
 /// App-Attribution headers sent on every outbound OpenRouter call.
 /// Skipping `None` fields avoids emitting blank-but-set headers, which
 /// OpenRouter would record as a real attribution. Both `None` reverts
@@ -281,6 +355,84 @@ impl OpenRouterClient {
             model: parsed.model,
             usage: parsed.usage,
         })
+    }
+
+    /// Open a streaming chat completion against a single model. Fallback
+    /// chain handling is the caller's responsibility (pipeline layer).
+    pub async fn execute_stream(
+        &self,
+        req: ChatRequest,
+    ) -> Result<DeltaStream, LlmError> {
+        use eventsource_stream::Eventsource;
+        use futures_util::StreamExt;
+
+        if self.api_key.is_empty() {
+            return Err(LlmError::Config("openrouter: api key not set".into()));
+        }
+        if req.model.is_empty() {
+            return Err(LlmError::Config(
+                "openrouter: execute_stream requires a non-empty model".into(),
+            ));
+        }
+
+        let wire = serde_json::json!({
+            "model": req.model,
+            "messages": req.messages,
+            "temperature": req.temperature,
+            "max_tokens": req.max_tokens,
+            "stream": true,
+            // Forward audit fields when set.
+            "user": req.user,
+            "session_id": req.session_id,
+            "metadata": req.metadata,
+        });
+
+        let resp = self
+            .http
+            .post(&self.base_url)
+            .bearer_auth(&self.api_key)
+            .header(reqwest::header::ACCEPT, "text/event-stream")
+            .json(&wire)
+            .send()
+            .await?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let text = resp.text().await.unwrap_or_default();
+            return Err(LlmError::Status(status, text));
+        }
+
+        let stream = resp.bytes_stream().eventsource().filter_map(|ev| async move {
+            match ev {
+                Ok(e) => {
+                    if e.data == "[DONE]" {
+                        return None;
+                    }
+                    match serde_json::from_str::<WireStreamFrame>(&e.data) {
+                        Ok(frame) => {
+                            let choice = frame
+                                .choices
+                                .into_iter()
+                                .next()
+                                .unwrap_or_default();
+                            Some(Ok(DeltaChunk {
+                                content: choice.delta.content.filter(|s| !s.is_empty()),
+                                finish_reason: choice.finish_reason,
+                                usage: frame.usage,
+                                generation_id: frame.id,
+                                model: frame.model,
+                            }))
+                        }
+                        Err(_) => Some(Err(LlmError::StreamParse(
+                            e.data.chars().take(256).collect(),
+                        ))),
+                    }
+                }
+                Err(e) => Some(Err(LlmError::Stream(e.to_string()))),
+            }
+        });
+
+        Ok(DeltaStream(stream.boxed()))
     }
 }
 
@@ -810,5 +962,139 @@ mod tests {
             .await
             .expect("non-empty fallback succeeds");
         assert_eq!(resp.reply, "ok");
+    }
+
+    #[tokio::test]
+    async fn execute_stream_yields_deltas_then_terminal_usage() {
+        use futures_util::StreamExt;
+
+        let server = MockServer::start().await;
+        // Two delta frames + a terminal frame with usage + the `[DONE]`
+        // sentinel. Crucially, the body chunks arrive as a single raw text
+        // body — wiremock does not flush per-chunk, but the eventsource-stream
+        // parser tolerates the whole body arriving at once because it splits
+        // on the wire-level `\n\n` boundary itself.
+        let body = "\
+data: {\"choices\":[{\"delta\":{\"content\":\"你\"}}]}\n\n\
+data: {\"choices\":[{\"delta\":{\"content\":\"好\"}}]}\n\n\
+data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":2,\"total_tokens\":5},\"id\":\"gen-xyz\",\"model\":\"x-ai/grok-4-fast\"}\n\n\
+data: [DONE]\n\n";
+
+        Mock::given(path("/api/v1/chat/completions"))
+            .and(wiremock::matchers::body_partial_json(
+                serde_json::json!({"stream": true}),
+            ))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(body, "text/event-stream"),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = OpenRouterClient::with_base_url(
+            "test-key".into(),
+            AppAttribution::default(),
+            format!("{}/api/v1/chat/completions", server.uri()),
+        );
+
+        let mut stream = client
+            .execute_stream(ChatRequest {
+                model: "x-ai/grok-4-fast".into(),
+                fallback_model: Vec::new(),
+                messages: vec![ChatMessage { role: "user".into(), content: "hi".into() }],
+                temperature: 0.0,
+                max_tokens: 16,
+                ..Default::default()
+            })
+            .await
+            .expect("stream opens");
+
+        let mut contents = Vec::new();
+        let mut last_usage: Option<UsageBlock> = None;
+        let mut last_gen_id: Option<String> = None;
+        let mut last_model: Option<String> = None;
+        while let Some(item) = stream.next().await {
+            let chunk = item.expect("delta chunk parses");
+            if let Some(c) = chunk.content { contents.push(c); }
+            if chunk.usage.is_some()         { last_usage = chunk.usage; }
+            if chunk.generation_id.is_some() { last_gen_id = chunk.generation_id; }
+            if chunk.model.is_some()         { last_model = chunk.model; }
+        }
+        assert_eq!(contents, vec!["你".to_string(), "好".to_string()]);
+        let u = last_usage.expect("usage present on terminal chunk");
+        assert_eq!(u.prompt_tokens, 3);
+        assert_eq!(u.completion_tokens, 2);
+        assert_eq!(u.total_tokens, 5);
+        assert_eq!(last_gen_id.as_deref(), Some("gen-xyz"));
+        assert_eq!(last_model.as_deref(), Some("x-ai/grok-4-fast"));
+    }
+
+    #[tokio::test]
+    async fn execute_stream_returns_status_error_when_upstream_4xx() {
+        let server = MockServer::start().await;
+        Mock::given(path("/api/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(429).set_body_string("rate-limited"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = OpenRouterClient::with_base_url(
+            "test-key".into(),
+            AppAttribution::default(),
+            format!("{}/api/v1/chat/completions", server.uri()),
+        );
+        let err = client
+            .execute_stream(ChatRequest {
+                model: "x-ai/grok-4-fast".into(),
+                messages: vec![ChatMessage { role: "user".into(), content: "hi".into() }],
+                temperature: 0.0,
+                max_tokens: 16,
+                ..Default::default()
+            })
+            .await
+            .expect_err("4xx → Err before any stream yielded");
+        assert!(
+            matches!(err, LlmError::Status(s, _) if s.as_u16() == 429),
+            "expected Status(429), got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_stream_yields_parse_error_on_bad_frame() {
+        use futures_util::StreamExt;
+        let server = MockServer::start().await;
+        let body = "data: not-json\n\n";
+        Mock::given(path("/api/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(body, "text/event-stream"),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = OpenRouterClient::with_base_url(
+            "test-key".into(),
+            AppAttribution::default(),
+            format!("{}/api/v1/chat/completions", server.uri()),
+        );
+        let mut stream = client
+            .execute_stream(ChatRequest {
+                model: "x-ai/grok-4-fast".into(),
+                messages: vec![ChatMessage { role: "user".into(), content: "hi".into() }],
+                temperature: 0.0,
+                max_tokens: 16,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        let item = stream.next().await.expect("at least one item");
+        assert!(
+            matches!(item, Err(LlmError::StreamParse(_))),
+            "expected StreamParse error, got {item:?}"
+        );
     }
 }

--- a/crates/eros-engine-server/Cargo.toml
+++ b/crates/eros-engine-server/Cargo.toml
@@ -49,3 +49,6 @@ futures-util = { workspace = true }
 tokio-stream = { workspace = true }
 async-stream = { workspace = true }
 ulid         = { workspace = true }
+
+[dev-dependencies]
+wiremock = "0.6"

--- a/crates/eros-engine-server/Cargo.toml
+++ b/crates/eros-engine-server/Cargo.toml
@@ -10,9 +10,9 @@ name = "eros-engine"
 path = "src/main.rs"
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "0.1.3" }
-eros-engine-llm  = { path = "../eros-engine-llm", version = "0.1.3" }
-eros-engine-store = { path = "../eros-engine-store", version = "0.1.3" }
+eros-engine-core = { path = "../eros-engine-core", version = "0.2.0" }
+eros-engine-llm  = { path = "../eros-engine-llm", version = "0.2.0" }
+eros-engine-store = { path = "../eros-engine-store", version = "0.2.0" }
 axum = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }
@@ -45,3 +45,7 @@ sha2 = { workspace = true }
 subtle = { workspace = true }
 hex = { workspace = true }
 urlencoding = "2"
+futures-util = { workspace = true }
+tokio-stream = { workspace = true }
+async-stream = { workspace = true }
+ulid         = { workspace = true }

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0-only",
       "identifier": "AGPL-3.0-only"
     },
-    "version": "0.1.3"
+    "version": "0.2.0"
   },
   "servers": [
     {
@@ -291,13 +291,12 @@
         ]
       }
     },
-    "/comp/chat/{session_id}/message_async": {
+    "/comp/chat/{session_id}/message/stream": {
       "post": {
         "tags": [
           "companion"
         ],
-        "summary": "Accept a user message and process it in the background. The client\nthen polls `/pending/{message_id}` for the assistant reply.",
-        "operationId": "send_message_async",
+        "operationId": "send_message_stream",
         "parameters": [
           {
             "name": "session_id",
@@ -314,76 +313,25 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SendMessageRequest"
+                "$ref": "#/components/schemas/StreamSendRequest"
               }
             }
           },
           "required": true
         },
         "responses": {
-          "202": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AsyncSendResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "missing or invalid bearer"
-          },
-          "403": {
-            "description": "not your session"
-          },
-          "404": {
-            "description": "session not found"
-          }
-        },
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/comp/chat/{session_id}/pending/{message_id}": {
-      "get": {
-        "tags": [
-          "companion"
-        ],
-        "summary": "Poll for the AI reply to a user message. Returns `processing` until\nthe assistant or system_error row appears, then `completed` / `error`.",
-        "operationId": "check_pending",
-        "parameters": [
-          {
-            "name": "session_id",
-            "in": "path",
-            "description": "Chat session id",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          },
-          {
-            "name": "message_id",
-            "in": "path",
-            "description": "User message id to poll on",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "responses": {
           "200": {
+            "description": "SSE event stream (text/event-stream)",
+            "content": {
+              "text/event-stream": {}
+            }
+          },
+          "400": {
             "description": "",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PendingCheckResponse"
+                  "$ref": "#/components/schemas/StreamPreErrorBody"
                 }
               }
             }
@@ -392,10 +340,54 @@
             "description": "missing or invalid bearer"
           },
           "403": {
-            "description": "not your session"
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StreamPreErrorBody"
+                }
+              }
+            }
           },
           "404": {
-            "description": "session not found"
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StreamPreErrorBody"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StreamPreErrorBody"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StreamPreErrorBody"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StreamPreErrorBody"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -820,27 +812,6 @@
           }
         }
       },
-      "AsyncSendResponse": {
-        "type": "object",
-        "required": [
-          "status",
-          "user_message_id",
-          "session_id"
-        ],
-        "properties": {
-          "session_id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "status": {
-            "type": "string"
-          },
-          "user_message_id": {
-            "type": "string",
-            "format": "uuid"
-          }
-        }
-      },
       "ChatHistoryEntry": {
         "type": "object",
         "required": [
@@ -862,41 +833,6 @@
           "sent_at": {
             "type": "string",
             "format": "date-time"
-          }
-        }
-      },
-      "CompanionReplyPayload": {
-        "type": "object",
-        "required": [
-          "reply",
-          "message_id",
-          "lead_score",
-          "should_show_cta",
-          "agent_training_level",
-          "sent_at"
-        ],
-        "properties": {
-          "agent_training_level": {
-            "type": "number",
-            "format": "double"
-          },
-          "lead_score": {
-            "type": "number",
-            "format": "double"
-          },
-          "message_id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "reply": {
-            "type": "string"
-          },
-          "sent_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "should_show_cta": {
-            "type": "boolean"
           }
         }
       },
@@ -1158,27 +1094,6 @@
           }
         }
       },
-      "PendingCheckResponse": {
-        "type": "object",
-        "required": [
-          "status"
-        ],
-        "properties": {
-          "message": {
-            "oneOf": [
-              {
-                "type": "null"
-              },
-              {
-                "$ref": "#/components/schemas/CompanionReplyPayload"
-              }
-            ]
-          },
-          "status": {
-            "type": "string"
-          }
-        }
-      },
       "PersonaGenomeDto": {
         "type": "object",
         "description": "Genome row exposed on `GET /comp/personas`. Matches\n`eros_engine_core::persona::PersonaGenome` field-for-field but with\n`ToSchema` so utoipa can render it.",
@@ -1390,6 +1305,47 @@
           "session_id": {
             "type": "string",
             "format": "uuid"
+          }
+        }
+      },
+      "StreamPreErrorBody": {
+        "type": "object",
+        "description": "Pre-stream error body per spec §1.3. Schema-only struct for utoipa;\nruntime renders the same shape via StreamPreError.",
+        "required": [
+          "code",
+          "message",
+          "user_message"
+        ],
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "original_user_message_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "user_message": {
+            "type": "string"
+          }
+        }
+      },
+      "StreamSendRequest": {
+        "type": "object",
+        "required": [
+          "content",
+          "client_msg_id"
+        ],
+        "properties": {
+          "client_msg_id": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
           }
         }
       },

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -1341,11 +1341,30 @@
           "client_msg_id"
         ],
         "properties": {
+          "audit": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/LlmAuditDto"
+              }
+            ]
+          },
           "client_msg_id": {
             "type": "string"
           },
           "content": {
             "type": "string"
+          },
+          "prompt_traits": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/PromptTraitDto"
+            }
           }
         }
       },

--- a/crates/eros-engine-server/src/error.rs
+++ b/crates/eros-engine-server/src/error.rs
@@ -28,10 +28,39 @@ pub enum AppError {
     Sqlx(#[from] sqlx::Error),
     #[error(transparent)]
     Json(#[from] serde_json::Error),
+    /// Streaming-specific pre-stream error. Renders the spec §1.3 body
+    /// schema (code / message / user_message [+ optional extras]).
+    #[error("stream pre-error: {0}")]
+    StreamPre(StreamPreError),
+}
+
+#[derive(Debug, Clone)]
+pub struct StreamPreError {
+    pub status: StatusCode,
+    pub code: &'static str,
+    pub message: String,
+    pub user_message: String,
+    pub original_user_message_id: Option<uuid::Uuid>,
+}
+
+impl std::fmt::Display for StreamPreError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.code)
+    }
 }
 
 impl IntoResponse for AppError {
     fn into_response(self) -> Response {
+        if let AppError::StreamPre(e) = &self {
+            let mut body = serde_json::Map::new();
+            body.insert("code".into(), json!(e.code));
+            body.insert("message".into(), json!(e.message));
+            body.insert("user_message".into(), json!(e.user_message));
+            if let Some(id) = e.original_user_message_id {
+                body.insert("original_user_message_id".into(), json!(id.to_string()));
+            }
+            return (e.status, Json(serde_json::Value::Object(body))).into_response();
+        }
         let (status, code) = match &self {
             AppError::NotFound(_) => (StatusCode::NOT_FOUND, "not_found"),
             AppError::Unauthorized(_) => (StatusCode::UNAUTHORIZED, "unauthorized"),
@@ -44,5 +73,28 @@ impl IntoResponse for AppError {
             Json(json!({ "error": code, "message": self.to_string() })),
         )
             .into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn stream_pre_error_renders_spec_body_with_original_message_id() {
+        let id = uuid::Uuid::new_v4();
+        let err = AppError::StreamPre(StreamPreError {
+            status: StatusCode::CONFLICT,
+            code: "duplicate_in_progress",
+            message: "same client_msg_id still generating".into(),
+            user_message: "请稍后再试".into(),
+            original_user_message_id: Some(id),
+        });
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+        let body_bytes = axum::body::to_bytes(resp.into_body(), 1024).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+        assert_eq!(v["code"], "duplicate_in_progress");
+        assert_eq!(v["original_user_message_id"], id.to_string());
     }
 }

--- a/crates/eros-engine-server/src/main.rs
+++ b/crates/eros-engine-server/src/main.rs
@@ -268,6 +268,7 @@ async fn run_server() -> Result<()> {
         openrouter,
         voyage,
         model_config,
+        stream_slots: Arc::new(crate::state::StreamSlots::default()),
         marketplace_svc_url,
         marketplace_s2s_secret,
         marketplace_s2s_secret_previous,

--- a/crates/eros-engine-server/src/main.rs
+++ b/crates/eros-engine-server/src/main.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 mod auth;
 mod error;
+mod middleware;
 mod openapi;
 mod pipeline;
 mod prompt;
@@ -297,6 +298,7 @@ async fn run_server() -> Result<()> {
     let app: Router = open_router
         .with_state(state)
         .merge(Scalar::with_url("/docs", api))
+        .layer(crate::middleware::SseHeadersLayer)
         .layer(tower_http::trace::TraceLayer::new_for_http());
 
     let listener = tokio::net::TcpListener::bind(&cfg.bind_addr).await?;

--- a/crates/eros-engine-server/src/middleware.rs
+++ b/crates/eros-engine-server/src/middleware.rs
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! HTTP-layer middleware.
+//!
+//! Currently:
+//!   - `SseHeadersLayer` — injects `X-Accel-Buffering: no` +
+//!     `Cache-Control: no-cache, no-transform, private` on responses whose
+//!     `Content-Type` starts with `text/event-stream`. Required by spec §1.1
+//!     so CDNs / reverse-proxies do not buffer the SSE body.
+
+use axum::http::{HeaderValue, Request, Response};
+use std::task::{Context, Poll};
+use tower::{Layer, Service};
+
+#[derive(Clone, Default)]
+pub struct SseHeadersLayer;
+
+impl<S> Layer<S> for SseHeadersLayer {
+    type Service = SseHeadersService<S>;
+    fn layer(&self, inner: S) -> Self::Service {
+        SseHeadersService { inner }
+    }
+}
+
+#[derive(Clone)]
+pub struct SseHeadersService<S> {
+    inner: S,
+}
+
+impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for SseHeadersService<S>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    ReqBody: Send + 'static,
+    ResBody: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<Self::Response, Self::Error>> + Send>,
+    >;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        let fut = self.inner.call(req);
+        Box::pin(async move {
+            let mut resp = fut.await?;
+            let is_sse = resp
+                .headers()
+                .get(axum::http::header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.starts_with("text/event-stream"))
+                .unwrap_or(false);
+            if is_sse {
+                resp.headers_mut()
+                    .insert("X-Accel-Buffering", HeaderValue::from_static("no"));
+                resp.headers_mut().insert(
+                    axum::http::header::CACHE_CONTROL,
+                    HeaderValue::from_static("no-cache, no-transform, private"),
+                );
+            }
+            Ok(resp)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::StatusCode;
+    use axum::routing::get;
+    use axum::Router;
+    use tower::ServiceExt;
+
+    async fn sse_handler() -> Response<Body> {
+        Response::builder()
+            .status(StatusCode::OK)
+            .header(axum::http::header::CONTENT_TYPE, "text/event-stream")
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    async fn json_handler() -> Response<Body> {
+        Response::builder()
+            .status(StatusCode::OK)
+            .header(axum::http::header::CONTENT_TYPE, "application/json")
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn injects_headers_for_sse_response() {
+        let app = Router::new()
+            .route("/sse", get(sse_handler))
+            .layer(SseHeadersLayer);
+        let resp = app
+            .oneshot(Request::builder().uri("/sse").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.headers().get("X-Accel-Buffering").unwrap(), "no");
+        assert_eq!(
+            resp.headers().get(axum::http::header::CACHE_CONTROL).unwrap(),
+            "no-cache, no-transform, private"
+        );
+    }
+
+    #[tokio::test]
+    async fn leaves_non_sse_response_alone() {
+        let app = Router::new()
+            .route("/json", get(json_handler))
+            .layer(SseHeadersLayer);
+        let resp = app
+            .oneshot(Request::builder().uri("/json").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert!(resp.headers().get("X-Accel-Buffering").is_none());
+    }
+}

--- a/crates/eros-engine-server/src/middleware.rs
+++ b/crates/eros-engine-server/src/middleware.rs
@@ -102,7 +102,9 @@ mod tests {
             .unwrap();
         assert_eq!(resp.headers().get("X-Accel-Buffering").unwrap(), "no");
         assert_eq!(
-            resp.headers().get(axum::http::header::CACHE_CONTROL).unwrap(),
+            resp.headers()
+                .get(axum::http::header::CACHE_CONTROL)
+                .unwrap(),
             "no-cache, no-transform, private"
         );
     }

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -325,6 +325,67 @@ fn insights_to_bullets(insights: &Value) -> Vec<String> {
 
 // ─── Reply ──────────────────────────────────────────────────────────
 
+/// Build a ChatRequest for the Reply action. Shared by the sync
+/// `ReplyHandler` and the streaming `pipeline::stream::run_stream`.
+pub(super) async fn build_reply_request(
+    state: &AppState,
+    input: &DecisionInput,
+    plan: &ActionPlan,
+    session_id: Uuid,
+    user_id: Uuid,
+    instance_id: Uuid,
+) -> Result<ChatRequest, AppError> {
+    let chat_repo = ChatRepo { pool: &state.pool };
+    let history = chat_repo.history(session_id, HISTORY_WINDOW, 0).await?;
+
+    let query_text = match &input.event {
+        Event::UserMessage { content, .. } => content.as_str(),
+        _ => "",
+    };
+
+    let (mut profile_groups, relationship_facts) =
+        recall_memory(state, user_id, instance_id, query_text).await;
+
+    let insight_bullets = load_insight_bullets(&state.pool, user_id).await;
+    if !insight_bullets.is_empty() {
+        profile_groups.insert(0, ("基础画像".into(), insight_bullets));
+    }
+
+    let tip_personality = input
+        .persona
+        .genome
+        .tip_personality
+        .as_deref()
+        .unwrap_or("normal");
+
+    let pending_gifts: Vec<PendingGift> = vec![];
+
+    let prompt_traits: &[PromptTrait] = match &input.event {
+        Event::UserMessage { prompt_traits, .. } => prompt_traits.as_slice(),
+        _ => &[],
+    };
+
+    let system_prompt = build_prompt(
+        &input.persona,
+        &profile_groups,
+        &relationship_facts,
+        Some(&input.affinity),
+        &pending_gifts,
+        tip_personality,
+        plan.reply_style,
+        &plan.context_hints,
+        prompt_traits,
+    );
+
+    Ok(assemble_chat_request(
+        state,
+        input,
+        system_prompt,
+        history,
+        audit_from_event(&input.event),
+    ))
+}
+
 pub struct ReplyHandler<'a> {
     pub state: &'a AppState,
     pub session_id: Uuid,
@@ -339,67 +400,11 @@ impl<'a> ActionHandler for ReplyHandler<'a> {
         input: &DecisionInput,
         plan: &ActionPlan,
     ) -> Result<Option<ChatRequest>, AppError> {
-        let chat_repo = ChatRepo {
-            pool: &self.state.pool,
-        };
-        let history = chat_repo
-            .history(self.session_id, HISTORY_WINDOW, 0)
-            .await?;
-
-        // Use the current user message as the recall query.
-        let query_text = match &input.event {
-            Event::UserMessage { content, .. } => content.as_str(),
-            _ => "",
-        };
-
-        let (mut profile_groups, relationship_facts) =
-            recall_memory(self.state, self.user_id, self.instance_id, query_text).await;
-
-        // T14: prepend structured insights as a labelled group so the LLM
-        // sees both the JSONB profile (city/MBTI/...) and the categorised
-        // pgvector recalls under the same `【你对他的了解（通用画像）】`
-        // section. "基础画像" anchors at position 0 so it always renders
-        // first regardless of which categories the dreaming-lite pass
-        // happens to have populated.
-        let insight_bullets = load_insight_bullets(&self.state.pool, self.user_id).await;
-        if !insight_bullets.is_empty() {
-            profile_groups.insert(0, ("基础画像".into(), insight_bullets));
-        }
-
-        let tip_personality = input
-            .persona
-            .genome
-            .tip_personality
-            .as_deref()
-            .unwrap_or("normal");
-
-        // Reply path never has pending gifts — those flow through GiftHandler.
-        let pending_gifts: Vec<PendingGift> = vec![];
-
-        let prompt_traits: &[PromptTrait] = match &input.event {
-            Event::UserMessage { prompt_traits, .. } => prompt_traits.as_slice(),
-            _ => &[],
-        };
-
-        let system_prompt = build_prompt(
-            &input.persona,
-            &profile_groups,
-            &relationship_facts,
-            Some(&input.affinity),
-            &pending_gifts,
-            tip_personality,
-            plan.reply_style,
-            &plan.context_hints,
-            prompt_traits,
-        );
-
-        Ok(Some(assemble_chat_request(
-            self.state,
-            input,
-            system_prompt,
-            history,
-            audit_from_event(&input.event),
-        )))
+        let req = build_reply_request(
+            self.state, input, plan, self.session_id, self.user_id, self.instance_id,
+        )
+        .await?;
+        Ok(Some(req))
     }
 }
 

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -434,7 +434,13 @@ pub(super) async fn build_gift_request(
         &[],
     );
 
-    Ok(assemble_chat_request(state, input, system_prompt, history, None))
+    Ok(assemble_chat_request(
+        state,
+        input,
+        system_prompt,
+        history,
+        None,
+    ))
 }
 
 pub struct ReplyHandler<'a> {
@@ -452,7 +458,12 @@ impl<'a> ActionHandler for ReplyHandler<'a> {
         plan: &ActionPlan,
     ) -> Result<Option<ChatRequest>, AppError> {
         let req = build_reply_request(
-            self.state, input, plan, self.session_id, self.user_id, self.instance_id,
+            self.state,
+            input,
+            plan,
+            self.session_id,
+            self.user_id,
+            self.instance_id,
         )
         .await?;
         Ok(Some(req))

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -386,6 +386,57 @@ pub(super) async fn build_reply_request(
     ))
 }
 
+/// Build a ChatRequest for the GiftReaction action. Shared by the sync
+/// `GiftHandler` and the streaming `pipeline::stream::run_stream`.
+pub(super) async fn build_gift_request(
+    state: &AppState,
+    input: &DecisionInput,
+    plan: &ActionPlan,
+    session_id: Uuid,
+    user_id: Uuid,
+    instance_id: Uuid,
+    pending: &[PendingGift],
+) -> Result<ChatRequest, AppError> {
+    let chat_repo = ChatRepo { pool: &state.pool };
+    let history = chat_repo.history(session_id, HISTORY_WINDOW, 0).await?;
+
+    let query_text = history
+        .iter()
+        .rev()
+        .find(|m| m.role == "user")
+        .map(|m| m.content.as_str())
+        .unwrap_or("");
+
+    let (mut profile_groups, relationship_facts) =
+        recall_memory(state, user_id, instance_id, query_text).await;
+
+    let insight_bullets = load_insight_bullets(&state.pool, user_id).await;
+    if !insight_bullets.is_empty() {
+        profile_groups.insert(0, ("基础画像".into(), insight_bullets));
+    }
+
+    let tip_personality = input
+        .persona
+        .genome
+        .tip_personality
+        .as_deref()
+        .unwrap_or("normal");
+
+    let system_prompt = build_prompt(
+        &input.persona,
+        &profile_groups,
+        &relationship_facts,
+        Some(&input.affinity),
+        pending,
+        tip_personality,
+        plan.reply_style,
+        &plan.context_hints,
+        &[],
+    );
+
+    Ok(assemble_chat_request(state, input, system_prompt, history, None))
+}
+
 pub struct ReplyHandler<'a> {
     pub state: &'a AppState,
     pub session_id: Uuid,
@@ -461,59 +512,17 @@ impl<'a> ActionHandler for GiftHandler<'a> {
         input: &DecisionInput,
         plan: &ActionPlan,
     ) -> Result<Option<ChatRequest>, AppError> {
-        let chat_repo = ChatRepo {
-            pool: &self.state.pool,
-        };
-        let history = chat_repo
-            .history(self.session_id, HISTORY_WINDOW, 0)
-            .await?;
-
-        // Gift events have no user message of their own. Fall back to the
-        // most recent user turn from history so memory recall still has a
-        // semantic anchor (e.g. user said "I miss you" → tipped → reaction
-        // can reference what they were just talking about).
-        let query_text = history
-            .iter()
-            .rev()
-            .find(|m| m.role == "user")
-            .map(|m| m.content.as_str())
-            .unwrap_or("");
-
-        let (mut profile_groups, relationship_facts) =
-            recall_memory(self.state, self.user_id, self.instance_id, query_text).await;
-
-        let insight_bullets = load_insight_bullets(&self.state.pool, self.user_id).await;
-        if !insight_bullets.is_empty() {
-            profile_groups.insert(0, ("基础画像".into(), insight_bullets));
-        }
-
-        let tip_personality = input
-            .persona
-            .genome
-            .tip_personality
-            .as_deref()
-            .unwrap_or("normal");
-
-        // Gift path: prompt_traits flow only from UserMessage; ignore for gift reactions.
-        let system_prompt = build_prompt(
-            &input.persona,
-            &profile_groups,
-            &relationship_facts,
-            Some(&input.affinity),
-            &self.pending,
-            tip_personality,
-            plan.reply_style,
-            &plan.context_hints,
-            &[],
-        );
-
-        Ok(Some(assemble_chat_request(
+        let req = build_gift_request(
             self.state,
             input,
-            system_prompt,
-            history,
-            None,
-        )))
+            plan,
+            self.session_id,
+            self.user_id,
+            self.instance_id,
+            &self.pending,
+        )
+        .await?;
+        Ok(Some(req))
     }
 }
 

--- a/crates/eros-engine-server/src/pipeline/mod.rs
+++ b/crates/eros-engine-server/src/pipeline/mod.rs
@@ -15,6 +15,7 @@
 pub mod dreaming;
 pub mod handlers;
 pub mod post_process;
+pub mod stream;
 pub mod sync;
 
 use uuid::Uuid;

--- a/crates/eros-engine-server/src/pipeline/mod.rs
+++ b/crates/eros-engine-server/src/pipeline/mod.rs
@@ -181,12 +181,19 @@ pub async fn run(
         }
     }
 
-    // 10. Spawn post-process. AppState is `Clone`; the openrouter / voyage
-    // / model_config inside it are `Arc`-wrapped so the clone is cheap and
-    // the spawned future is `'static` (no `&'a` borrows leak in).
+    // 10. Spawn post-process. Wrap the (at most one) assistant message into
+    // a single-element Vec so the post-process signature matches the
+    // streaming path's multi-message bursts.
+    let produced: Vec<post_process::ProducedMessage> = match &response {
+        Some(r) => vec![post_process::ProducedMessage {
+            message_id: Uuid::nil(), // sync path does not produce a streamable id
+            full_text: r.reply.clone(),
+            action: plan.action_type,
+        }],
+        None => vec![],
+    };
     let state_bg = state.clone();
     let plan_bg = plan.clone();
-    let response_bg = response.clone();
     let event_bg = event;
     tokio::spawn(async move {
         post_process::run(
@@ -196,7 +203,7 @@ pub async fn run(
             instance_id,
             event_bg,
             plan_bg,
-            response_bg,
+            produced,
         )
         .await;
     });

--- a/crates/eros-engine-server/src/pipeline/mod.rs
+++ b/crates/eros-engine-server/src/pipeline/mod.rs
@@ -53,7 +53,7 @@ pub async fn run(
     let affinity = load_affinity_with_decay(state, session_id, user_id, instance_id).await?;
 
     // 4. Conversation signals.
-    let signals = compute_signals(state, session_id, &affinity).await?;
+    let signals = compute_signals_for_session(&state.pool, session_id, &affinity).await?;
 
     // 5. Build decision input.
     let input = DecisionInput {
@@ -274,8 +274,8 @@ async fn load_affinity_with_decay(
     Ok(affinity)
 }
 
-async fn compute_signals(
-    state: &AppState,
+pub async fn compute_signals_for_session(
+    pool: &sqlx::PgPool,
     session_id: Uuid,
     affinity: &Affinity,
 ) -> Result<ConversationSignals, AppError> {
@@ -283,7 +283,7 @@ async fn compute_signals(
         "SELECT COUNT(*) FROM engine.chat_messages WHERE session_id = $1 AND role = 'user'",
     )
     .bind(session_id)
-    .fetch_one(&state.pool)
+    .fetch_one(pool)
     .await
     .unwrap_or(0);
 
@@ -291,7 +291,7 @@ async fn compute_signals(
         "SELECT MAX(sent_at) FROM engine.chat_messages WHERE session_id = $1 AND role = 'user'",
     )
     .bind(session_id)
-    .fetch_optional(&state.pool)
+    .fetch_optional(pool)
     .await
     .ok()
     .flatten();

--- a/crates/eros-engine-server/src/pipeline/post_process.rs
+++ b/crates/eros-engine-server/src/pipeline/post_process.rs
@@ -32,8 +32,12 @@ use crate::state::AppState;
 // ─── ProducedMessage ───────────────────────────────────────────────
 
 /// One assistant message persisted during a burst (sync or streaming path).
-/// `action` mirrors the spec's `meta.action_type` discriminator.
+/// `action` mirrors the spec's `meta.action_type` discriminator. `message_id`
+/// and `action` are unused by today's per-message side-effects but are kept
+/// on the struct for the audit / lead-score hooks that a future task will
+/// thread per-message.
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct ProducedMessage {
     pub message_id: Uuid,
     pub full_text: String,

--- a/crates/eros-engine-server/src/pipeline/post_process.rs
+++ b/crates/eros-engine-server/src/pipeline/post_process.rs
@@ -18,7 +18,7 @@
 
 use uuid::Uuid;
 
-use eros_engine_core::types::{ActionPlan, ActionType, ChatResponse, Event};
+use eros_engine_core::types::{ActionPlan, ActionType, Event};
 use eros_engine_llm::model_config::ModelConfig;
 use eros_engine_llm::openrouter::{ChatMessage, ChatRequest, OpenRouterClient};
 use eros_engine_llm::voyage::VoyageClient;
@@ -28,6 +28,17 @@ use eros_engine_store::insight::InsightRepo;
 use eros_engine_store::memory::{MemoryLayer, MemoryRepo};
 
 use crate::state::AppState;
+
+// ─── ProducedMessage ───────────────────────────────────────────────
+
+/// One assistant message persisted during a burst (sync or streaming path).
+/// `action` mirrors the spec's `meta.action_type` discriminator.
+#[derive(Debug, Clone)]
+pub struct ProducedMessage {
+    pub message_id: Uuid,
+    pub full_text: String,
+    pub action: ActionType,
+}
 
 // ─── Top-level dispatcher ──────────────────────────────────────────
 
@@ -39,26 +50,26 @@ pub async fn run(
     instance_id: Uuid,
     event: Event,
     plan: ActionPlan,
-    response: Option<ChatResponse>,
+    produced: Vec<ProducedMessage>,
 ) {
     let user_msg = match &event {
         Event::UserMessage { content, .. } => content.clone(),
         _ => String::new(),
     };
-    let reply = response
-        .as_ref()
-        .map(|r| r.reply.clone())
-        .unwrap_or_default();
 
     let fut_insight = async {
-        if !user_msg.is_empty() && !reply.is_empty() {
-            extract_insights(&state, session_id, user_id, &user_msg, &reply).await;
+        for m in &produced {
+            if !user_msg.is_empty() && !m.full_text.is_empty() {
+                extract_insights(&state, session_id, user_id, &user_msg, &m.full_text).await;
+            }
         }
     };
 
     let fut_memory = async {
-        if !user_msg.is_empty() && !reply.is_empty() {
-            write_turn(&state, session_id, user_id, instance_id, &user_msg, &reply).await;
+        for m in &produced {
+            if !user_msg.is_empty() && !m.full_text.is_empty() {
+                write_turn(&state, session_id, user_id, instance_id, &user_msg, &m.full_text).await;
+            }
         }
     };
 

--- a/crates/eros-engine-server/src/pipeline/post_process.rs
+++ b/crates/eros-engine-server/src/pipeline/post_process.rs
@@ -72,7 +72,15 @@ pub async fn run(
     let fut_memory = async {
         for m in &produced {
             if !user_msg.is_empty() && !m.full_text.is_empty() {
-                write_turn(&state, session_id, user_id, instance_id, &user_msg, &m.full_text).await;
+                write_turn(
+                    &state,
+                    session_id,
+                    user_id,
+                    instance_id,
+                    &user_msg,
+                    &m.full_text,
+                )
+                .await;
             }
         }
     };

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! Streaming pipeline — ProtocolFrame state machine + run_stream generator.
+//!
+//! Wire-level frame layout follows
+//! `docs/superpowers/specs/2026-05-19-sse-streaming-chat-0.2-design.md` §1.5.
+//!
+//! Task 4 only ships the type layer; the `run_stream` generator lands in
+//! later tasks (T10/T11/T12).
+
+use eros_engine_llm::openrouter::UsageBlock;
+use serde::Serialize;
+use ulid::Ulid;
+
+/// Stream-level error code enum. Renders to the spec's lowercase string.
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum StreamErrorCode {
+    UpstreamUnavailable,
+    RateLimited,
+    Internal,
+    Timeout,
+}
+
+/// Action type tag used in `meta` frames.
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum FrameActionType {
+    Reply,
+    Ghost,
+    GiftReaction,
+}
+
+/// One wire frame in the SSE protocol.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ProtocolFrame {
+    Meta {
+        message_id: String,
+        action_type: FrameActionType,
+        model: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        continues_from: Option<String>,
+    },
+    Delta {
+        message_id: String,
+        content: String,
+    },
+    Done {
+        message_id: String,
+        truncated: bool,
+        usage: Option<UsageBlock>,
+        generation_id: Option<String>,
+    },
+    Final {
+        lead_score: f64,
+        should_show_cta: bool,
+        agent_training_level: f64,
+    },
+    Error {
+        code: StreamErrorCode,
+        retryable: bool,
+        message: String,
+        user_message: String,
+    },
+}
+
+/// Render a 128-bit id as a Crockford Base32 ULID string (26 chars).
+pub fn ulid_string(u: Ulid) -> String {
+    u.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn meta_frame_serializes_with_required_fields() {
+        let id = Ulid::new();
+        let f = ProtocolFrame::Meta {
+            message_id: ulid_string(id),
+            action_type: FrameActionType::Reply,
+            model: "x-ai/grok-4-fast".into(),
+            continues_from: None,
+        };
+        let s = serde_json::to_string(&f).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(v["type"], "meta");
+        assert_eq!(v["action_type"], "reply");
+        assert_eq!(v["model"], "x-ai/grok-4-fast");
+        assert!(v.get("continues_from").is_none(), "must be omitted when None");
+        assert_eq!(v["message_id"].as_str().unwrap().len(), 26);
+    }
+
+    #[test]
+    fn meta_frame_serializes_continues_from_when_present() {
+        let prev = ulid_string(Ulid::new());
+        let f = ProtocolFrame::Meta {
+            message_id: ulid_string(Ulid::new()),
+            action_type: FrameActionType::Reply,
+            model: "x-ai/grok-4-fast".into(),
+            continues_from: Some(prev.clone()),
+        };
+        let v: serde_json::Value = serde_json::to_value(&f).unwrap();
+        assert_eq!(v["continues_from"], prev);
+    }
+
+    #[test]
+    fn delta_frame_serializes_with_content() {
+        let id = ulid_string(Ulid::new());
+        let f = ProtocolFrame::Delta { message_id: id.clone(), content: "你好".into() };
+        let v: serde_json::Value = serde_json::to_value(&f).unwrap();
+        assert_eq!(v["type"], "delta");
+        assert_eq!(v["message_id"], id);
+        assert_eq!(v["content"], "你好");
+    }
+
+    #[test]
+    fn done_frame_serializes_with_usage_and_truncated_flag() {
+        let f = ProtocolFrame::Done {
+            message_id: ulid_string(Ulid::new()),
+            truncated: true,
+            usage: Some(UsageBlock {
+                prompt_tokens: 10,
+                completion_tokens: 4,
+                total_tokens: 14,
+                cost: None,
+            }),
+            generation_id: Some("gen-1".into()),
+        };
+        let v: serde_json::Value = serde_json::to_value(&f).unwrap();
+        assert_eq!(v["type"], "done");
+        assert_eq!(v["truncated"], true);
+        assert_eq!(v["usage"]["prompt_tokens"], 10);
+        assert_eq!(v["generation_id"], "gen-1");
+    }
+
+    #[test]
+    fn final_frame_carries_three_floats() {
+        let f = ProtocolFrame::Final {
+            lead_score: 0.71,
+            should_show_cta: false,
+            agent_training_level: 0.42,
+        };
+        let v: serde_json::Value = serde_json::to_value(&f).unwrap();
+        assert_eq!(v["type"], "final");
+        assert!((v["lead_score"].as_f64().unwrap() - 0.71).abs() < 1e-9);
+        assert_eq!(v["should_show_cta"], false);
+    }
+
+    #[test]
+    fn error_frame_uses_snake_case_code() {
+        let f = ProtocolFrame::Error {
+            code: StreamErrorCode::UpstreamUnavailable,
+            retryable: true,
+            message: "internal".into(),
+            user_message: "AI 服务暂时不可用，稍后再试".into(),
+        };
+        let v: serde_json::Value = serde_json::to_value(&f).unwrap();
+        assert_eq!(v["type"], "error");
+        assert_eq!(v["code"], "upstream_unavailable");
+        assert_eq!(v["retryable"], true);
+    }
+
+    #[test]
+    fn done_frame_emits_null_usage_when_absent() {
+        let f = ProtocolFrame::Done {
+            message_id: ulid_string(Ulid::new()),
+            truncated: false,
+            usage: None,
+            generation_id: None,
+        };
+        let v: serde_json::Value = serde_json::to_value(&f).unwrap();
+        // Spec §1.5 done schema permits `usage: null` — do NOT omit.
+        assert!(v.get("usage").is_some());
+        assert!(v["usage"].is_null());
+    }
+}

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -160,6 +160,9 @@ fn drive_chat_burst(
                                 }
                                 if c.usage.is_some()         { last_usage = c.usage; }
                                 if c.generation_id.is_some() { last_gen_id = c.generation_id; }
+                                if matches!(c.finish_reason.as_deref(), Some("length")) {
+                                    truncated = true;
+                                }
                             }
                             Err(e) => {
                                 tracing::warn!("stream: upstream chunk err: {e}");
@@ -235,6 +238,8 @@ pub struct PersistedUserMessage {
     pub user_id: Uuid,
     pub instance_id: Uuid,
     pub content: String,
+    pub prompt_traits: Vec<eros_engine_core::types::PromptTrait>,
+    pub audit: Option<eros_engine_core::types::LlmAudit>,
 }
 
 /// Produce a stream of `ProtocolFrame` events for a single burst. The
@@ -298,8 +303,8 @@ pub fn run_stream(
             event: Event::UserMessage {
                 content: user_msg.content.clone(),
                 message_id: user_msg.user_message_id,
-                prompt_traits: vec![],
-                audit: None,
+                prompt_traits: user_msg.prompt_traits.clone(),
+                audit: user_msg.audit.clone(),
             },
             affinity: affinity.clone(),
             persona,
@@ -414,8 +419,8 @@ pub fn run_stream(
                 let event_bg = Event::UserMessage {
                     content: user_msg.content.clone(),
                     message_id: user_msg.user_message_id,
-                    prompt_traits: vec![],
-                    audit: None,
+                    prompt_traits: user_msg.prompt_traits.clone(),
+                    audit: user_msg.audit.clone(),
                 };
                 let user_id_bg = user_msg.user_id;
                 let instance_id_bg = user_msg.instance_id;
@@ -529,6 +534,18 @@ pub fn replay_stream(
                     usage,
                     generation_id: row.generation_id.clone(),
                 };
+            }
+            // If every persisted assistant row was truncated, emit the same
+            // terminal Error that the original burst emitted so the client
+            // knows retrying is appropriate.
+            if !rows.is_empty() && rows.iter().all(|r| r.truncated) {
+                yield ProtocolFrame::Error {
+                    code: StreamErrorCode::UpstreamUnavailable,
+                    retryable: true,
+                    message: "all fallback models truncated (replayed)".into(),
+                    user_message: "AI 服务暂时不可用，稍后再试".into(),
+                };
+                return;
             }
         }
         let final_frame = compute_final_frame(&state, session_id, user_id).await;
@@ -692,7 +709,7 @@ mod tests {
         let state = std::sync::Arc::new(crate::routes::companion::test_state(pool.clone()));
         let chat_repo = ChatRepo { pool: &state.pool };
         let user_message_id = match chat_repo
-            .upsert_user_message_idempotent(session_id, "hi", "01J1111111111111111111111A", 24)
+            .upsert_user_message_idempotent(session_id, "hi", "01J1111111111111111111111A")
             .await
             .unwrap()
         {
@@ -708,6 +725,8 @@ mod tests {
                 user_id,
                 instance_id,
                 content: "hi".into(),
+                prompt_traits: vec![],
+                audit: None,
             },
         )
         .collect()
@@ -753,7 +772,7 @@ data: [DONE]\n\n";
 
         let chat_repo = ChatRepo { pool: &pool };
         let user_message_id = match chat_repo
-            .upsert_user_message_idempotent(session_id, "hi", "01J2222222222222222222222A", 24)
+            .upsert_user_message_idempotent(session_id, "hi", "01J2222222222222222222222A")
             .await
             .unwrap()
         {
@@ -769,6 +788,8 @@ data: [DONE]\n\n";
                 user_id,
                 instance_id,
                 content: "hi".into(),
+                prompt_traits: vec![],
+                audit: None,
             },
         )
         .collect()

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -69,6 +69,11 @@ pub fn ulid_string(u: Ulid) -> String {
     u.to_string()
 }
 
+/// Maximum number of model attempts per streaming burst. Spec §5 chose 2
+/// (= 1 primary + 1 fallback) because streaming exposes each fallback as
+/// a separate visible bubble; depth > 2 starts feeling like a bug to users.
+pub const MAX_STREAM_FALLBACK_DEPTH: usize = 2;
+
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -186,8 +191,186 @@ pub fn run_stream(
                 let final_frame = compute_final_frame(&state, user_msg.session_id, user_msg.user_id).await;
                 yield final_frame;
             }
+            ActionType::Reply => {
+                let req = match crate::pipeline::handlers::build_reply_request(
+                    &state, &input, &plan, user_msg.session_id, user_msg.user_id, user_msg.instance_id,
+                ).await {
+                    Ok(r) => r,
+                    Err(e) => {
+                        yield ProtocolFrame::Error {
+                            code: StreamErrorCode::Internal,
+                            retryable: false,
+                            message: format!("build_reply_request failed: {e}"),
+                            user_message: "服务出现问题，请稍后再试".into(),
+                        };
+                        return;
+                    }
+                };
+                let chain: Vec<String> = std::iter::once(req.model.clone())
+                    .chain(req.fallback_model.iter().cloned())
+                    .filter(|s| !s.is_empty())
+                    .take(MAX_STREAM_FALLBACK_DEPTH)
+                    .collect();
+                if chain.is_empty() {
+                    yield ProtocolFrame::Error {
+                        code: StreamErrorCode::Internal,
+                        retryable: false,
+                        message: "no models configured".into(),
+                        user_message: "服务出现问题，请稍后再试".into(),
+                    };
+                    return;
+                }
+                let mut produced: Vec<crate::pipeline::post_process::ProducedMessage> = Vec::new();
+                let mut continues_from: Option<Ulid> = None;
+                let mut yielded_any_done = false;
+
+                'fallback: for (idx, model_id) in chain.iter().enumerate() {
+                    let msg_ulid = Ulid::new();
+                    let msg_uuid: Uuid = msg_ulid.into();
+                    let mut acc = String::new();
+                    let mut last_usage: Option<eros_engine_llm::openrouter::UsageBlock> = None;
+                    let mut last_gen_id: Option<String> = None;
+                    let mut truncated = false;
+
+                    yield ProtocolFrame::Meta {
+                        message_id: ulid_string(msg_ulid),
+                        action_type: FrameActionType::Reply,
+                        model: model_id.clone(),
+                        continues_from: continues_from.map(ulid_string),
+                    };
+
+                    let mut per_model_req = req.clone();
+                    per_model_req.model = model_id.clone();
+                    per_model_req.fallback_model = Vec::new();
+
+                    match state.openrouter.execute_stream(per_model_req).await {
+                        Ok(mut s) => {
+                            use futures_util::StreamExt as _;
+                            while let Some(item) = s.next().await {
+                                match item {
+                                    Ok(c) => {
+                                        if let Some(content) = c.content {
+                                            acc.push_str(&content);
+                                            yield ProtocolFrame::Delta {
+                                                message_id: ulid_string(msg_ulid),
+                                                content,
+                                            };
+                                        }
+                                        if c.usage.is_some()         { last_usage = c.usage; }
+                                        if c.generation_id.is_some() { last_gen_id = c.generation_id; }
+                                    }
+                                    Err(e) => {
+                                        tracing::warn!("stream: upstream chunk err: {e}");
+                                        truncated = true;
+                                        break;
+                                    }
+                                }
+                            }
+                            if !truncated && acc.is_empty() {
+                                truncated = true;
+                            }
+                        }
+                        Err(e) => {
+                            tracing::warn!("stream: upstream open err: {e}");
+                            truncated = true;
+                        }
+                    }
+
+                    // Persist BEFORE yielding Done (spec §2.3 risk R7).
+                    let row = eros_engine_store::chat::AssistantInsert {
+                        id: msg_uuid,
+                        content: acc.clone(),
+                        assistant_action_type: "reply".into(),
+                        continues_from_message_id: continues_from.map(Into::into),
+                        truncated,
+                        model: Some(model_id.clone()),
+                        usage: last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok()),
+                        generation_id: last_gen_id.clone(),
+                    };
+                    if let Err(e) = chat_repo
+                        .insert_assistant_batch(user_msg.session_id, user_msg.user_message_id, &[row])
+                        .await
+                    {
+                        tracing::warn!("stream: assistant persist failed: {e}");
+                    }
+                    produced.push(crate::pipeline::post_process::ProducedMessage {
+                        message_id: msg_uuid,
+                        full_text: acc.clone(),
+                        action: eros_engine_core::types::ActionType::Reply,
+                    });
+                    yielded_any_done = true;
+
+                    yield ProtocolFrame::Done {
+                        message_id: ulid_string(msg_ulid),
+                        truncated,
+                        usage: last_usage,
+                        generation_id: last_gen_id,
+                    };
+
+                    if !truncated {
+                        break 'fallback;
+                    }
+                    if idx + 1 == chain.len() {
+                        yield ProtocolFrame::Error {
+                            code: StreamErrorCode::UpstreamUnavailable,
+                            retryable: true,
+                            message: "all fallback models truncated".into(),
+                            user_message: "AI 服务暂时不可用，稍后再试".into(),
+                        };
+                        return;
+                    }
+                    continues_from = Some(msg_ulid);
+                }
+
+                // Reset ghost streak (mirrors sync pipeline policy).
+                if let Err(e) = sqlx::query(
+                    "UPDATE engine.companion_affinity SET ghost_streak = 0, updated_at = now() \
+                     WHERE session_id = $1 AND ghost_streak <> 0",
+                )
+                .bind(user_msg.session_id)
+                .execute(&state.pool)
+                .await
+                {
+                    tracing::warn!("stream: ghost streak reset failed: {e}");
+                }
+
+                if yielded_any_done {
+                    let final_frame = compute_final_frame(&state, user_msg.session_id, user_msg.user_id).await;
+                    yield final_frame;
+                }
+
+                // Spawn post-process; do not await.
+                let state_bg = (*state).clone();
+                let plan_bg = plan.clone();
+                let event_bg = eros_engine_core::types::Event::UserMessage {
+                    content: user_msg.content.clone(),
+                    message_id: user_msg.user_message_id,
+                    prompt_traits: vec![],
+                    audit: None,
+                };
+                let user_id_bg = user_msg.user_id;
+                let instance_id_bg = user_msg.instance_id;
+                let session_id_bg = user_msg.session_id;
+                tokio::spawn(async move {
+                    crate::pipeline::post_process::run(
+                        state_bg,
+                        session_id_bg,
+                        user_id_bg,
+                        instance_id_bg,
+                        event_bg,
+                        plan_bg,
+                        produced,
+                    )
+                    .await;
+                });
+            }
+            ActionType::GiftReaction => {
+                // T12 fills this in. For now, yield Final-only so the stream terminates.
+                let final_frame = compute_final_frame(&state, user_msg.session_id, user_msg.user_id).await;
+                yield final_frame;
+            }
             _ => {
-                // Reply / GiftReaction implemented in T11/T12; Proactive returns Final only.
+                // Proactive and any future variants: Final-only.
                 let final_frame = compute_final_frame(&state, user_msg.session_id, user_msg.user_id).await;
                 yield final_frame;
             }
@@ -407,5 +590,71 @@ mod tests {
         // Tolerant: the test just proves the generator runs end-to-end and
         // terminates. T11/T15 add per-frame assertions for Reply/replay paths.
         assert!(frames.last().is_some(), "must emit at least one frame");
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn run_stream_reply_terminates_cleanly_with_mock_openrouter(pool: PgPool) {
+        use futures_util::StreamExt;
+        use wiremock::matchers::path as wm_path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+
+        let mock = MockServer::start().await;
+        let body = "\
+data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n\
+data: {\"choices\":[{\"delta\":{\"content\":\" there\"}}],\"usage\":{\"prompt_tokens\":2,\"completion_tokens\":2,\"total_tokens\":4},\"id\":\"gen-r\",\"model\":\"primary\"}\n\n\
+data: [DONE]\n\n";
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+
+        let user_id = Uuid::new_v4();
+        let (_g, instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                eros_engine_llm::openrouter::AppAttribution::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+
+        let chat_repo = ChatRepo { pool: &pool };
+        let user_message_id = match chat_repo
+            .upsert_user_message_idempotent(session_id, "hi", "01J2222222222222222222222A", 24)
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
+
+        let frames: Vec<ProtocolFrame> = run_stream(
+            std::sync::Arc::new(state),
+            PersistedUserMessage {
+                user_message_id,
+                session_id,
+                user_id,
+                instance_id,
+                content: "hi".into(),
+            },
+        )
+        .collect()
+        .await;
+
+        // Tolerant assertions: PDE may pick Ghost depending on persona/seed,
+        // but if it picks Reply the stream must end without an Error frame
+        // and end with Final.
+        assert!(
+            !frames.iter().any(|f| matches!(f, ProtocolFrame::Error { .. })),
+            "no error frame expected, got {:?}", frames,
+        );
+        assert!(matches!(frames.last(), Some(ProtocolFrame::Final { .. })));
     }
 }

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -469,6 +469,70 @@ async fn compute_final_frame(
     }
 }
 
+/// Build a frame stream from previously persisted assistant rows for a
+/// given user_message_id. The chain is given in original chronological
+/// order; emits one (meta, single-delta, done) trio per row, then one
+/// `final` computed from current session state. Ghost replay emits a
+/// synthetic Meta+Done(no usage, not truncated) followed by Final.
+pub fn replay_stream(
+    state: Arc<AppState>,
+    session_id: Uuid,
+    user_id: Uuid,
+    ghost: bool,
+    rows: Vec<eros_engine_store::chat::ChatMessage>,
+) -> impl futures_util::Stream<Item = ProtocolFrame> + Send + 'static {
+    async_stream::stream! {
+        if ghost {
+            let msg_id = Ulid::new();
+            yield ProtocolFrame::Meta {
+                message_id: ulid_string(msg_id),
+                action_type: FrameActionType::Ghost,
+                model: String::new(),
+                continues_from: None,
+            };
+            yield ProtocolFrame::Done {
+                message_id: ulid_string(msg_id),
+                truncated: false,
+                usage: None,
+                generation_id: None,
+            };
+        } else {
+            for row in &rows {
+                let msg_ulid = Ulid::from(row.id);
+                let prev_ulid = row.continues_from_message_id.map(Ulid::from);
+                let action = match row.assistant_action_type.as_deref() {
+                    Some("gift_reaction") => FrameActionType::GiftReaction,
+                    _ => FrameActionType::Reply,
+                };
+                yield ProtocolFrame::Meta {
+                    message_id: ulid_string(msg_ulid),
+                    action_type: action,
+                    model: row.model.clone().unwrap_or_default(),
+                    continues_from: prev_ulid.map(ulid_string),
+                };
+                if !row.content.is_empty() {
+                    yield ProtocolFrame::Delta {
+                        message_id: ulid_string(msg_ulid),
+                        content: row.content.clone(),
+                    };
+                }
+                let usage = row
+                    .usage
+                    .as_ref()
+                    .and_then(|v| serde_json::from_value(v.clone()).ok());
+                yield ProtocolFrame::Done {
+                    message_id: ulid_string(msg_ulid),
+                    truncated: row.truncated,
+                    usage,
+                    generation_id: row.generation_id.clone(),
+                };
+            }
+        }
+        let final_frame = compute_final_frame(&state, session_id, user_id).await;
+        yield final_frame;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -12,8 +12,13 @@ use serde::Serialize;
 use ulid::Ulid;
 
 /// Stream-level error code enum. Renders to the spec's lowercase string.
+///
+/// `RateLimited` and `Timeout` are spec-defined codes (§1.5) reserved for
+/// the per-stream rate-limit and 120s hard-timeout enforcement that the
+/// 0.2 generator does not yet implement (open §1.9 follow-up).
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
+#[allow(dead_code)]
 pub enum StreamErrorCode {
     UpstreamUnavailable,
     RateLimited,

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -82,8 +82,8 @@ pub const MAX_STREAM_FALLBACK_DEPTH: usize = 2;
 use std::sync::Arc;
 use uuid::Uuid;
 
-use eros_engine_core::types::{ActionType, DecisionInput, Event};
 use eros_engine_core::pde;
+use eros_engine_core::types::{ActionType, DecisionInput, Event};
 use eros_engine_store::affinity::AffinityRepo;
 use eros_engine_store::chat::ChatRepo;
 use eros_engine_store::persona::PersonaRepo;
@@ -96,6 +96,7 @@ use crate::state::AppState;
 /// burst, returns the produced messages via `produced_out` for the caller
 /// to spawn post_process with. Does NOT yield Final — the caller emits it
 /// after the burst so it reflects post-burst state.
+#[allow(clippy::too_many_arguments)]
 fn drive_chat_burst(
     state: Arc<AppState>,
     session_id: Uuid,
@@ -104,7 +105,9 @@ fn drive_chat_burst(
     persist_action: &'static str, // "reply" | "gift_reaction"
     plan_action: ActionType,
     req: eros_engine_llm::openrouter::ChatRequest,
-    produced_out: std::sync::Arc<std::sync::Mutex<Vec<crate::pipeline::post_process::ProducedMessage>>>,
+    produced_out: std::sync::Arc<
+        std::sync::Mutex<Vec<crate::pipeline::post_process::ProducedMessage>>,
+    >,
 ) -> impl futures_util::Stream<Item = ProtocolFrame> + Send + 'static {
     async_stream::stream! {
         let chat_repo = ChatRepo { pool: &state.pool };
@@ -440,20 +443,15 @@ pub fn run_stream(
 }
 
 /// Compute the spec's `final` frame from current session/user state.
-async fn compute_final_frame(
-    state: &AppState,
-    session_id: Uuid,
-    user_id: Uuid,
-) -> ProtocolFrame {
-    let lead_score: f64 = sqlx::query_scalar(
-        "SELECT lead_score FROM engine.chat_sessions WHERE id = $1",
-    )
-    .bind(session_id)
-    .fetch_optional(&state.pool)
-    .await
-    .ok()
-    .flatten()
-    .unwrap_or(0.0);
+async fn compute_final_frame(state: &AppState, session_id: Uuid, user_id: Uuid) -> ProtocolFrame {
+    let lead_score: f64 =
+        sqlx::query_scalar("SELECT lead_score FROM engine.chat_sessions WHERE id = $1")
+            .bind(session_id)
+            .fetch_optional(&state.pool)
+            .await
+            .ok()
+            .flatten()
+            .unwrap_or(0.0);
 
     let training_level: f64 = match (eros_engine_store::insight::InsightRepo { pool: &state.pool })
         .load(user_id)
@@ -556,7 +554,10 @@ mod tests {
         assert_eq!(v["type"], "meta");
         assert_eq!(v["action_type"], "reply");
         assert_eq!(v["model"], "x-ai/grok-4-fast");
-        assert!(v.get("continues_from").is_none(), "must be omitted when None");
+        assert!(
+            v.get("continues_from").is_none(),
+            "must be omitted when None"
+        );
         assert_eq!(v["message_id"].as_str().unwrap().len(), 26);
     }
 
@@ -576,7 +577,10 @@ mod tests {
     #[test]
     fn delta_frame_serializes_with_content() {
         let id = ulid_string(Ulid::new());
-        let f = ProtocolFrame::Delta { message_id: id.clone(), content: "你好".into() };
+        let f = ProtocolFrame::Delta {
+            message_id: id.clone(),
+            content: "你好".into(),
+        };
         let v: serde_json::Value = serde_json::to_value(&f).unwrap();
         assert_eq!(v["type"], "delta");
         assert_eq!(v["message_id"], id);
@@ -646,10 +650,7 @@ mod tests {
 
     use sqlx::PgPool;
 
-    async fn seed_persona_and_session(
-        pool: &PgPool,
-        user_id: Uuid,
-    ) -> (Uuid, Uuid, Uuid) {
+    async fn seed_persona_and_session(pool: &PgPool, user_id: Uuid) -> (Uuid, Uuid, Uuid) {
         let genome_id: Uuid = sqlx::query_scalar(
             "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata, is_active) \
              VALUES ('GhostTest', 'sp', '{}'::jsonb, true) RETURNING id",
@@ -678,8 +679,8 @@ mod tests {
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
     async fn run_stream_terminates_with_final_or_error(pool: PgPool) {
-        use futures_util::StreamExt;
         use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+        use futures_util::StreamExt;
 
         let user_id = Uuid::new_v4();
         let (_g, instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
@@ -719,10 +720,10 @@ mod tests {
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
     async fn run_stream_reply_terminates_cleanly_with_mock_openrouter(pool: PgPool) {
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
         use futures_util::StreamExt;
         use wiremock::matchers::path as wm_path;
         use wiremock::{Mock, MockServer, ResponseTemplate};
-        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
 
         let mock = MockServer::start().await;
         let body = "\
@@ -777,8 +778,10 @@ data: [DONE]\n\n";
         // but if it picks Reply the stream must end without an Error frame
         // and end with Final.
         assert!(
-            !frames.iter().any(|f| matches!(f, ProtocolFrame::Error { .. })),
-            "no error frame expected, got {:?}", frames,
+            !frames
+                .iter()
+                .any(|f| matches!(f, ProtocolFrame::Error { .. })),
+            "no error frame expected, got {frames:?}",
         );
         assert!(matches!(frames.last(), Some(ProtocolFrame::Final { .. })));
     }

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -85,6 +85,140 @@ use eros_engine_store::persona::PersonaRepo;
 
 use crate::state::AppState;
 
+/// Per-burst driver: walks the model fallback chain, emits Meta/Delta/Done
+/// per attempt, persists each logical message before its Done, and yields
+/// a final Error{UpstreamUnavailable} if the chain exhausts. On a clean
+/// burst, returns the produced messages via `produced_out` for the caller
+/// to spawn post_process with. Does NOT yield Final — the caller emits it
+/// after the burst so it reflects post-burst state.
+fn drive_chat_burst(
+    state: Arc<AppState>,
+    session_id: Uuid,
+    user_message_id: Uuid,
+    frame_action: FrameActionType,
+    persist_action: &'static str, // "reply" | "gift_reaction"
+    plan_action: ActionType,
+    req: eros_engine_llm::openrouter::ChatRequest,
+    produced_out: std::sync::Arc<std::sync::Mutex<Vec<crate::pipeline::post_process::ProducedMessage>>>,
+) -> impl futures_util::Stream<Item = ProtocolFrame> + Send + 'static {
+    async_stream::stream! {
+        let chat_repo = ChatRepo { pool: &state.pool };
+        let chain: Vec<String> = std::iter::once(req.model.clone())
+            .chain(req.fallback_model.iter().cloned())
+            .filter(|s| !s.is_empty())
+            .take(MAX_STREAM_FALLBACK_DEPTH)
+            .collect();
+        if chain.is_empty() {
+            yield ProtocolFrame::Error {
+                code: StreamErrorCode::Internal,
+                retryable: false,
+                message: "no models configured".into(),
+                user_message: "服务出现问题，请稍后再试".into(),
+            };
+            return;
+        }
+        let mut continues_from: Option<Ulid> = None;
+        for (idx, model_id) in chain.iter().enumerate() {
+            let msg_ulid = Ulid::new();
+            let msg_uuid: Uuid = msg_ulid.into();
+            let mut acc = String::new();
+            let mut last_usage: Option<eros_engine_llm::openrouter::UsageBlock> = None;
+            let mut last_gen_id: Option<String> = None;
+            let mut truncated = false;
+
+            yield ProtocolFrame::Meta {
+                message_id: ulid_string(msg_ulid),
+                action_type: frame_action,
+                model: model_id.clone(),
+                continues_from: continues_from.map(ulid_string),
+            };
+
+            let mut per_model_req = req.clone();
+            per_model_req.model = model_id.clone();
+            per_model_req.fallback_model = Vec::new();
+
+            match state.openrouter.execute_stream(per_model_req).await {
+                Ok(mut s) => {
+                    use futures_util::StreamExt as _;
+                    while let Some(item) = s.next().await {
+                        match item {
+                            Ok(c) => {
+                                if let Some(content) = c.content {
+                                    acc.push_str(&content);
+                                    yield ProtocolFrame::Delta {
+                                        message_id: ulid_string(msg_ulid),
+                                        content,
+                                    };
+                                }
+                                if c.usage.is_some()         { last_usage = c.usage; }
+                                if c.generation_id.is_some() { last_gen_id = c.generation_id; }
+                            }
+                            Err(e) => {
+                                tracing::warn!("stream: upstream chunk err: {e}");
+                                truncated = true;
+                                break;
+                            }
+                        }
+                    }
+                    if !truncated && acc.is_empty() {
+                        truncated = true;
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!("stream: upstream open err: {e}");
+                    truncated = true;
+                }
+            }
+
+            // Persist BEFORE yielding Done (spec §2.3 risk R7).
+            let row = eros_engine_store::chat::AssistantInsert {
+                id: msg_uuid,
+                content: acc.clone(),
+                assistant_action_type: persist_action.into(),
+                continues_from_message_id: continues_from.map(Into::into),
+                truncated,
+                model: Some(model_id.clone()),
+                usage: last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok()),
+                generation_id: last_gen_id.clone(),
+            };
+            if let Err(e) = chat_repo
+                .insert_assistant_batch(session_id, user_message_id, &[row])
+                .await
+            {
+                tracing::warn!("stream: assistant persist failed: {e}");
+            }
+            if let Ok(mut p) = produced_out.lock() {
+                p.push(crate::pipeline::post_process::ProducedMessage {
+                    message_id: msg_uuid,
+                    full_text: acc.clone(),
+                    action: plan_action,
+                });
+            }
+
+            yield ProtocolFrame::Done {
+                message_id: ulid_string(msg_ulid),
+                truncated,
+                usage: last_usage,
+                generation_id: last_gen_id,
+            };
+
+            if !truncated {
+                return;
+            }
+            if idx + 1 == chain.len() {
+                yield ProtocolFrame::Error {
+                    code: StreamErrorCode::UpstreamUnavailable,
+                    retryable: true,
+                    message: "all fallback models truncated".into(),
+                    user_message: "AI 服务暂时不可用，稍后再试".into(),
+                };
+                return;
+            }
+            continues_from = Some(msg_ulid);
+        }
+    }
+}
+
 /// All persisted bits needed to drive a streaming burst.
 #[derive(Debug, Clone)]
 pub struct PersistedUserMessage {
@@ -191,136 +325,65 @@ pub fn run_stream(
                 let final_frame = compute_final_frame(&state, user_msg.session_id, user_msg.user_id).await;
                 yield final_frame;
             }
-            ActionType::Reply => {
-                let req = match crate::pipeline::handlers::build_reply_request(
-                    &state, &input, &plan, user_msg.session_id, user_msg.user_id, user_msg.instance_id,
-                ).await {
+            ActionType::Reply | ActionType::GiftReaction => {
+                let is_gift = matches!(plan.action_type, ActionType::GiftReaction);
+                let req_res = if is_gift {
+                    crate::pipeline::handlers::build_gift_request(
+                        &state, &input, &plan,
+                        user_msg.session_id, user_msg.user_id, user_msg.instance_id,
+                        &[],
+                    ).await
+                } else {
+                    crate::pipeline::handlers::build_reply_request(
+                        &state, &input, &plan,
+                        user_msg.session_id, user_msg.user_id, user_msg.instance_id,
+                    ).await
+                };
+                let req = match req_res {
                     Ok(r) => r,
                     Err(e) => {
                         yield ProtocolFrame::Error {
                             code: StreamErrorCode::Internal,
                             retryable: false,
-                            message: format!("build_reply_request failed: {e}"),
+                            message: format!("build_*_request failed: {e}"),
                             user_message: "服务出现问题，请稍后再试".into(),
                         };
                         return;
                     }
                 };
-                let chain: Vec<String> = std::iter::once(req.model.clone())
-                    .chain(req.fallback_model.iter().cloned())
-                    .filter(|s| !s.is_empty())
-                    .take(MAX_STREAM_FALLBACK_DEPTH)
-                    .collect();
-                if chain.is_empty() {
-                    yield ProtocolFrame::Error {
-                        code: StreamErrorCode::Internal,
-                        retryable: false,
-                        message: "no models configured".into(),
-                        user_message: "服务出现问题，请稍后再试".into(),
-                    };
-                    return;
-                }
-                let mut produced: Vec<crate::pipeline::post_process::ProducedMessage> = Vec::new();
-                let mut continues_from: Option<Ulid> = None;
-                let mut yielded_any_done = false;
+                let (frame_action, persist_action, plan_action) = if is_gift {
+                    (FrameActionType::GiftReaction, "gift_reaction", ActionType::GiftReaction)
+                } else {
+                    (FrameActionType::Reply, "reply", ActionType::Reply)
+                };
 
-                'fallback: for (idx, model_id) in chain.iter().enumerate() {
-                    let msg_ulid = Ulid::new();
-                    let msg_uuid: Uuid = msg_ulid.into();
-                    let mut acc = String::new();
-                    let mut last_usage: Option<eros_engine_llm::openrouter::UsageBlock> = None;
-                    let mut last_gen_id: Option<String> = None;
-                    let mut truncated = false;
-
-                    yield ProtocolFrame::Meta {
-                        message_id: ulid_string(msg_ulid),
-                        action_type: FrameActionType::Reply,
-                        model: model_id.clone(),
-                        continues_from: continues_from.map(ulid_string),
-                    };
-
-                    let mut per_model_req = req.clone();
-                    per_model_req.model = model_id.clone();
-                    per_model_req.fallback_model = Vec::new();
-
-                    match state.openrouter.execute_stream(per_model_req).await {
-                        Ok(mut s) => {
-                            use futures_util::StreamExt as _;
-                            while let Some(item) = s.next().await {
-                                match item {
-                                    Ok(c) => {
-                                        if let Some(content) = c.content {
-                                            acc.push_str(&content);
-                                            yield ProtocolFrame::Delta {
-                                                message_id: ulid_string(msg_ulid),
-                                                content,
-                                            };
-                                        }
-                                        if c.usage.is_some()         { last_usage = c.usage; }
-                                        if c.generation_id.is_some() { last_gen_id = c.generation_id; }
-                                    }
-                                    Err(e) => {
-                                        tracing::warn!("stream: upstream chunk err: {e}");
-                                        truncated = true;
-                                        break;
-                                    }
-                                }
-                            }
-                            if !truncated && acc.is_empty() {
-                                truncated = true;
-                            }
+                let produced_out: std::sync::Arc<std::sync::Mutex<Vec<crate::pipeline::post_process::ProducedMessage>>> =
+                    std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+                let burst = drive_chat_burst(
+                    state.clone(),
+                    user_msg.session_id,
+                    user_msg.user_message_id,
+                    frame_action,
+                    persist_action,
+                    plan_action,
+                    req,
+                    produced_out.clone(),
+                );
+                {
+                    use futures_util::StreamExt as _;
+                    let mut burst = Box::pin(burst);
+                    while let Some(frame) = burst.next().await {
+                        if matches!(frame, ProtocolFrame::Error { .. }) {
+                            yield frame;
+                            return;
                         }
-                        Err(e) => {
-                            tracing::warn!("stream: upstream open err: {e}");
-                            truncated = true;
-                        }
+                        yield frame;
                     }
-
-                    // Persist BEFORE yielding Done (spec §2.3 risk R7).
-                    let row = eros_engine_store::chat::AssistantInsert {
-                        id: msg_uuid,
-                        content: acc.clone(),
-                        assistant_action_type: "reply".into(),
-                        continues_from_message_id: continues_from.map(Into::into),
-                        truncated,
-                        model: Some(model_id.clone()),
-                        usage: last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok()),
-                        generation_id: last_gen_id.clone(),
-                    };
-                    if let Err(e) = chat_repo
-                        .insert_assistant_batch(user_msg.session_id, user_msg.user_message_id, &[row])
-                        .await
-                    {
-                        tracing::warn!("stream: assistant persist failed: {e}");
-                    }
-                    produced.push(crate::pipeline::post_process::ProducedMessage {
-                        message_id: msg_uuid,
-                        full_text: acc.clone(),
-                        action: eros_engine_core::types::ActionType::Reply,
-                    });
-                    yielded_any_done = true;
-
-                    yield ProtocolFrame::Done {
-                        message_id: ulid_string(msg_ulid),
-                        truncated,
-                        usage: last_usage,
-                        generation_id: last_gen_id,
-                    };
-
-                    if !truncated {
-                        break 'fallback;
-                    }
-                    if idx + 1 == chain.len() {
-                        yield ProtocolFrame::Error {
-                            code: StreamErrorCode::UpstreamUnavailable,
-                            retryable: true,
-                            message: "all fallback models truncated".into(),
-                            user_message: "AI 服务暂时不可用，稍后再试".into(),
-                        };
-                        return;
-                    }
-                    continues_from = Some(msg_ulid);
                 }
+                let produced: Vec<crate::pipeline::post_process::ProducedMessage> = produced_out
+                    .lock()
+                    .map(|g| g.clone())
+                    .unwrap_or_default();
 
                 // Reset ghost streak (mirrors sync pipeline policy).
                 if let Err(e) = sqlx::query(
@@ -334,15 +397,13 @@ pub fn run_stream(
                     tracing::warn!("stream: ghost streak reset failed: {e}");
                 }
 
-                if yielded_any_done {
-                    let final_frame = compute_final_frame(&state, user_msg.session_id, user_msg.user_id).await;
-                    yield final_frame;
-                }
+                let final_frame = compute_final_frame(&state, user_msg.session_id, user_msg.user_id).await;
+                yield final_frame;
 
                 // Spawn post-process; do not await.
                 let state_bg = (*state).clone();
                 let plan_bg = plan.clone();
-                let event_bg = eros_engine_core::types::Event::UserMessage {
+                let event_bg = Event::UserMessage {
                     content: user_msg.content.clone(),
                     message_id: user_msg.user_message_id,
                     prompt_traits: vec![],
@@ -363,11 +424,6 @@ pub fn run_stream(
                     )
                     .await;
                 });
-            }
-            ActionType::GiftReaction => {
-                // T12 fills this in. For now, yield Final-only so the stream terminates.
-                let final_frame = compute_final_frame(&state, user_msg.session_id, user_msg.user_id).await;
-                yield final_frame;
             }
             _ => {
                 // Proactive and any future variants: Final-only.

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -69,6 +69,167 @@ pub fn ulid_string(u: Ulid) -> String {
     u.to_string()
 }
 
+use std::sync::Arc;
+use uuid::Uuid;
+
+use eros_engine_core::types::{ActionType, DecisionInput, Event};
+use eros_engine_core::pde;
+use eros_engine_store::affinity::AffinityRepo;
+use eros_engine_store::chat::ChatRepo;
+use eros_engine_store::persona::PersonaRepo;
+
+use crate::state::AppState;
+
+/// All persisted bits needed to drive a streaming burst.
+#[derive(Debug, Clone)]
+pub struct PersistedUserMessage {
+    pub user_message_id: Uuid,
+    pub session_id: Uuid,
+    pub user_id: Uuid,
+    pub instance_id: Uuid,
+    pub content: String,
+}
+
+/// Produce a stream of `ProtocolFrame` events for a single burst. The
+/// generator owns its `AppState` clone so it stays `'static` and survives
+/// `Sse`'s body lifetime. Task 10 implements the Ghost branch; T11/T12
+/// fill in Reply / GiftReaction.
+pub fn run_stream(
+    state: Arc<AppState>,
+    user_msg: PersistedUserMessage,
+) -> impl futures_util::Stream<Item = ProtocolFrame> + Send + 'static {
+    async_stream::stream! {
+        let chat_repo = ChatRepo { pool: &state.pool };
+        let persona_repo = PersonaRepo { pool: &state.pool };
+        let affinity_repo = AffinityRepo { pool: &state.pool };
+
+        let persona = match persona_repo.load_companion(user_msg.instance_id).await {
+            Ok(Some(p)) => p,
+            _ => {
+                yield ProtocolFrame::Error {
+                    code: StreamErrorCode::Internal,
+                    retryable: false,
+                    message: "persona instance not found".into(),
+                    user_message: "服务出现问题，请稍后再试".into(),
+                };
+                return;
+            }
+        };
+        let mut affinity = match affinity_repo
+            .load_or_create(user_msg.session_id, user_msg.user_id, user_msg.instance_id)
+            .await
+        {
+            Ok(mut a) => { a.apply_time_decay(); a }
+            Err(e) => {
+                tracing::warn!("stream: affinity load failed: {e}");
+                yield ProtocolFrame::Error {
+                    code: StreamErrorCode::Internal,
+                    retryable: false,
+                    message: format!("affinity load failed: {e}"),
+                    user_message: "服务出现问题，请稍后再试".into(),
+                };
+                return;
+            }
+        };
+        let signals = match super::compute_signals_for_session(
+            &state.pool, user_msg.session_id, &affinity,
+        ).await {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!("stream: signals failed: {e}");
+                yield ProtocolFrame::Error {
+                    code: StreamErrorCode::Internal,
+                    retryable: false,
+                    message: format!("signals failed: {e}"),
+                    user_message: "服务出现问题，请稍后再试".into(),
+                };
+                return;
+            }
+        };
+
+        let input = DecisionInput {
+            event: Event::UserMessage {
+                content: user_msg.content.clone(),
+                message_id: user_msg.user_message_id,
+                prompt_traits: vec![],
+                audit: None,
+            },
+            affinity: affinity.clone(),
+            persona,
+            signals,
+        };
+        let plan = pde::decide(&input);
+
+        match plan.action_type {
+            ActionType::Ghost => {
+                let msg_id = Ulid::new();
+                // Persist the ghost decision on the user row so replay can
+                // distinguish "ghost outcome" from "still generating" (§1.10).
+                if let Err(e) = chat_repo.mark_user_message_ghosted(user_msg.user_message_id).await {
+                    tracing::warn!("stream: ghost mark failed: {e}");
+                }
+                if let Err(e) = affinity_repo.record_ghost(&mut affinity).await {
+                    tracing::warn!("stream: record_ghost failed: {e}");
+                }
+                yield ProtocolFrame::Meta {
+                    message_id: ulid_string(msg_id),
+                    action_type: FrameActionType::Ghost,
+                    model: String::new(),
+                    continues_from: None,
+                };
+                yield ProtocolFrame::Done {
+                    message_id: ulid_string(msg_id),
+                    truncated: false,
+                    usage: None,
+                    generation_id: None,
+                };
+                let final_frame = compute_final_frame(&state, user_msg.session_id, user_msg.user_id).await;
+                yield final_frame;
+            }
+            _ => {
+                // Reply / GiftReaction implemented in T11/T12; Proactive returns Final only.
+                let final_frame = compute_final_frame(&state, user_msg.session_id, user_msg.user_id).await;
+                yield final_frame;
+            }
+        }
+    }
+}
+
+/// Compute the spec's `final` frame from current session/user state.
+async fn compute_final_frame(
+    state: &AppState,
+    session_id: Uuid,
+    user_id: Uuid,
+) -> ProtocolFrame {
+    let lead_score: f64 = sqlx::query_scalar(
+        "SELECT lead_score FROM engine.chat_sessions WHERE id = $1",
+    )
+    .bind(session_id)
+    .fetch_optional(&state.pool)
+    .await
+    .ok()
+    .flatten()
+    .unwrap_or(0.0);
+
+    let training_level: f64 = match (eros_engine_store::insight::InsightRepo { pool: &state.pool })
+        .load(user_id)
+        .await
+    {
+        Ok(Some(row)) => eros_engine_store::insight::compute_training_level(&row.insights),
+        _ => 0.0,
+    };
+    let should_show_cta = lead_score >= 7.0 && training_level >= 0.4;
+    // Normalise lead_score from 0..10 to 0..1 to match the spec's declared
+    // [0.0, 1.0] range. Operator dashboards still see the 0..10 raw value
+    // via the sync /message handler.
+    let normalised_lead = (lead_score / 10.0).clamp(0.0, 1.0);
+    ProtocolFrame::Final {
+        lead_score: normalised_lead,
+        should_show_cta,
+        agent_training_level: training_level,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -173,5 +334,78 @@ mod tests {
         // Spec §1.5 done schema permits `usage: null` — do NOT omit.
         assert!(v.get("usage").is_some());
         assert!(v["usage"].is_null());
+    }
+
+    use sqlx::PgPool;
+
+    async fn seed_persona_and_session(
+        pool: &PgPool,
+        user_id: Uuid,
+    ) -> (Uuid, Uuid, Uuid) {
+        let genome_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata, is_active) \
+             VALUES ('GhostTest', 'sp', '{}'::jsonb, true) RETURNING id",
+        )
+        .fetch_one(pool)
+        .await
+        .unwrap();
+        let instance_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_instances (genome_id, owner_uid) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(genome_id)
+        .bind(user_id)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+        let session_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(user_id)
+        .bind(instance_id)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+        (genome_id, instance_id, session_id)
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn run_stream_terminates_with_final_or_error(pool: PgPool) {
+        use futures_util::StreamExt;
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+
+        let user_id = Uuid::new_v4();
+        let (_g, instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+
+        // test_state's openrouter client points at the real api root — that's
+        // fine here because the Ghost branch never makes an LLM call. If the
+        // PDE picks Reply, the test will fail when the LLM call short-circuits;
+        // that's OK — Reply path testing lives in T11.
+        let state = std::sync::Arc::new(crate::routes::companion::test_state(pool.clone()));
+        let chat_repo = ChatRepo { pool: &state.pool };
+        let user_message_id = match chat_repo
+            .upsert_user_message_idempotent(session_id, "hi", "01J1111111111111111111111A", 24)
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
+
+        let frames: Vec<ProtocolFrame> = run_stream(
+            state.clone(),
+            PersistedUserMessage {
+                user_message_id,
+                session_id,
+                user_id,
+                instance_id,
+                content: "hi".into(),
+            },
+        )
+        .collect()
+        .await;
+
+        // Tolerant: the test just proves the generator runs end-to-end and
+        // terminates. T11/T15 add per-frame assertions for Reply/replay paths.
+        assert!(frames.last().is_some(), "must emit at least one frame");
     }
 }

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -1221,6 +1221,7 @@ pub(crate) fn test_state(pool: sqlx::PgPool) -> AppState {
         )),
         voyage: Arc::new(eros_engine_llm::voyage::VoyageClient::new("stub".into())),
         model_config: Arc::new(eros_engine_llm::model_config::ModelConfig::default()),
+        stream_slots: std::sync::Arc::new(crate::state::StreamSlots::default()),
         // s2s middleware is opted-out in companion tests (no secret
         // configured → /s2s/* returns 401). The s2s integration tests
         // in routes/s2s.rs override `marketplace_s2s_secret` after

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -45,7 +45,7 @@ use eros_engine_core::types::Event;
 use eros_engine_core::types::LlmAudit;
 use eros_engine_core::types::PromptTrait;
 use eros_engine_store::affinity::AffinityRepo;
-use eros_engine_store::chat::{ChatMessage as StoreChatMessage, ChatRepo, ChatSession};
+use eros_engine_store::chat::{ChatRepo, ChatSession};
 use eros_engine_store::insight::{compute_training_level, InsightRepo};
 use eros_engine_store::ownership::OwnershipRepo;
 use eros_engine_store::persona::PersonaRepo;

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -177,7 +177,6 @@ pub struct CompanionReplyResponse {
     pub model: Option<String>,
 }
 
-
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct HistoryQuery {
     pub limit: Option<i64>,
@@ -788,8 +787,6 @@ async fn send_message(
         model,
     }))
 }
-
-
 
 /// Paginated chat history (oldest-first) for the given session.
 #[utoipa::path(

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -177,28 +177,6 @@ pub struct CompanionReplyResponse {
     pub model: Option<String>,
 }
 
-#[derive(Debug, Serialize, utoipa::ToSchema)]
-pub struct AsyncSendResponse {
-    pub status: String,
-    pub user_message_id: Uuid,
-    pub session_id: Uuid,
-}
-
-#[derive(Debug, Serialize, utoipa::ToSchema)]
-pub struct CompanionReplyPayload {
-    pub reply: String,
-    pub message_id: Uuid,
-    pub lead_score: f64,
-    pub should_show_cta: bool,
-    pub agent_training_level: f64,
-    pub sent_at: DateTime<Utc>,
-}
-
-#[derive(Debug, Serialize, utoipa::ToSchema)]
-pub struct PendingCheckResponse {
-    pub status: String,
-    pub message: Option<CompanionReplyPayload>,
-}
 
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct HistoryQuery {
@@ -811,161 +789,7 @@ async fn send_message(
     }))
 }
 
-/// Accept a user message and process it in the background. The client
-/// then polls `/pending/{message_id}` for the assistant reply.
-#[utoipa::path(
-    post,
-    path = "/comp/chat/{session_id}/message_async",
-    tag = "companion",
-    params(("session_id" = Uuid, Path, description = "Chat session id")),
-    request_body = SendMessageRequest,
-    responses(
-        (status = 202, body = AsyncSendResponse),
-        (status = 401, description = "missing or invalid bearer"),
-        (status = 403, description = "not your session"),
-        (status = 404, description = "session not found")
-    ),
-    security(("bearer" = []))
-)]
-async fn send_message_async(
-    State(state): State<AppState>,
-    Path(session_id): Path<Uuid>,
-    Extension(AuthUser(user_id)): Extension<AuthUser>,
-    Json(mut req): Json<SendMessageRequest>,
-) -> Result<(axum::http::StatusCode, Json<AsyncSendResponse>), AppError> {
-    let session = require_session_for_user(&state, session_id, user_id).await?;
 
-    if req.message.trim().is_empty() {
-        return Err(AppError::BadRequest("message must not be empty".into()));
-    }
-
-    // Per-message NFT ownership recheck — see `send_message`.
-    let persona_repo = PersonaRepo { pool: &state.pool };
-    if let Some(instance_id) = session.instance_id {
-        let companion = persona_repo
-            .load_companion(instance_id)
-            .await?
-            .ok_or_else(|| AppError::NotFound("instance not found".into()))?;
-        let asset_id_opt = persona_repo
-            .get_asset_id_for_genome(companion.instance.genome_id)
-            .await?;
-        enforce_nft_ownership(&state.pool, user_id, asset_id_opt.as_deref()).await?;
-    }
-
-    // Validate BEFORE we persist the user message so a bad request leaves no row.
-    let prompt_traits = validate_prompt_traits(req.prompt_traits.as_deref().unwrap_or(&[]))?;
-    let audit = validate_llm_audit(req.audit.take())?;
-
-    let chat_repo = ChatRepo { pool: &state.pool };
-    let user_message_id = chat_repo
-        .append_message(session_id, "user", &req.message)
-        .await?;
-
-    let state_bg = state.clone();
-    let msg_copy = req.message.clone();
-    let traits_copy = prompt_traits;
-    let audit_copy = audit;
-    tokio::spawn(async move {
-        let event = Event::UserMessage {
-            content: msg_copy,
-            message_id: user_message_id,
-            prompt_traits: traits_copy,
-            audit: audit_copy,
-        };
-        if let Err(e) = pipeline::run(&state_bg, session_id, event).await {
-            tracing::error!("engine pipeline failed for session {session_id}: {e}");
-            let repo = ChatRepo {
-                pool: &state_bg.pool,
-            };
-            let _ = repo
-                .append_message(session_id, "system_error", &format!("AI reply failed: {e}"))
-                .await;
-        }
-    });
-
-    Ok((
-        axum::http::StatusCode::ACCEPTED,
-        Json(AsyncSendResponse {
-            status: "processing".into(),
-            user_message_id,
-            session_id,
-        }),
-    ))
-}
-
-/// Poll for the AI reply to a user message. Returns `processing` until
-/// the assistant or system_error row appears, then `completed` / `error`.
-#[utoipa::path(
-    get,
-    path = "/comp/chat/{session_id}/pending/{message_id}",
-    tag = "companion",
-    params(
-        ("session_id" = Uuid, Path, description = "Chat session id"),
-        ("message_id" = Uuid, Path, description = "User message id to poll on")
-    ),
-    responses(
-        (status = 200, body = PendingCheckResponse),
-        (status = 401, description = "missing or invalid bearer"),
-        (status = 403, description = "not your session"),
-        (status = 404, description = "session not found")
-    ),
-    security(("bearer" = []))
-)]
-async fn check_pending(
-    State(state): State<AppState>,
-    Path((session_id, message_id)): Path<(Uuid, Uuid)>,
-    Extension(AuthUser(user_id)): Extension<AuthUser>,
-) -> Result<Json<PendingCheckResponse>, AppError> {
-    require_session_for_user(&state, session_id, user_id).await?;
-
-    let reply: Option<StoreChatMessage> = sqlx::query_as::<_, StoreChatMessage>(
-        "SELECT * FROM engine.chat_messages \
-         WHERE session_id = $1 \
-           AND sent_at > (SELECT sent_at FROM engine.chat_messages WHERE id = $2) \
-           AND role IN ('assistant', 'system_error') \
-         ORDER BY sent_at ASC LIMIT 1",
-    )
-    .bind(session_id)
-    .bind(message_id)
-    .fetch_optional(&state.pool)
-    .await?;
-
-    match reply {
-        Some(msg) if msg.role == "assistant" => {
-            let lead_score: f64 =
-                sqlx::query_scalar("SELECT lead_score FROM engine.chat_sessions WHERE id = $1")
-                    .bind(session_id)
-                    .fetch_optional(&state.pool)
-                    .await
-                    .ok()
-                    .flatten()
-                    .unwrap_or(0.0);
-
-            let training_level = read_training_level(&state, user_id).await;
-            let should_show_cta = lead_score >= 7.0 && training_level >= 0.4;
-
-            Ok(Json(PendingCheckResponse {
-                status: "completed".into(),
-                message: Some(CompanionReplyPayload {
-                    reply: msg.content,
-                    message_id: msg.id,
-                    lead_score,
-                    should_show_cta,
-                    agent_training_level: training_level,
-                    sent_at: msg.sent_at,
-                }),
-            }))
-        }
-        Some(_) => Ok(Json(PendingCheckResponse {
-            status: "error".into(),
-            message: None,
-        })),
-        None => Ok(Json(PendingCheckResponse {
-            status: "processing".into(),
-            message: None,
-        })),
-    }
-}
 
 /// Paginated chat history (oldest-first) for the given session.
 #[utoipa::path(
@@ -1175,8 +999,6 @@ pub fn router() -> OpenApiRouter<AppState> {
         .routes(routes!(list_personas))
         .routes(routes!(start_chat))
         .routes(routes!(send_message))
-        .routes(routes!(send_message_async))
-        .routes(routes!(check_pending))
         .routes(routes!(get_history))
         .routes(routes!(list_sessions))
         .routes(routes!(get_profile))

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -382,7 +382,9 @@ fn typing_delay_ms_from(seed: Uuid) -> u64 {
 /// - `text.trim()` non-empty
 /// - `text.chars().count()` ≤ `MAX_PROMPT_TRAIT_TEXT_CHARS`
 /// - `text` contains no control characters (would break bullet rendering)
-fn validate_prompt_traits(dtos: &[PromptTraitDto]) -> Result<Vec<PromptTrait>, AppError> {
+pub(crate) fn validate_prompt_traits(
+    dtos: &[PromptTraitDto],
+) -> Result<Vec<PromptTrait>, AppError> {
     if dtos.len() > MAX_PROMPT_TRAITS {
         return Err(AppError::BadRequest(format!(
             "too many prompt_traits (max {MAX_PROMPT_TRAITS})"
@@ -474,7 +476,7 @@ fn filter_usage_keys(
 /// Validate a caller-supplied `audit` object against the documented caps.
 /// Returns `Ok(None)` when the field is absent. `Err(BadRequest)` for any
 /// cap violation — first failure wins so the message points at one cause.
-fn validate_llm_audit(dto: Option<LlmAuditDto>) -> Result<Option<LlmAudit>, AppError> {
+pub(crate) fn validate_llm_audit(dto: Option<LlmAuditDto>) -> Result<Option<LlmAudit>, AppError> {
     let Some(dto) = dto else { return Ok(None) };
 
     if let Some(ref u) = dto.user {
@@ -2002,194 +2004,5 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(count, 1);
-    }
-
-    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
-    async fn send_message_async_rejects_invalid_tag_regex(pool: PgPool) {
-        let user_id = Uuid::new_v4();
-        let genome_id = seed_genome(&pool, "Vega").await;
-        let instance_id = seed_instance(&pool, genome_id, user_id).await;
-        let session_id = seed_session(&pool, user_id, instance_id).await;
-
-        let state = test_state(pool.clone());
-        let mut app = build_router(state);
-        let token = mint_test_jwt(user_id);
-
-        let body = serde_json::to_vec(&json!({
-            "message": "hi",
-            "prompt_traits": [{ "tag": "BadTag", "text": "x" }],
-        }))
-        .unwrap();
-
-        let req = Request::builder()
-            .method("POST")
-            .uri(format!("/comp/chat/{session_id}/message_async"))
-            .header(header::AUTHORIZATION, format!("Bearer {token}"))
-            .header(header::CONTENT_TYPE, "application/json")
-            .body(Body::from(body))
-            .unwrap();
-        let (status, _resp) = send_request(&mut app, req).await;
-        assert_eq!(status, StatusCode::BAD_REQUEST);
-
-        // Async route also validates BEFORE persisting — no user row.
-        let count: i64 =
-            sqlx::query_scalar("SELECT COUNT(*) FROM engine.chat_messages WHERE session_id = $1")
-                .bind(session_id)
-                .fetch_one(&pool)
-                .await
-                .unwrap();
-        assert_eq!(count, 0);
-    }
-
-    // ─── LlmAudit HTTP integration tests ────────────────────────────
-
-    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
-    async fn send_message_async_rejects_oversized_audit_user(pool: PgPool) {
-        let user_id = Uuid::new_v4();
-        let genome_id = seed_genome(&pool, "Vega").await;
-        let instance_id = seed_instance(&pool, genome_id, user_id).await;
-        let session_id = seed_session(&pool, user_id, instance_id).await;
-
-        let state = test_state(pool.clone());
-        let mut app = build_router(state);
-        let token = mint_test_jwt(user_id);
-
-        let body = serde_json::to_vec(&json!({
-            "message": "hi",
-            "audit": { "user": "x".repeat(MAX_LLM_AUDIT_STRING_CHARS + 1) },
-        }))
-        .unwrap();
-
-        let req = Request::builder()
-            .method("POST")
-            .uri(format!("/comp/chat/{session_id}/message_async"))
-            .header(header::AUTHORIZATION, format!("Bearer {token}"))
-            .header(header::CONTENT_TYPE, "application/json")
-            .body(Body::from(body))
-            .unwrap();
-        let (status, _resp) = send_request(&mut app, req).await;
-        assert_eq!(status, StatusCode::BAD_REQUEST);
-
-        let count: i64 =
-            sqlx::query_scalar("SELECT COUNT(*) FROM engine.chat_messages WHERE session_id = $1")
-                .bind(session_id)
-                .fetch_one(&pool)
-                .await
-                .unwrap();
-        assert_eq!(count, 0, "validation must fire before persistence");
-    }
-
-    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
-    async fn send_message_async_rejects_too_many_metadata_keys(pool: PgPool) {
-        let user_id = Uuid::new_v4();
-        let genome_id = seed_genome(&pool, "Vega").await;
-        let instance_id = seed_instance(&pool, genome_id, user_id).await;
-        let session_id = seed_session(&pool, user_id, instance_id).await;
-
-        let state = test_state(pool.clone());
-        let mut app = build_router(state);
-        let token = mint_test_jwt(user_id);
-
-        let mut metadata = serde_json::Map::new();
-        for i in 0..(MAX_LLM_AUDIT_METADATA_KEYS + 1) {
-            metadata.insert(format!("k{i}"), Value::String("v".into()));
-        }
-        let body = serde_json::to_vec(&json!({
-            "message": "hi",
-            "audit": { "metadata": metadata },
-        }))
-        .unwrap();
-
-        let req = Request::builder()
-            .method("POST")
-            .uri(format!("/comp/chat/{session_id}/message_async"))
-            .header(header::AUTHORIZATION, format!("Bearer {token}"))
-            .header(header::CONTENT_TYPE, "application/json")
-            .body(Body::from(body))
-            .unwrap();
-        let (status, _resp) = send_request(&mut app, req).await;
-        assert_eq!(status, StatusCode::BAD_REQUEST);
-    }
-
-    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
-    async fn send_message_async_rejects_non_string_metadata_value(pool: PgPool) {
-        let user_id = Uuid::new_v4();
-        let genome_id = seed_genome(&pool, "Vega").await;
-        let instance_id = seed_instance(&pool, genome_id, user_id).await;
-        let session_id = seed_session(&pool, user_id, instance_id).await;
-
-        let state = test_state(pool.clone());
-        let mut app = build_router(state);
-        let token = mint_test_jwt(user_id);
-
-        let body = serde_json::to_vec(&json!({
-            "message": "hi",
-            "audit": { "metadata": { "feature": 123 } },
-        }))
-        .unwrap();
-
-        let req = Request::builder()
-            .method("POST")
-            .uri(format!("/comp/chat/{session_id}/message_async"))
-            .header(header::AUTHORIZATION, format!("Bearer {token}"))
-            .header(header::CONTENT_TYPE, "application/json")
-            .body(Body::from(body))
-            .unwrap();
-        let (status, _resp) = send_request(&mut app, req).await;
-        assert_eq!(status, StatusCode::BAD_REQUEST);
-    }
-
-    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
-    async fn send_message_async_accepts_valid_audit(pool: PgPool) {
-        let user_id = Uuid::new_v4();
-        let genome_id = seed_genome(&pool, "Vega").await;
-        let instance_id = seed_instance(&pool, genome_id, user_id).await;
-        let session_id = seed_session(&pool, user_id, instance_id).await;
-
-        let state = test_state(pool.clone());
-        let mut app = build_router(state);
-        let token = mint_test_jwt(user_id);
-
-        let body = serde_json::to_vec(&json!({
-            "message": "hi",
-            "audit": {
-                "user": "u_abc",
-                "session_id": "conv_xyz",
-                "metadata": { "feature": "chat", "plan": "pro" }
-            },
-        }))
-        .unwrap();
-
-        let req = Request::builder()
-            .method("POST")
-            .uri(format!("/comp/chat/{session_id}/message_async"))
-            .header(header::AUTHORIZATION, format!("Bearer {token}"))
-            .header(header::CONTENT_TYPE, "application/json")
-            .body(Body::from(body))
-            .unwrap();
-        let (status, _resp) = send_request(&mut app, req).await;
-        assert_eq!(status, StatusCode::ACCEPTED);
-
-        let user_msg_count: i64 = sqlx::query_scalar(
-            "SELECT COUNT(*) FROM engine.chat_messages WHERE session_id = $1 AND role = 'user'",
-        )
-        .bind(session_id)
-        .fetch_one(&pool)
-        .await
-        .unwrap();
-        assert_eq!(user_msg_count, 1);
-
-        let leak_count: i64 = sqlx::query_scalar(
-            "SELECT COUNT(*) FROM engine.chat_messages \
-             WHERE session_id = $1 AND (content LIKE '%u_abc%' OR content LIKE '%conv_xyz%')",
-        )
-        .bind(session_id)
-        .fetch_one(&pool)
-        .await
-        .unwrap();
-        assert_eq!(
-            leak_count, 0,
-            "audit strings must never appear in chat_messages.content"
-        );
     }
 }

--- a/crates/eros-engine-server/src/routes/companion_stream.rs
+++ b/crates/eros-engine-server/src/routes/companion_stream.rs
@@ -21,20 +21,25 @@ use eros_engine_store::persona::PersonaRepo;
 use crate::auth::middleware::AuthUser;
 use crate::error::{AppError, StreamPreError};
 use crate::pipeline::stream::{replay_stream, run_stream, PersistedUserMessage, ProtocolFrame};
-use crate::routes::companion::enforce_nft_ownership;
+use crate::routes::companion::{
+    enforce_nft_ownership, validate_llm_audit, validate_prompt_traits, LlmAuditDto, PromptTraitDto,
+};
 use crate::state::AppState;
 
 const MAX_CONTENT_CHARS: usize = 4096;
 const MIN_CLIENT_MSG_ID_LEN: usize = 26;
 const MAX_CLIENT_MSG_ID_LEN: usize = 36;
 const CONCURRENT_STREAMS_PER_USER: u32 = 3;
-const IDEMPOTENCY_WINDOW_HOURS: i64 = 24;
 const SSE_KEEPALIVE_SECS: u64 = 15;
 
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct StreamSendRequest {
     pub content: String,
     pub client_msg_id: String,
+    #[serde(default)]
+    pub prompt_traits: Option<Vec<PromptTraitDto>>,
+    #[serde(default)]
+    pub audit: Option<LlmAuditDto>,
 }
 
 /// Pre-stream error body per spec §1.3. Schema-only struct for utoipa;
@@ -117,10 +122,29 @@ pub async fn send_message_stream(
     State(state): State<AppState>,
     Path(session_id): Path<Uuid>,
     Extension(AuthUser(user_id)): Extension<AuthUser>,
-    Json(req): Json<StreamSendRequest>,
+    Json(mut req): Json<StreamSendRequest>,
 ) -> Result<Sse<impl Stream<Item = Result<Event, Infallible>>>, AppError> {
     // Validate payload first — before any DB call — so 422/400 never waste a roundtrip.
     validate_payload(&req)?;
+    let prompt_traits = validate_prompt_traits(req.prompt_traits.as_deref().unwrap_or(&[]))
+        .map_err(|e| {
+            AppError::StreamPre(StreamPreError {
+                status: StatusCode::BAD_REQUEST,
+                code: "invalid_payload",
+                message: e.to_string(),
+                user_message: "请求无效".into(),
+                original_user_message_id: None,
+            })
+        })?;
+    let audit = validate_llm_audit(req.audit.take()).map_err(|e| {
+        AppError::StreamPre(StreamPreError {
+            status: StatusCode::BAD_REQUEST,
+            code: "invalid_payload",
+            message: e.to_string(),
+            user_message: "请求无效".into(),
+            original_user_message_id: None,
+        })
+    })?;
 
     let chat_repo = ChatRepo { pool: &state.pool };
     let session = chat_repo.get_session(session_id).await?.ok_or_else(|| {
@@ -176,12 +200,7 @@ pub async fn send_message_stream(
         })?;
 
     let outcome = chat_repo
-        .upsert_user_message_idempotent(
-            session_id,
-            &req.content,
-            &req.client_msg_id,
-            IDEMPOTENCY_WINDOW_HOURS,
-        )
+        .upsert_user_message_idempotent(session_id, &req.content, &req.client_msg_id)
         .await?;
     // Resolve the proto stream. Replay returns early with a boxed stream;
     // Inserted continues to run_stream below. Boxing erases the concrete type
@@ -196,6 +215,8 @@ pub async fn send_message_stream(
                     user_id,
                     instance_id,
                     content: req.content.clone(),
+                    prompt_traits: prompt_traits.clone(),
+                    audit: audit.clone(),
                 };
                 Box::pin(run_stream(state_arc, user_msg))
             }
@@ -348,7 +369,7 @@ mod tests {
         // Pre-seed an original-request outcome.
         let chat_repo = ChatRepo { pool: &pool };
         let user_msg_id = match chat_repo
-            .upsert_user_message_idempotent(session_id, "hi", "01J3333333333333333333333A", 24)
+            .upsert_user_message_idempotent(session_id, "hi", "01J3333333333333333333333A")
             .await
             .unwrap()
         {

--- a/crates/eros-engine-server/src/routes/companion_stream.rs
+++ b/crates/eros-engine-server/src/routes/companion_stream.rs
@@ -20,7 +20,7 @@ use eros_engine_store::persona::PersonaRepo;
 
 use crate::auth::middleware::AuthUser;
 use crate::error::{AppError, StreamPreError};
-use crate::pipeline::stream::{run_stream, PersistedUserMessage, ProtocolFrame};
+use crate::pipeline::stream::{replay_stream, run_stream, PersistedUserMessage, ProtocolFrame};
 use crate::routes::companion::enforce_nft_ownership;
 use crate::state::AppState;
 
@@ -185,43 +185,42 @@ pub async fn send_message_stream(
             IDEMPOTENCY_WINDOW_HOURS,
         )
         .await?;
-    let user_message_id = match outcome {
-        UpsertUserOutcome::Inserted { message_id } => message_id,
-        UpsertUserOutcome::DuplicateInProgress { user_message_id } => {
-            return Err(AppError::StreamPre(StreamPreError {
-                status: StatusCode::CONFLICT,
-                code: "duplicate_in_progress",
-                message: "same (session_id, client_msg_id) is still generating".into(),
-                user_message: "上一条消息正在处理中，请稍候".into(),
-                original_user_message_id: Some(user_message_id),
-            }));
-        }
-        UpsertUserOutcome::Replay { .. } => {
-            // T15 implements the replay path. Until then, signal 409 so we
-            // don't double-bill OpenRouter for repeat requests.
-            return Err(AppError::StreamPre(StreamPreError {
-                status: StatusCode::CONFLICT,
-                code: "duplicate_in_progress",
-                message: "replay path not yet implemented (T15)".into(),
-                user_message: "请稍后重试".into(),
-                original_user_message_id: None,
-            }));
-        }
-    };
-
-    let state_arc = Arc::new(state.clone());
-    let user_msg = PersistedUserMessage {
-        user_message_id,
-        session_id,
-        user_id,
-        instance_id,
-        content: req.content.clone(),
-    };
+    // Resolve the proto stream. Replay returns early with a boxed stream;
+    // Inserted continues to run_stream below. Boxing erases the concrete type
+    // so both branches can feed the same SSE wrapper.
+    let proto: std::pin::Pin<Box<dyn futures_util::Stream<Item = ProtocolFrame> + Send>> =
+        match outcome {
+            UpsertUserOutcome::Inserted { message_id } => {
+                let state_arc = Arc::new(state.clone());
+                let user_msg = PersistedUserMessage {
+                    user_message_id: message_id,
+                    session_id,
+                    user_id,
+                    instance_id,
+                    content: req.content.clone(),
+                };
+                Box::pin(run_stream(state_arc, user_msg))
+            }
+            UpsertUserOutcome::DuplicateInProgress { user_message_id } => {
+                return Err(AppError::StreamPre(StreamPreError {
+                    status: StatusCode::CONFLICT,
+                    code: "duplicate_in_progress",
+                    message: "same (session_id, client_msg_id) is still generating".into(),
+                    user_message: "上一条消息正在处理中，请稍候".into(),
+                    original_user_message_id: Some(user_message_id),
+                }));
+            }
+            UpsertUserOutcome::Replay { ghost, assistant_chain, .. } => {
+                let state_arc = Arc::new(state.clone());
+                Box::pin(replay_stream(
+                    state_arc, session_id, user_id, ghost, assistant_chain,
+                ))
+            }
+        };
 
     // Move the StreamSlotGuard into the stream so it is released only when
     // the response body finishes. `StreamSlotGuard` holds `Arc<StreamSlots>`
     // so it satisfies the `'static` bound required by axum's `Sse`.
-    let proto = run_stream(state_arc, user_msg);
     let sse = futures_util::StreamExt::map(
         async_stream::stream! {
             let _guard = guard;
@@ -309,5 +308,73 @@ mod tests {
         let body = to_bytes(resp.into_body(), 1024).await.unwrap();
         let v: Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(v["code"], "unprocessable");
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn stream_replay_emits_same_frames_for_repeat_client_msg_id(pool: PgPool) {
+        use eros_engine_store::chat::{AssistantInsert, ChatRepo, UpsertUserOutcome};
+        let user_id = Uuid::new_v4();
+        let genome_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata, is_active) \
+             VALUES ('R', 'p', '{}'::jsonb, true) RETURNING id",
+        )
+        .fetch_one(&pool).await.unwrap();
+        let instance_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_instances (genome_id, owner_uid) VALUES ($1, $2) RETURNING id",
+        ).bind(genome_id).bind(user_id).fetch_one(&pool).await.unwrap();
+        let session_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
+        ).bind(user_id).bind(instance_id).fetch_one(&pool).await.unwrap();
+
+        // Pre-seed an original-request outcome.
+        let chat_repo = ChatRepo { pool: &pool };
+        let user_msg_id = match chat_repo
+            .upsert_user_message_idempotent(session_id, "hi", "01J3333333333333333333333A", 24)
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
+        let assistant_uuid: Uuid = ulid::Ulid::new().into();
+        chat_repo
+            .insert_assistant_batch(
+                session_id,
+                user_msg_id,
+                &[AssistantInsert {
+                    id: assistant_uuid,
+                    content: "replayed reply".into(),
+                    assistant_action_type: "reply".into(),
+                    continues_from_message_id: None,
+                    truncated: false,
+                    model: Some("primary".into()),
+                    usage: Some(serde_json::json!({"prompt_tokens":1,"completion_tokens":2,"total_tokens":3})),
+                    generation_id: Some("gen-1".into()),
+                }],
+            )
+            .await
+            .unwrap();
+
+        let state = crate::routes::companion::test_state(pool);
+        let mut app = build_router(state);
+        let token = mint_jwt(user_id);
+        let body = serde_json::to_vec(&json!({"content":"hi","client_msg_id":"01J3333333333333333333333A"})).unwrap();
+        let req = Request::builder()
+            .method("POST")
+            .uri(format!("/comp/chat/{session_id}/message/stream"))
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        let resp = app.call(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let ct = resp.headers().get(header::CONTENT_TYPE).unwrap().to_str().unwrap();
+        assert!(ct.starts_with("text/event-stream"));
+        let bytes = to_bytes(resp.into_body(), 1024 * 1024).await.unwrap();
+        let body_text = std::str::from_utf8(&bytes).unwrap();
+        // The replayed delta carries the persisted content verbatim.
+        assert!(body_text.contains("replayed reply"), "body: {body_text}");
+        // And the final frame closes the stream.
+        assert!(body_text.contains("\"type\":\"final\""), "body: {body_text}");
     }
 }

--- a/crates/eros-engine-server/src/routes/companion_stream.rs
+++ b/crates/eros-engine-server/src/routes/companion_stream.rs
@@ -1,0 +1,313 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! POST /comp/chat/{session_id}/message/stream — SSE streaming chat.
+//!
+//! Spec: docs/superpowers/specs/2026-05-19-sse-streaming-chat-0.2-design.md
+
+use axum::extract::{Extension, Path, State};
+use axum::http::StatusCode;
+use axum::response::sse::{Event, KeepAlive, Sse};
+use axum::Json;
+use futures_util::Stream;
+use serde::{Deserialize, Serialize};
+use std::convert::Infallible;
+use std::sync::Arc;
+use std::time::Duration;
+use utoipa_axum::{router::OpenApiRouter, routes};
+use uuid::Uuid;
+
+use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+use eros_engine_store::persona::PersonaRepo;
+
+use crate::auth::middleware::AuthUser;
+use crate::error::{AppError, StreamPreError};
+use crate::pipeline::stream::{run_stream, PersistedUserMessage, ProtocolFrame};
+use crate::routes::companion::enforce_nft_ownership;
+use crate::state::AppState;
+
+const MAX_CONTENT_CHARS: usize = 4096;
+const MIN_CLIENT_MSG_ID_LEN: usize = 26;
+const MAX_CLIENT_MSG_ID_LEN: usize = 36;
+const CONCURRENT_STREAMS_PER_USER: u32 = 3;
+const IDEMPOTENCY_WINDOW_HOURS: i64 = 24;
+const SSE_KEEPALIVE_SECS: u64 = 15;
+
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
+pub struct StreamSendRequest {
+    pub content: String,
+    pub client_msg_id: String,
+}
+
+/// Pre-stream error body per spec §1.3. Schema-only struct for utoipa;
+/// runtime renders the same shape via StreamPreError.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct StreamPreErrorBody {
+    pub code: String,
+    pub message: String,
+    pub user_message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub original_user_message_id: Option<String>,
+}
+
+fn validate_payload(req: &StreamSendRequest) -> Result<(), AppError> {
+    if req.content.is_empty() {
+        return Err(AppError::StreamPre(StreamPreError {
+            status: StatusCode::UNPROCESSABLE_ENTITY,
+            code: "unprocessable",
+            message: "content must not be empty".into(),
+            user_message: "请输入一条消息".into(),
+            original_user_message_id: None,
+        }));
+    }
+    if req.content.chars().count() > MAX_CONTENT_CHARS {
+        return Err(AppError::StreamPre(StreamPreError {
+            status: StatusCode::UNPROCESSABLE_ENTITY,
+            code: "unprocessable",
+            message: format!("content exceeds {MAX_CONTENT_CHARS} chars"),
+            user_message: "消息过长，请缩短后重试".into(),
+            original_user_message_id: None,
+        }));
+    }
+    let id_len = req.client_msg_id.len();
+    if !(MIN_CLIENT_MSG_ID_LEN..=MAX_CLIENT_MSG_ID_LEN).contains(&id_len) {
+        return Err(AppError::StreamPre(StreamPreError {
+            status: StatusCode::BAD_REQUEST,
+            code: "invalid_payload",
+            message: format!(
+                "client_msg_id must be {MIN_CLIENT_MSG_ID_LEN}..={MAX_CLIENT_MSG_ID_LEN} chars"
+            ),
+            user_message: "请求无效".into(),
+            original_user_message_id: None,
+        }));
+    }
+    if req
+        .client_msg_id
+        .chars()
+        .any(|c| c.is_whitespace() || !c.is_ascii() || !c.is_ascii_graphic())
+    {
+        return Err(AppError::StreamPre(StreamPreError {
+            status: StatusCode::BAD_REQUEST,
+            code: "invalid_payload",
+            message: "client_msg_id must be ASCII printable, no whitespace".into(),
+            user_message: "请求无效".into(),
+            original_user_message_id: None,
+        }));
+    }
+    Ok(())
+}
+
+#[utoipa::path(
+    post,
+    path = "/comp/chat/{session_id}/message/stream",
+    tag = "companion",
+    params(("session_id" = Uuid, Path, description = "Chat session id")),
+    request_body = StreamSendRequest,
+    responses(
+        (status = 200, description = "SSE event stream (text/event-stream)", content_type = "text/event-stream"),
+        (status = 400, body = StreamPreErrorBody),
+        (status = 401, description = "missing or invalid bearer"),
+        (status = 403, body = StreamPreErrorBody),
+        (status = 404, body = StreamPreErrorBody),
+        (status = 409, body = StreamPreErrorBody),
+        (status = 422, body = StreamPreErrorBody),
+        (status = 429, body = StreamPreErrorBody),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn send_message_stream(
+    State(state): State<AppState>,
+    Path(session_id): Path<Uuid>,
+    Extension(AuthUser(user_id)): Extension<AuthUser>,
+    Json(req): Json<StreamSendRequest>,
+) -> Result<Sse<impl Stream<Item = Result<Event, Infallible>>>, AppError> {
+    // Validate payload first — before any DB call — so 422/400 never waste a roundtrip.
+    validate_payload(&req)?;
+
+    let chat_repo = ChatRepo { pool: &state.pool };
+    let session = chat_repo.get_session(session_id).await?.ok_or_else(|| {
+        AppError::StreamPre(StreamPreError {
+            status: StatusCode::NOT_FOUND,
+            code: "session_not_found",
+            message: "session not found".into(),
+            user_message: "会话不存在".into(),
+            original_user_message_id: None,
+        })
+    })?;
+    if session.user_id != user_id {
+        return Err(AppError::StreamPre(StreamPreError {
+            status: StatusCode::FORBIDDEN,
+            code: "session_forbidden",
+            message: "session not owned by JWT user".into(),
+            user_message: "无权访问该会话".into(),
+            original_user_message_id: None,
+        }));
+    }
+    let instance_id = session.instance_id.ok_or_else(|| {
+        AppError::StreamPre(StreamPreError {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            code: "internal",
+            message: "session has no instance_id".into(),
+            user_message: "服务出现问题，请稍后再试".into(),
+            original_user_message_id: None,
+        })
+    })?;
+    let persona_repo = PersonaRepo { pool: &state.pool };
+    let companion = persona_repo
+        .load_companion(instance_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("instance not found".into()))?;
+    let asset_id_opt = persona_repo
+        .get_asset_id_for_genome(companion.instance.genome_id)
+        .await?;
+    enforce_nft_ownership(&state.pool, user_id, asset_id_opt.as_deref()).await?;
+
+    // Acquire a stream slot. `StreamSlotGuard` is now `'static` (holds Arc),
+    // so it can be moved into the SSE body below.
+    let guard = state
+        .stream_slots
+        .try_acquire(user_id, CONCURRENT_STREAMS_PER_USER)
+        .ok_or_else(|| {
+            AppError::StreamPre(StreamPreError {
+                status: StatusCode::TOO_MANY_REQUESTS,
+                code: "rate_limited",
+                message: format!(
+                    "per-user stream cap reached ({CONCURRENT_STREAMS_PER_USER})"
+                ),
+                user_message: "请求过多，请稍后再试".into(),
+                original_user_message_id: None,
+            })
+        })?;
+
+    let outcome = chat_repo
+        .upsert_user_message_idempotent(
+            session_id,
+            &req.content,
+            &req.client_msg_id,
+            IDEMPOTENCY_WINDOW_HOURS,
+        )
+        .await?;
+    let user_message_id = match outcome {
+        UpsertUserOutcome::Inserted { message_id } => message_id,
+        UpsertUserOutcome::DuplicateInProgress { user_message_id } => {
+            return Err(AppError::StreamPre(StreamPreError {
+                status: StatusCode::CONFLICT,
+                code: "duplicate_in_progress",
+                message: "same (session_id, client_msg_id) is still generating".into(),
+                user_message: "上一条消息正在处理中，请稍候".into(),
+                original_user_message_id: Some(user_message_id),
+            }));
+        }
+        UpsertUserOutcome::Replay { .. } => {
+            // T15 implements the replay path. Until then, signal 409 so we
+            // don't double-bill OpenRouter for repeat requests.
+            return Err(AppError::StreamPre(StreamPreError {
+                status: StatusCode::CONFLICT,
+                code: "duplicate_in_progress",
+                message: "replay path not yet implemented (T15)".into(),
+                user_message: "请稍后重试".into(),
+                original_user_message_id: None,
+            }));
+        }
+    };
+
+    let state_arc = Arc::new(state.clone());
+    let user_msg = PersistedUserMessage {
+        user_message_id,
+        session_id,
+        user_id,
+        instance_id,
+        content: req.content.clone(),
+    };
+
+    // Move the StreamSlotGuard into the stream so it is released only when
+    // the response body finishes. `StreamSlotGuard` holds `Arc<StreamSlots>`
+    // so it satisfies the `'static` bound required by axum's `Sse`.
+    let proto = run_stream(state_arc, user_msg);
+    let sse = futures_util::StreamExt::map(
+        async_stream::stream! {
+            let _guard = guard;
+            futures_util::pin_mut!(proto);
+            while let Some(frame) = futures_util::StreamExt::next(&mut proto).await {
+                yield frame;
+            }
+        },
+        |frame: ProtocolFrame| {
+            let json = serde_json::to_string(&frame)
+                .expect("ProtocolFrame serialization is infallible");
+            Ok::<_, Infallible>(Event::default().data(json))
+        },
+    );
+
+    Ok(Sse::new(sse).keep_alive(
+        KeepAlive::new()
+            .interval(Duration::from_secs(SSE_KEEPALIVE_SECS))
+            .text("ping"),
+    ))
+}
+
+pub fn router() -> OpenApiRouter<AppState> {
+    OpenApiRouter::new().routes(routes!(send_message_stream))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::{to_bytes, Body};
+    use axum::http::{header, Request};
+    use axum::Router;
+    use jsonwebtoken::{encode, EncodingKey, Header};
+    use serde_json::{json, Value};
+    use sqlx::PgPool;
+    use tower::Service;
+
+    fn mint_jwt(uid: Uuid) -> String {
+        let exp = (chrono::Utc::now() + chrono::Duration::hours(1)).timestamp();
+        encode(
+            &Header::default(),
+            &json!({ "sub": uid.to_string(), "exp": exp }),
+            &EncodingKey::from_secret(crate::routes::companion::TEST_SECRET.as_ref()),
+        )
+        .unwrap()
+    }
+
+    fn build_router(state: AppState) -> Router {
+        let (axum, _api) = crate::routes::router(state.clone()).split_for_parts();
+        axum.with_state(state)
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn stream_422_when_content_empty(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata, is_active) \
+             VALUES ('S', 'p', '{}'::jsonb, true) RETURNING id",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let instance_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_instances (genome_id, owner_uid) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(genome_id).bind(user_id).fetch_one(&pool).await.unwrap();
+        let session_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(user_id).bind(instance_id).fetch_one(&pool).await.unwrap();
+
+        let state = crate::routes::companion::test_state(pool);
+        let mut app = build_router(state);
+        let token = mint_jwt(user_id);
+        let body = serde_json::to_vec(&json!({"content":"","client_msg_id":"01J2222222222222222222222A"})).unwrap();
+        let req = Request::builder()
+            .method("POST")
+            .uri(format!("/comp/chat/{session_id}/message/stream"))
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        let resp = app.call(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body = to_bytes(resp.into_body(), 1024).await.unwrap();
+        let v: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["code"], "unprocessable");
+    }
+}

--- a/crates/eros-engine-server/src/routes/companion_stream.rs
+++ b/crates/eros-engine-server/src/routes/companion_stream.rs
@@ -169,9 +169,7 @@ pub async fn send_message_stream(
             AppError::StreamPre(StreamPreError {
                 status: StatusCode::TOO_MANY_REQUESTS,
                 code: "rate_limited",
-                message: format!(
-                    "per-user stream cap reached ({CONCURRENT_STREAMS_PER_USER})"
-                ),
+                message: format!("per-user stream cap reached ({CONCURRENT_STREAMS_PER_USER})"),
                 user_message: "请求过多，请稍后再试".into(),
                 original_user_message_id: None,
             })
@@ -210,10 +208,18 @@ pub async fn send_message_stream(
                     original_user_message_id: Some(user_message_id),
                 }));
             }
-            UpsertUserOutcome::Replay { ghost, assistant_chain, .. } => {
+            UpsertUserOutcome::Replay {
+                ghost,
+                assistant_chain,
+                ..
+            } => {
                 let state_arc = Arc::new(state.clone());
                 Box::pin(replay_stream(
-                    state_arc, session_id, user_id, ghost, assistant_chain,
+                    state_arc,
+                    session_id,
+                    user_id,
+                    ghost,
+                    assistant_chain,
                 ))
             }
         };
@@ -230,8 +236,8 @@ pub async fn send_message_stream(
             }
         },
         |frame: ProtocolFrame| {
-            let json = serde_json::to_string(&frame)
-                .expect("ProtocolFrame serialization is infallible");
+            let json =
+                serde_json::to_string(&frame).expect("ProtocolFrame serialization is infallible");
             Ok::<_, Infallible>(Event::default().data(json))
         },
     );
@@ -290,12 +296,18 @@ mod tests {
         let session_id: Uuid = sqlx::query_scalar(
             "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
         )
-        .bind(user_id).bind(instance_id).fetch_one(&pool).await.unwrap();
+        .bind(user_id)
+        .bind(instance_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
 
         let state = crate::routes::companion::test_state(pool);
         let mut app = build_router(state);
         let token = mint_jwt(user_id);
-        let body = serde_json::to_vec(&json!({"content":"","client_msg_id":"01J2222222222222222222222A"})).unwrap();
+        let body =
+            serde_json::to_vec(&json!({"content":"","client_msg_id":"01J2222222222222222222222A"}))
+                .unwrap();
         let req = Request::builder()
             .method("POST")
             .uri(format!("/comp/chat/{session_id}/message/stream"))
@@ -318,13 +330,20 @@ mod tests {
             "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata, is_active) \
              VALUES ('R', 'p', '{}'::jsonb, true) RETURNING id",
         )
-        .fetch_one(&pool).await.unwrap();
+        .fetch_one(&pool)
+        .await
+        .unwrap();
         let instance_id: Uuid = sqlx::query_scalar(
             "INSERT INTO engine.persona_instances (genome_id, owner_uid) VALUES ($1, $2) RETURNING id",
         ).bind(genome_id).bind(user_id).fetch_one(&pool).await.unwrap();
         let session_id: Uuid = sqlx::query_scalar(
             "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
-        ).bind(user_id).bind(instance_id).fetch_one(&pool).await.unwrap();
+        )
+        .bind(user_id)
+        .bind(instance_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
 
         // Pre-seed an original-request outcome.
         let chat_repo = ChatRepo { pool: &pool };
@@ -358,7 +377,10 @@ mod tests {
         let state = crate::routes::companion::test_state(pool);
         let mut app = build_router(state);
         let token = mint_jwt(user_id);
-        let body = serde_json::to_vec(&json!({"content":"hi","client_msg_id":"01J3333333333333333333333A"})).unwrap();
+        let body = serde_json::to_vec(
+            &json!({"content":"hi","client_msg_id":"01J3333333333333333333333A"}),
+        )
+        .unwrap();
         let req = Request::builder()
             .method("POST")
             .uri(format!("/comp/chat/{session_id}/message/stream"))
@@ -368,13 +390,21 @@ mod tests {
             .unwrap();
         let resp = app.call(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
-        let ct = resp.headers().get(header::CONTENT_TYPE).unwrap().to_str().unwrap();
+        let ct = resp
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .unwrap()
+            .to_str()
+            .unwrap();
         assert!(ct.starts_with("text/event-stream"));
         let bytes = to_bytes(resp.into_body(), 1024 * 1024).await.unwrap();
         let body_text = std::str::from_utf8(&bytes).unwrap();
         // The replayed delta carries the persisted content verbatim.
         assert!(body_text.contains("replayed reply"), "body: {body_text}");
         // And the final frame closes the stream.
-        assert!(body_text.contains("\"type\":\"final\""), "body: {body_text}");
+        assert!(
+            body_text.contains("\"type\":\"final\""),
+            "body: {body_text}"
+        );
     }
 }

--- a/crates/eros-engine-server/src/routes/mod.rs
+++ b/crates/eros-engine-server/src/routes/mod.rs
@@ -21,6 +21,7 @@ use crate::auth::s2s::require_s2s;
 use crate::state::AppState;
 
 pub mod companion;
+pub mod companion_stream;
 pub mod debug;
 pub mod health;
 pub mod s2s;
@@ -35,6 +36,7 @@ pub mod s2s;
 pub fn router(state: AppState) -> OpenApiRouter<AppState> {
     let comp = OpenApiRouter::new()
         .merge(companion::router())
+        .merge(companion_stream::router())
         .merge(debug::router(state.config.expose_affinity_debug))
         .layer(from_fn_with_state(state.clone(), require_auth));
 
@@ -54,6 +56,7 @@ pub fn router_for_openapi(expose_affinity_debug: bool) -> OpenApiRouter<AppState
     OpenApiRouter::new()
         .merge(health::router())
         .merge(companion::router())
+        .merge(companion_stream::router())
         .merge(debug::router(expose_affinity_debug))
         .merge(s2s::router())
 }

--- a/crates/eros-engine-server/src/state.rs
+++ b/crates/eros-engine-server/src/state.rs
@@ -66,7 +66,13 @@ pub struct StreamSlots {
 }
 
 impl StreamSlots {
-    pub fn try_acquire(&self, user_id: Uuid, cap: u32) -> Option<StreamSlotGuard> {
+    /// Attempt to acquire a stream slot for `user_id`.
+    ///
+    /// Returns `Some(StreamSlotGuard)` if the current count is below `cap`,
+    /// or `None` if the cap is already reached. The guard is `'static` (it
+    /// holds an `Arc<StreamSlots>`) so it can be moved into SSE stream bodies
+    /// without lifetime trouble.
+    pub fn try_acquire(self: &Arc<Self>, user_id: Uuid, cap: u32) -> Option<StreamSlotGuard> {
         let mut guard = self.inner.lock().expect("StreamSlots mutex poisoned");
         let entry = guard.entry(user_id).or_insert(0);
         if *entry >= cap {
@@ -74,18 +80,22 @@ impl StreamSlots {
         }
         *entry += 1;
         Some(StreamSlotGuard {
-            slots: self,
+            slots: Arc::clone(self),
             user_id,
         })
     }
 }
 
-pub struct StreamSlotGuard<'a> {
-    slots: &'a StreamSlots,
+/// An RAII guard that decrements the per-user stream count when dropped.
+///
+/// Holds an `Arc<StreamSlots>` so it is `'static` and can be moved into
+/// long-lived futures / SSE stream bodies.
+pub struct StreamSlotGuard {
+    slots: Arc<StreamSlots>,
     user_id: Uuid,
 }
 
-impl Drop for StreamSlotGuard<'_> {
+impl Drop for StreamSlotGuard {
     fn drop(&mut self) {
         if let Ok(mut guard) = self.slots.inner.lock() {
             if let Some(count) = guard.get_mut(&self.user_id) {
@@ -226,7 +236,7 @@ mod tests {
 
     #[test]
     fn stream_slots_acquire_until_cap_then_blocks() {
-        let slots = StreamSlots::default();
+        let slots = Arc::new(StreamSlots::default());
         let uid = Uuid::new_v4();
 
         let g1 = slots.try_acquire(uid, 2).expect("1st acquire under cap");

--- a/crates/eros-engine-server/src/state.rs
+++ b/crates/eros-engine-server/src/state.rs
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 use sqlx::PgPool;
-use std::collections::HashSet;
-use std::sync::Arc;
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
+use uuid::Uuid;
 
 #[derive(Clone)]
 pub struct AppState {
@@ -13,6 +14,7 @@ pub struct AppState {
     pub openrouter: Arc<eros_engine_llm::openrouter::OpenRouterClient>,
     pub voyage: Arc<eros_engine_llm::voyage::VoyageClient>,
     pub model_config: Arc<eros_engine_llm::model_config::ModelConfig>,
+    pub stream_slots: Arc<StreamSlots>,
     /// Base URL of the marketplace service used by the self-heal /since
     /// puller. `None` runs the engine in OSS-only mode (no outbound pull
     /// loop spawned). Populated from `MARKETPLACE_SVC_URL` in main.rs.
@@ -48,6 +50,52 @@ pub(crate) fn parse_usage_hidden_keys(raw: Option<&str>) -> HashSet<String> {
         .filter(|s| !s.is_empty())
         .map(String::from)
         .collect()
+}
+
+/// Per-user in-flight SSE stream counter. Used by the
+/// `send_message_stream` handler to enforce spec §1.9 (≤3 concurrent
+/// active streams per user, returning HTTP 429 over the cap).
+///
+/// Lock contention is negligible: each handler hits the map twice — once
+/// to acquire, once to release — and the map is small (one entry per
+/// active user). A Mutex<HashMap> beats taking on a `dashmap` dependency
+/// for a hot path that runs at chat cadence.
+#[derive(Debug, Default)]
+pub struct StreamSlots {
+    inner: Mutex<HashMap<Uuid, u32>>,
+}
+
+impl StreamSlots {
+    pub fn try_acquire(&self, user_id: Uuid, cap: u32) -> Option<StreamSlotGuard> {
+        let mut guard = self.inner.lock().expect("StreamSlots mutex poisoned");
+        let entry = guard.entry(user_id).or_insert(0);
+        if *entry >= cap {
+            return None;
+        }
+        *entry += 1;
+        Some(StreamSlotGuard {
+            slots: self,
+            user_id,
+        })
+    }
+}
+
+pub struct StreamSlotGuard<'a> {
+    slots: &'a StreamSlots,
+    user_id: Uuid,
+}
+
+impl Drop for StreamSlotGuard<'_> {
+    fn drop(&mut self) {
+        if let Ok(mut guard) = self.slots.inner.lock() {
+            if let Some(count) = guard.get_mut(&self.user_id) {
+                *count = count.saturating_sub(1);
+                if *count == 0 {
+                    guard.remove(&self.user_id);
+                }
+            }
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -174,5 +222,18 @@ mod tests {
     fn usage_hidden_keys_from_env_empty_when_blank() {
         let out = parse_usage_hidden_keys(Some(""));
         assert!(out.is_empty());
+    }
+
+    #[test]
+    fn stream_slots_acquire_until_cap_then_blocks() {
+        let slots = StreamSlots::default();
+        let uid = Uuid::new_v4();
+
+        let g1 = slots.try_acquire(uid, 2).expect("1st acquire under cap");
+        let g2 = slots.try_acquire(uid, 2).expect("2nd acquire at cap-1");
+        assert!(slots.try_acquire(uid, 2).is_none(), "3rd at cap rejected");
+        drop(g1);
+        let _g3 = slots.try_acquire(uid, 2).expect("acquire after drop ok");
+        drop(g2);
     }
 }

--- a/crates/eros-engine-store/Cargo.toml
+++ b/crates/eros-engine-store/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "memory", "pgvector", "postgres", "sqlx"]
 categories = ["database"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "0.1.3" }
+eros-engine-core = { path = "../eros-engine-core", version = "0.2.0" }
 sqlx = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/eros-engine-store/migrations/0012_chat_streaming.sql
+++ b/crates/eros-engine-store/migrations/0012_chat_streaming.sql
@@ -1,0 +1,51 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+--
+-- engine.chat_messages gains the metadata needed for SSE streaming + idempotent
+-- replay. Spec §2.5.
+--
+-- Columns are nullable / default-safe so the existing sync `/message` handler
+-- (which never sets them) keeps working. The replay path tolerates NULL
+-- columns by synthesising sensible defaults.
+
+ALTER TABLE engine.chat_messages
+    -- Caller-supplied idempotency key, set only on role='user' rows from the
+    -- streaming handler. NULL for everything else (sync path, gift_user,
+    -- system_error, all assistant rows).
+    ADD COLUMN client_msg_id TEXT NULL,
+    -- Marker set on the user row when the AI chose Ghost for this turn,
+    -- so replay can distinguish ghost-result from "still generating".
+    ADD COLUMN ghost_decision BOOLEAN NOT NULL DEFAULT false,
+    -- On assistant rows, the user-message id that drove this burst. NULL
+    -- for sync-path rows (which the streaming path never reads). Used by
+    -- the replay path to find all assistant rows for a (session, client_msg_id).
+    ADD COLUMN user_message_id UUID NULL,
+    -- On assistant rows, the prior assistant message this one continues.
+    -- Only set when a fallback model fired after a truncated primary.
+    ADD COLUMN continues_from_message_id UUID NULL,
+    -- Assistant-row only: was this logical message cut off mid-stream?
+    ADD COLUMN truncated BOOLEAN NOT NULL DEFAULT false,
+    -- Replay metadata: model id actually served, OpenRouter usage block,
+    -- OpenRouter generation id. NULL on rows the streaming path never
+    -- produced (sync handler keeps writing only id/role/content).
+    ADD COLUMN model TEXT NULL,
+    ADD COLUMN usage JSONB NULL,
+    ADD COLUMN generation_id TEXT NULL,
+    -- Assistant-row only: encodes whether the row is a normal reply or a
+    -- gift_reaction. NULL on user / gift_user / system_error rows and on
+    -- legacy assistant rows from the sync path.
+    ADD COLUMN assistant_action_type TEXT NULL
+        CHECK (assistant_action_type IS NULL
+               OR assistant_action_type IN ('reply', 'gift_reaction'));
+
+-- Unique on (session_id, client_msg_id) for user rows — application enforces
+-- the 24 h window by filtering on sent_at when checking for collisions. The
+-- partial predicate excludes legacy NULL rows (every pre-0.2 row) so the
+-- index is small.
+CREATE UNIQUE INDEX chat_messages_client_msg_id_uidx
+    ON engine.chat_messages (session_id, client_msg_id)
+    WHERE client_msg_id IS NOT NULL;
+
+-- Speeds replay-lookup of "all assistant rows for this user message".
+CREATE INDEX chat_messages_user_message_id_idx
+    ON engine.chat_messages (user_message_id)
+    WHERE user_message_id IS NOT NULL;

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -207,7 +207,7 @@ pub struct AssistantInsert {
 /// to decide between normal processing, replay, and 409.
 #[derive(Debug)]
 pub enum UpsertUserOutcome {
-    /// First time seeing `(session_id, client_msg_id)` within the window.
+    /// First time seeing `(session_id, client_msg_id)`.
     Inserted { message_id: Uuid },
     /// Original request completed. Caller should synthesise SSE frames from
     /// the persisted rows (assistant_chain may be empty for a ghost outcome).
@@ -222,32 +222,31 @@ pub enum UpsertUserOutcome {
 }
 
 impl<'a> ChatRepo<'a> {
-    /// Insert a user message keyed by `client_msg_id`, deduplicating within
-    /// the last `window_hours` hours. Application-level enforcement of the
-    /// 24 h window (vs a partial unique index with `now()`, which Postgres
-    /// rejects). Resolves the outcome under one short-lived transaction so
-    /// the dedup decision and write happen against a consistent snapshot.
+    /// Insert a user message keyed by `client_msg_id` with permanent
+    /// idempotency. The partial unique index on `(session_id, client_msg_id)`
+    /// has no time component, so deduplication is permanent: any prior row
+    /// with the same key is a replay candidate. A future janitor can GC old
+    /// rows, but the application treats any prior `(session_id, client_msg_id)`
+    /// row as authoritative. Resolves the outcome under one short-lived
+    /// transaction so the dedup decision and write happen against a consistent
+    /// snapshot.
     pub async fn upsert_user_message_idempotent(
         &self,
         session_id: Uuid,
         content: &str,
         client_msg_id: &str,
-        window_hours: i64,
     ) -> Result<UpsertUserOutcome, sqlx::Error> {
         let mut tx = self.pool.begin().await?;
 
-        // Look for an existing user row with the same (session_id, client_msg_id)
-        // inside the dedup window. The partial unique index guarantees at most
-        // one match if any.
+        // Look for an existing user row with the same (session_id, client_msg_id).
+        // The partial unique index guarantees at most one match if any.
         let existing: Option<ChatMessage> = sqlx::query_as::<_, ChatMessage>(
             "SELECT * FROM engine.chat_messages \
              WHERE session_id = $1 AND client_msg_id = $2 AND role = 'user' \
-               AND sent_at > now() - make_interval(hours => $3) \
              LIMIT 1",
         )
         .bind(session_id)
         .bind(client_msg_id)
-        .bind(window_hours)
         .fetch_optional(&mut *tx)
         .await?;
 
@@ -437,7 +436,7 @@ mod tests {
         let s = repo.create_session(user_id, instance_id).await.unwrap();
 
         let outcome = repo
-            .upsert_user_message_idempotent(s.id, "hello", "01J0000000000000000000000A", 24)
+            .upsert_user_message_idempotent(s.id, "hello", "01J0000000000000000000000A")
             .await
             .unwrap();
         match outcome {
@@ -456,7 +455,7 @@ mod tests {
         let s = repo.create_session(user_id, instance_id).await.unwrap();
 
         let first = match repo
-            .upsert_user_message_idempotent(s.id, "hello", "01J0000000000000000000000A", 24)
+            .upsert_user_message_idempotent(s.id, "hello", "01J0000000000000000000000A")
             .await
             .unwrap()
         {
@@ -484,7 +483,7 @@ mod tests {
         .unwrap();
 
         let outcome = repo
-            .upsert_user_message_idempotent(s.id, "hello", "01J0000000000000000000000A", 24)
+            .upsert_user_message_idempotent(s.id, "hello", "01J0000000000000000000000A")
             .await
             .unwrap();
         match outcome {
@@ -510,7 +509,7 @@ mod tests {
         let s = repo.create_session(user_id, instance_id).await.unwrap();
 
         let first = match repo
-            .upsert_user_message_idempotent(s.id, "hello", "01J0000000000000000000000A", 24)
+            .upsert_user_message_idempotent(s.id, "hello", "01J0000000000000000000000A")
             .await
             .unwrap()
         {
@@ -519,7 +518,7 @@ mod tests {
         };
 
         match repo
-            .upsert_user_message_idempotent(s.id, "hello", "01J0000000000000000000000A", 24)
+            .upsert_user_message_idempotent(s.id, "hello", "01J0000000000000000000000A")
             .await
             .unwrap()
         {
@@ -538,7 +537,7 @@ mod tests {
         let s = repo.create_session(user_id, instance_id).await.unwrap();
 
         let first = match repo
-            .upsert_user_message_idempotent(s.id, "hello", "01J0000000000000000000000A", 24)
+            .upsert_user_message_idempotent(s.id, "hello", "01J0000000000000000000000A")
             .await
             .unwrap()
         {
@@ -548,7 +547,7 @@ mod tests {
         repo.mark_user_message_ghosted(first).await.unwrap();
 
         match repo
-            .upsert_user_message_idempotent(s.id, "hello", "01J0000000000000000000000A", 24)
+            .upsert_user_message_idempotent(s.id, "hello", "01J0000000000000000000000A")
             .await
             .unwrap()
         {

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -276,7 +276,9 @@ impl<'a> ChatRepo<'a> {
                     assistant_chain: vec![],
                 }
             } else {
-                UpsertUserOutcome::DuplicateInProgress { user_message_id: row.id }
+                UpsertUserOutcome::DuplicateInProgress {
+                    user_message_id: row.id,
+                }
             });
         }
 
@@ -472,7 +474,9 @@ mod tests {
                 continues_from_message_id: None,
                 truncated: false,
                 model: Some("x-ai/grok-4-fast".into()),
-                usage: Some(serde_json::json!({"prompt_tokens":3,"completion_tokens":2,"total_tokens":5})),
+                usage: Some(
+                    serde_json::json!({"prompt_tokens":3,"completion_tokens":2,"total_tokens":5}),
+                ),
                 generation_id: Some("gen-1".into()),
             }],
         )
@@ -484,7 +488,11 @@ mod tests {
             .await
             .unwrap();
         match outcome {
-            UpsertUserOutcome::Replay { user_message_id, ghost, assistant_chain } => {
+            UpsertUserOutcome::Replay {
+                user_message_id,
+                ghost,
+                assistant_chain,
+            } => {
                 assert_eq!(user_message_id, first);
                 assert!(!ghost);
                 assert_eq!(assistant_chain.len(), 1);
@@ -544,7 +552,11 @@ mod tests {
             .await
             .unwrap()
         {
-            UpsertUserOutcome::Replay { ghost, assistant_chain, .. } => {
+            UpsertUserOutcome::Replay {
+                ghost,
+                assistant_chain,
+                ..
+            } => {
                 assert!(ghost);
                 assert!(assistant_chain.is_empty());
             }

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -36,6 +36,26 @@ pub struct ChatMessage {
     pub content: String,
     pub extracted_facts: Option<serde_json::Value>,
     pub sent_at: DateTime<Utc>,
+
+    // Streaming + idempotency metadata (added in migration 0012).
+    #[serde(default)]
+    pub client_msg_id: Option<String>,
+    #[serde(default)]
+    pub ghost_decision: bool,
+    #[serde(default)]
+    pub user_message_id: Option<Uuid>,
+    #[serde(default)]
+    pub continues_from_message_id: Option<Uuid>,
+    #[serde(default)]
+    pub truncated: bool,
+    #[serde(default)]
+    pub model: Option<String>,
+    #[serde(default)]
+    pub usage: Option<serde_json::Value>,
+    #[serde(default)]
+    pub generation_id: Option<String>,
+    #[serde(default)]
+    pub assistant_action_type: Option<String>,
 }
 
 pub struct ChatRepo<'a> {
@@ -170,6 +190,173 @@ impl<'a> ChatRepo<'a> {
     }
 }
 
+/// One assistant row to insert in a burst.
+#[derive(Debug, Clone)]
+pub struct AssistantInsert {
+    pub id: Uuid,
+    pub content: String,
+    pub assistant_action_type: String, // "reply" | "gift_reaction"
+    pub continues_from_message_id: Option<Uuid>,
+    pub truncated: bool,
+    pub model: Option<String>,
+    pub usage: Option<serde_json::Value>,
+    pub generation_id: Option<String>,
+}
+
+/// Outcome of `upsert_user_message_idempotent`. The application uses this
+/// to decide between normal processing, replay, and 409.
+#[derive(Debug)]
+pub enum UpsertUserOutcome {
+    /// First time seeing `(session_id, client_msg_id)` within the window.
+    Inserted { message_id: Uuid },
+    /// Original request completed. Caller should synthesise SSE frames from
+    /// the persisted rows (assistant_chain may be empty for a ghost outcome).
+    Replay {
+        user_message_id: Uuid,
+        ghost: bool,
+        assistant_chain: Vec<ChatMessage>,
+    },
+    /// Same key seen, but no assistant row and no ghost flag — the original
+    /// request is still in flight. Caller should return HTTP 409.
+    DuplicateInProgress { user_message_id: Uuid },
+}
+
+impl<'a> ChatRepo<'a> {
+    /// Insert a user message keyed by `client_msg_id`, deduplicating within
+    /// the last `window_hours` hours. Application-level enforcement of the
+    /// 24 h window (vs a partial unique index with `now()`, which Postgres
+    /// rejects). Resolves the outcome under one short-lived transaction so
+    /// the dedup decision and write happen against a consistent snapshot.
+    pub async fn upsert_user_message_idempotent(
+        &self,
+        session_id: Uuid,
+        content: &str,
+        client_msg_id: &str,
+        window_hours: i64,
+    ) -> Result<UpsertUserOutcome, sqlx::Error> {
+        let mut tx = self.pool.begin().await?;
+
+        // Look for an existing user row with the same (session_id, client_msg_id)
+        // inside the dedup window. The partial unique index guarantees at most
+        // one match if any.
+        let existing: Option<ChatMessage> = sqlx::query_as::<_, ChatMessage>(
+            "SELECT * FROM engine.chat_messages \
+             WHERE session_id = $1 AND client_msg_id = $2 AND role = 'user' \
+               AND sent_at > now() - make_interval(hours => $3) \
+             LIMIT 1",
+        )
+        .bind(session_id)
+        .bind(client_msg_id)
+        .bind(window_hours)
+        .fetch_optional(&mut *tx)
+        .await?;
+
+        if let Some(row) = existing {
+            let assistant_chain: Vec<ChatMessage> = sqlx::query_as::<_, ChatMessage>(
+                "SELECT * FROM engine.chat_messages \
+                 WHERE user_message_id = $1 AND role = 'assistant' \
+                 ORDER BY sent_at ASC",
+            )
+            .bind(row.id)
+            .fetch_all(&mut *tx)
+            .await?;
+
+            tx.commit().await?;
+
+            return Ok(if !assistant_chain.is_empty() {
+                UpsertUserOutcome::Replay {
+                    user_message_id: row.id,
+                    ghost: false,
+                    assistant_chain,
+                }
+            } else if row.ghost_decision {
+                UpsertUserOutcome::Replay {
+                    user_message_id: row.id,
+                    ghost: true,
+                    assistant_chain: vec![],
+                }
+            } else {
+                UpsertUserOutcome::DuplicateInProgress { user_message_id: row.id }
+            });
+        }
+
+        // First time: insert + bump last_active_at.
+        let id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_messages (session_id, role, content, client_msg_id) \
+             VALUES ($1, 'user', $2, $3) RETURNING id",
+        )
+        .bind(session_id)
+        .bind(content)
+        .bind(client_msg_id)
+        .fetch_one(&mut *tx)
+        .await?;
+        sqlx::query("UPDATE engine.chat_sessions SET last_active_at = now() WHERE id = $1")
+            .bind(session_id)
+            .execute(&mut *tx)
+            .await?;
+        tx.commit().await?;
+        Ok(UpsertUserOutcome::Inserted { message_id: id })
+    }
+
+    /// Mark a user message as having received a `ghost` decision from the
+    /// pipeline. Idempotent — re-marking is a no-op.
+    pub async fn mark_user_message_ghosted(
+        &self,
+        user_message_id: Uuid,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query(
+            "UPDATE engine.chat_messages SET ghost_decision = true \
+             WHERE id = $1 AND role = 'user' AND ghost_decision = false",
+        )
+        .bind(user_message_id)
+        .execute(self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Persist a burst of assistant messages keyed back to the driving user
+    /// message. Caller picks the ULID-shaped `id` so the streamed `meta.message_id`
+    /// matches the DB row. Bumps `last_active_at` once at the end.
+    pub async fn insert_assistant_batch(
+        &self,
+        session_id: Uuid,
+        user_message_id: Uuid,
+        rows: &[AssistantInsert],
+    ) -> Result<(), sqlx::Error> {
+        if rows.is_empty() {
+            return Ok(());
+        }
+        let mut tx = self.pool.begin().await?;
+        for row in rows {
+            sqlx::query(
+                "INSERT INTO engine.chat_messages \
+                   (id, session_id, role, content, user_message_id, \
+                    continues_from_message_id, truncated, model, usage, generation_id, \
+                    assistant_action_type) \
+                 VALUES ($1, $2, 'assistant', $3, $4, $5, $6, $7, $8, $9, $10)",
+            )
+            .bind(row.id)
+            .bind(session_id)
+            .bind(&row.content)
+            .bind(user_message_id)
+            .bind(row.continues_from_message_id)
+            .bind(row.truncated)
+            .bind(&row.model)
+            .bind(&row.usage)
+            .bind(&row.generation_id)
+            .bind(&row.assistant_action_type)
+            .execute(&mut *tx)
+            .await?;
+        }
+        sqlx::query("UPDATE engine.chat_sessions SET last_active_at = now() WHERE id = $1")
+            .bind(session_id)
+            .execute(&mut *tx)
+            .await?;
+        tx.commit().await?;
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -238,5 +425,130 @@ mod tests {
         let first = repo.create_session(user_id, instance_id).await.unwrap();
         let resumed = repo.create_or_resume(user_id, instance_id).await.unwrap();
         assert_eq!(first.id, resumed.id);
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn upsert_user_message_idempotent_first_insert(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let user_id = Uuid::new_v4();
+        let instance_id = Uuid::new_v4();
+        let s = repo.create_session(user_id, instance_id).await.unwrap();
+
+        let outcome = repo
+            .upsert_user_message_idempotent(s.id, "hello", "01J0000000000000000000000A", 24)
+            .await
+            .unwrap();
+        match outcome {
+            UpsertUserOutcome::Inserted { message_id } => {
+                assert_ne!(message_id, Uuid::nil());
+            }
+            other => panic!("expected Inserted, got {other:?}"),
+        }
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn upsert_user_message_idempotent_replay_after_done(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let user_id = Uuid::new_v4();
+        let instance_id = Uuid::new_v4();
+        let s = repo.create_session(user_id, instance_id).await.unwrap();
+
+        let first = match repo
+            .upsert_user_message_idempotent(s.id, "hello", "01J0000000000000000000000A", 24)
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            o => panic!("expected Inserted, got {o:?}"),
+        };
+
+        repo.insert_assistant_batch(
+            s.id,
+            first,
+            &[AssistantInsert {
+                id: Uuid::new_v4(),
+                content: "hi back".into(),
+                assistant_action_type: "reply".into(),
+                continues_from_message_id: None,
+                truncated: false,
+                model: Some("x-ai/grok-4-fast".into()),
+                usage: Some(serde_json::json!({"prompt_tokens":3,"completion_tokens":2,"total_tokens":5})),
+                generation_id: Some("gen-1".into()),
+            }],
+        )
+        .await
+        .unwrap();
+
+        let outcome = repo
+            .upsert_user_message_idempotent(s.id, "hello", "01J0000000000000000000000A", 24)
+            .await
+            .unwrap();
+        match outcome {
+            UpsertUserOutcome::Replay { user_message_id, ghost, assistant_chain } => {
+                assert_eq!(user_message_id, first);
+                assert!(!ghost);
+                assert_eq!(assistant_chain.len(), 1);
+                assert_eq!(assistant_chain[0].content, "hi back");
+            }
+            other => panic!("expected Replay, got {other:?}"),
+        }
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn upsert_user_message_idempotent_409_when_no_assistant_and_not_ghost(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let user_id = Uuid::new_v4();
+        let instance_id = Uuid::new_v4();
+        let s = repo.create_session(user_id, instance_id).await.unwrap();
+
+        let first = match repo
+            .upsert_user_message_idempotent(s.id, "hello", "01J0000000000000000000000A", 24)
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            o => panic!("expected Inserted, got {o:?}"),
+        };
+
+        match repo
+            .upsert_user_message_idempotent(s.id, "hello", "01J0000000000000000000000A", 24)
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::DuplicateInProgress { user_message_id } => {
+                assert_eq!(user_message_id, first);
+            }
+            other => panic!("expected DuplicateInProgress, got {other:?}"),
+        }
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn upsert_user_message_idempotent_replay_when_ghost(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let user_id = Uuid::new_v4();
+        let instance_id = Uuid::new_v4();
+        let s = repo.create_session(user_id, instance_id).await.unwrap();
+
+        let first = match repo
+            .upsert_user_message_idempotent(s.id, "hello", "01J0000000000000000000000A", 24)
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            o => panic!("expected Inserted, got {o:?}"),
+        };
+        repo.mark_user_message_ghosted(first).await.unwrap();
+
+        match repo
+            .upsert_user_message_idempotent(s.id, "hello", "01J0000000000000000000000A", 24)
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Replay { ghost, assistant_chain, .. } => {
+                assert!(ghost);
+                assert!(assistant_chain.is_empty());
+            }
+            other => panic!("expected Replay, got {other:?}"),
+        }
     }
 }

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -80,7 +80,57 @@ curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json"
 
 `is_new=false` if you call `/start` again with the same `genome_id` for the same user — the engine resumes the existing session rather than creating a duplicate.
 
+### `POST /comp/chat/{session_id}/message/stream`
+
+Streaming chat turn. Returns `text/event-stream` with the
+`meta → delta* → done → final` state machine described in the
+[SSE streaming chat 0.2 design spec](superpowers/specs/2026-05-19-sse-streaming-chat-0.2-design.md).
+
+The body **must** include `client_msg_id` (26..36 ASCII-printable chars,
+any UUID or ULID). Replays of the same `(session_id, client_msg_id)` within
+24 h reconstruct the original frames from the database without re-calling
+OpenRouter.
+
+```bash
+curl -N -X POST \
+  -H "Authorization: Bearer $JWT" \
+  -H "Content-Type: application/json" \
+  -H "Accept: text/event-stream" \
+  -d '{"content":"hi","client_msg_id":"01J3333333333333333333333A"}' \
+  http://localhost:8080/comp/chat/<session_id>/message/stream
+```
+
+Sample frames (one JSON object per `data:` line):
+
+```text
+data: {"type":"meta","message_id":"01J...","action_type":"reply","model":"x-ai/grok-4-fast"}
+
+data: {"type":"delta","message_id":"01J...","content":"你好"}
+
+data: {"type":"done","message_id":"01J...","truncated":false,"usage":{"prompt_tokens":12,"completion_tokens":4,"total_tokens":16},"generation_id":"gen-abc"}
+
+data: {"type":"final","lead_score":0.42,"should_show_cta":false,"agent_training_level":0.18}
+```
+
+Concurrent active streams per user are capped at 3. The keep-alive heartbeat
+(`: ping`) is emitted every 15 s so reverse-proxies don't time out the
+idle connection.
+
+Pre-stream errors (HTTP 4xx/5xx before the first SSE byte) carry a JSON
+body with `code`, `message`, `user_message` and — for
+`409 duplicate_in_progress` — an `original_user_message_id`. See the
+[spec](superpowers/specs/2026-05-19-sse-streaming-chat-0.2-design.md#13-pre-stream-errors-http-status-json-body)
+for the full code table.
+
+Once the first SSE byte has been written, terminal failures arrive as an
+in-band `error` frame and the stream closes; the HTTP response has already
+committed `200 OK`.
+
 ### `POST /comp/chat/{session_id}/message`
+
+> **Deprecated in 0.2.** Prefer `/message/stream` for new integrations.
+> The sync endpoint is retained through the 0.2.x patch window and
+> removed in 0.3.0.
 
 Synchronous chat turn. Blocks until the LLM responds.
 
@@ -108,9 +158,7 @@ curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json"
 `usage` / `generation_id` / `model` are optional echoes of OpenRouter's
 response. They are omitted when upstream didn't return them or when no
 LLM call was made for this turn. The engine treats `usage` as an opaque
-JSON object — callers deserialize as needed. Only on `/message`; the
-`/message_async` route does not surface these fields (see
-[llm-audit.md](llm-audit.md)).
+JSON object — callers deserialize as needed. See [llm-audit.md](llm-audit.md).
 
 **Optional: per-request prompt traits.** The body may include a
 `prompt_traits` array — see [prompt-traits.md](prompt-traits.md). Example:
@@ -149,27 +197,6 @@ curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json"
 Caps: `audit.user` and `audit.session_id` ≤ 256 chars; `audit.metadata`
 ≤ 16 keys, key matches `[A-Za-z0-9_.-]{1,64}`, value is a string ≤ 512
 chars. Violations return `400 BadRequest`.
-
-Both `prompt_traits` and `audit` are accepted by `/message_async` as
-well — the async route does not surface `usage` / `generation_id` /
-`model` on its response, but the audit fields still ride through to
-OpenRouter.
-
-### `POST /comp/chat/{session_id}/message_async`
-
-Same shape as `/message` but returns a `message_id` immediately. The LLM call runs in background; poll `/pending/{message_id}` until it's ready.
-
-### `GET /comp/chat/{session_id}/pending/{message_id}`
-
-```json
-{ "ready": false }
-```
-
-or:
-
-```json
-{ "ready": true, "reply": { /* same shape as /message response */ } }
-```
 
 ### `GET /comp/chat/{session_id}/history?limit=50&offset=0`
 

--- a/docs/api-reference.zh.md
+++ b/docs/api-reference.zh.md
@@ -80,7 +80,51 @@ curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json"
 
 `is_new=false` 表示同一用戶用同一個 `genome_id` 再調 `/start`——引擎恢復已有 session 而不是建重複的。
 
+### `POST /comp/chat/{session_id}/message/stream`
+
+流式聊天，返回 `text/event-stream`，使用 `meta → delta* → done → final`
+状态机（详见 [SSE streaming chat 0.2 设计文档](superpowers/specs/2026-05-19-sse-streaming-chat-0.2-design.md)）。
+
+请求体必须包含 `client_msg_id`（26..36 个 ASCII 可打印字符，任意 UUID 或
+ULID）。24 小时内同一对 `(session_id, client_msg_id)` 的重复请求将从
+数据库重放历史帧，不会再次调用 OpenRouter。
+
+```bash
+curl -N -X POST \
+  -H "Authorization: Bearer $JWT" \
+  -H "Content-Type: application/json" \
+  -H "Accept: text/event-stream" \
+  -d '{"content":"hi","client_msg_id":"01J3333333333333333333333A"}' \
+  http://localhost:8080/comp/chat/<session_id>/message/stream
+```
+
+示例帧（每行 `data:` 后跟一个 JSON 对象）：
+
+```text
+data: {"type":"meta","message_id":"01J...","action_type":"reply","model":"x-ai/grok-4-fast"}
+
+data: {"type":"delta","message_id":"01J...","content":"你好"}
+
+data: {"type":"done","message_id":"01J...","truncated":false,"usage":{"prompt_tokens":12,"completion_tokens":4,"total_tokens":16},"generation_id":"gen-abc"}
+
+data: {"type":"final","lead_score":0.42,"should_show_cta":false,"agent_training_level":0.18}
+```
+
+每个用户最多 3 条并发活跃流。保活心跳（`: ping`）每 15 秒发一次，
+防止反向代理因空闲超时断开连接。
+
+流前错误（第一个 SSE 字节写出之前的 HTTP 4xx/5xx）携带含 `code`、
+`message`、`user_message` 字段的 JSON 响应体；`409 duplicate_in_progress`
+时还会带 `original_user_message_id`。完整错误码表见
+[设计文档](superpowers/specs/2026-05-19-sse-streaming-chat-0.2-design.md#13-pre-stream-errors-http-status-json-body)。
+
+一旦第一个 SSE 字节写出，终端错误以带内 `error` 帧的形式到达并关闭流；
+此时 HTTP 响应已提交 `200 OK`。
+
 ### `POST /comp/chat/{session_id}/message`
+
+> **0.2 弃用。** 新接入请改用 `/message/stream`。同步端点在 0.2.x 期间
+> 保留兼容，在 0.3.0 中正式移除。
 
 同步對話一輪。阻塞到 LLM 響應為止。
 
@@ -107,8 +151,7 @@ curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json"
 
 `usage` / `generation_id` / `model` 是 OpenRouter 响应的可选回显。
 上游未返回或本轮没有 LLM 调用时省略。引擎把 `usage` 当作不透明 JSON
-对象，调用方按需反序列化。只有 `/message` 会带，`/message_async`
-不在响应里暴露这三个字段（详见 [llm-audit.zh.md](llm-audit.zh.md)）。
+对象，调用方按需反序列化。详见 [llm-audit.zh.md](llm-audit.zh.md)。
 
 **可选：单轮 prompt traits。** 请求体可附加 `prompt_traits` 数组 ——
 详见 [prompt-traits.zh.md](prompt-traits.zh.md)。示例：
@@ -147,26 +190,6 @@ curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json"
 限制：`audit.user` 与 `audit.session_id` ≤ 256 字符；`audit.metadata`
 ≤ 16 个 key，key 满足 `[A-Za-z0-9_.-]{1,64}`，value 必须是 string
 且 ≤ 512 字符。违反返回 `400 BadRequest`。
-
-`prompt_traits` 与 `audit` 同样被 `/message_async` 接受 —— 异步路由
-的响应里不带 `usage` / `generation_id` / `model`，但 audit 字段仍会
-透传到 OpenRouter。
-
-### `POST /comp/chat/{session_id}/message_async`
-
-跟 `/message` 形狀一樣，但立即返回一個 `message_id`。LLM 調用在後台跑；輪詢 `/pending/{message_id}` 直到 ready。
-
-### `GET /comp/chat/{session_id}/pending/{message_id}`
-
-```json
-{ "ready": false }
-```
-
-或者：
-
-```json
-{ "ready": true, "reply": { /* 跟 /message 響應形狀一致 */ } }
-```
 
 ### `GET /comp/chat/{session_id}/history?limit=50&offset=0`
 

--- a/fly.toml
+++ b/fly.toml
@@ -21,6 +21,12 @@ primary_region = "nrt"
   MODEL_CONFIG_PATH = "/etc/eros-engine/model_config.toml"
   RUST_LOG = "info"
 
+# Long SSE streams (POST /comp/chat/{id}/message/stream): the server's
+# 15s keepalive comment (`: ping`) lands well inside Fly's default proxy
+# idle window, so the stream stays open as long as the handler is alive.
+# The machines `[http_service]` schema does not expose a per-request
+# timeout knob; if a stream needs to exceed Fly's response budget, the
+# fix is a server-side 120s hard cap (spec §1.9), not a fly.toml change.
 [http_service]
   internal_port = 8080
   force_https = true


### PR DESCRIPTION
## Summary

Adds `POST /comp/chat/{session_id}/message/stream` (SSE) per the design at
`docs/superpowers/specs/2026-05-19-sse-streaming-chat-0.2-design.md`,
and removes the redundant long-poll endpoints (`send_message_async` +
`check_pending`).

- New per-model `OpenRouterClient::execute_stream` returns `Stream<DeltaChunk>` via `eventsource-stream`; fallback orchestration moves into the pipeline layer (cap=2).
- New `pipeline::stream::{run_stream, replay_stream}` generator emits typed `ProtocolFrame`s (Meta / Delta / Done / Final / Error) with persist-before-Done so client disconnects can't lose `done`-completed bursts.
- Idempotency on `(session_id, client_msg_id)` within a 24h app-level window (Postgres rejects `now()` in partial-index predicates). Replay re-synthesises frames from persisted DB rows without re-calling OpenRouter; Ghost replay is distinguished from "still generating" via a `ghost_decision` flag on the user row.
- Per-user concurrent-stream cap (3) via an `Arc<Mutex<HashMap>>` slot counter on `AppState`; SSE keep-alive `: ping` every 15s.
- `SseHeadersLayer` injects `X-Accel-Buffering: no` + `Cache-Control: no-cache, no-transform, private` on responses with `text/event-stream` content type.
- Removed: `send_message_async`, `check_pending`, `AsyncSendResponse`, `CompanionReplyPayload`, `PendingCheckResponse`. The sync `/message` handler stays through 0.2.x (planned removal in 0.3.0).
- Migration `0012_chat_streaming.sql` adds: `client_msg_id`, `ghost_decision`, `user_message_id`, `continues_from_message_id`, `truncated`, `model`, `usage`, `generation_id`, `assistant_action_type` + partial unique index on `(session_id, client_msg_id)` and a covering index on `user_message_id`.
- Workspace bumped to 0.2.0; OpenAPI snapshot regenerated; `docs/api-reference.{md,zh.md}` + README updated.

Known follow-ups (not in this PR):

- Per-stream 120s hard timeout + per-message 4096-token cap + 4096-frame cap (codes `Timeout` / `RateLimited` reserved in `StreamErrorCode`).
- Issue #23 (Supabase REVOKE/RLS lockdown migration) — separate PR.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --no-run` clean
- [x] Unit tests pass: `eros-engine-core` (31), `eros-engine-llm` (38, incl. 3 new wiremock SSE tests), `eros-engine-server` middleware + state + pipeline::stream serde (+10 new tests)
- [ ] CI: `#[sqlx::test]` integration tests for `ChatRepo::upsert_user_message_idempotent` (4 tests) and the `/message/stream` handler's 422 + replay paths (2 tests) — these need the CI Postgres and were not executable locally
- [ ] Manual e2e: `curl -N -H Accept: text/event-stream … /message/stream` on a deployed instance — observe `meta → delta* → done → final` and a `: ping` within ~15s

🤖 Generated with [Claude Code](https://claude.com/claude-code)