### PR TITLE
refactor: drop affinity from bff start + fix usage-key filter in SSE

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,11 +14,13 @@ OPENROUTER_API_KEY=sk-or-...
 # OPENROUTER_APP_REFERER=https://eros.example
 # OPENROUTER_APP_TITLE=Eros
 
-# OpenRouter response-side usage filter (optional). Comma-separated list
-# of top-level keys to strip from the sync /message response's `usage`
-# object before it leaves the engine. Tracing is unaffected. Hide your
-# wholesale cost from downstream customers without losing operator
-# observability.
+# OpenRouter response-side usage filter (optional). Comma-separated list of
+# top-level keys to strip from the `usage` object before it leaves the engine
+# — applies to BOTH the sync POST /comp/chat/{sid}/message response AND the
+# SSE streaming `done` frame (POST /comp/chat/{sid}/message/stream). The full
+# unfiltered usage is still persisted to the DB and emitted to tracing, so
+# operator observability is unaffected; this only hides keys (e.g. your
+# wholesale `cost`) from downstream API clients. Empty/unset = no filtering.
 # OPENROUTER_USAGE_HIDDEN_KEYS=cost,cost_details
 
 # Supabase project — same as eros-gateway.

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ for frame layout and error semantics.
 | `OPENROUTER_API_KEY` | yes | Chat completions, routed by `examples/model_config.toml` unless overridden. |
 | `OPENROUTER_APP_REFERER` | no | When set, sent as `HTTP-Referer` on every outbound OpenRouter call. Shows up on OpenRouter's app analytics dashboard. |
 | `OPENROUTER_APP_TITLE` | no | When set, sent as `X-Title`. Display name in OpenRouter app analytics. Pairs with `OPENROUTER_APP_REFERER`; both optional. |
-| `OPENROUTER_USAGE_HIDDEN_KEYS` | no | Comma-separated list of top-level keys to strip from the sync `/message` response's `usage` object. Useful for hiding wholesale `cost` / `cost_details` from downstream customers. Server-side tracing is unaffected. |
+| `OPENROUTER_USAGE_HIDDEN_KEYS` | no | Comma-separated list of top-level keys to strip from the `usage` object — both the sync `/message` response and the SSE streaming `done` frame. Useful for hiding wholesale `cost` / `cost_details` from downstream customers. The full usage is still persisted and traced server-side. |
 | `VOYAGE_API_KEY` | yes | Embeddings. Empty keys fail server boot. |
 | `SUPABASE_URL` | no | Supabase project URL. Kept in `.env.example` for client/deploy conventions; the server does not read it today. |
 | `SUPABASE_JWT_SECRET` | yes | JWT signing secret for default auth. |

--- a/README.zh.md
+++ b/README.zh.md
@@ -174,7 +174,7 @@ Server 默認監聽 `0.0.0.0:8080`。Scalar API docs 在 `/docs`，OpenAPI JSON 
 | `OPENROUTER_API_KEY` | 是 | Chat completions；默認由 `examples/model_config.toml` 路由。 |
 | `OPENROUTER_APP_REFERER` | 否 | 設了之後每次出站 OpenRouter 調用都帶 `HTTP-Referer`。會出現在 OpenRouter 的 app 分析面板上。 |
 | `OPENROUTER_APP_TITLE` | 否 | 設了之後帶 `X-Title`。OpenRouter app analytics 顯示名稱。和 `OPENROUTER_APP_REFERER` 一對；兩個都可選。 |
