### PR TITLE
feat: chat cold-mount latency cuts — warm machine + BFF layer (Plans A/B/C)

### DIFF
--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -16,6 +16,54 @@
     }
   ],
   "paths": {
+    "/bff/v1/comp/chat/start": {
+      "post": {
+        "tags": [
+          "bff-companion"
+        ],
+        "summary": "Cold-mount bundle: resolves (or creates) the session, then returns\nhistory + affinity in a single round-trip. Replaces three sequential\ncalls (start + history + affinity) for `eros-engine-web` cold-mount.",
+        "operationId": "bff_start_chat",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BffStartRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BffStartResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "missing genome_id and no existing instance"
+          },
+          "401": {
+            "description": "missing or invalid bearer"
+          },
+          "403": {
+            "description": "not your instance / nft gate"
+          },
+          "404": {
+            "description": "instance/genome not found"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
     "/bff/v1/comp/chat/{session_id}/history": {
       "get": {
         "tags": [
@@ -923,6 +971,83 @@
             "type": "integer",
             "description": "Count of `messages` in this response (== `messages.len()`). NOT the\ntotal row count for the session — pagination doesn't know how many\nrows remain. Mirrors `HistoryResponse::total`.",
             "minimum": 0
+          }
+        }
+      },
+      "BffStartRequest": {
+        "type": "object",
+        "properties": {
+          "genome_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid"
+          },
+          "history_limit": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "History page size for the bundled history. Default 50, capped at 50.\nBFF-only field; not present in the canonical /comp/chat/start body."
+          },
+          "instance_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid"
+          },
+          "is_demo": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          }
+        }
+      },
+      "BffStartResponse": {
+        "type": "object",
+        "required": [
+          "session_id",
+          "instance_id",
+          "persona_name",
+          "is_new",
+          "history"
+        ],
+        "properties": {
+          "affinity": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/AffinitySnapshot",
+                "description": "Affinity snapshot. `None` covers three cases the FE treats identically\nas \"no calibration to show\":\n  1. `EXPOSE_AFFINITY_DEBUG=false` — debug gate closed.\n  2. Brand-new session — no row created yet.\n  3. Resumed session that has never had an affinity-producing event."
+              }
+            ]
+          },
+          "history": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BffHistoryEntry"
+            },
+            "description": "Most-recent N messages, oldest-first. Empty for brand-new sessions."
+          },
+          "instance_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "is_new": {
+            "type": "boolean"
+          },
+          "persona_name": {
+            "type": "string"
+          },
+          "session_id": {
+            "type": "string",
+            "format": "uuid"
           }
         }
       },

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -16,6 +16,73 @@
     }
   ],
   "paths": {
+    "/bff/v1/comp/chat/{session_id}/history": {
+      "get": {
+        "tags": [
+          "bff-companion"
+        ],
+        "summary": "Slim chat history for the chat-screen mount. Same auth, same ownership\ncheck, same `limit ∈ [1, 50]` clamp as `/comp/.../history`. **Intentional\ndivergence:** default `limit=50` (canonical defaults to 20). Reason:\nBFF exists for cold-mount where the FE wants a full backscroll in one\nround-trip.",
+        "operationId": "bff_get_history",
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "description": "Chat session id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Max rows (default 50, capped at 50)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "Page offset, default 0",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BffHistoryResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "missing or invalid bearer"
+          },
+          "403": {
+            "description": "not your session"
+          },
+          "404": {
+            "description": "session not found"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
     "/comp/affinity/{session_id}": {
       "get": {
         "tags": [
@@ -812,6 +879,52 @@
           }
         }
       },
+      "BffHistoryEntry": {
+        "type": "object",
+        "required": [
+          "role",
+          "content",
+          "sent_at"
+        ],
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "role": {
+            "type": "string",
+            "description": "\"user\" | \"assistant\" | \"gift_user\" | \"system_error\""
+          },
+          "sent_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "BffHistoryResponse": {
+        "type": "object",
+        "required": [
+          "session_id",
+          "messages",
+          "total"
+        ],
+        "properties": {
+          "messages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BffHistoryEntry"
+            }
+          },
+          "session_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "total": {
+            "type": "integer",
+            "description": "Count of `messages` in this response (== `messages.len()`). NOT the\ntotal row count for the session — pagination doesn't know how many\nrows remain. Mirrors `HistoryResponse::total`.",
+            "minimum": 0
+          }
+        }
+      },
       "ChatHistoryEntry": {
         "type": "object",
         "required": [
@@ -1441,6 +1554,10 @@
     {
       "name": "companion",
       "description": "Chat sessions, messages, affinity, profile"
+    },
+    {
+      "name": "bff-companion",
+      "description": "Frontend-shaped mirror of /comp/* for first-party clients; shape may diverge from canonical without notice"
     },
     {
       "name": "debug",

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -108,7 +108,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AffinityDebugResponse"
+                  "$ref": "#/components/schemas/AffinitySnapshot"
                 }
               }
             }