-| `OPENROUTER_USAGE_HIDDEN_KEYS` | 否 | 逗号分隔的顶层 key 列表，从 sync `/message` 响应的 `usage` 对象里剔除。常用于把批发 `cost` / `cost_details` 隐藏起来不外泄给下游客户。服务器端 tracing 不受影响。 |
+| `OPENROUTER_USAGE_HIDDEN_KEYS` | 否 | 逗号分隔的顶层 key 列表，从 `usage` 对象里剔除 —— sync `/message` 响应和 SSE 流式 `done` 帧都生效。常用于把批发 `cost` / `cost_details` 隐藏起来不外泄给下游客户。完整 usage 仍会落库并写入服务器端 tracing。 |
 | `VOYAGE_API_KEY` | 是 | Embeddings。空 key 會拒絕啟動。 |
 | `SUPABASE_URL` | 否 | Supabase project URL。保留在 `.env.example` 裡方便 client / deploy 約定；目前 server 不讀取它。 |
 | `SUPABASE_JWT_SECRET` | 是 | 默認 auth 使用的 JWT signing secret。 |

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -68,7 +68,8 @@
         "tags": [
           "bff-companion"
         ],
-        "summary": "Cold-mount bundle: resolves (or creates) the session, then returns\nhistory + affinity in a single round-trip. Replaces three sequential\ncalls (start + history + affinity) for `eros-engine-web` cold-mount.",
+        "summary": "Cold-mount bundle: resolves (or creates) the session and returns its slim\nhistory in one round-trip (collapses the FE's start + history calls).",
+        "description": "Affinity is intentionally NOT bundled here: the FE reads affinity on its\nown (full values via its DB middleware; per-turn deltas via\n`/bff/v1/comp/affinity/{sid}/event`). This keeps bootstrap independent of\n`EXPOSE_AFFINITY_DEBUG` — turning that gate off does not change this shape.",
         "operationId": "bff_start_chat",
         "requestBody": {
           "content": {
@@ -1256,17 +1257,6 @@
           "history"
         ],
         "properties": {
-          "affinity": {
-            "oneOf": [
-              {
-                "type": "null"
-              },
-              {
-                "$ref": "#/components/schemas/AffinitySnapshot",
-                "description": "Affinity snapshot. `None` covers three cases the FE treats identically\nas \"no calibration to show\":\n  1. `EXPOSE_AFFINITY_DEBUG=false` — debug gate closed.\n  2. Brand-new session — no row created yet.\n  3. Resumed session that has never had an affinity-producing event."
-              }
-            ]
-          },
           "history": {
             "type": "array",
             "items": {

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -7,7 +7,6 @@
 //! Task 4 only ships the type layer; the `run_stream` generator lands in
 //! later tasks (T10/T11/T12).
 
-use eros_engine_llm::openrouter::UsageBlock;
 use serde::Serialize;
 use ulid::Ulid;
 
@@ -53,7 +52,11 @@ pub enum ProtocolFrame {
     Done {
         message_id: String,
         truncated: bool,
-        usage: Option<UsageBlock>,
+        /// OpenRouter usage, post-`OPENROUTER_USAGE_HIDDEN_KEYS` filtering.
+        /// A `serde_json::Value` (not `UsageBlock`) so configured keys can be
+        /// stripped before the frame reaches the client — the DB persists the
+        /// full unfiltered usage separately.
+        usage: Option<serde_json::Value>,
         generation_id: Option<String>,
     },
     Final {
@@ -88,6 +91,7 @@ use eros_engine_store::affinity::AffinityRepo;
 use eros_engine_store::chat::ChatRepo;
 use eros_engine_store::persona::PersonaRepo;
 
+use crate::routes::companion::filter_usage_keys;
 use crate::state::AppState;
 
 /// Per-burst driver: walks the model fallback chain, emits Meta/Delta/Done
@@ -206,10 +210,15 @@ fn drive_chat_burst(
                 });
             }
 
+            // Strip OPENROUTER_USAGE_HIDDEN_KEYS from the wire usage. The DB
+            // row above persists the full unfiltered usage; only the frame is
+            // filtered (mirrors the sync send_message path).
+            let mut wire_usage = last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok());
+            filter_usage_keys(&mut wire_usage, &state.config.openrouter_usage_hidden_keys);
             yield ProtocolFrame::Done {
                 message_id: ulid_string(msg_ulid),
                 truncated,
-                usage: last_usage,
+                usage: wire_usage,
                 generation_id: last_gen_id,
             };
 
@@ -524,10 +533,11 @@ pub fn replay_stream(
                         content: row.content.clone(),
                     };
                 }
-                let usage = row
-                    .usage
-                    .as_ref()
-                    .and_then(|v| serde_json::from_value(v.clone()).ok());
+                // Replay the persisted (full) usage, then strip
+                // OPENROUTER_USAGE_HIDDEN_KEYS for the wire — same contract as
+                // the live burst above.
+                let mut usage = row.usage.clone();
+                filter_usage_keys(&mut usage, &state.config.openrouter_usage_hidden_keys);
                 yield ProtocolFrame::Done {
                     message_id: ulid_string(msg_ulid),
                     truncated: row.truncated,
@@ -609,12 +619,11 @@ mod tests {
         let f = ProtocolFrame::Done {
             message_id: ulid_string(Ulid::new()),
             truncated: true,
-            usage: Some(UsageBlock {
-                prompt_tokens: 10,
-                completion_tokens: 4,
-                total_tokens: 14,
-                cost: None,
-            }),
+            usage: Some(serde_json::json!({
+                "prompt_tokens": 10,
+                "completion_tokens": 4,
+                "total_tokens": 14,
+            })),
             generation_id: Some("gen-1".into()),
         };
         let v: serde_json::Value = serde_json::to_value(&f).unwrap();
@@ -735,6 +744,65 @@ mod tests {
         // Tolerant: the test just proves the generator runs end-to-end and
         // terminates. T11/T15 add per-frame assertions for Reply/replay paths.
         assert!(frames.last().is_some(), "must emit at least one frame");
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn replay_done_strips_openrouter_usage_hidden_keys(pool: PgPool) {
+        use futures_util::StreamExt;
+
+        let user_id = Uuid::new_v4();
+        let (_g, _instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.config.openrouter_usage_hidden_keys =
+            std::collections::HashSet::from(["cost".to_string()]);
+        let state = std::sync::Arc::new(state);
+
+        // A persisted assistant row carrying full usage incl. `cost`.
+        let row = eros_engine_store::chat::ChatMessage {
+            id: Uuid::new_v4(),
+            session_id,
+            role: "assistant".into(),
+            content: "hello".into(),
+            extracted_facts: None,
+            sent_at: chrono::Utc::now(),
+            client_msg_id: None,
+            ghost_decision: false,
+            user_message_id: None,
+            continues_from_message_id: None,
+            truncated: false,
+            model: Some("x-ai/grok-4-fast".into()),
+            usage: Some(serde_json::json!({
+                "prompt_tokens": 1290,
+                "completion_tokens": 17,
+                "total_tokens": 1307,
+                "cost": 0.0015878
+            })),
+            generation_id: Some("gen-1".into()),
+            assistant_action_type: Some("reply".into()),
+        };
+
+        let frames: Vec<ProtocolFrame> =
+            replay_stream(state, session_id, user_id, false, vec![row])
+                .collect()
+                .await;
+
+        let usage = frames
+            .iter()
+            .find_map(|f| match f {
+                ProtocolFrame::Done { usage, .. } => Some(usage.clone()),
+                _ => None,
+            })
+            .expect("a Done frame")
+            .expect("usage present");
+
+        // The hidden key is gone; the rest survive.
+        assert!(
+            usage.get("cost").is_none(),
+            "cost must be stripped by OPENROUTER_USAGE_HIDDEN_KEYS; got {usage}"
+        );
+        assert_eq!(usage["prompt_tokens"], 1290);
+        assert_eq!(usage["total_tokens"], 1307);
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -874,4 +874,91 @@ data: [DONE]\n\n";
         );
         assert!(matches!(frames.last(), Some(ProtocolFrame::Final { .. })));
     }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn run_stream_done_strips_hidden_usage_keys_live(pool: PgPool) {
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+        use futures_util::StreamExt;
+        use wiremock::matchers::path as wm_path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        // Upstream usage carries `cost` — which OPENROUTER_USAGE_HIDDEN_KEYS hides.
+        let body = "\
+data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n\
+data: {\"choices\":[{\"delta\":{\"content\":\" there\"}}],\"usage\":{\"prompt_tokens\":2,\"completion_tokens\":2,\"total_tokens\":4,\"cost\":0.0015},\"id\":\"gen-r\",\"model\":\"primary\"}\n\n\
+data: [DONE]\n\n";
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+
+        let user_id = Uuid::new_v4();
+        let (_g, instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.config.openrouter_usage_hidden_keys =
+            std::collections::HashSet::from(["cost".to_string()]);
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                eros_engine_llm::openrouter::AppAttribution::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+
+        let chat_repo = ChatRepo { pool: &pool };
+        let user_message_id = match chat_repo
+            .upsert_user_message_idempotent(session_id, "hi", "01J3333333333333333333333A")
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
+
+        let frames: Vec<ProtocolFrame> = run_stream(
+            std::sync::Arc::new(state),
+            PersistedUserMessage {
+                user_message_id,
+                session_id,
+                user_id,
+                instance_id,
+                content: "hi".into(),
+                prompt_traits: vec![],
+                audit: None,
+            },
+        )
+        .collect()
+        .await;
+
+        // PDE may pick Ghost (no usage) or Reply (usage present). Either way, no
+        // Done frame may leak `cost`. If Reply ran, this proves the live-burst
+        // filter; if Ghost ran, usage is None and the guard is trivially held.
+        let mut saw_filtered_usage = false;
+        for f in &frames {
+            if let ProtocolFrame::Done { usage: Some(u), .. } = f {
+                assert!(
+                    u.get("cost").is_none(),
+                    "live Done frame leaked hidden key `cost`: {u}"
+                );
+                assert_eq!(u["prompt_tokens"], 2, "non-hidden keys must survive");
+                saw_filtered_usage = true;
+            }
+        }
+        // If the reply path ran, confirm we actually exercised the filter.
+        if frames
+            .iter()
+            .any(|f| matches!(f, ProtocolFrame::Delta { .. }))
+        {
+            assert!(
+                saw_filtered_usage,
+                "a Reply burst ran but no Done frame carried usage to filter"
+            );
+        }
+    }
 }

--- a/crates/eros-engine-server/src/routes/bff/companion.rs
+++ b/crates/eros-engine-server/src/routes/bff/companion.rs
@@ -13,14 +13,12 @@ use serde::{Deserialize, Serialize};
 use utoipa_axum::{router::OpenApiRouter, routes};
 use uuid::Uuid;
 
-use eros_engine_store::affinity::AffinityRepo;
 use eros_engine_store::chat::ChatRepo;
 
 use crate::auth::middleware::AuthUser;
 use crate::error::AppError;
 use crate::routes::companion::resolve_or_create_session;
 use crate::routes::companion::{require_session_for_user, HistoryQuery, StartChatRequest};
-use crate::routes::dto::AffinitySnapshot;
 use crate::state::AppState;
 
 // ─── DTOs ───────────────────────────────────────────────────────────
@@ -73,12 +71,6 @@ pub struct BffStartResponse {
     pub is_new: bool,
     /// Most-recent N messages, oldest-first. Empty for brand-new sessions.
     pub history: Vec<BffHistoryEntry>,
-    /// Affinity snapshot. `None` covers three cases the FE treats identically
-    /// as "no calibration to show":
-    ///   1. `EXPOSE_AFFINITY_DEBUG=false` — debug gate closed.
-    ///   2. Brand-new session — no row created yet.
-    ///   3. Resumed session that has never had an affinity-producing event.
-    pub affinity: Option<AffinitySnapshot>,
 }
 
 // ─── Handler ────────────────────────────────────────────────────────
@@ -136,9 +128,13 @@ async fn bff_get_history(
     }))
 }
 
-/// Cold-mount bundle: resolves (or creates) the session, then returns
-/// history + affinity in a single round-trip. Replaces three sequential
-/// calls (start + history + affinity) for `eros-engine-web` cold-mount.
+/// Cold-mount bundle: resolves (or creates) the session and returns its slim
+/// history in one round-trip (collapses the FE's start + history calls).
+///
+/// Affinity is intentionally NOT bundled here: the FE reads affinity on its
+/// own (full values via its DB middleware; per-turn deltas via
+/// `/bff/v1/comp/affinity/{sid}/event`). This keeps bootstrap independent of
+/// `EXPOSE_AFFINITY_DEBUG` — turning that gate off does not change this shape.
 #[utoipa::path(
     post,
     path = "/bff/v1/comp/chat/start",
@@ -162,27 +158,9 @@ async fn bff_start_chat(
     let resolved = resolve_or_create_session(&state, user_id, &canonical_req).await?;
     let history_limit = req.history_limit.unwrap_or(50).clamp(1, 50);
 
-    let history_fut = async {
-        Ok::<_, AppError>(
-            ChatRepo { pool: &state.pool }
-                .history_slim(resolved.session_id, history_limit, 0)
-                .await?,
-        )
-    };
-    let affinity_fut = async {
-        if !state.config.expose_affinity_debug {
-            return Ok::<Option<AffinitySnapshot>, AppError>(None);
-        }
-        let snapshot = AffinityRepo { pool: &state.pool }
-            .load(resolved.session_id)
-            .await?
-            .map(|mut a| {
-                a.apply_time_decay();
-                AffinitySnapshot::from(a)
-            });
-        Ok(snapshot)
-    };
-    let (rows, affinity) = tokio::try_join!(history_fut, affinity_fut)?;
+    let rows = ChatRepo { pool: &state.pool }
+        .history_slim(resolved.session_id, history_limit, 0)
+        .await?;
 
     let history = rows
         .into_iter()
@@ -199,7 +177,6 @@ async fn bff_start_chat(
         persona_name: resolved.persona_name,
         is_new: resolved.is_new,
         history,
-        affinity,
     }))
 }
 
@@ -409,7 +386,7 @@ mod tests {
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
-    async fn bff_start_brand_new_session_returns_empty_history_no_affinity(pool: PgPool) {
+    async fn bff_start_brand_new_session_returns_empty_history(pool: PgPool) {
         let user_id = Uuid::new_v4();
         let genome_id = seed_genome(&pool, "Aria").await;
 
@@ -429,8 +406,8 @@ mod tests {
         assert!(body["session_id"].is_string());
         assert!(body["instance_id"].is_string());
         assert!(body["history"].as_array().unwrap().is_empty());
-        // No affinity row yet for a brand-new session — spec §3.4 case 2.
-        assert!(body["affinity"].is_null());
+        // Bootstrap no longer bundles affinity — the field must be absent.
+        assert!(body.get("affinity").is_none());
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
@@ -506,43 +483,10 @@ mod tests {
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
-    async fn bff_start_affinity_null_when_debug_gate_closed(pool: PgPool) {
-        // Spec §3.4 case 1: affinity field hidden when EXPOSE_AFFINITY_DEBUG=false.
-        let user_id = Uuid::new_v4();
-        let genome_id = seed_genome(&pool, "Aria").await;
-        let instance_id = seed_instance(&pool, genome_id, user_id).await;
-        let session_id = seed_session(&pool, user_id, instance_id).await;
-        // Pre-seed an affinity row so the field would otherwise be non-null.
-        sqlx::query(
-            "INSERT INTO engine.companion_affinity (session_id, user_id, instance_id, warmth) \
-             VALUES ($1, $2, $3, 0.42)",
-        )
-        .bind(session_id)
-        .bind(user_id)
-        .bind(instance_id)
-        .execute(&pool)
-        .await
-        .unwrap();
-
-        let mut state = test_state(pool);
-        state.config.expose_affinity_debug = false; // close the gate
-        let mut app = build_router(state);
-        let token = mint_test_jwt(user_id);
-
-        let (status, body) = send_request(
-            &mut app,
-            bff_start_request(&token, json!({ "genome_id": genome_id })),
-        )
-        .await;
-        assert_eq!(status, StatusCode::OK);
-        assert!(
-            body["affinity"].is_null(),
-            "affinity must be hidden when EXPOSE_AFFINITY_DEBUG=false; got {body}"
-        );
-    }
-
-    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
-    async fn bff_start_affinity_present_when_debug_gate_open(pool: PgPool) {
+    async fn bff_start_does_not_bundle_affinity_even_with_debug_open(pool: PgPool) {
+        // Bootstrap is decoupled from affinity: even with a pre-seeded affinity
+        // row AND EXPOSE_AFFINITY_DEBUG on (test default), the start response
+        // carries no `affinity` field. The FE reads affinity separately.
         let user_id = Uuid::new_v4();
         let genome_id = seed_genome(&pool, "Aria").await;
         let instance_id = seed_instance(&pool, genome_id, user_id).await;
@@ -568,12 +512,10 @@ mod tests {
         )
         .await;
         assert_eq!(status, StatusCode::OK);
-        let affinity = &body["affinity"];
         assert!(
-            affinity.is_object(),
-            "expected affinity object, got {affinity}"
+            body.get("affinity").is_none(),
+            "start must not bundle affinity; got {body}"
         );
-        assert!((affinity["warmth"].as_f64().unwrap() - 0.42).abs() < 1e-9);
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -457,7 +457,7 @@ pub(crate) fn validate_prompt_traits(
 /// Only top-level keys are affected; nested sub-keys inside a retained
 /// object (e.g. `prompt_tokens.details`) are out of scope — list the
 /// parent key to suppress the whole subtree.
-fn filter_usage_keys(
+pub(crate) fn filter_usage_keys(
     usage: &mut Option<serde_json::Value>,
     hidden: &std::collections::HashSet<String>,
 ) {

--- a/crates/eros-engine-server/src/state.rs
+++ b/crates/eros-engine-server/src/state.rs
@@ -129,11 +129,12 @@ pub struct ServerConfig {
     /// re-claims the row. Should comfortably exceed the worst-case
     /// processing time (one LLM call + N voyage embeddings).
     pub dreaming_claim_stale_threshold: Duration,
-    /// Top-level keys removed from `CompanionReplyResponse.usage`
-    /// before the response leaves the engine. Empty = pass-through.
-    /// Tracing fields are unaffected — operator observability stays
-    /// intact regardless of this setting. Populated from
-    /// `OPENROUTER_USAGE_HIDDEN_KEYS` (comma-separated).
+    /// Top-level keys removed from the `usage` object before it leaves the
+    /// engine — both `CompanionReplyResponse.usage` (sync) and the SSE
+    /// streaming `done` frame. Empty = pass-through. The DB persists the full
+    /// unfiltered usage and tracing is unaffected, so operator observability
+    /// stays intact. Populated from `OPENROUTER_USAGE_HIDDEN_KEYS`
+    /// (comma-separated).
     pub openrouter_usage_hidden_keys: HashSet<String>,
 }
 

--- a/docs/llm-audit.md
+++ b/docs/llm-audit.md
@@ -73,7 +73,10 @@ OPENROUTER_USAGE_HIDDEN_KEYS=cost,cost_details
 
 Behaviour:
 
-- Applies to the sync `/comp/chat/{id}/message` response only.
+- Applies to **both** the sync `/comp/chat/{id}/message` response and the
+  SSE streaming `done` frame (`/comp/chat/{id}/message/stream`).
+- The full unfiltered `usage` is still persisted to the DB; only the
+  client-facing payload is filtered.
 - Does **not** affect `tracing::info!` output — operator observability
   stays intact regardless of this setting.
 - Async route (`/message_async`), polling route, and background paths

--- a/docs/llm-audit.zh.md
+++ b/docs/llm-audit.zh.md
@@ -71,7 +71,9 @@ OPENROUTER_USAGE_HIDDEN_KEYS=cost,cost_details
 
 行为：
 
-- 只作用于 sync `/comp/chat/{id}/message` 的响应。
+- sync `/comp/chat/{id}/message` 响应**和** SSE 流式 `done` 帧
+  （`/comp/chat/{id}/message/stream`）都生效。
+- 完整未过滤的 `usage` 仍会落库；只过滤面向 client 的负载。
 - **不**影响 `tracing::info!` 输出 —— 运维可见性照旧。
 - 异步路由（`/message_async`）、轮询路由、后台路径（dreaming /
   post_process）本来就不把 `usage` 返回给 client，env 设了也没区别。

--- a/docs/superpowers/specs/2026-05-20-history-latency-cuts-design.md
+++ b/docs/superpowers/specs/2026-05-20-history-latency-cuts-design.md
@@ -271,6 +271,16 @@ Drop the new `routes/bff/` module and the `routes::router` merge line. Zero impa
 
 ## 3. Plan C — `POST /bff/v1/comp/chat/start`
 
+> **Amendment (2026-05-20, v0.2.1):** the `affinity` field described below was
+> **removed** from `BffStartResponse` shortly after it shipped, before any FE
+> consumer depended on it. The FE bootstrap reads affinity separately (full
+> values via its own DB middleware; per-turn deltas via
+> `GET /bff/v1/comp/affinity/{sid}/event`, see
+> `2026-05-20-affinity-event-delta-design.md`), so bundling it here coupled
+> bootstrap to `EXPOSE_AFFINITY_DEBUG` for no benefit. `bff_start_chat` now
+> returns session + slim history only; the §3.3/§3.4 affinity bits below are
+> historical. Pre-consumption removal, so no `v2` bump.
+
 ### 3.1 Problem & lever
 
 Cold-mount on `eros-engine-web` serialises three engine calls. Folding session creation + history + affinity into one BFF endpoint collapses **3 RT → 1 RT**.


### PR DESCRIPTION
Two changes bundled (the second was requested to land before this merges).

## 1. Drop `affinity` from `POST /bff/v1/comp/chat/start`
The FE bootstrap no longer needs affinity bundled — it reads full affinity via its own DB middleware and per-turn deltas via `GET /bff/v1/comp/affinity/{sid}/event` (#27). Bundling it here coupled bootstrap to `EXPOSE_AFFINITY_DEBUG` for no benefit; with that gate about to be turned off in prod the field would just go `null`.
- `BffStartResponse` drops `affinity`; `bff_start_chat` is now a single history read (no `try_join` / affinity branch); unused imports removed.
- Tests: drop the two debug-gate affinity tests; add `bff_start_does_not_bundle_affinity_even_with_debug_open`.
- Removed **pre-consumption** (no FE consumer shipped yet) → no `/bff/v2` bump. Spec §3 amended.

## 2. Fix `OPENROUTER_USAGE_HIDDEN_KEYS` on the SSE `done` frame (regression since v0.2.0)
The usage-key filter only ran on the sync `/message` path, so the streaming `done` frame leaked the full `usage` (incl. `cost`) regardless of the config.
- `filter_usage_keys` → `pub(crate)`, applied at both streaming done sites (live burst + DB replay). `ProtocolFrame::Done.usage` is now `Option<Value>`; the DB still persists the full unfiltered usage (tracing unaffected) — same contract as sync.
- Tests: `replay_done_strips_openrouter_usage_hidden_keys` (deterministic) + `run_stream_done_strips_hidden_usage_keys_live` (mock OpenRouter with `cost`).
- Docs corrected (claimed sync-only): `.env.example`, `state.rs`, README(.zh), docs/llm-audit(.zh).

## Test plan
- [x] `cargo fmt --check` / `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p eros-engine-server` — **140 passed, 0 failed** (real Postgres)
- [x] OpenAPI snapshot regenerated + idempotent
- [x] codex review (both changes): SHIP — no blocking; correctness + persist-vs-wire confirmed

## Follow-up (after merge)
Redeploy `eros-engine`; set prod `EXPOSE_AFFINITY_DEBUG=false` + `EMA_INERTIA=0.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)