@@ -792,8 +792,39 @@
   },
   "components": {
     "schemas": {
-      "AffinityDebugResponse": {
+      "AffinityDeltasDto": {
         "type": "object",
+        "description": "Mirror of `eros_engine_core::affinity::AffinityDeltas` with `ToSchema`\nfor OpenAPI emission. Field-for-field conversion both ways.",
+        "properties": {
+          "intimacy": {
+            "type": "number",
+            "format": "double"
+          },
+          "intrigue": {
+            "type": "number",
+            "format": "double"
+          },
+          "patience": {
+            "type": "number",
+            "format": "double"
+          },
+          "tension": {
+            "type": "number",
+            "format": "double"
+          },
+          "trust": {
+            "type": "number",
+            "format": "double"
+          },
+          "warmth": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "AffinitySnapshot": {
+        "type": "object",
+        "description": "Point-in-time projection of a session's `Affinity`. Same field set\nas the historical `AffinityDebugResponse`; renamed because it now\nflows through non-debug surfaces too.",
         "required": [
           "warmth",
           "trust",
@@ -842,36 +873,6 @@
           },
           "updated_at": {
             "type": "string"
-          },
-          "warmth": {
-            "type": "number",
-            "format": "double"
-          }
-        }
-      },
-      "AffinityDeltasDto": {
-        "type": "object",
-        "description": "Mirror of `eros_engine_core::affinity::AffinityDeltas` with `ToSchema`\nfor OpenAPI emission. Field-for-field conversion both ways.",
-        "properties": {
-          "intimacy": {
-            "type": "number",
-            "format": "double"
-          },
-          "intrigue": {
-            "type": "number",
-            "format": "double"
-          },
-          "patience": {
-            "type": "number",
-            "format": "double"
-          },
-          "tension": {
-            "type": "number",
-            "format": "double"
-          },
-          "trust": {
-            "type": "number",
-            "format": "double"
           },
           "warmth": {
             "type": "number",

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -184,7 +184,7 @@
           "companion"
         ],
         "summary": "Start (or resume) a chat session for the JWT user.",
-        "description": "Resolution rules:\n  * `instance_id` provided → must belong to the JWT user.\n  * else `genome_id` provided → look up (or auto-create) the user's\n    active instance of that genome.\n  * else: the only active genome the user already has an instance of\n    wins; otherwise 400.",
+        "description": "Resolution rules:\n  * `instance_id` provided → must belong to the JWT user.\n  * else `genome_id` provided → look up (or auto-create) the user's\n    active instance of that genome.\n  * else (neither provided) → 400 Bad Request.",
         "operationId": "start_chat",
         "requestBody": {
           "content": {

--- a/crates/eros-engine-server/src/openapi.rs
+++ b/crates/eros-engine-server/src/openapi.rs
@@ -57,6 +57,8 @@ impl Modify for SecurityAddon {
     tags(
         (name = "health", description = "Liveness probe"),
         (name = "companion", description = "Chat sessions, messages, affinity, profile"),
+        (name = "bff-companion", description = "Frontend-shaped mirror of /comp/* for first-party clients; \
+                                                shape may diverge from canonical without notice"),
         (name = "debug", description = "Env-gated introspection (affinity vector exposure)"),
         (name = "s2s", description = "Server-to-server endpoints for the marketplace svc \
                                       (HMAC-signed; do not expose to user-agent traffic)")

--- a/crates/eros-engine-server/src/routes/bff/companion.rs
+++ b/crates/eros-engine-server/src/routes/bff/companion.rs
@@ -9,15 +9,18 @@ use axum::{
     Json,
 };
 use chrono::{DateTime, Utc};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use utoipa_axum::{router::OpenApiRouter, routes};
 use uuid::Uuid;
 
+use eros_engine_store::affinity::AffinityRepo;
 use eros_engine_store::chat::ChatRepo;
 
 use crate::auth::middleware::AuthUser;
 use crate::error::AppError;
-use crate::routes::companion::{require_session_for_user, HistoryQuery};
+use crate::routes::companion::resolve_or_create_session;
+use crate::routes::companion::{require_session_for_user, HistoryQuery, StartChatRequest};
+use crate::routes::dto::AffinitySnapshot;
 use crate::state::AppState;
 
 // ─── DTOs ───────────────────────────────────────────────────────────
@@ -38,6 +41,44 @@ pub struct BffHistoryResponse {
     /// total row count for the session — pagination doesn't know how many
     /// rows remain. Mirrors `HistoryResponse::total`.
     pub total: usize,
+}
+
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
+pub struct BffStartRequest {
+    pub instance_id: Option<Uuid>,
+    pub genome_id: Option<Uuid>,
+    #[serde(default)]
+    pub is_demo: Option<bool>,
+    /// History page size for the bundled history. Default 50, capped at 50.
+    /// BFF-only field; not present in the canonical /comp/chat/start body.
+    #[serde(default)]
+    pub history_limit: Option<i64>,
+}
+
+impl From<&BffStartRequest> for StartChatRequest {
+    fn from(b: &BffStartRequest) -> Self {
+        StartChatRequest {
+            instance_id: b.instance_id,
+            genome_id: b.genome_id,
+            is_demo: b.is_demo,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct BffStartResponse {
+    pub session_id: Uuid,
+    pub instance_id: Uuid,
+    pub persona_name: String,
+    pub is_new: bool,
+    /// Most-recent N messages, oldest-first. Empty for brand-new sessions.
+    pub history: Vec<BffHistoryEntry>,
+    /// Affinity snapshot. `None` covers three cases the FE treats identically
+    /// as "no calibration to show":
+    ///   1. `EXPOSE_AFFINITY_DEBUG=false` — debug gate closed.
+    ///   2. Brand-new session — no row created yet.
+    ///   3. Resumed session that has never had an affinity-producing event.
+    pub affinity: Option<AffinitySnapshot>,
 }
 
 // ─── Handler ────────────────────────────────────────────────────────
@@ -95,10 +136,79 @@ async fn bff_get_history(
     }))
 }
 
+/// Cold-mount bundle: resolves (or creates) the session, then returns
+/// history + affinity in a single round-trip. Replaces three sequential
+/// calls (start + history + affinity) for `eros-engine-web` cold-mount.
+#[utoipa::path(
+    post,
+    path = "/bff/v1/comp/chat/start",
+    tag = "bff-companion",
+    request_body = BffStartRequest,
+    responses(
+        (status = 200, body = BffStartResponse),
+        (status = 400, description = "missing genome_id and no existing instance"),
+        (status = 401, description = "missing or invalid bearer"),
+        (status = 403, description = "not your instance / nft gate"),
+        (status = 404, description = "instance/genome not found")
+    ),
+    security(("bearer" = []))
+)]
+async fn bff_start_chat(
+    State(state): State<AppState>,
+    Extension(AuthUser(user_id)): Extension<AuthUser>,
+    Json(req): Json<BffStartRequest>,
+) -> Result<Json<BffStartResponse>, AppError> {
+    let canonical_req = StartChatRequest::from(&req);
+    let resolved = resolve_or_create_session(&state, user_id, &canonical_req).await?;
+    let history_limit = req.history_limit.unwrap_or(50).clamp(1, 50);
+
+    let history_fut = async {
+        Ok::<_, AppError>(
+            ChatRepo { pool: &state.pool }
+                .history_slim(resolved.session_id, history_limit, 0)
+                .await?,
+        )
+    };
+    let affinity_fut = async {
+        if !state.config.expose_affinity_debug {
+            return Ok::<Option<AffinitySnapshot>, AppError>(None);
+        }
+        let snapshot = AffinityRepo { pool: &state.pool }
+            .load(resolved.session_id)
+            .await?
+            .map(|mut a| {
+                a.apply_time_decay();
+                AffinitySnapshot::from(a)
+            });
+        Ok(snapshot)
+    };
+    let (rows, affinity) = tokio::try_join!(history_fut, affinity_fut)?;
+
+    let history = rows
+        .into_iter()
+        .map(|r| BffHistoryEntry {
+            role: r.role,
+            content: r.content,
+            sent_at: r.sent_at,
+        })
+        .collect();
+
+    Ok(Json(BffStartResponse {
+        session_id: resolved.session_id,
+        instance_id: resolved.instance_id,
+        persona_name: resolved.persona_name,
+        is_new: resolved.is_new,
+        history,
+        affinity,
+    }))
+}
+
 // ─── Router ─────────────────────────────────────────────────────────
 
 pub fn router() -> OpenApiRouter<AppState> {
-    OpenApiRouter::new().routes(routes!(bff_get_history))
+    OpenApiRouter::new()
+        .routes(routes!(bff_get_history))
+        .routes(routes!(bff_start_chat))
 }
 
 #[cfg(test)]
@@ -281,5 +391,238 @@ mod tests {
         let (status, _body) =
             send_request(&mut app, bff_history_request(&token, missing, "")).await;
         assert_eq!(status, StatusCode::NOT_FOUND);
+    }
+
+    // ─── Plan C: POST /bff/v1/comp/chat/start tests ─────────────────
+
+    fn bff_start_request(token: &str, body: serde_json::Value) -> Request<Body> {
+        Request::builder()
+            .method("POST")
+            .uri("/bff/v1/comp/chat/start")
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_vec(&body).unwrap()))
+            .unwrap()
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn bff_start_brand_new_session_returns_empty_history_no_affinity(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+
+        let state = test_state(pool.clone());
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        let (status, body) = send_request(
+            &mut app,
+            bff_start_request(&token, json!({ "genome_id": genome_id })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "body={body}");
+
+        assert!(body["is_new"].as_bool().unwrap());
+        assert_eq!(body["persona_name"], "Aria");
+        assert!(body["session_id"].is_string());
+        assert!(body["instance_id"].is_string());
+        assert!(body["history"].as_array().unwrap().is_empty());
+        // No affinity row yet for a brand-new session — spec §3.4 case 2.
+        assert!(body["affinity"].is_null());
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn bff_start_resumed_session_returns_history(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+        sqlx::query(
+            "INSERT INTO engine.chat_messages (session_id, role, content) \
+             VALUES ($1, 'user', 'hello'), ($1, 'assistant', 'hi back')",
+        )
+        .bind(session_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let state = test_state(pool);
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        let (status, body) = send_request(
+            &mut app,
+            bff_start_request(&token, json!({ "genome_id": genome_id })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+
+        assert!(!body["is_new"].as_bool().unwrap());
+        assert_eq!(body["session_id"], json!(session_id.to_string()));
+        let history = body["history"].as_array().expect("history array");
+        assert_eq!(history.len(), 2);
+        assert_eq!(history[0]["role"], "user");
+        assert_eq!(history[0]["content"], "hello");
+        assert_eq!(history[1]["role"], "assistant");
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn bff_start_history_limit_clamped_to_50(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+        for n in 0..60 {
+            sqlx::query(
+                "INSERT INTO engine.chat_messages (session_id, role, content) \
+                         VALUES ($1, 'user', $2)",
+            )
+            .bind(session_id)
+            .bind(format!("m{n}"))
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        let state = test_state(pool);
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        let (status, body) = send_request(
+            &mut app,
+            bff_start_request(
+                &token,
+                json!({ "genome_id": genome_id, "history_limit": 999 }),
+            ),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["history"].as_array().unwrap().len(), 50);
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn bff_start_affinity_null_when_debug_gate_closed(pool: PgPool) {
+        // Spec §3.4 case 1: affinity field hidden when EXPOSE_AFFINITY_DEBUG=false.
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+        // Pre-seed an affinity row so the field would otherwise be non-null.
+        sqlx::query(
+            "INSERT INTO engine.companion_affinity (session_id, user_id, instance_id, warmth) \
+             VALUES ($1, $2, $3, 0.42)",
+        )
+        .bind(session_id)
+        .bind(user_id)
+        .bind(instance_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let mut state = test_state(pool);
+        state.config.expose_affinity_debug = false; // close the gate
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        let (status, body) = send_request(
+            &mut app,
+            bff_start_request(&token, json!({ "genome_id": genome_id })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(
+            body["affinity"].is_null(),
+            "affinity must be hidden when EXPOSE_AFFINITY_DEBUG=false; got {body}"
+        );
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn bff_start_affinity_present_when_debug_gate_open(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+        sqlx::query(
+            "INSERT INTO engine.companion_affinity (session_id, user_id, instance_id, warmth) \
+             VALUES ($1, $2, $3, 0.42)",
+        )
+        .bind(session_id)
+        .bind(user_id)
+        .bind(instance_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let state = test_state(pool); // expose_affinity_debug=true by default in tests
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        let (status, body) = send_request(
+            &mut app,
+            bff_start_request(&token, json!({ "genome_id": genome_id })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let affinity = &body["affinity"];
+        assert!(
+            affinity.is_object(),
+            "expected affinity object, got {affinity}"
+        );
+        assert!((affinity["warmth"].as_f64().unwrap() - 0.42).abs() < 1e-9);
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn bff_start_403_on_nft_unowned_genome(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata, is_active, asset_id) \
+             VALUES ('Locked', 'sys', '{}'::jsonb, true, 'asset-x') RETURNING id",
+        )
+        .fetch_one(&pool).await.unwrap();
+
+        let state = test_state(pool);
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        let (status, _body) = send_request(
+            &mut app,
+            bff_start_request(&token, json!({ "genome_id": genome_id })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::FORBIDDEN);
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn bff_start_matches_canonical_start_session_id(pool: PgPool) {
+        // Same input on both endpoints should resolve to the same session for the
+        // same JWT user. Confirms resolve_or_create_session is the only mover.
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let state = test_state(pool.clone());
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        // First: canonical
+        let req = Request::builder()
+            .method("POST")
+            .uri("/comp/chat/start")
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(
+                serde_json::to_vec(&json!({ "genome_id": genome_id })).unwrap(),
+            ))
+            .unwrap();
+        let (status, canon) = send_request(&mut app, req).await;
+        assert_eq!(status, StatusCode::OK);
+        let canonical_session_id = canon["session_id"].as_str().unwrap().to_string();
+
+        // Then: BFF on the same input — must resume the same session.
+        let (status, bff) = send_request(
+            &mut app,
+            bff_start_request(&token, json!({ "genome_id": genome_id })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(bff["session_id"].as_str().unwrap(), canonical_session_id);
+        assert!(!bff["is_new"].as_bool().unwrap()); // canonical already created it
     }
 }

--- a/crates/eros-engine-server/src/routes/bff/companion.rs
+++ b/crates/eros-engine-server/src/routes/bff/companion.rs
@@ -243,11 +243,14 @@ mod tests {
         let session_id = seed_session(&pool, user_id, instance_id).await;
 
         // Seed three rows directly so we don't depend on pipeline::run.
+        // Explicit, strictly-increasing sent_at: a single multi-row INSERT
+        // shares one now() across all rows, so ORDER BY sent_at would tie and
+        // the result order would be undefined.
         sqlx::query(
-            "INSERT INTO engine.chat_messages (session_id, role, content, extracted_facts) \
-             VALUES ($1, 'user', 'alpha', '{\"facts\":[\"x\"]}'::jsonb),
-                    ($1, 'assistant', 'beta', NULL),
-                    ($1, 'user', 'gamma', '{\"facts\":[\"y\"]}'::jsonb)",
+            "INSERT INTO engine.chat_messages (session_id, role, content, extracted_facts, sent_at) \
+             VALUES ($1, 'user', 'alpha', '{\"facts\":[\"x\"]}'::jsonb, now() - interval '2 seconds'),
+                    ($1, 'assistant', 'beta', NULL, now() - interval '1 second'),
+                    ($1, 'user', 'gamma', '{\"facts\":[\"y\"]}'::jsonb, now())",
         )
         .bind(session_id)
         .execute(&pool)
@@ -436,9 +439,12 @@ mod tests {
         let genome_id = seed_genome(&pool, "Aria").await;
         let instance_id = seed_instance(&pool, genome_id, user_id).await;
         let session_id = seed_session(&pool, user_id, instance_id).await;
+        // Explicit, strictly-increasing sent_at so the two rows order
+        // deterministically — a single multi-row INSERT shares one now().
         sqlx::query(
-            "INSERT INTO engine.chat_messages (session_id, role, content) \
-             VALUES ($1, 'user', 'hello'), ($1, 'assistant', 'hi back')",
+            "INSERT INTO engine.chat_messages (session_id, role, content, sent_at) \
+             VALUES ($1, 'user', 'hello', now() - interval '1 second'), \
+                    ($1, 'assistant', 'hi back', now())",
         )
         .bind(session_id)
         .execute(&pool)

--- a/crates/eros-engine-server/src/routes/bff/companion.rs
+++ b/crates/eros-engine-server/src/routes/bff/companion.rs
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! BFF mirror of `/comp/*` (`/bff/v1/comp/*`).
+//!
+//! See `docs/superpowers/specs/2026-05-20-history-latency-cuts-design.md`
+//! §0.1 (convention), §2 (history endpoint), §3 (start endpoint).
+
+#![allow(dead_code)] // handlers wired into routes::router in Task 5.
+
+use utoipa_axum::router::OpenApiRouter;
+
+use crate::state::AppState;
+
+/// Build the BFF companion router. Handlers are added in the implementation
+/// order specified by the plan: `bff_get_history` first (Task 5), then
+/// `bff_start_chat` (Task 10).
+pub fn router() -> OpenApiRouter<AppState> {
+    OpenApiRouter::new()
+}

--- a/crates/eros-engine-server/src/routes/bff/companion.rs
+++ b/crates/eros-engine-server/src/routes/bff/companion.rs
@@ -4,15 +4,282 @@
 //! See `docs/superpowers/specs/2026-05-20-history-latency-cuts-design.md`
 //! §0.1 (convention), §2 (history endpoint), §3 (start endpoint).
 
-#![allow(dead_code)] // handlers wired into routes::router in Task 5.
+use axum::{
+    extract::{Extension, Path, Query, State},
+    Json,
+};
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use utoipa_axum::{router::OpenApiRouter, routes};
+use uuid::Uuid;
 
-use utoipa_axum::router::OpenApiRouter;
+use eros_engine_store::chat::ChatRepo;
 
+use crate::auth::middleware::AuthUser;
+use crate::error::AppError;
+use crate::routes::companion::{require_session_for_user, HistoryQuery};
 use crate::state::AppState;
 
-/// Build the BFF companion router. Handlers are added in the implementation
-/// order specified by the plan: `bff_get_history` first (Task 5), then
-/// `bff_start_chat` (Task 10).
+// ─── DTOs ───────────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct BffHistoryEntry {
+    /// "user" | "assistant" | "gift_user" | "system_error"
+    pub role: String,
+    pub content: String,
+    pub sent_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct BffHistoryResponse {
+    pub session_id: Uuid,
+    pub messages: Vec<BffHistoryEntry>,
+    /// Count of `messages` in this response (== `messages.len()`). NOT the
+    /// total row count for the session — pagination doesn't know how many
+    /// rows remain. Mirrors `HistoryResponse::total`.
+    pub total: usize,
+}
+
+// ─── Handler ────────────────────────────────────────────────────────
+
+/// Slim chat history for the chat-screen mount. Same auth, same ownership
+/// check, same `limit ∈ [1, 50]` clamp as `/comp/.../history`. **Intentional
+/// divergence:** default `limit=50` (canonical defaults to 20). Reason:
+/// BFF exists for cold-mount where the FE wants a full backscroll in one
+/// round-trip.
+#[utoipa::path(
+    get,
+    path = "/bff/v1/comp/chat/{session_id}/history",
+    tag = "bff-companion",
+    params(
+        ("session_id" = Uuid, Path, description = "Chat session id"),
+        ("limit" = Option<i64>, Query, description = "Max rows (default 50, capped at 50)"),
+        ("offset" = Option<i64>, Query, description = "Page offset, default 0")
+    ),
+    responses(
+        (status = 200, body = BffHistoryResponse),
+        (status = 401, description = "missing or invalid bearer"),
+        (status = 403, description = "not your session"),
+        (status = 404, description = "session not found")
+    ),
+    security(("bearer" = []))
+)]
+async fn bff_get_history(
+    State(state): State<AppState>,
+    Path(session_id): Path<Uuid>,
+    Extension(AuthUser(user_id)): Extension<AuthUser>,
+    Query(query): Query<HistoryQuery>,
+) -> Result<Json<BffHistoryResponse>, AppError> {
+    require_session_for_user(&state, session_id, user_id).await?;
+    let limit = query.limit.unwrap_or(50).clamp(1, 50);
+    let offset = query.offset.unwrap_or(0).max(0);
+
+    let rows = ChatRepo { pool: &state.pool }
+        .history_slim(session_id, limit, offset)
+        .await?;
+
+    let messages: Vec<BffHistoryEntry> = rows
+        .into_iter()
+        .map(|r| BffHistoryEntry {
+            role: r.role,
+            content: r.content,
+            sent_at: r.sent_at,
+        })
+        .collect();
+    let total = messages.len();
+
+    Ok(Json(BffHistoryResponse {
+        session_id,
+        messages,
+        total,
+    }))
+}
+
+// ─── Router ─────────────────────────────────────────────────────────
+
 pub fn router() -> OpenApiRouter<AppState> {
-    OpenApiRouter::new()
+    OpenApiRouter::new().routes(routes!(bff_get_history))
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{header, Request, StatusCode},
+    };
+    use serde_json::json;
+    use sqlx::PgPool;
+    use uuid::Uuid;
+
+    use crate::routes::companion::test_state;
+    use crate::routes::companion::testutil::{
+        build_router, mint_test_jwt, seed_genome, seed_instance, seed_session, send_request,
+    };
+
+    fn bff_history_request(token: &str, session_id: Uuid, query: &str) -> Request<Body> {
+        Request::builder()
+            .method("GET")
+            .uri(format!("/bff/v1/comp/chat/{session_id}/history{query}"))
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn bff_history_returns_slim_messages_in_order(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+
+        // Seed three rows directly so we don't depend on pipeline::run.
+        sqlx::query(
+            "INSERT INTO engine.chat_messages (session_id, role, content, extracted_facts) \
+             VALUES ($1, 'user', 'alpha', '{\"facts\":[\"x\"]}'::jsonb),
+                    ($1, 'assistant', 'beta', NULL),
+                    ($1, 'user', 'gamma', '{\"facts\":[\"y\"]}'::jsonb)",
+        )
+        .bind(session_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let state = test_state(pool);
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        let (status, body) =
+            send_request(&mut app, bff_history_request(&token, session_id, "")).await;
+        assert_eq!(status, StatusCode::OK, "got body: {body}");
+
+        let messages = body["messages"].as_array().expect("messages array");
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[0]["role"], "user");
+        assert_eq!(messages[0]["content"], "alpha");
+        assert_eq!(messages[1]["role"], "assistant");
+        assert_eq!(messages[2]["content"], "gamma");
+
+        // No extracted_facts on any row — pure projection.
+        for m in messages {
+            assert!(
+                m.get("extracted_facts").is_none(),
+                "BFF slim DTO must not expose extracted_facts; got {m}"
+            );
+        }
+
+        // `total` reflects page count, not grand total.
+        assert_eq!(body["total"], 3);
+        assert_eq!(body["session_id"], json!(session_id.to_string()));
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn bff_history_default_limit_is_50(pool: PgPool) {
+        // Intentional divergence from canonical /comp/.../history which
+        // defaults to 20. Spec §2.2.
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+
+        // Insert 60 rows; BFF default should return 50.
+        for n in 0..60 {
+            sqlx::query(
+                "INSERT INTO engine.chat_messages (session_id, role, content) \
+                 VALUES ($1, 'user', $2)",
+            )
+            .bind(session_id)
+            .bind(format!("m{n}"))
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        let state = test_state(pool);
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        let (status, body) =
+            send_request(&mut app, bff_history_request(&token, session_id, "")).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["messages"].as_array().unwrap().len(), 50);
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn bff_history_clamps_limit_to_50(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+        for n in 0..60 {
+            sqlx::query(
+                "INSERT INTO engine.chat_messages (session_id, role, content) \
+                         VALUES ($1, 'user', $2)",
+            )
+            .bind(session_id)
+            .bind(format!("m{n}"))
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        let state = test_state(pool);
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        let (status, body) = send_request(
+            &mut app,
+            bff_history_request(&token, session_id, "?limit=999"),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["messages"].as_array().unwrap().len(), 50);
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn bff_history_401_without_bearer(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+
+        let state = test_state(pool);
+        let mut app = build_router(state);
+
+        let req = Request::builder()
+            .uri(format!("/bff/v1/comp/chat/{session_id}/history"))
+            .body(Body::empty())
+            .unwrap();
+        let (status, _body) = send_request(&mut app, req).await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn bff_history_403_on_other_users_session(pool: PgPool) {
+        let owner = Uuid::new_v4();
+        let intruder = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, owner).await;
+        let session_id = seed_session(&pool, owner, instance_id).await;
+
+        let state = test_state(pool);
+        let mut app = build_router(state);
+        let token = mint_test_jwt(intruder);
+
+        let (status, _body) =
+            send_request(&mut app, bff_history_request(&token, session_id, "")).await;
+        assert_eq!(status, StatusCode::FORBIDDEN);
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn bff_history_404_on_missing_session(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let state = test_state(pool);
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        let missing = Uuid::new_v4();
+        let (status, _body) =
+            send_request(&mut app, bff_history_request(&token, missing, "")).await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+    }
 }

--- a/crates/eros-engine-server/src/routes/bff/mod.rs
+++ b/crates/eros-engine-server/src/routes/bff/mod.rs
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-#![allow(dead_code)] // wired into routes::router in Task 5.
 //! BFF (backend-for-frontend) routes — `/bff/v1/<area>/*`.
 //!
 //! Frontend-shaped mirror of the canonical engine routes. See

--- a/crates/eros-engine-server/src/routes/bff/mod.rs
+++ b/crates/eros-engine-server/src/routes/bff/mod.rs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+#![allow(dead_code)] // wired into routes::router in Task 5.
+//! BFF (backend-for-frontend) routes — `/bff/v1/<area>/*`.
+//!
+//! Frontend-shaped mirror of the canonical engine routes. See
+//! `docs/superpowers/specs/2026-05-20-history-latency-cuts-design.md`
+//! §0.1 for the layer convention.
+//!
+//! Convention quick-reference:
+//!   * `/bff/v1/<area>/*` mirrors `/<area>/*` path-for-path; shape diverges.
+//!   * Canonical routes are NEVER edited to satisfy the FE; add a BFF
+//!     route instead.
+//!   * BFF handlers never call other BFF handlers — they reach down to
+//!     repos / shared helpers directly.
+//!   * Each BFF handler has a distinct Rust function name (e.g.
+//!     `bff_get_history`) so utoipa-axum emits a unique `operationId`.
+
+use utoipa_axum::router::OpenApiRouter;
+
+use crate::state::AppState;
+
+pub mod companion;
+
+/// Compose all `/bff/v1/*` handlers into one router. Auth is applied
+/// at the call site in `routes::router` (the merged `comp` subtree's
+/// `require_auth` layer covers this).
+pub fn router() -> OpenApiRouter<AppState> {
+    OpenApiRouter::new().merge(companion::router())
+}

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -565,38 +565,40 @@ async fn list_personas(
     Ok(Json(ListPersonasResponse { personas }))
 }
 
-/// Start (or resume) a chat session for the JWT user.
+/// Output of `resolve_or_create_session`. Carries everything either the
+/// canonical `start_chat` or the BFF `bff_start_chat` needs to build its
+/// response. `is_new` is `true` when this call **created** the session row,
+/// `false` when an existing session was resumed.
+#[derive(Debug, Clone)]
+pub(crate) struct ResolvedSession {
+    pub session_id: Uuid,
+    pub instance_id: Uuid,
+    pub persona_name: String,
+    pub is_new: bool,
+}
+
+/// Shared session-resolution flow used by `POST /comp/chat/start` and
+/// `POST /bff/v1/comp/chat/start`. Encapsulates instance lookup, NFT
+/// ownership gate (with the **exact** ordering both endpoints depend on),
+/// and resume-or-create on `chat_sessions`. Caller is responsible for
+/// building its own response DTO from the returned `ResolvedSession`.
 ///
-/// Resolution rules:
-///   * `instance_id` provided → must belong to the JWT user.
-///   * else `genome_id` provided → look up (or auto-create) the user's
-///     active instance of that genome.
-///   * else: the only active genome the user already has an instance of
-///     wins; otherwise 400.
-#[utoipa::path(
-    post,
-    path = "/comp/chat/start",
-    tag = "companion",
-    request_body = StartChatRequest,
-    responses(
-        (status = 200, body = StartChatResponse),
-        (status = 400, description = "missing genome_id and no existing instance"),
-        (status = 401, description = "missing or invalid bearer"),
-        (status = 404, description = "instance/genome not found")
-    ),
-    security(("bearer" = []))
-)]
-async fn start_chat(
-    State(state): State<AppState>,
-    Extension(AuthUser(user_id)): Extension<AuthUser>,
-    Json(req): Json<StartChatRequest>,
-) -> Result<Json<StartChatResponse>, AppError> {
+/// **NFT gate ordering (load-bearing):**
+///   * Explicit `instance_id` → gate runs AFTER load + owner check, so we
+///     never gate a missing or non-owned instance.
+///   * `genome_id` only → gate runs BEFORE find-or-create on
+///     `persona_instances`, so a non-owner who hits the create-fallback
+///     does NOT leave a stray row.
+pub(crate) async fn resolve_or_create_session(
+    state: &AppState,
+    user_id: Uuid,
+    req: &StartChatRequest,
+) -> Result<ResolvedSession, AppError> {
     let persona_repo = PersonaRepo { pool: &state.pool };
     let chat_repo = ChatRepo { pool: &state.pool };
 
     let instance_id = match req.instance_id {
         Some(iid) => {
-            // Verify ownership + active status.
             let companion = persona_repo
                 .load_companion(iid)
                 .await?
@@ -606,7 +608,6 @@ async fn start_chat(
                     "instance not owned by this user".into(),
                 ));
             }
-            // NEW: NFT gate (orthogonal to owner_uid — NFT ownership is wallet-bound).
             let asset_id_opt = persona_repo
                 .get_asset_id_for_genome(companion.instance.genome_id)
                 .await?;
@@ -618,7 +619,6 @@ async fn start_chat(
                 .genome_id
                 .ok_or_else(|| AppError::BadRequest("missing genome_id (or instance_id)".into()))?;
 
-            // Validate genome exists + is active.
             let genome = persona_repo
                 .get_genome(genome_id)
                 .await?
@@ -627,13 +627,9 @@ async fn start_chat(
                 return Err(AppError::BadRequest("genome is not active".into()));
             }
 
-            // NEW: NFT gate runs BEFORE looking for an instance or creating one.
-            // A non-owner who hits the create_instance fallback would otherwise
-            // leave behind an empty persona_instances row.
             let asset_id_opt = persona_repo.get_asset_id_for_genome(genome_id).await?;
             enforce_nft_ownership(&state.pool, user_id, asset_id_opt.as_deref()).await?;
 
-            // Look for an existing active instance for this user×genome.
             let existing: Option<(Uuid,)> = sqlx::query_as(
                 "SELECT id FROM engine.persona_instances \
                  WHERE genome_id = $1 AND owner_uid = $2 AND status = 'active'",
@@ -650,13 +646,11 @@ async fn start_chat(
         }
     };
 
-    // Load persona for the response payload.
     let companion = persona_repo
         .load_companion(instance_id)
         .await?
         .ok_or_else(|| AppError::NotFound("persona not loadable".into()))?;
 
-    // Resume the most recent session for (user, instance) or create one.
     let existing: Option<ChatSession> = sqlx::query_as::<_, ChatSession>(
         "SELECT * FROM engine.chat_sessions \
          WHERE user_id = $1 AND instance_id = $2 \
@@ -688,11 +682,46 @@ async fn start_chat(
         }
     };
 
-    Ok(Json(StartChatResponse {
+    Ok(ResolvedSession {
         session_id,
         instance_id,
         persona_name: companion.genome.name,
         is_new,
+    })
+}
+
+/// Start (or resume) a chat session for the JWT user.
+///
+/// Resolution rules:
+///   * `instance_id` provided → must belong to the JWT user.
+///   * else `genome_id` provided → look up (or auto-create) the user's
+///     active instance of that genome.
+///   * else: the only active genome the user already has an instance of
+///     wins; otherwise 400.
+#[utoipa::path(
+    post,
+    path = "/comp/chat/start",
+    tag = "companion",
+    request_body = StartChatRequest,
+    responses(
+        (status = 200, body = StartChatResponse),
+        (status = 400, description = "missing genome_id and no existing instance"),
+        (status = 401, description = "missing or invalid bearer"),
+        (status = 404, description = "instance/genome not found")
+    ),
+    security(("bearer" = []))
+)]
+async fn start_chat(
+    State(state): State<AppState>,
+    Extension(AuthUser(user_id)): Extension<AuthUser>,
+    Json(req): Json<StartChatRequest>,
+) -> Result<Json<StartChatResponse>, AppError> {
+    let resolved = resolve_or_create_session(&state, user_id, &req).await?;
+    Ok(Json(StartChatResponse {
+        session_id: resolved.session_id,
+        instance_id: resolved.instance_id,
+        persona_name: resolved.persona_name,
+        is_new: resolved.is_new,
     }))
 }
 
@@ -2025,5 +2054,74 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(count, 1);
+    }
+
+    // ─── resolve_or_create_session parity tests ──────────────────────
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn resolve_or_create_session_returns_resolved_for_legacy_genome(pool: PgPool) {
+        // resolve_or_create_session is the extracted core of start_chat. Brand-new
+        // user × legacy (asset-less) genome → creates a new instance + new session.
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Vita").await;
+        let state = test_state(pool.clone());
+
+        let req = StartChatRequest {
+            instance_id: None,
+            genome_id: Some(genome_id),
+            is_demo: None,
+        };
+        let resolved = resolve_or_create_session(&state, user_id, &req)
+            .await
+            .expect("resolve_or_create_session");
+
+        assert!(resolved.is_new);
+        assert_eq!(resolved.persona_name, "Vita");
+        // A second call with the same input should resume — not create a new session.
+        let resumed = resolve_or_create_session(&state, user_id, &req)
+            .await
+            .expect("resume");
+        assert!(!resumed.is_new);
+        assert_eq!(resumed.session_id, resolved.session_id);
+        assert_eq!(resumed.instance_id, resolved.instance_id);
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn resolve_or_create_session_nft_gate_blocks_unowned_genome(pool: PgPool) {
+        // genome_id branch: NFT gate must run BEFORE we look for an instance.
+        let user_id = Uuid::new_v4();
+        let genome_id = sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata, is_active, asset_id) \
+             VALUES ('NftPersona', 'sys', '{}'::jsonb, true, 'asset-x') RETURNING id",
+        )
+        .fetch_one(&pool).await.unwrap();
+        let state = test_state(pool.clone());
+
+        let req = StartChatRequest {
+            instance_id: None,
+            genome_id: Some(genome_id),
+            is_demo: None,
+        };
+        let err = resolve_or_create_session(&state, user_id, &req)
+            .await
+            .expect_err("should reject unowned NFT-gated genome");
+        match err {
+            AppError::Forbidden(msg) => {
+                assert!(msg.contains("nft_ownership_required"), "msg={msg}")
+            }
+            other => panic!("expected Forbidden, got {other:?}"),
+        }
+
+        // Confirm no orphan persona_instances row was created — this is what
+        // makes "gate before find-or-create" load-bearing.
+        let leftover: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM engine.persona_instances WHERE genome_id = $1 AND owner_uid = $2",
+        )
+        .bind(genome_id)
+        .bind(user_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(leftover, 0, "NFT gate must reject before create_instance");
     }
 }

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -320,7 +320,7 @@ pub struct GiftEventResponse {
 
 /// Verify a session exists and is owned by `user_id`. Returns the session
 /// row on success, `404` if missing, `403` if owned by someone else.
-async fn require_session_for_user(
+pub(crate) async fn require_session_for_user(
     state: &AppState,
     session_id: Uuid,
     user_id: Uuid,

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -696,8 +696,7 @@ pub(crate) async fn resolve_or_create_session(
 ///   * `instance_id` provided → must belong to the JWT user.
 ///   * else `genome_id` provided → look up (or auto-create) the user's
 ///     active instance of that genome.
-///   * else: the only active genome the user already has an instance of
-///     wins; otherwise 400.
+///   * else (neither provided) → 400 Bad Request.
 #[utoipa::path(
     post,
     path = "/comp/chat/start",

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -1067,38 +1067,44 @@ pub(crate) fn test_state(pool: sqlx::PgPool) -> AppState {
 // pipeline" — this is exactly what the gift-event test does, and it
 // matches the route's chosen implementation strategy.
 // ────────────────────────────────────────────────────────────────────
-#[cfg(test)]
-mod tests {
-    use super::*;
 
+// Test helpers shared with sibling test modules (e.g. routes::bff::companion).
+// Lives outside `mod tests` so other modules' `#[cfg(test)]` blocks can reach
+// them via `crate::routes::companion::testutil` — `mod tests` is private by convention.
+#[cfg(test)]
+pub(crate) mod testutil {
     use axum::{
         body::{to_bytes, Body},
-        http::{header, Request, StatusCode},
+        http::{Request, StatusCode},
         Router,
     };
     use jsonwebtoken::{encode, EncodingKey, Header};
     use serde_json::{json, Value};
     use sqlx::PgPool;
     use tower::Service;
+    use uuid::Uuid;
 
-    // ─── Test helpers ───────────────────────────────────────────────
+    use crate::state::AppState;
 
-    fn mint_test_jwt(uid: Uuid) -> String {
+    pub(crate) fn mint_test_jwt(uid: Uuid) -> String {
         let exp = (chrono::Utc::now() + chrono::Duration::hours(1)).timestamp();
         encode(
             &Header::default(),
             &json!({ "sub": uid.to_string(), "exp": exp }),
-            &EncodingKey::from_secret(TEST_SECRET.as_ref()),
+            &EncodingKey::from_secret(super::TEST_SECRET.as_ref()),
         )
         .expect("test jwt encodes")
     }
 
-    fn build_router(state: AppState) -> Router {
+    pub(crate) fn build_router(state: AppState) -> Router {
         let (axum_router, _api) = crate::routes::router(state.clone()).split_for_parts();
         axum_router.with_state(state)
     }
 
-    async fn send_request(router: &mut Router, req: Request<Body>) -> (StatusCode, Value) {
+    pub(crate) async fn send_request(
+        router: &mut Router,
+        req: Request<Body>,
+    ) -> (StatusCode, Value) {
         let resp = router.call(req).await.expect("router call infallible");
         let status = resp.status();
         let body_bytes = to_bytes(resp.into_body(), 1024 * 1024)
@@ -1112,7 +1118,7 @@ mod tests {
         (status, json)
     }
 
-    async fn seed_genome(pool: &PgPool, name: &str) -> Uuid {
+    pub(crate) async fn seed_genome(pool: &PgPool, name: &str) -> Uuid {
         sqlx::query_scalar::<_, Uuid>(
             "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata, is_active) \
              VALUES ($1, 'you are a companion', '{}'::jsonb, true) RETURNING id",
@@ -1123,7 +1129,7 @@ mod tests {
         .unwrap()
     }
 
-    async fn seed_session(pool: &PgPool, user_id: Uuid, instance_id: Uuid) -> Uuid {
+    pub(crate) async fn seed_session(pool: &PgPool, user_id: Uuid, instance_id: Uuid) -> Uuid {
         sqlx::query_scalar::<_, Uuid>(
             "INSERT INTO engine.chat_sessions (user_id, instance_id) \
              VALUES ($1, $2) RETURNING id",
@@ -1135,7 +1141,7 @@ mod tests {
         .unwrap()
     }
 
-    async fn seed_instance(pool: &PgPool, genome_id: Uuid, owner: Uuid) -> Uuid {
+    pub(crate) async fn seed_instance(pool: &PgPool, genome_id: Uuid, owner: Uuid) -> Uuid {
         sqlx::query_scalar::<_, Uuid>(
             "INSERT INTO engine.persona_instances (genome_id, owner_uid) \
              VALUES ($1, $2) RETURNING id",
@@ -1146,6 +1152,21 @@ mod tests {
         .await
         .unwrap()
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::testutil::{
+        build_router, mint_test_jwt, seed_genome, seed_instance, seed_session, send_request,
+    };
+    use super::*;
+
+    use axum::{
+        body::Body,
+        http::{header, Request, StatusCode},
+    };
+    use serde_json::{json, Value};
+    use sqlx::PgPool;
 
     // ─── Test 1: public /healthz still works without bearer ─────────
 

--- a/crates/eros-engine-server/src/routes/debug.rs
+++ b/crates/eros-engine-server/src/routes/debug.rs
@@ -10,7 +10,6 @@ use axum::{
     extract::{Extension, Path, State},
     Json,
 };
-use serde::Serialize;
 use utoipa_axum::{router::OpenApiRouter, routes};
 use uuid::Uuid;
 
@@ -18,21 +17,13 @@ use eros_engine_store::affinity::AffinityRepo;
 
 use crate::auth::middleware::AuthUser;
 use crate::error::AppError;
+use crate::routes::dto::AffinitySnapshot;
 use crate::state::AppState;
 
-#[derive(Debug, Serialize, utoipa::ToSchema)]
-pub struct AffinityDebugResponse {
-    pub warmth: f64,
-    pub trust: f64,
-    pub intrigue: f64,
-    pub intimacy: f64,
-    pub patience: f64,
-    pub tension: f64,
-    pub ghost_streak: i32,
-    pub total_ghosts: i32,
-    pub relationship_label: Option<String>,
-    pub updated_at: String,
-}
+/// Back-compat alias retained for one release so external OpenAPI consumers
+/// that referenced the old type name don't break instantly. Will be removed
+/// in the next minor; new code uses `AffinitySnapshot` directly.
+pub type AffinityDebugResponse = AffinitySnapshot;
 
 /// Inspect the live affinity vector for a session. The session must be
 /// owned by the JWT user; otherwise 403.
@@ -42,7 +33,7 @@ pub struct AffinityDebugResponse {
     tag = "debug",
     params(("session_id" = Uuid, Path, description = "Chat session id")),
     responses(
-        (status = 200, body = AffinityDebugResponse),
+        (status = 200, body = AffinitySnapshot),
         (status = 401, description = "missing or invalid bearer"),
         (status = 403, description = "not your session"),
         (status = 404, description = "session has no affinity")
@@ -53,7 +44,7 @@ async fn get_affinity(
     State(state): State<AppState>,
     Extension(AuthUser(user_id)): Extension<AuthUser>,
     Path(session_id): Path<Uuid>,
-) -> Result<Json<AffinityDebugResponse>, AppError> {
+) -> Result<Json<AffinitySnapshot>, AppError> {
     let repo = AffinityRepo { pool: &state.pool };
     let mut a = repo
         .load(session_id)
@@ -63,31 +54,7 @@ async fn get_affinity(
         return Err(AppError::Forbidden("not your session".into()));
     }
     a.apply_time_decay();
-
-    let label = a.relationship_label.map(|l| {
-        use eros_engine_core::affinity::RelationshipLabel as L;
-        match l {
-            L::Stranger => "stranger",
-            L::Romantic => "romantic",
-            L::Friend => "friend",
-            L::Frenemy => "frenemy",
-            L::SlowBurn => "slow_burn",
-        }
-        .to_string()
-    });
-
-    Ok(Json(AffinityDebugResponse {
-        warmth: a.warmth,
-        trust: a.trust,
-        intrigue: a.intrigue,
-        intimacy: a.intimacy,
-        patience: a.patience,
-        tension: a.tension,
-        ghost_streak: a.ghost_streak,
-        total_ghosts: a.total_ghosts,
-        relationship_label: label,
-        updated_at: a.updated_at.to_rfc3339(),
-    }))
+    Ok(Json(AffinitySnapshot::from(a)))
 }
 
 /// Build the debug router. Returns an empty router when `enabled = false`

--- a/crates/eros-engine-server/src/routes/debug.rs
+++ b/crates/eros-engine-server/src/routes/debug.rs
@@ -20,9 +20,18 @@ use crate::error::AppError;
 use crate::routes::dto::AffinitySnapshot;
 use crate::state::AppState;
 
-/// Back-compat alias retained for one release so external OpenAPI consumers
-/// that referenced the old type name don't break instantly. Will be removed
+/// Back-compat alias retained for one release so in-crate callers that
+/// referenced the old type name don't break instantly. Will be removed
 /// in the next minor; new code uses `AffinitySnapshot` directly.
+///
+/// Note: this alias does NOT help external OpenAPI consumers — utoipa
+/// resolves `pub type` transparently so the snapshot already renames
+/// to `AffinitySnapshot`. Any OpenAPI codegen will see the rename
+/// immediately on upgrade.
+#[deprecated(
+    since = "0.2.1",
+    note = "use `crate::routes::dto::AffinitySnapshot` directly; alias will be removed next minor"
+)]
 pub type AffinityDebugResponse = AffinitySnapshot;
 
 /// Inspect the live affinity vector for a session. The session must be

--- a/crates/eros-engine-server/src/routes/dto.rs
+++ b/crates/eros-engine-server/src/routes/dto.rs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! Shared response DTOs used by more than one routing subtree.
+//!
+//! Currently holds:
+//!   * `AffinitySnapshot` — point-in-time view of the 6-axis affinity
+//!     vector, used by both `/comp/affinity/{sid}` (debug) and
+//!     `/bff/v1/comp/chat/start` (Plan C).
+
+use serde::Serialize;
+
+use eros_engine_core::affinity::{Affinity, RelationshipLabel};
+
+/// Point-in-time projection of a session's `Affinity`. Same field set
+/// as the historical `AffinityDebugResponse`; renamed because it now
+/// flows through non-debug surfaces too.
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
+pub struct AffinitySnapshot {
+    pub warmth: f64,
+    pub trust: f64,
+    pub intrigue: f64,
+    pub intimacy: f64,
+    pub patience: f64,
+    pub tension: f64,
+    pub ghost_streak: i32,
+    pub total_ghosts: i32,
+    pub relationship_label: Option<String>,
+    pub updated_at: String,
+}
+
+fn label_to_str(l: RelationshipLabel) -> String {
+    match l {
+        RelationshipLabel::Stranger => "stranger",
+        RelationshipLabel::Romantic => "romantic",
+        RelationshipLabel::Friend => "friend",
+        RelationshipLabel::Frenemy => "frenemy",
+        RelationshipLabel::SlowBurn => "slow_burn",
+    }
+    .to_string()
+}
+
+impl From<Affinity> for AffinitySnapshot {
+    fn from(a: Affinity) -> Self {
+        Self {
+            warmth: a.warmth,
+            trust: a.trust,
+            intrigue: a.intrigue,
+            intimacy: a.intimacy,
+            patience: a.patience,
+            tension: a.tension,
+            ghost_streak: a.ghost_streak,
+            total_ghosts: a.total_ghosts,
+            relationship_label: a.relationship_label.map(label_to_str),
+            updated_at: a.updated_at.to_rfc3339(),
+        }
+    }
+}

--- a/crates/eros-engine-server/src/routes/mod.rs
+++ b/crates/eros-engine-server/src/routes/mod.rs
@@ -20,6 +20,7 @@ use crate::auth::middleware::require_auth;
 use crate::auth::s2s::require_s2s;
 use crate::state::AppState;
 
+pub mod bff;
 pub mod companion;
 pub mod companion_stream;
 pub mod debug;

--- a/crates/eros-engine-server/src/routes/mod.rs
+++ b/crates/eros-engine-server/src/routes/mod.rs
@@ -24,6 +24,7 @@ pub mod bff;
 pub mod companion;
 pub mod companion_stream;
 pub mod debug;
+pub mod dto;
 pub mod health;
 pub mod s2s;
 

--- a/crates/eros-engine-server/src/routes/mod.rs
+++ b/crates/eros-engine-server/src/routes/mod.rs
@@ -3,7 +3,7 @@
 //!
 //! The HTTP surface is split into three independently-authed sub-trees:
 //!   * Public:        `/healthz` — no auth
-//!   * Bearer JWT:    `/comp/*`  — Supabase JWT (see auth::middleware)
+//!   * Bearer JWT:    `/comp/*`, `/bff/v1/*`  — Supabase JWT (see auth::middleware)
 //!   * HMAC S2S:      `/s2s/*`   — shared-secret signature (see auth::s2s)
 //!
 //! Auth layers are applied to the per-subtree merge, NOT the top-level
@@ -60,5 +60,6 @@ pub fn router_for_openapi(expose_affinity_debug: bool) -> OpenApiRouter<AppState
         .merge(companion::router())
         .merge(companion_stream::router())
         .merge(debug::router(expose_affinity_debug))
+        .merge(bff::router())
         .merge(s2s::router())
 }

--- a/crates/eros-engine-server/src/routes/mod.rs
+++ b/crates/eros-engine-server/src/routes/mod.rs
@@ -39,6 +39,7 @@ pub fn router(state: AppState) -> OpenApiRouter<AppState> {
         .merge(companion::router())
         .merge(companion_stream::router())
         .merge(debug::router(state.config.expose_affinity_debug))
+        .merge(bff::router())
         .layer(from_fn_with_state(state.clone(), require_auth));
 
     let s2s_routes = s2s::router().layer(from_fn_with_state(state.clone(), require_s2s));

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -58,6 +58,16 @@ pub struct ChatMessage {
     pub assistant_action_type: Option<String>,
 }
 
+/// Projection-narrowed `ChatMessage` for BFF / UI-rendering paths that
+/// don't need `extracted_facts`, idempotency keys, or SSE metadata.
+/// Carries only the columns a chat-history viewer renders.
+#[derive(Debug, Clone, Serialize, sqlx::FromRow)]
+pub struct ChatMessageSlim {
+    pub role: String,
+    pub content: String,
+    pub sent_at: DateTime<Utc>,
+}
+
 pub struct ChatRepo<'a> {
     pub pool: &'a PgPool,
 }
@@ -164,6 +174,31 @@ impl<'a> ChatRepo<'a> {
         // gateway's `get_history` semantics.
         let mut rows = sqlx::query_as::<_, ChatMessage>(
             "SELECT * FROM engine.chat_messages \
+             WHERE session_id = $1 \
+             ORDER BY sent_at DESC \
+             LIMIT $2 OFFSET $3",
+        )
+        .bind(session_id)
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(self.pool)
+        .await?;
+        rows.reverse();
+        Ok(rows)
+    }
+
+    /// Projection-narrowed read used by BFF endpoints (and any caller that
+    /// doesn't need `extracted_facts` / idempotency / SSE metadata). Same
+    /// DESC+reverse trick as `history()` so the result is chronological.
+    /// Uses the existing `(session_id, sent_at DESC)` index — no migration.
+    pub async fn history_slim(
+        &self,
+        session_id: Uuid,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<ChatMessageSlim>, sqlx::Error> {
+        let mut rows = sqlx::query_as::<_, ChatMessageSlim>(
+            "SELECT role, content, sent_at FROM engine.chat_messages \
              WHERE session_id = $1 \
              ORDER BY sent_at DESC \
              LIMIT $2 OFFSET $3",
@@ -397,6 +432,57 @@ mod tests {
         assert_eq!(history[0].content, "hello");
         assert_eq!(history[1].role, "assistant");
         assert_eq!(history[2].content, "how are you?");
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn history_slim_returns_role_content_sent_at_in_order(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let user_id = Uuid::new_v4();
+        let instance_id = Uuid::new_v4();
+        let s = repo.create_session(user_id, instance_id).await.unwrap();
+
+        repo.append_message(s.id, "user", "alpha").await.unwrap();
+        repo.append_message(s.id, "assistant", "beta")
+            .await
+            .unwrap();
+        repo.append_message(s.id, "user", "gamma").await.unwrap();
+
+        let slim = repo.history_slim(s.id, 50, 0).await.unwrap();
+        assert_eq!(slim.len(), 3);
+        // Chronological order: oldest first (matches history()).
+        assert_eq!(slim[0].role, "user");
+        assert_eq!(slim[0].content, "alpha");
+        assert_eq!(slim[1].role, "assistant");
+        assert_eq!(slim[1].content, "beta");
+        assert_eq!(slim[2].role, "user");
+        assert_eq!(slim[2].content, "gamma");
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn history_slim_respects_limit_and_offset(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let user_id = Uuid::new_v4();
+        let instance_id = Uuid::new_v4();
+        let s = repo.create_session(user_id, instance_id).await.unwrap();
+        for n in 0..5 {
+            repo.append_message(s.id, "user", &format!("m{n}"))
+                .await
+                .unwrap();
+        }
+
+        // Most-recent 2, reversed to ASC — should be ["m3", "m4"].
+        let page = repo.history_slim(s.id, 2, 0).await.unwrap();
+        assert_eq!(
+            page.iter().map(|m| m.content.as_str()).collect::<Vec<_>>(),
+            vec!["m3", "m4"]
+        );
+
+        // offset=2 → next-most-recent 2, reversed — should be ["m1", "m2"].
+        let page = repo.history_slim(s.id, 2, 2).await.unwrap();
+        assert_eq!(
+            page.iter().map(|m| m.content.as_str()).collect::<Vec<_>>(),
+            vec!["m1", "m2"]
+        );
     }
 
     #[sqlx::test(migrations = "./migrations")]

--- a/docs/superpowers/specs/2026-05-20-history-latency-cuts-design.md
+++ b/docs/superpowers/specs/2026-05-20-history-latency-cuts-design.md
@@ -47,12 +47,14 @@ Plans B and C introduce a new top-level routing tree:
 ### Convention rules
 
 1. **`/bff/v1/<area>/*` mirrors the path layout of `/<area>/*`.** Same `session_id` / `instance_id` semantics in the path. The transformation lives in request/response *shape*, not URL structure.
-2. **BFF routes serve `eros-engine-web` (and any future first-party web/mobile client).** They are NOT a stable third-party API surface. We may aggregate, reshape, or drop fields without versioning beyond `v1`.
+2. **BFF routes serve `eros-engine-web` (and any future first-party web/mobile client).** They are NOT a stable third-party API surface. **Additive** changes (new optional fields, new endpoints, looser validation) ship in-place within `v1`. **Breaking** changes (removed/renamed fields, tightened validation, changed required body shape) go to `/bff/v2/...` — see rule 5.
 3. **Engine-canonical routes (`/comp/*` etc.) are NEVER modified to satisfy frontend ergonomics.** If the FE needs a different shape, add a BFF route. This keeps the OSS engine contract stable for downstream consumers.
-4. **BFF endpoints reuse the same auth (Supabase JWT) and middleware** as their engine counterparts — same `require_auth` layer attached to the merged sub-router.
-5. **`v1` is reserved for additive evolution.** Breaking BFF shape changes go to `/bff/v2/...` and the old version sticks around for one minor release before deletion.
+4. **BFF endpoints reuse the same auth (Supabase JWT) and middleware** as their engine counterparts — same `require_auth` layer attached to the merged sub-router. They also inherit the engine's `AppError` JSON taxonomy (`{ "error": code, "message": ... }`) and the bare-`401` auth-middleware response — no BFF-specific error envelope.
+5. **`v1` is reserved for additive evolution; breaking changes mean `v2`.** A `/bff/v2/...` endpoint may co-exist with its `v1` predecessor for one minor release before the `v1` form is deleted.
 6. **The `v` version in the URL is BFF-layer-wide, not per-endpoint.** All `/bff/v1/*` endpoints share the same versioning lifecycle. Avoid stamping individual endpoints with different versions.
-7. **OSS scope: BFF for `/comp/*` lives in `eros-engine` (AGPL-3.0).** The transformation is a thin shape adapter on top of an already-OSS surface — no commercial IP. Future BFF for closed-source areas (`/match/*`, etc.) will live in the future closed `eros-gateway`, mirroring its own non-OSS counterparts.
+7. **OSS scope: BFF for `/comp/*` lives in `eros-engine` (AGPL-3.0).** The transformation is a thin shape adapter on top of an already-OSS surface — no commercial IP. Future BFF for closed-source areas (`/match/*`, etc.) will live in the future closed `eros-gateway`, mirroring its own non-OSS counterparts. BFF routes in **this** OSS repo MUST NOT import from, or assume the existence of, `eros-gateway`.
+8. **BFF routes never call other BFF routes or canonical HTTP handlers.** They reach down to repos (`ChatRepo`, `AffinityRepo`, …) and shared `pub(crate)` helpers (`resolve_or_create_session`, …) directly. This keeps auth, error mapping, and OpenAPI explicit — no in-process HTTP recursion, no double-wrapping of `AppError`.
+9. **Each BFF handler gets a distinct Rust function name** (`bff_get_history`, `bff_start_chat`, …) so utoipa-axum emits a unique OpenAPI `operationId` that doesn't collide with the canonical handler of the same shape. All BFF handlers tag themselves `bff-companion` (or future `bff-<area>`), declared in `openapi.rs`.
 
 ### Why a BFF layer?
 
@@ -105,22 +107,22 @@ Each BFF handler's `#[utoipa::path]` uses the full path including the `/bff/v1/`
 
 That's the entire change.
 
-### 1.2 Note on prod deploy
+### 1.2 Note on deploy
 
-The repo `fly.toml` is the file that drives the live `erosnx.etherfun.net` deploy. This PR's one-line change ships directly via `flyctl deploy`. (The file's "Adapt to your own deployment" header is for downstream forks; it's our prod config too.)
+The repo `fly.toml` is the live config for whoever runs this image: this PR's one-line change ships directly via `flyctl deploy <your-app>`. The file's "example config — adapt to your own deployment" header still applies for downstream forks; operators of any first-party deploy keep their app name / region in their own private values file or `flyctl deploy` args, not in this OSS file.
 
 ### 1.3 Verification
 
 After `flyctl deploy`:
 
 ```
-flyctl status -a eros-engine
+flyctl status -a <your-app>
 # expected: ≥ 1 machine in `started` state when traffic is zero
 ```
 
 ### 1.4 Cost
 
-~$5/mo for one `shared-cpu-1x` (256 MB) running 24/7 in NRT at current Fly pricing.
+One `shared-cpu-1x` (currently `512 MB` per `fly.toml`) running 24/7 in NRT. At current Fly pricing this is a small recurring compute charge (single-digit USD/mo before bandwidth and org allowances); call it "a coffee a month" rather than pin a precise number that will rot.
 
 ### 1.5 Rollback
 
@@ -141,7 +143,7 @@ GET /bff/v1/comp/chat/{session_id}/history?limit=50&offset=0
 Auth: Bearer <Supabase JWT>
 ```
 
-Same auth, same `(session_id, user_id)` ownership check, same `limit ∈ [1, 50] default 50`, same `offset ≥ 0` as the engine endpoint. The only difference is the response shape.
+Same auth, same `(session_id, user_id)` ownership check, same `limit ∈ [1, 50]`, same `offset ≥ 0` as the engine endpoint. **Intentional divergence: BFF defaults `limit=50` (the cap), engine defaults `limit=20`.** Reason: BFF exists for cold-mount, where the FE wants a full backscroll in one round-trip; the canonical endpoint stays conservative for OSS consumers paging through history. Plan-stage tests pin both defaults so the divergence is explicit.
 
 ### 2.3 Response DTO
 
@@ -159,6 +161,10 @@ pub struct BffHistoryEntry {
 pub struct BffHistoryResponse {
     pub session_id: Uuid,
     pub messages: Vec<BffHistoryEntry>,
+    /// Count of `messages` in this response (== `messages.len()`). NOT the
+    /// total row count for the session — pagination doesn't know how many
+    /// rows remain. Mirrors the existing `/comp/.../history` `total` field
+    /// so a FE that already keys off it doesn't have to relearn semantics.
     pub total: usize,
 }
 ```
@@ -226,7 +232,7 @@ Same `idx_chat_messages_session (session_id, sent_at DESC)` index, same DESC+rev
     ),
     security(("bearer" = []))
 )]
-async fn get_history(
+async fn bff_get_history(
     State(state): State<AppState>,
     Path(session_id): Path<Uuid>,
     Extension(AuthUser(user_id)): Extension<AuthUser>,
@@ -282,7 +288,7 @@ Body:
 }
 ```
 
-The request body is identical to today's `POST /comp/chat/start`. The response is the bundled FE shape.
+The request body **extends** today's `POST /comp/chat/start` body (`instance_id`, `genome_id`, `is_demo`) with one optional BFF-only field, `history_limit`. The canonical endpoint never sees `history_limit`; it is consumed and dropped at the BFF boundary. The response is the bundled FE shape.
 
 ### 3.3 Request / Response DTOs
 
@@ -318,7 +324,7 @@ No `include_history` / `include_affinity` flags — the BFF endpoint **always bu
 ### 3.4 Handler logic
 
 ```rust
-async fn start_chat(
+async fn bff_start_chat(
     State(state): State<AppState>,
     Extension(AuthUser(user_id)): Extension<AuthUser>,
     Json(req): Json<BffStartRequest>,
@@ -330,21 +336,26 @@ async fn start_chat(
     let resolved = resolve_or_create_session(&state, user_id, &req).await?;
     let history_limit = req.history_limit.unwrap_or(50).clamp(1, 50);
 
-    // 2. Fire history + affinity in parallel against the same pool.
+    // 2. Fire history + affinity in parallel on the same sqlx pool. Both
+    //    arms return Result<_, AppError> directly so try_join! has nothing
+    //    to coerce.
     let history_fut = async {
-        ChatRepo { pool: &state.pool }
-            .history_slim(resolved.session_id, history_limit, 0).await
+        Ok::<_, AppError>(
+            ChatRepo { pool: &state.pool }
+                .history_slim(resolved.session_id, history_limit, 0)
+                .await?
+        )
     };
     let affinity_fut = async {
-        if !state.config.expose_affinity_debug { return Ok::<_, AppError>(None); }
+        if !state.config.expose_affinity_debug {
+            return Ok::<_, AppError>(None);
+        }
         Ok(AffinityRepo { pool: &state.pool }
-            .load(resolved.session_id).await?
+            .load(resolved.session_id)
+            .await?
             .map(|mut a| { a.apply_time_decay(); AffinitySnapshot::from(a) }))
     };
-    let (rows, affinity) = tokio::try_join!(
-        async { Ok::<_, AppError>(history_fut.await?) },
-        affinity_fut,
-    )?;
+    let (rows, affinity) = tokio::try_join!(history_fut, affinity_fut)?;
 
     let history = rows.into_iter().map(|r| BffHistoryEntry {
         role: r.role, content: r.content, sent_at: r.sent_at,
@@ -362,10 +373,13 @@ async fn start_chat(
 ```
 
 Key points:
-- `tokio::try_join!` runs both reads concurrently on the same shared pool — no extra connection cost.
-- Brand-new session ⇒ `history: []` (definitionally empty) and `affinity: None` (no row yet).
-- `affinity: None` is also returned when the debug gate is closed (§3.5).
-- The session-resolution step (instance lookup, NFT gate, session create/resume) is the **same logic** as `/comp/chat/start`. To avoid copy-paste, extract it into a pure helper that both handlers call. See §3.6.
+- `tokio::try_join!` runs both reads concurrently on the same shared sqlx pool. No new pool is opened, but the two arms each check out a pooled connection for the duration of their query — peak handler concurrency for one BFF call is two connections, not one. Bench cost is negligible since both queries are sub-ms indexed lookups.
+- Brand-new session ⇒ `history: []` (definitionally empty).
+- `affinity: None` covers **three** cases that the FE should treat as "no calibration to show":
+  1. `EXPOSE_AFFINITY_DEBUG=false` — gate closed (§3.5).
+  2. Brand-new session — `create_session_with_metadata` doesn't create an affinity row; `AffinityRepo::load_or_create` only runs inside message/gift flows.
+  3. Resumed session that has never had an affinity-producing event yet — same reason: no row exists.
+- The session-resolution step (instance lookup, NFT gate, session create/resume) is the **same logic** as `/comp/chat/start`. To avoid copy-paste, extract it into a pure helper that both handlers call. See §3.6. The handler's documented response set is `200 / 401 / 403 / 404` — `403` propagates from the NFT gate inside `resolve_or_create_session` exactly like the canonical endpoint.
 
 ### 3.5 Affinity gating (`EXPOSE_AFFINITY_DEBUG`)
 
@@ -410,7 +424,7 @@ pub(crate) async fn resolve_or_create_session(
 }
 ```
 
-Both `start_chat` (engine) and `start_chat` (BFF) call this. The canonical engine handler keeps building its own response shape; the BFF handler builds the bundled shape. Zero behaviour change to the existing endpoint.
+Both `start_chat` (canonical, in `routes/companion.rs`) and `bff_start_chat` (in `routes/bff/companion.rs`) call this. The canonical engine handler keeps building its own response shape; the BFF handler builds the bundled shape. Zero behaviour change to the existing endpoint.
 
 ### 3.7 Backwards compatibility
 
@@ -423,7 +437,9 @@ Plan C is **additive** — ships in any 0.2.x patch. No need to wait for 0.3.
 ### 3.9 Open items for plan stage
 
 - **Whether to allow `history_limit = 0`.** Recommend: no. Clamp to `[1, 50]`. A caller that doesn't want history can use a different endpoint (or pagination later). Avoids ambiguous semantics.
-- **Tracing / metrics.** Add `bff.start.bundle_emitted` counter so we can measure web adoption once the consumer PR lands.
+- **Tracing / metrics.** Add `bff.start.bundle_emitted` counter so we can measure web adoption once the consumer PR lands. On each BFF handler add a `tracing` span with `route`, `session_id`, `instance_id`, `is_new`, `history_count`, `affinity_present`, `affinity_gate_open`, and elapsed durations for the resolve / history / affinity slices — handy for spotting the next bottleneck after Plans A/B/C land.
+- **NFT-gate parity tests.** `resolve_or_create_session` must preserve the canonical handler's NFT-gate ordering (gate on explicit `instance_id` after the load+owner check; gate on `genome_id` before find-or-create). E2E coverage should hit both `/comp/chat/start` and `/bff/v1/comp/chat/start` with the same gated input and assert identical 4xx response.
+- **Concurrent-first-call idempotency.** Canonical `/comp/chat/start` is resume-or-create with no DB-level unique `(user_id, instance_id, status='active')` constraint, so two simultaneous first calls can race and create two sessions. Plan C does not change this — but the web migration concentrates more cold-mount POSTs through this code path, which makes the race observable in a way it wasn't before. Plan stage should decide whether to add the unique constraint now or treat as a follow-up; do **not** silently inherit the race.
 
 ---
 
@@ -493,26 +509,41 @@ Plan B — /bff/v1/comp/chat/{session_id}/history
          pub fn router() -> OpenApiRouter<AppState>  { /* merge of bff handlers */ }
   B3   crates/eros-engine-server/src/routes/bff/companion.rs (new):
          + BffHistoryEntry, BffHistoryResponse
-         + handler get_history
+         + handler bff_get_history  (distinct name so OpenAPI operationId
+           doesn't collide with companion::get_history)
   B4   routes/mod.rs: add bff::router() to the `comp` merged subtree
          (so it inherits require_auth)
-  B5   cargo test -p eros-engine-server  (BFF history E2E: success / 401 / 403 / 404)
-  B6   regenerate OpenAPI snapshot (utoipa picks up new path/tag automatically)
+  B4a  routes/mod.rs: add bff::router() to router_for_openapi() too —
+         CI diffs `openapi.json` against `print-openapi` output, so the
+         BFF routes must appear in the openapi-extraction router
+  B4b  openapi.rs: extend the `tags(...)` list with
+         (name = "bff-companion", description = "BFF mirror of /comp/* shaped for eros-engine-web")
+  B5   cargo test -p eros-engine-server  (BFF history E2E: success / 401 / 403 / 404,
+         plus default-limit-is-50 assertion to pin the intentional divergence
+         from canonical's default of 20)
+  B6   regenerate OpenAPI snapshot:
+         cargo run -p eros-engine-server --quiet -- print-openapi \
+           > crates/eros-engine-server/openapi.json
 
 Plan C — /bff/v1/comp/chat/start
   C1   routes/companion.rs: extract resolve_or_create_session as pub(crate) fn;
-         refactor existing start_chat to call it
+         refactor existing start_chat to call it. Preserve NFT-gate ordering
+         (gate on explicit instance_id AFTER load+owner check; gate on
+         genome_id BEFORE find-or-create — see §3.9 NFT-gate parity tests)
   C2   routes/dto.rs (new): move AffinityDebugResponse → AffinitySnapshot;
          add From<Affinity> for AffinitySnapshot;
          routes/debug.rs updates its import + re-export under old name for one release
   C3   routes/bff/companion.rs:
          + BffStartRequest, BffStartResponse
-         + handler start_chat (uses resolve_or_create_session + history_slim + AffinityRepo)
+         + handler bff_start_chat (distinct name — see B3 note;
+           uses resolve_or_create_session + history_slim + AffinityRepo)
   C4   cargo test -p eros-engine-server  (BFF start E2E:
          brand-new-session-empty-history / resumed-session-with-history /
          affinity-null-when-debug-off / affinity-present-when-debug-on /
-         shared-resolver-matches-engine-endpoint)
-  C5   regenerate OpenAPI snapshot
+         shared-resolver-matches-engine-endpoint /
+         nft-gate-rejects-explicit-instance-id-not-owned /
+         nft-gate-rejects-genome-without-nft)
+  C5   regenerate OpenAPI snapshot (same command as B6)
 ```
 
 Web migration (separately tracked in `eros-engine-web/docs/superpowers/specs/`):

--- a/fly.toml
+++ b/fly.toml
@@ -32,7 +32,12 @@ primary_region = "nrt"
   force_https = true
   auto_stop_machines = "stop"
   auto_start_machines = true
-  min_machines_running = 0
+  # Keep one warm machine in the primary region so the next-after-idle
+  # visitor doesn't pay the ~500ms–3s Rust binary cold-start tax. Cost is
+  # one always-started shared-cpu-1x in NRT — a few USD/mo before
+  # bandwidth and org allowances. `auto_stop_machines = "stop"` stays, so
+  # capacity above 1 still scales down to 1 (not zero).
+  min_machines_running = 1
   processes = ["app"]
 
   [http_service.concurrency]


### PR DESCRIPTION
## Summary

Cuts `/app/chat/<companion>` cold-mount latency on `eros-engine-web` from **740–3450 ms → 100–180 ms** (≈6–19×) via three orthogonal, additive mitigations. Implements the design in `docs/superpowers/specs/2026-05-20-history-latency-cuts-design.md` (codex-reviewed). No migrations, no schema changes, canonical `/comp/*` contract untouched.

### Plan A — warm machine
- `fly.toml`: `min_machines_running = 0 → 1` in NRT. Eliminates the ~500 ms–3 s Rust cold-start tax. `auto_stop_machines = "stop"` retained (scales down to 1, not 0). ~a few USD/mo.

### Plan B — `GET /bff/v1/comp/chat/{sid}/history`
- New BFF route returning a slim DTO (`role`, `content`, `sent_at`) — drops `extracted_facts` (dreaming-lite internal) the FE never reads.
- Backed by new `ChatRepo::history_slim` (projection-narrowed read, same `(session_id, sent_at DESC)` index, no migration).
- Intentionally defaults `limit=50` (canonical defaults to 20) so cold-mount pulls a full backscroll in one trip — pinned by test.

### Plan C — `POST /bff/v1/comp/chat/start`
- New BFF route bundling **session + history + affinity in one round-trip** (3 RT → 1 RT).
- History + affinity reads run concurrently via `tokio::try_join!` on the shared pool.
- Affinity honors the `EXPOSE_AFFINITY_DEBUG` gate (symmetric with the standalone debug endpoint).
- Reuses the extracted `resolve_or_create_session` helper for byte-for-byte parity with canonical `/comp/chat/start` (NFT-gate ordering preserved + parity-tested).

### Supporting refactors
- New `routes/bff/` module + `bff-companion` OpenAPI tag, wired into both runtime and `router_for_openapi`.
- `AffinityDebugResponse` → `routes::dto::AffinitySnapshot` (+ `From<Affinity>`), with a `#[deprecated]` one-release alias.
- OpenAPI snapshot regenerated (idempotent; CI drift-check green).

## New BFF-layer convention (§0.1 of the spec)
`/bff/v1/<area>/*` mirrors `/<area>/*`; frontend-shaped, not a stable third-party surface; canonical routes are never reshaped for FE ergonomics; BFF never calls BFF.

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --no-run` compiles (13 new `#[sqlx::test]`: 6 Plan B + 2 resolver-parity + 7 Plan C; live pass runs in CI against Postgres)
- [x] OpenAPI snapshot idempotent + CI drift-check green
- [x] codex pre-merge review: SHIP (no blocking issues; auth/ownership/affinity-gate all PASS; no migrations/schema changes)
- [ ] Post-deploy: `flyctl status -a eros-engine` shows ≥1 warm machine at idle

## Deploy notes
- Deploys to the shared prod Supabase Postgres but adds **no migration** (`release_command = "migrate"` is a no-op for this change).
- `min_machines_running = 1` introduces a constant ~a-few-USD/mo NRT compute cost.
- Web migration to consume these endpoints is tracked separately in `eros-engine-web`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)