### PR TITLE
feat: six-axis affinity activation (LLM evaluator + row lock)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,7 +42,7 @@ VOYAGE_API_KEY=pa-...
 # Server
 BIND_ADDR=0.0.0.0:8080
 EXPOSE_AFFINITY_DEBUG=true
-EMA_INERTIA=0.8
+EMA_INERTIA=0.5
 # Demo sessions (started with is_demo=true) use this lower inertia so the
 # affinity meters move visibly across the demo turn budget. Lower = faster.
 DEMO_EMA_INERTIA=0.3

--- a/crates/eros-engine-core/src/affinity.rs
+++ b/crates/eros-engine-core/src/affinity.rs
@@ -45,7 +45,7 @@ pub struct AffinityDeltas {
 
 impl Affinity {
     /// Apply LLM-evaluated deltas with EMA smoothing.
-    /// `ema_inertia ∈ [0, 1]` — 0 means full update, 0.8 is standard.
+    /// `ema_inertia ∈ [0, 1]` — 0 means full update; v1 default is 0.5 (gain 0.5).
     pub fn apply_deltas(&mut self, d: &AffinityDeltas, ema_inertia: f64) {
         let blend = 1.0 - ema_inertia;
         self.warmth = clamp(self.warmth + blend * d.warmth, -1.0, 1.0);

--- a/crates/eros-engine-core/src/affinity.rs
+++ b/crates/eros-engine-core/src/affinity.rs
@@ -177,6 +177,21 @@ mod tests {
     }
 
     #[test]
+    fn apply_deltas_combined_then_gains_and_clamps() {
+        // A pre-summed (rule + llm) delta on a hot axis at v1 pacing
+        // (ema_inertia 0.5 → gain 0.5): 0.3 + 0.5 * 0.15 = 0.375.
+        let mut a = fresh(); // warmth 0.3
+        a.apply_deltas(
+            &AffinityDeltas {
+                warmth: 0.15,
+                ..Default::default()
+            },
+            0.5,
+        );
+        assert!((a.warmth - 0.375).abs() < 1e-9);
+    }
+
+    #[test]
     fn time_decay_reduces_intrigue_recovers_patience_softens_tension() {
         let mut a = fresh();
         a.intrigue = 0.5;

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -475,4 +475,26 @@ fallback = ""
             r.fallback_model
         );
     }
+
+    // Regression: the committed deployed config (examples/model_config.toml,
+    // copied to /etc/eros-engine in the Docker image) must always parse and
+    // must define the affinity_evaluation task the post-process evaluator
+    // depends on — otherwise resolve() silently falls back to the wrong model.
+    #[test]
+    fn committed_example_config_parses_and_has_affinity_task() {
+        let text = include_str!("../../../examples/model_config.toml");
+        let cfg = ModelConfig::from_toml_str(text)
+            .expect("examples/model_config.toml must parse");
+        let r = cfg.resolve("affinity_evaluation", None);
+        assert_eq!(r.model, "anthropic/claude-haiku-4.5");
+        assert_eq!(r.max_tokens, 250);
+        assert!((r.temperature - 0.3).abs() < 1e-9);
+        assert_eq!(
+            r.fallback_model,
+            vec![
+                "google/gemini-3.1-flash-lite".to_string(),
+                "deepseek/deepseek-v4-flash".to_string(),
+            ]
+        );
+    }
 }

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -483,8 +483,7 @@ fallback = ""
     #[test]
     fn committed_example_config_parses_and_has_affinity_task() {
         let text = include_str!("../../../examples/model_config.toml");
-        let cfg = ModelConfig::from_toml_str(text)
-            .expect("examples/model_config.toml must parse");
+        let cfg = ModelConfig::from_toml_str(text).expect("examples/model_config.toml must parse");
         let r = cfg.resolve("affinity_evaluation", None);
         assert_eq!(r.model, "anthropic/claude-haiku-4.5");
         assert_eq!(r.max_tokens, 250);

--- a/crates/eros-engine-server/src/pipeline/post_process.rs
+++ b/crates/eros-engine-server/src/pipeline/post_process.rs
@@ -302,6 +302,60 @@ fn find_json_block(raw: &str) -> Option<&str> {
     None
 }
 
+/// Per-axis safety cap on the LLM's raw delta, applied before the pacing
+/// gain. A guardrail against a misbehaving model — independent of
+/// `ema_inertia`. The two jobs (safety cap vs. pacing) are deliberately
+/// separate (see the design spec §5).
+#[allow(dead_code)] // wired in Task 6
+const LLM_AXIS_CAP: f64 = 0.15;
+
+/// Raw shape of the affinity evaluator's JSON output. `patience` is
+/// intentionally absent — it is rule-owned, so any `patience` the model
+/// emits is dropped by serde (unknown field). Missing axes default to 0.
+#[derive(Debug, Default, serde::Deserialize)]
+#[allow(dead_code)] // wired in Task 6
+struct LlmAffinityEval {
+    #[serde(default)]
+    warmth: f64,
+    #[serde(default)]
+    trust: f64,
+    #[serde(default)]
+    intrigue: f64,
+    #[serde(default)]
+    intimacy: f64,
+    #[serde(default)]
+    tension: f64,
+    #[serde(default)]
+    reason: String,
+}
+
+/// Parse + per-axis clamp the evaluator output into rule-mergeable deltas.
+/// Any failure (non-JSON, no object) → all-zero deltas + empty reason, so
+/// the rule deltas still persist and the affinity write never fails because
+/// the evaluator failed. `patience` is forced to 0 (rule-owned).
+#[allow(dead_code)] // wired in Task 6
+fn parse_affinity_eval(raw: &str) -> (eros_engine_core::affinity::AffinityDeltas, String) {
+    use eros_engine_core::affinity::AffinityDeltas;
+    let parsed: Option<LlmAffinityEval> = serde_json::from_str(raw)
+        .ok()
+        .or_else(|| find_json_block(raw).and_then(|b| serde_json::from_str(b).ok()));
+    let Some(e) = parsed else {
+        return (AffinityDeltas::default(), String::new());
+    };
+    let cap = |v: f64| v.clamp(-LLM_AXIS_CAP, LLM_AXIS_CAP);
+    (
+        AffinityDeltas {
+            warmth: cap(e.warmth),
+            trust: cap(e.trust),
+            intrigue: cap(e.intrigue),
+            intimacy: cap(e.intimacy),
+            tension: cap(e.tension),
+            patience: 0.0,
+        },
+        e.reason,
+    )
+}
+
 const INSIGHT_TASK: &str = "insight_extraction";
 
 /// Top-level entry: extract facts → structured insights → InsightRepo merge.
@@ -522,5 +576,66 @@ mod tests {
     #[test]
     fn find_json_block_returns_none_when_no_object() {
         assert!(find_json_block("no json here").is_none());
+    }
+
+    #[test]
+    fn parse_affinity_eval_valid_clamps_and_keeps_reason() {
+        let raw = r#"{"warmth":0.08,"trust":0.03,"intimacy":0.06,"intrigue":0.02,"tension":-0.01,"reason":"暖"}"#;
+        let (d, reason) = parse_affinity_eval(raw);
+        assert!((d.warmth - 0.08).abs() < 1e-9);
+        assert!((d.trust - 0.03).abs() < 1e-9);
+        assert!((d.intimacy - 0.06).abs() < 1e-9);
+        assert!((d.intrigue - 0.02).abs() < 1e-9);
+        assert!((d.tension - (-0.01)).abs() < 1e-9);
+        assert_eq!(d.patience, 0.0);
+        assert_eq!(reason, "暖");
+    }
+
+    #[test]
+    fn parse_affinity_eval_clamps_out_of_range() {
+        let raw = r#"{"warmth":5.0,"trust":-2.0,"reason":"x"}"#;
+        let (d, _) = parse_affinity_eval(raw);
+        assert!((d.warmth - 0.15).abs() < 1e-9, "warmth caps at +0.15");
+        assert!(
+            (d.trust - (-0.15)).abs() < 1e-9,
+            "trust delta caps at -0.15"
+        );
+    }
+
+    #[test]
+    fn parse_affinity_eval_ignores_patience_field() {
+        let raw = r#"{"warmth":0.1,"patience":0.99,"reason":"x"}"#;
+        let (d, _) = parse_affinity_eval(raw);
+        assert_eq!(d.patience, 0.0, "patience from the model is ignored");
+        assert!((d.warmth - 0.1).abs() < 1e-9);
+    }
+
+    #[test]
+    fn parse_affinity_eval_garbage_returns_default() {
+        let (d, reason) = parse_affinity_eval("not json at all");
+        assert_eq!(d.warmth, 0.0);
+        assert_eq!(d.trust, 0.0);
+        assert_eq!(d.intrigue, 0.0);
+        assert_eq!(d.intimacy, 0.0);
+        assert_eq!(d.tension, 0.0);
+        assert_eq!(d.patience, 0.0);
+        assert!(reason.is_empty());
+    }
+
+    #[test]
+    fn parse_affinity_eval_missing_fields_default_zero() {
+        let raw = r#"{"warmth":0.1,"reason":"only warmth"}"#;
+        let (d, _) = parse_affinity_eval(raw);
+        assert!((d.warmth - 0.1).abs() < 1e-9);
+        assert_eq!(d.trust, 0.0);
+        assert_eq!(d.intimacy, 0.0);
+    }
+
+    #[test]
+    fn parse_affinity_eval_extracts_from_fenced_block() {
+        let raw = "```json\n{\"warmth\":0.05,\"reason\":\"fenced\"}\n```";
+        let (d, reason) = parse_affinity_eval(raw);
+        assert!((d.warmth - 0.05).abs() < 1e-9);
+        assert_eq!(reason, "fenced");
     }
 }

--- a/crates/eros-engine-server/src/pipeline/post_process.rs
+++ b/crates/eros-engine-server/src/pipeline/post_process.rs
@@ -26,6 +26,7 @@ use eros_engine_store::affinity::AffinityRepo;
 use eros_engine_store::chat::ChatRepo;
 use eros_engine_store::insight::InsightRepo;
 use eros_engine_store::memory::{MemoryLayer, MemoryRepo};
+use eros_engine_store::persona::PersonaRepo;
 
 use crate::state::AppState;
 
@@ -85,14 +86,73 @@ pub async fn run(
         }
     };
 
-    let fut_affinity = persist_affinity(
-        &state,
-        session_id,
-        user_id,
-        instance_id,
-        plan.action_type,
-        plan.affinity_deltas.clone(),
-    );
+    let fut_affinity = async {
+        // Join the (possibly multi-message) assistant burst into one text;
+        // run ONE eval per turn → ONE combined event.
+        let assistant_msg = produced
+            .iter()
+            .map(|m| m.full_text.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        // Semantic eval: Reply turns only, with a non-trivial user message
+        // and a non-empty produced assistant message. Other actions
+        // (Proactive / GiftReaction / Ghost) keep rule-only deltas in v1.
+        let run_eval = plan.action_type == ActionType::Reply
+            && user_msg.chars().count() >= AFFINITY_EVAL_MIN_CHARS
+            && !assistant_msg.trim().is_empty();
+
+        let (llm_deltas, reason) = if run_eval {
+            let persona_repo = PersonaRepo { pool: &state.pool };
+            let affinity_repo = AffinityRepo { pool: &state.pool };
+            let persona_name = match persona_repo.load_companion(instance_id).await {
+                Ok(Some(p)) => p.genome.name,
+                _ => String::new(),
+            };
+            // Snapshot the current vector for prompt context only; the
+            // authoritative value is re-read under lock in persist_with_event.
+            match affinity_repo.load(session_id).await {
+                Ok(Some(current)) if !persona_name.is_empty() => {
+                    evaluate_affinity(
+                        &state,
+                        session_id,
+                        &persona_name,
+                        &current,
+                        &user_msg,
+                        &assistant_msg,
+                    )
+                    .await
+                }
+                _ => (
+                    eros_engine_core::affinity::AffinityDeltas::default(),
+                    String::new(),
+                ),
+            }
+        } else {
+            (
+                eros_engine_core::affinity::AffinityDeltas::default(),
+                String::new(),
+            )
+        };
+
+        let combined = merge_deltas(&plan.affinity_deltas, &llm_deltas);
+        let context = if reason.is_empty() {
+            serde_json::json!({})
+        } else {
+            serde_json::json!({ "affinity_reason": reason })
+        };
+
+        persist_affinity(
+            &state,
+            session_id,
+            user_id,
+            instance_id,
+            plan.action_type,
+            combined,
+            context,
+        )
+        .await;
+    };
 
     let should_update_lead = matches!(
         plan.action_type,
@@ -123,6 +183,7 @@ async fn persist_affinity(
     instance_id: Uuid,
     action: ActionType,
     deltas: eros_engine_core::affinity::AffinityDeltas,
+    context: serde_json::Value,
 ) {
     let repo = AffinityRepo { pool: &state.pool };
 
@@ -143,11 +204,10 @@ async fn persist_affinity(
         state.config.ema_inertia
     };
 
+    // No pre-read decay here: persist_with_event re-reads the row under a
+    // lock and applies time decay from that locked row (design spec §6.2).
     let mut affinity = match repo.load_or_create(session_id, user_id, instance_id).await {
-        Ok(mut a) => {
-            a.apply_time_decay();
-            a
-        }
+        Ok(a) => a,
         Err(e) => {
             tracing::warn!("affinity load_or_create failed: {e}");
             return;
@@ -168,13 +228,7 @@ async fn persist_affinity(
                 ActionType::Ghost => unreachable!(),
             };
             if let Err(e) = repo
-                .persist_with_event(
-                    &mut affinity,
-                    &deltas,
-                    ema_inertia,
-                    event_type,
-                    serde_json::json!({}),
-                )
+                .persist_with_event(&mut affinity, &deltas, ema_inertia, event_type, context)
                 .await
             {
                 tracing::warn!("affinity persist_with_event failed: {e}");
@@ -306,14 +360,12 @@ fn find_json_block(raw: &str) -> Option<&str> {
 /// gain. A guardrail against a misbehaving model — independent of
 /// `ema_inertia`. The two jobs (safety cap vs. pacing) are deliberately
 /// separate (see the design spec §5).
-#[allow(dead_code)] // wired in Task 6
 const LLM_AXIS_CAP: f64 = 0.15;
 
 /// Raw shape of the affinity evaluator's JSON output. `patience` is
 /// intentionally absent — it is rule-owned, so any `patience` the model
 /// emits is dropped by serde (unknown field). Missing axes default to 0.
 #[derive(Debug, Default, serde::Deserialize)]
-#[allow(dead_code)] // wired in Task 6
 struct LlmAffinityEval {
     #[serde(default)]
     warmth: f64,
@@ -333,7 +385,6 @@ struct LlmAffinityEval {
 /// Any failure (non-JSON, no object) → all-zero deltas + empty reason, so
 /// the rule deltas still persist and the affinity write never fails because
 /// the evaluator failed. `patience` is forced to 0 (rule-owned).
-#[allow(dead_code)] // wired in Task 6
 fn parse_affinity_eval(raw: &str) -> (eros_engine_core::affinity::AffinityDeltas, String) {
     use eros_engine_core::affinity::AffinityDeltas;
     let parsed: Option<LlmAffinityEval> = serde_json::from_str(raw)
@@ -359,7 +410,6 @@ fn parse_affinity_eval(raw: &str) -> (eros_engine_core::affinity::AffinityDeltas
 /// Sum the rule (behavioral) and LLM (semantic) contributions per axis.
 /// `patience` is rule-owned — the evaluator always passes 0 for it — so
 /// the sum naturally keeps the rule value.
-#[allow(dead_code)] // wired in Task 6
 fn merge_deltas(
     rule: &eros_engine_core::affinity::AffinityDeltas,
     llm: &eros_engine_core::affinity::AffinityDeltas,
@@ -372,6 +422,58 @@ fn merge_deltas(
         patience: rule.patience + llm.patience,
         tension: rule.tension + llm.tension,
     }
+}
+
+const AFFINITY_TASK: &str = "affinity_evaluation";
+
+/// Skip the haiku eval on trivially short user turns (e.g. "k" / "ok") —
+/// there is nothing semantic to score and the rule deltas still apply.
+/// Tunable; small enough that any real sentence runs the eval.
+const AFFINITY_EVAL_MIN_CHARS: usize = 4;
+
+/// Run the haiku affinity evaluator for one Reply turn. Returns the clamped
+/// per-axis LLM deltas + the model's reason. Any failure (LLM error,
+/// non-JSON) yields all-zero deltas + empty reason so the rule deltas still
+/// persist and the affinity write never fails because the evaluator failed.
+async fn evaluate_affinity(
+    state: &AppState,
+    session_id: Uuid,
+    persona_name: &str,
+    affinity: &eros_engine_core::affinity::Affinity,
+    user_msg: &str,
+    assistant_msg: &str,
+) -> (eros_engine_core::affinity::AffinityDeltas, String) {
+    use eros_engine_core::affinity::AffinityDeltas;
+
+    let prompt =
+        crate::prompt::affinity_eval_prompt(persona_name, affinity, user_msg, assistant_msg);
+    let resolved = state.model_config.resolve(AFFINITY_TASK, None);
+    let req = ChatRequest {
+        model: resolved.model,
+        fallback_model: resolved.fallback_model,
+        messages: vec![ChatMessage {
+            role: "user".into(),
+            content: prompt,
+        }],
+        temperature: resolved.temperature as f32,
+        max_tokens: resolved.max_tokens,
+        ..Default::default()
+    };
+
+    let raw = match state.openrouter.execute(req).await {
+        Ok(resp) => {
+            super::log_openrouter_usage(AFFINITY_TASK, Some(session_id), &resp);
+            resp.reply
+        }
+        Err(e) => {
+            tracing::warn!("affinity eval LLM call failed: {e}");
+            return (AffinityDeltas::default(), String::new());
+        }
+    };
+
+    let (deltas, reason) = parse_affinity_eval(&raw);
+    tracing::debug!(affinity_reason = %reason, "affinity eval parsed");
+    (deltas, reason)
 }
 
 const INSIGHT_TASK: &str = "insight_extraction";

--- a/crates/eros-engine-server/src/pipeline/post_process.rs
+++ b/crates/eros-engine-server/src/pipeline/post_process.rs
@@ -356,6 +356,24 @@ fn parse_affinity_eval(raw: &str) -> (eros_engine_core::affinity::AffinityDeltas
     )
 }
 
+/// Sum the rule (behavioral) and LLM (semantic) contributions per axis.
+/// `patience` is rule-owned — the evaluator always passes 0 for it — so
+/// the sum naturally keeps the rule value.
+#[allow(dead_code)] // wired in Task 6
+fn merge_deltas(
+    rule: &eros_engine_core::affinity::AffinityDeltas,
+    llm: &eros_engine_core::affinity::AffinityDeltas,
+) -> eros_engine_core::affinity::AffinityDeltas {
+    eros_engine_core::affinity::AffinityDeltas {
+        warmth: rule.warmth + llm.warmth,
+        trust: rule.trust + llm.trust,
+        intrigue: rule.intrigue + llm.intrigue,
+        intimacy: rule.intimacy + llm.intimacy,
+        patience: rule.patience + llm.patience,
+        tension: rule.tension + llm.tension,
+    }
+}
+
 const INSIGHT_TASK: &str = "insight_extraction";
 
 /// Top-level entry: extract facts → structured insights → InsightRepo merge.
@@ -637,5 +655,31 @@ mod tests {
         let (d, reason) = parse_affinity_eval(raw);
         assert!((d.warmth - 0.05).abs() < 1e-9);
         assert_eq!(reason, "fenced");
+    }
+
+    #[test]
+    fn merge_deltas_sums_per_axis_patience_from_rule_only() {
+        use eros_engine_core::affinity::AffinityDeltas;
+        let rule = AffinityDeltas {
+            intrigue: 0.02,
+            patience: 0.02,
+            ..Default::default()
+        };
+        let llm = AffinityDeltas {
+            warmth: 0.08,
+            intrigue: 0.03,
+            tension: 0.01,
+            ..Default::default()
+        };
+        let c = merge_deltas(&rule, &llm);
+        assert!((c.warmth - 0.08).abs() < 1e-9);
+        assert!((c.intrigue - 0.05).abs() < 1e-9, "0.02 rule + 0.03 llm");
+        assert!((c.tension - 0.01).abs() < 1e-9);
+        assert!(
+            (c.patience - 0.02).abs() < 1e-9,
+            "rule only (llm patience is 0)"
+        );
+        assert_eq!(c.trust, 0.0);
+        assert_eq!(c.intimacy, 0.0);
     }
 }

--- a/crates/eros-engine-server/src/pipeline/post_process.rs
+++ b/crates/eros-engine-server/src/pipeline/post_process.rs
@@ -431,6 +431,13 @@ const AFFINITY_TASK: &str = "affinity_evaluation";
 /// Tunable; small enough that any real sentence runs the eval.
 const AFFINITY_EVAL_MIN_CHARS: usize = 4;
 
+/// Upper bound on the evaluator LLM call. The OpenRouter client has no
+/// request timeout of its own, and the affinity write (incl. the already-
+/// computed rule deltas) waits on this call — so an unbounded stall would
+/// delay or lose the turn's affinity event. On elapse we fall back to
+/// rule-only deltas (the spec §4.5 "timeout → default" path).
+const AFFINITY_EVAL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
 /// Run the haiku affinity evaluator for one Reply turn. Returns the clamped
 /// per-axis LLM deltas + the model's reason. Any failure (LLM error,
 /// non-JSON) yields all-zero deltas + empty reason so the rule deltas still
@@ -460,13 +467,20 @@ async fn evaluate_affinity(
         ..Default::default()
     };
 
-    let raw = match state.openrouter.execute(req).await {
-        Ok(resp) => {
+    let raw = match tokio::time::timeout(AFFINITY_EVAL_TIMEOUT, state.openrouter.execute(req)).await
+    {
+        Ok(Ok(resp)) => {
             super::log_openrouter_usage(AFFINITY_TASK, Some(session_id), &resp);
             resp.reply
         }
-        Err(e) => {
+        Ok(Err(e)) => {
             tracing::warn!("affinity eval LLM call failed: {e}");
+            return (AffinityDeltas::default(), String::new());
+        }
+        Err(_elapsed) => {
+            tracing::warn!(
+                "affinity eval timed out after {AFFINITY_EVAL_TIMEOUT:?}; using rule-only deltas"
+            );
             return (AffinityDeltas::default(), String::new());
         }
     };

--- a/crates/eros-engine-server/src/prompt.rs
+++ b/crates/eros-engine-server/src/prompt.rs
@@ -129,8 +129,7 @@ pub fn style_directive(style: ReplyStyle) -> &'static str {
 /// intrigue/tension) as small per-turn *changes*, not absolute values.
 /// All six current values are shown for context, but `patience` is
 /// rule-owned and is deliberately excluded from the requested output.
-/// The caller (post-process affinity evaluator) is wired in Task 6.
-#[allow(dead_code)]
+/// Called by the post-process affinity evaluator.
 pub fn affinity_eval_prompt(
     persona_name: &str,
     affinity: &Affinity,

--- a/crates/eros-engine-server/src/prompt.rs
+++ b/crates/eros-engine-server/src/prompt.rs
@@ -129,7 +129,7 @@ pub fn style_directive(style: ReplyStyle) -> &'static str {
 /// intrigue/tension) as small per-turn *changes*, not absolute values.
 /// All six current values are shown for context, but `patience` is
 /// rule-owned and is deliberately excluded from the requested output.
-// The caller (post-process affinity evaluator) is added in a later task.
+/// The caller (post-process affinity evaluator) is wired in Task 6.
 #[allow(dead_code)]
 pub fn affinity_eval_prompt(
     persona_name: &str,
@@ -660,6 +660,22 @@ mod tests {
         assert!(
             !p.contains("\"patience\""),
             "patience is rule-owned and must not be in the JSON output schema"
+        );
+        // axis-to-label binding: the labeled line must carry the correct value
+        assert!(
+            p.contains("warmth 温暖（-1~1）：当前 0.42"),
+            "warmth label must bind to warmth value"
+        );
+        assert!(
+            p.contains("patience 耐心（0~1）：当前 0.66"),
+            "patience display value must render"
+        );
+        // five-axis JSON output schema (+reason) must be present
+        assert!(
+            p.contains(
+                r#"{"warmth": 0.0, "trust": 0.0, "intrigue": 0.0, "intimacy": 0.0, "tension": 0.0, "reason": "..."}"#
+            ),
+            "five-axis JSON output schema (+reason) must be present"
         );
     }
 

--- a/crates/eros-engine-server/src/prompt.rs
+++ b/crates/eros-engine-server/src/prompt.rs
@@ -123,6 +123,48 @@ pub fn style_directive(style: ReplyStyle) -> &'static str {
     }
 }
 
+/// Build the per-turn affinity-evaluation prompt for the post-process LLM
+/// scorer. Asks the model to rate how this single exchange should move the
+/// LLM-owned axes (warmth/trust/intimacy + content nudges to
+/// intrigue/tension) as small per-turn *changes*, not absolute values.
+/// All six current values are shown for context, but `patience` is
+/// rule-owned and is deliberately excluded from the requested output.
+// The caller (post-process affinity evaluator) is added in a later task.
+#[allow(dead_code)]
+pub fn affinity_eval_prompt(
+    persona_name: &str,
+    affinity: &Affinity,
+    user_msg: &str,
+    assistant_msg: &str,
+) -> String {
+    format!(
+        "你在评估这一轮对话对「{persona_name}」好感度的影响。\n\
+         好感度有六个维度，当前值如下：\n\
+         - warmth 温暖（-1~1）：当前 {warmth:.2}。冷淡/敌意为负，亲切/热情为正。\n\
+         - trust 信任（0~1）：当前 {trust:.2}。自我袒露、言行一致会提升。\n\
+         - intrigue 好奇（0~1）：当前 {intrigue:.2}。话题新鲜、有内容会提升。\n\
+         - intimacy 亲密（0~1）：当前 {intimacy:.2}。情感或身体上的靠近会提升。\n\
+         - patience 耐心（0~1）：当前 {patience:.2}。由规则维护，请勿评估。\n\
+         - tension 张力（0~1）：当前 {tension:.2}。调情、暧昧或冲突会提升。\n\
+         \n\
+         本轮对话：\n\
+         用户：{user_msg}\n\
+         {persona_name}：{assistant_msg}\n\
+         \n\
+         判断这一轮应让 warmth、trust、intrigue、intimacy、tension 各变化多少\
+         （是【变化量】，不是绝对值；patience 不要输出）。\n\
+         普通寒暄接近 0；真正动情或暧昧的瞬间幅度更大，每个维度大致在 ±0.15 之间。\n\
+         严格只输出 JSON，reason 用一句中文简述：\n\
+         {{\"warmth\": 0.0, \"trust\": 0.0, \"intrigue\": 0.0, \"intimacy\": 0.0, \"tension\": 0.0, \"reason\": \"...\"}}",
+        warmth = affinity.warmth,
+        trust = affinity.trust,
+        intrigue = affinity.intrigue,
+        intimacy = affinity.intimacy,
+        patience = affinity.patience,
+        tension = affinity.tension,
+    )
+}
+
 /// Gift reaction directives keyed on persona.tip_personality.
 pub fn gift_reaction_context(gifts: &[PendingGift], tip_personality: &str) -> String {
     if gifts.is_empty() {
@@ -578,6 +620,47 @@ mod tests {
     #[test]
     fn test_gift_reaction_empty_when_no_gifts() {
         assert!(gift_reaction_context(&[], "normal").is_empty());
+    }
+
+    fn fixture_affinity() -> Affinity {
+        let now = chrono::Utc::now();
+        Affinity {
+            id: Uuid::nil(),
+            session_id: Uuid::nil(),
+            user_id: Uuid::nil(),
+            instance_id: Uuid::nil(),
+            warmth: 0.42,
+            trust: 0.31,
+            intrigue: 0.55,
+            intimacy: 0.22,
+            patience: 0.66,
+            tension: 0.13,
+            ghost_streak: 0,
+            last_ghost_at: None,
+            total_ghosts: 0,
+            relationship_label: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    #[test]
+    fn affinity_eval_prompt_includes_six_values_and_exchange() {
+        let a = fixture_affinity();
+        let p = affinity_eval_prompt("Mia", &a, "我今天好累", "抱抱你");
+        // persona + the turn exchange
+        assert!(p.contains("Mia"));
+        assert!(p.contains("我今天好累"));
+        assert!(p.contains("抱抱你"));
+        // all six current values are shown (incl. patience, for context)
+        for v in ["0.42", "0.31", "0.55", "0.22", "0.66", "0.13"] {
+            assert!(p.contains(v), "missing current value {v} in prompt");
+        }
+        // patience must NOT be a requested output key
+        assert!(
+            !p.contains("\"patience\""),
+            "patience is rule-owned and must not be in the JSON output schema"
+        );
     }
 
     // ─── Insight prompt tests ──────────────────────────────────────

--- a/crates/eros-engine-server/src/state.rs
+++ b/crates/eros-engine-server/src/state.rs
@@ -143,7 +143,7 @@ impl ServerConfig {
         let ema_inertia = std::env::var("EMA_INERTIA")
             .ok()
             .and_then(|v| v.parse().ok())
-            .unwrap_or(0.8);
+            .unwrap_or(0.5);
         let dreaming_disabled = std::env::var("DREAMING_DISABLED")
             .map(|v| v == "1" || v == "true")
             .unwrap_or(false);

--- a/crates/eros-engine-store/src/affinity.rs
+++ b/crates/eros-engine-store/src/affinity.rs
@@ -180,8 +180,13 @@ impl<'a> AffinityRepo<'a> {
         .await
     }
 
-    /// Apply EMA-smoothed deltas in core, persist updated row, log event
-    /// — all in a single transaction. Mutates `affinity` in place.
+    /// Apply EMA-smoothed deltas in core, persist updated row, log event —
+    /// all in a single transaction. The current vector is re-read **inside**
+    /// the tx under `SELECT ... FOR UPDATE`, so overlapping same-session
+    /// writes serialize instead of clobbering each other (the lost-update
+    /// bug the six-axis activation makes real — design spec §6.2). Time
+    /// decay is computed from the locked row, not a pre-read snapshot.
+    /// Mutates `affinity` in place to reflect the persisted state.
     pub async fn persist_with_event(
         &self,
         affinity: &mut Affinity,
@@ -190,31 +195,42 @@ impl<'a> AffinityRepo<'a> {
         event_type: &str,
         context: serde_json::Value,
     ) -> Result<(), sqlx::Error> {
-        // Snapshot pre-EMA axis values to derive the post-EMA effective change.
+        let mut tx = self.pool.begin().await?;
+
+        // Lock the row and read the freshest committed values inside the tx.
+        let locked = sqlx::query_as::<_, AffinityRow>(
+            "SELECT * FROM engine.companion_affinity WHERE id = $1 FOR UPDATE",
+        )
+        .bind(affinity.id)
+        .fetch_one(&mut *tx)
+        .await?;
+        let mut current = locked.into_domain();
+
+        // Decay from the locked row, then snapshot the pre-delta baseline so
+        // effective_deltas captures only the delta application, not decay.
+        current.apply_time_decay();
         let before = AffinityDeltas {
-            warmth: affinity.warmth,
-            trust: affinity.trust,
-            intrigue: affinity.intrigue,
-            intimacy: affinity.intimacy,
-            patience: affinity.patience,
-            tension: affinity.tension,
+            warmth: current.warmth,
+            trust: current.trust,
+            intrigue: current.intrigue,
+            intimacy: current.intimacy,
+            patience: current.patience,
+            tension: current.tension,
         };
 
-        affinity.apply_deltas(deltas, ema_inertia);
-        let label = affinity.infer_label();
-        affinity.relationship_label = label;
+        current.apply_deltas(deltas, ema_inertia);
+        let label = current.infer_label();
+        current.relationship_label = label;
 
         // Post-EMA effective change = after − before (captures EMA + clamping).
         let effective = AffinityDeltas {
-            warmth: affinity.warmth - before.warmth,
-            trust: affinity.trust - before.trust,
-            intrigue: affinity.intrigue - before.intrigue,
-            intimacy: affinity.intimacy - before.intimacy,
-            patience: affinity.patience - before.patience,
-            tension: affinity.tension - before.tension,
+            warmth: current.warmth - before.warmth,
+            trust: current.trust - before.trust,
+            intrigue: current.intrigue - before.intrigue,
+            intimacy: current.intimacy - before.intimacy,
+            patience: current.patience - before.patience,
+            tension: current.tension - before.tension,
         };
-
-        let mut tx = self.pool.begin().await?;
 
         sqlx::query(
             "UPDATE engine.companion_affinity \
@@ -223,13 +239,13 @@ impl<'a> AffinityRepo<'a> {
                  relationship_label = $8, updated_at = now() \
              WHERE id = $1",
         )
-        .bind(affinity.id)
-        .bind(affinity.warmth)
-        .bind(affinity.trust)
-        .bind(affinity.intrigue)
-        .bind(affinity.intimacy)
-        .bind(affinity.patience)
-        .bind(affinity.tension)
+        .bind(current.id)
+        .bind(current.warmth)
+        .bind(current.trust)
+        .bind(current.intrigue)
+        .bind(current.intimacy)
+        .bind(current.patience)
+        .bind(current.tension)
         .bind(label.map(label_to_str))
         .execute(&mut *tx)
         .await?;
@@ -241,7 +257,7 @@ impl<'a> AffinityRepo<'a> {
                (affinity_id, event_type, deltas, effective_deltas, context) \
              VALUES ($1, $2, $3, $4, $5)",
         )
-        .bind(affinity.id)
+        .bind(current.id)
         .bind(event_type)
         .bind(deltas_json)
         .bind(effective_json)
@@ -250,6 +266,9 @@ impl<'a> AffinityRepo<'a> {
         .await?;
 
         tx.commit().await?;
+
+        // Reflect the persisted state back to the caller.
+        *affinity = current;
         Ok(())
     }
 
@@ -491,6 +510,104 @@ mod tests {
         ] {
             assert_eq!(eff[axis].as_f64().unwrap(), 0.0, "axis {axis} must be 0");
         }
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn concurrent_persist_with_event_does_not_lose_updates(pool: PgPool) {
+        let repo = AffinityRepo { pool: &pool };
+        let user_id = Uuid::new_v4();
+        let instance_id = Uuid::new_v4();
+        let session_id = make_session(&pool, user_id, instance_id).await;
+        let base = repo
+            .load_or_create(session_id, user_id, instance_id)
+            .await
+            .unwrap();
+        let start_warmth = base.warmth; // default 0.3
+
+        // Two overlapping writers, each +0.1 warmth at full gain (ema 0.0).
+        // Without row locking the second UPDATE clobbers the first and the
+        // result is 0.4 (one lost increment); with FOR UPDATE it is 0.5.
+        let p1 = pool.clone();
+        let p2 = pool.clone();
+        let h1 = tokio::spawn(async move {
+            let repo = AffinityRepo { pool: &p1 };
+            let mut a = repo.load(session_id).await.unwrap().unwrap();
+            repo.persist_with_event(
+                &mut a,
+                &AffinityDeltas {
+                    warmth: 0.1,
+                    ..Default::default()
+                },
+                0.0,
+                "message",
+                serde_json::json!({}),
+            )
+            .await
+            .unwrap();
+        });
+        let h2 = tokio::spawn(async move {
+            let repo = AffinityRepo { pool: &p2 };
+            let mut a = repo.load(session_id).await.unwrap().unwrap();
+            repo.persist_with_event(
+                &mut a,
+                &AffinityDeltas {
+                    warmth: 0.1,
+                    ..Default::default()
+                },
+                0.0,
+                "message",
+                serde_json::json!({}),
+            )
+            .await
+            .unwrap();
+        });
+        h1.await.unwrap();
+        h2.await.unwrap();
+
+        let reloaded = repo.load(session_id).await.unwrap().unwrap();
+        assert!(
+            (reloaded.warmth - (start_warmth + 0.2)).abs() < 1e-9,
+            "both increments must land: expected {}, got {}",
+            start_warmth + 0.2,
+            reloaded.warmth
+        );
+        let count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM engine.companion_affinity_events WHERE affinity_id = $1",
+        )
+        .bind(base.id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(count, 2, "each turn writes exactly one event row");
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn persist_with_event_flips_label_when_axes_cross_thresholds(pool: PgPool) {
+        let repo = AffinityRepo { pool: &pool };
+        let user_id = Uuid::new_v4();
+        let instance_id = Uuid::new_v4();
+        let session_id = make_session(&pool, user_id, instance_id).await;
+        let mut a = repo
+            .load_or_create(session_id, user_id, instance_id)
+            .await
+            .unwrap();
+        // Defaults warmth 0.3 / intimacy 0.0 / tension 0.1 → not Romantic.
+        // Cross the Romantic thresholds (warmth>=0.7, intimacy>=0.4,
+        // tension>=0.3) at full gain — confirms the now-live axes drive labels.
+        let deltas = AffinityDeltas {
+            warmth: 0.5,   // 0.3 -> 0.8
+            intimacy: 0.5, // 0.0 -> 0.5
+            tension: 0.3,  // 0.1 -> 0.4
+            ..Default::default()
+        };
+        repo.persist_with_event(&mut a, &deltas, 0.0, "message", serde_json::json!({}))
+            .await
+            .unwrap();
+        let reloaded = repo.load(session_id).await.unwrap().unwrap();
+        assert_eq!(
+            reloaded.relationship_label,
+            Some(RelationshipLabel::Romantic)
+        );
     }
 
     async fn seed_event(

--- a/docs/superpowers/specs/2026-05-20-six-axis-affinity-activation-design.md
+++ b/docs/superpowers/specs/2026-05-20-six-axis-affinity-activation-design.md
@@ -1,0 +1,238 @@
+# Six-axis affinity activation (engine) — Design
+
+**Status**: design, pending implementation plan
+**Date**: 2026-05-20
+**Repo**: `eros-engine` (OSS, AGPL-3.0)
+**Related**:
+- `2026-05-20-affinity-event-delta-design.md` — the `/bff/v1/comp/affinity/{sid}/event` surface this feeds.
+- `2026-05-20-affinity-source-migration-design.md` (eros-engine-web) — the FE consumer. This spec is its backend half.
+
+---
+
+## 0. Background & goal
+
+The six-axis affinity vector (`warmth`, `trust`, `intrigue`, `intimacy`, `patience`, `tension`) is meant to move as a user chats, drive the relationship-stage label, and be visible per-turn in the FE "好感度变化" strip. In practice it barely moves, and **`intimacy` / `warmth` / `trust` never move at all** during normal chat.
+
+### Goal
+
+1. Make all six axes actually respond to conversation, so meters move and stage labels change.
+2. Users should *perceptibly* see affinity change while chatting — target **a clear shift every ~3–5 strong turns** — without it feeling crude.
+3. Stay decoupled: no coupling between the message SSE stream and affinity computation (confirmed direction — see the FE spec §8).
+4. Engine-only change. Zero FE change required; the FE migration spec already consumes what this produces.
+
+---
+
+## 1. Root cause (current state)
+
+The chat pipeline's only affinity-delta source is the deterministic `predict_reply_deltas` in `eros-engine-core/src/pde.rs`. It writes **three** axes only:
+
+```rust
+d.intrigue += 0.02   // user message ≥ 30 chars
+d.patience += 0.02 / -0.02 / -0.05   // long / short / stale
+d.tension  += 0.03   // stale > 24h
+```
+
+It **never writes `warmth`, `trust`, or `intimacy`** — they stay at `AffinityDeltas::default()` (`0.0`). `Affinity::apply_deltas` then computes `x += (1 − ema_inertia) × delta`, so for those three axes `x += gain × 0 = 0` — frozen regardless of `ema_inertia`. The "EMA" knob is therefore irrelevant to the frozen axes; it is in reality a **linear delta gain**, not an exponential moving average.
+
+The intended LLM layer was never built: `pde.rs` says *"Phase 2: rules only. Phase 6 adds the LLM fallback path."* Phase 6 never landed. A `[tasks.pde_decision]` slot exists in `model_config.toml` but is explicitly *"not consumed by current code."*
+
+---
+
+## 2. Design overview
+
+Keep the deterministic rules for the **behavioral** signals they already handle (timing, message length, ghosting). Add an **LLM evaluator** for the **semantic** signals (what was actually said, emotional depth, flirtation). Sum the two contributions and persist a single event per turn through the existing `persist_with_event` path. The FE's existing baseline-and-poll on `/event` picks it up.
+
+```
+User turn ─▶ pde::decide (request path, sync)
+               └─ rule deltas: patience + timing bumps to intrigue/tension     [behavioral]
+                         │  (carried on plan.affinity_deltas, unchanged)
+SSE reply streams ─▶ done ─▶ FE captures baseline event_id, then polls /event (existing)
+                         │
+           post_process (tokio::spawn, async — existing) :
+               ├─ load current affinity (+ time_decay)                  [existing]
+               ├─ NEW affinity LLM eval (haiku) ─▶ llm deltas:
+               │     warmth, trust, intimacy  + content bumps to intrigue/tension   [semantic]
+               ├─ combined = rule_deltas + llm_deltas   (per-axis sum, clamped)
+               └─ persist_with_event(combined, gain) ─ ONE event row (new event_id) [existing]
+                         │  updates engine.companion_affinity (absolute vector)
+                         │  inserts companion_affinity_events (effective_deltas)
+                         ▼
+           FE poll sees new event_id within ~2s (budget 5s) ─▶ renders effective_deltas
+           FE detail panel reads absolute vector from Supabase on open
+```
+
+No SSE protocol change. No new public engine endpoint. No FE change.
+
+---
+
+## 3. Axis ownership (hybrid by signal type)
+
+| axis     | range     | rule (behavioral)              | LLM (semantic)            |
+|----------|-----------|--------------------------------|---------------------------|
+| warmth   | −1 .. 1   | —                              | ✓ cold/warm/hostility     |
+| trust    | 0 .. 1    | —                              | ✓ self-disclosure, consistency |
+| intrigue | 0 .. 1    | ✓ long msg / question / new topic | ✓ content novelty       |
+| intimacy | 0 .. 1    | —                              | ✓ emotional / physical closeness |
+| patience | 0 .. 1    | ✓ timing / short reply / ghost | —                         |
+| tension  | 0 .. 1    | ✓ stale bump                   | ✓ flirtation / conflict   |
+
+- **Rule-only**: `patience`. (Pure pacing/tolerance — no LLM needed.)
+- **LLM-only**: `warmth`, `trust`, `intimacy`.
+- **Both (summed)**: `intrigue`, `tension`. Rules give the timing nudge; LLM gives the content nudge.
+
+The existing `predict_reply_deltas` already produces exactly the rule half — **no change to its axis coverage is required.** Magnitudes stay as-is for v1 (they are intentionally small behavioral nudges; the LLM is the primary mover). They remain tunable later.
+
+---
+
+## 4. The LLM evaluator (the new piece)
+
+### 4.1 Placement & lifecycle
+
+- Runs inside `post_process` (`pipeline/post_process.rs`), as a sibling fire-and-forget task to the existing `extract_insights` / `write_turn` LLM work, joined via the existing `tokio::join!`.
+- Runs **only on `Reply` turns** with a non-empty user message **and** a non-empty produced assistant message. `Proactive` (no user message) → rules only. `Gift` (client-supplied deltas via `/event/gift`) and `Ghost` (all-zero) → unchanged.
+- Never blocks the chat response — it is already after the SSE stream completed.
+
+### 4.2 Wiring
+
+The evaluator needs the turn's `user_msg` + `assistant_msg` + current `Affinity` + persona. These are available in `post_process::run` (`event`, `produced`) and via repos. Restructure the affinity future so it:
+
+1. computes `llm_deltas` (Reply turns only; else `AffinityDeltas::default()`),
+2. sums onto `plan.affinity_deltas` (the rule deltas already passed in),
+3. calls `persist_affinity` with the combined deltas.
+
+`persist_affinity` keeps its current shape (load → time_decay → `persist_with_event`). Only its input deltas change.
+
+### 4.3 Model task
+
+New `[tasks.affinity_evaluation]` in `examples/model_config.toml`:
+
+```toml
+[tasks.affinity_evaluation]
+model = "anthropic/claude-haiku-4.5"
+fallback = ["google/gemini-3.1-flash-lite", "deepseek/deepseek-v4-flash"]
+temperature = 0.3
+max_tokens = 250
+```
+
+Resolved via the existing `ModelConfig::resolve("affinity_evaluation", None)`. `pde_decision` keeps its reserved meaning (not repurposed).
+
+### 4.4 Prompt (new fn in `prompt.rs`)
+
+`affinity_eval_prompt(persona_name, affinity, user_msg, assistant_msg)` → a single user-role prompt that:
+
+- States the persona and the six axes with one-line definitions and current values.
+- Provides this turn's exchange (user message + AI reply).
+- Instructs: output **only** the LLM-owned axes (`warmth`, `trust`, `intimacy`, `intrigue`, `tension`) as per-turn *changes* (not absolute values), each a small float; `patience` is omitted (rule-owned). Magnitude should reflect how significant the turn was: near-zero for small talk, larger for genuine emotional/flirtatious moments. Bound guidance: roughly ±0.15 per axis.
+- Demands strict JSON only.
+
+Output contract:
+
+```json
+{ "warmth": 0.08, "trust": 0.03, "intimacy": 0.06, "intrigue": 0.02, "tension": -0.01, "reason": "短句，用于日志/debug" }
+```
+
+### 4.5 Parse, clamp, failure
+
+- Parse with the existing `find_json_block` helper (already in `post_process.rs`), then `serde` into a deltas struct.
+- **Clamp each LLM axis to `[-0.15, 0.15]`** before summing (safety guardrail against a misbehaving model — independent of the pacing gain).
+- Any failure (LLM error, timeout, non-JSON, missing fields) → LLM contribution = `AffinityDeltas::default()`. The rule deltas still persist. The affinity write **never** fails because the evaluator failed.
+- `patience` from the LLM is ignored even if present.
+
+---
+
+## 5. Merge & pacing
+
+- **Combine**: `combined[axis] = rule_delta[axis] + clamped_llm_delta[axis]` per axis.
+- **Gain (pacing knob)**: `persist_with_event` applies `apply_deltas` → `x += (1 − ema_inertia) × combined`, then clamps to each axis's valid range. Keep `ema_inertia` as the **single global pacing lever** (env `EMA_INERTIA`, no redeploy).
+- **Per-axis safety cap**: ±0.15 raw (LLM) — a guardrail, *not* the pacing lever. The two jobs are deliberately separate.
+
+### Chosen numbers (v1)
+
+| knob | value | effect |
+|------|-------|--------|
+| LLM raw cap / axis | ±0.15 | ceiling per turn before gain |
+| `ema_inertia` (gain) | 0.5 (gain 0.5) | effective ≤ 0.075/turn on a hot axis |
+| result | — | **~4 strong turns ≈ +0.3** on an active axis → meter visibly fills, can cross a stage threshold |
+
+This satisfies the "clear shift every ~3–5 turns" target while staying "earned". `DEMO_EMA_INERTIA` (demo sessions) stays a separate, faster value as today.
+
+The pre-EMA `combined` is stored verbatim in the event row's `deltas`; the post-EMA, post-clamp change is stored in `effective_deltas` (existing behavior of `persist_with_event`). The FE renders `effective_deltas`.
+
+---
+
+## 6. Persistence & event semantics
+
+- **One combined event per turn** — no protocol or event-log change. `persist_with_event` already:
+  - updates `engine.companion_affinity` (absolute vector, read by the FE from Supabase),
+  - re-infers `relationship_label` (now meaningful since `warmth`/`intimacy`/`trust` move → stage labels actually change),
+  - inserts one `companion_affinity_events` row with pre-EMA `deltas` + post-EMA `effective_deltas` + `context`.
+- **Store the evaluator's `reason`** in the event `context` JSONB (e.g. `{ "affinity_reason": "..." }`) for debugging. This replaces today's `json!({})` context on message turns.
+- The FE's existing baseline-and-poll (`affinityPoll.ts`, budget 12 × 400 ms ≈ 5 s) catches the new `event_id` after the spawned post-process writes it (~1–2 s). No timing change needed.
+
+### 6.1 `deltas` vs `effective_deltas` — no batching
+
+`persist_with_event` stores two values per event:
+
+- **`deltas`** = the **raw combined request** for this turn (rule + LLM, *before* gain & clamp) — "what we asked for".
+- **`effective_deltas`** = the **actual per-turn change** applied to the stored vector = `after − before` = `(1 − ema_inertia) × delta`, minus any 0/1-ceiling loss — "what really moved".
+
+There is **no accumulate-until-threshold batching** anywhere in the engine. Each event row is exactly one turn's increment. **Accumulation lives entirely in the absolute `companion_affinity` vector** (the running sum of `effective_deltas` over all turns).
+
+The "clear shift every ~3–5 turns" target therefore emerges from **two layers, not batching**:
+
+1. **Continuous** — each strong turn writes a real `effective_deltas` increment (~0.075 on a hot axis at v1 pacing), comfortably above the FE's 0.005 skip floor, so the per-turn strip renders every meaningful turn.
+2. **The "big moment"** — `infer_label()` re-runs every turn inside `persist_with_event`; when the accumulated absolute vector crosses a stage threshold (e.g. `warmth ≥ 0.7 && intimacy ≥ 0.4 && tension ≥ 0.3 → Romantic`), `relationship_label` flips and the FE fires a stage-transition badge. At ~0.075/turn a threshold is crossed roughly every few turns — that is the periodic "大变化", driven by accumulation crossing a line, not by artificial batching.
+
+A silent-accumulate-then-reveal model (meters dead for N turns, then one jump) is explicitly **not** adopted: it feels unresponsive between reveals, and the stage-transition layer already supplies the drama on top of continuous feedback.
+
+---
+
+## 7. Scope
+
+**In:**
+- `Reply`-turn six-axis movement via hybrid rules + LLM.
+- New `affinity_evaluation` model task + prompt + parse/clamp/merge.
+- Store the evaluator reason in event context.
+
+**Out (later / not now):**
+- Time-decay for `warmth`/`trust`/`intimacy` (relationship cooling on neglect). `apply_time_decay` stays as-is (intrigue/patience/tension only). Note as a follow-up.
+- Per-turn LLM eval for `Proactive` turns.
+- Two-phase UI (instant rules → delayed LLM as two events). The FE poll returns on the first new `event_id`; a single combined event is the deliberate v1 choice.
+- Any SSE/stream coupling (explicitly rejected — FE spec §8).
+- Tuning rule magnitudes (kept as-is for v1).
+
+---
+
+## 8. Frontend consumers (context — no change required here)
+
+Per `2026-05-20-affinity-source-migration-design.md`:
+- **Per-turn delta** ("好感度变化" strip) ← `/bff/v1/comp/affinity/{sid}/event` `effective_deltas`. The FE **skips any delta where every axis `|v| < 0.005`** — v1 pacing (≤0.075 on hot axes) clears this comfortably; flat turns correctly render nothing.
+- **Absolute vector** (radar + stage pill) ← Supabase `engine.companion_affinity` directly (lazy, on detail-panel open).
+- The header **IntimacyBar** is `agent_training_level` (insight-driven), independent of this work.
+
+Because both FE surfaces are fed by `persist_with_event`, writing real combined deltas there is sufficient — no engine API or FE code change.
+
+---
+
+## 9. Error handling & observability
+
+- Evaluator failure → rule-only deltas; write still proceeds (§4.5).
+- Log evaluator usage via the existing `log_openrouter_usage("affinity_evaluation", Some(session_id), &resp)`.
+- Log the parsed `reason` at `debug` and persist it in event `context` for after-the-fact inspection.
+- Existing `tracing::warn!` on affinity persist failure is retained.
+
+---
+
+## 10. Testing
+
+- **core** (`affinity.rs`): existing `apply_deltas` / clamp / label tests cover the math. Add a focused test that a combined (rule + llm) delta sums then gains/clamps as expected (pure function, no LLM).
+- **post_process** (`post_process.rs`): unit-test the evaluator JSON parse + per-axis clamp + "patience ignored" + failure-returns-default, deterministically (mirrors the existing `parse_facts` / `find_json_block` tests). The live LLM call itself is not unit-tested (consistent with `extract_facts`).
+- **store** (`affinity.rs`): existing `persist_with_event` tests already assert pre/post-EMA `deltas`/`effective_deltas` and clamping — unchanged.
+- **prompt** (`prompt.rs`): snapshot/format test that `affinity_eval_prompt` includes the six current values and the turn exchange.
+- **Stage labels**: a test that a turn pushing `warmth`/`intimacy` over thresholds flips `relationship_label` (via `infer_label`, already covered) — confirms the now-live axes drive labels.
+
+---
+
+## 11. Open questions
+
+None blocking. Rule-magnitude tuning, warmth/trust/intimacy decay, and Proactive-turn evaluation are explicitly deferred (§7).

--- a/docs/superpowers/specs/2026-05-20-six-axis-affinity-activation-design.md
+++ b/docs/superpowers/specs/2026-05-20-six-axis-affinity-activation-design.md
@@ -89,18 +89,29 @@ The existing `predict_reply_deltas` already produces exactly the rule half — *
 ### 4.1 Placement & lifecycle
 
 - Runs inside `post_process` (`pipeline/post_process.rs`), as a sibling fire-and-forget task to the existing `extract_insights` / `write_turn` LLM work, joined via the existing `tokio::join!`.
-- Runs **only on `Reply` turns** with a non-empty user message **and** a non-empty produced assistant message. `Proactive` (no user message) → rules only. `Gift` (client-supplied deltas via `/event/gift`) and `Ghost` (all-zero) → unchanged.
+- Runs **only on `Reply` turns** with a non-empty user message **and** a non-empty produced assistant message. Other actions are unchanged:
+  - `Proactive` (no user message) → rules only, no eval.
+  - `Ghost` → all-zero, unchanged.
+  - **Gift — two distinct paths, both unchanged in v1:** (1) the `/comp/chat/{sid}/event/gift` route applies *client-supplied* deltas directly; (2) the pipeline `GiftReaction` action currently applies PDE default (zero) deltas (`pde.rs:36`). The LLM eval is **not** wired to gift turns in v1 (a follow-up could evaluate gift reactions).
 - Never blocks the chat response — it is already after the SSE stream completed.
+- **Optional cost gate:** skip the eval on trivially short user turns (e.g. `< SHORT_MSG_CHARS`), where there's nothing semantic to score — saves a haiku call on "k"/"ok"-type turns. Rules still apply. Tunable; off → eval every reply turn.
 
 ### 4.2 Wiring
 
-The evaluator needs the turn's `user_msg` + `assistant_msg` + current `Affinity` + persona. These are available in `post_process::run` (`event`, `produced`) and via repos. Restructure the affinity future so it:
+The evaluator needs the turn's `user_msg` + `assistant_msg` + current `Affinity` + persona name:
+
+- `user_msg` — from `event` (already in `post_process::run`).
+- `assistant_msg` — **`produced` is a `Vec<ProducedMessage>`** (the streaming path can emit a multi-message burst for one user turn). Join the burst into one assistant text (`produced.iter().map(|m| m.full_text).join("\n")`); run **one eval per turn**, write **one combined event**. Empty join → no eval.
+- `Affinity` — loaded in `persist_affinity` (existing).
+- **persona** — **not** currently passed to `post_process::run` (it has `instance_id`, not the persona). Load it in the affinity future via `PersonaRepo::load_companion(instance_id)` (one extra indexed query, fine in a background task) and pass the persona name to the prompt. Persona name only; the system prompt is not needed.
+
+Restructure the affinity future so it:
 
 1. computes `llm_deltas` (Reply turns only; else `AffinityDeltas::default()`),
 2. sums onto `plan.affinity_deltas` (the rule deltas already passed in),
-3. calls `persist_affinity` with the combined deltas.
+3. calls `persist_affinity` with the combined deltas **and the evaluator `reason`**.
 
-`persist_affinity` keeps its current shape (load → time_decay → `persist_with_event`). Only its input deltas change.
+`persist_affinity` keeps its overall shape (load → time_decay → `persist_with_event`). Its inputs change: the combined deltas, and the `context` JSONB now carries `{ "affinity_reason": ... }` instead of today's hardcoded `json!({})` (§6).
 
 ### 4.3 Model task
 
@@ -115,6 +126,8 @@ max_tokens = 250
 ```
 
 Resolved via the existing `ModelConfig::resolve("affinity_evaluation", None)`. `pde_decision` keeps its reserved meaning (not repurposed).
+
+**Deployment caveat (don't ship only `examples/`):** the server loads its config from `MODEL_CONFIG_PATH` (`main.rs:230`; prod = `/etc/eros-engine/model_config.toml` in the Docker image), and `resolve()` on a **missing** task does not error — it warns and silently falls back to `defaults.fallback_model` → `x-ai/grok-4-mini` (`model_config.rs:107`). So the affinity eval would silently run on the wrong model if the *deployed* config lacks the task. The new `[tasks.affinity_evaluation]` block must be added to the **deployed** config (and the Dockerfile/image source), not just `examples/`. Consider promoting the "unknown task" `warn!` to a startup assertion for tasks the code depends on.
 
 ### 4.4 Prompt (new fn in `prompt.rs`)
 
@@ -185,21 +198,34 @@ The "clear shift every ~3–5 turns" target therefore emerges from **two layers,
 
 A silent-accumulate-then-reveal model (meters dead for N turns, then one jump) is explicitly **not** adopted: it feels unresponsive between reveals, and the stage-transition layer already supplies the drama on top of continuous feedback.
 
+### 6.2 Concurrency: prevent lost updates (required by this change)
+
+Affinity persistence is a **read-modify-write** with the read (`load_or_create`, `post_process.rs:146`) **outside** the write transaction, and `post_process` is `tokio::spawn`ed and **not awaited** (`stream.rs:437`, `mod.rs:198`). Two turns whose post-process tasks overlap both read the same vector, both apply their deltas to that stale snapshot, and the second `UPDATE` wins → one turn's increment is silently lost.
+
+Today this is harmless because deltas are ~0. **This change makes it a real correctness bug**: deltas become meaningful *and* the ~1–2 s LLM eval widens the overlap window from milliseconds to seconds, so a user sending a follow-up within a couple seconds reliably triggers it — silently corrupting the core IP metric.
+
+**Requirement:** the read-modify-write must be serialized per session. Do the current-value read **inside** the `persist_with_event` transaction under a row lock (`SELECT ... FOR UPDATE` on the `companion_affinity` row), apply deltas to the freshly-locked values, then `UPDATE` + insert the event in the same tx. Exact handling of `apply_time_decay` relative to the locked read is an implementation detail for the plan (decay must be computed from the locked row, not a pre-read snapshot). This converts overlapping same-session writes into a serialized sequence — no lost increments, monotonic event ordering.
+
+(The FE's `client_msg_id`→event echo for perfect turn↔event causality remains out of scope — see the FE spec's accepted residual edge.)
+
 ---
 
 ## 7. Scope
 
 **In:**
 - `Reply`-turn six-axis movement via hybrid rules + LLM.
-- New `affinity_evaluation` model task + prompt + parse/clamp/merge.
-- Store the evaluator reason in event context.
+- New `affinity_evaluation` model task + prompt + parse/clamp/merge, added to the **deployed** config (§4.3).
+- Persona-name load in the affinity future; multi-message burst join (§4.2).
+- Store the evaluator reason in event context (§6).
+- **Row-level locking in `persist_with_event` to prevent lost updates (§6.2).**
 
 **Out (later / not now):**
 - Time-decay for `warmth`/`trust`/`intimacy` (relationship cooling on neglect). `apply_time_decay` stays as-is (intrigue/patience/tension only). Note as a follow-up.
-- Per-turn LLM eval for `Proactive` turns.
+- Per-turn LLM eval for `Proactive` and `GiftReaction` turns.
 - Two-phase UI (instant rules → delayed LLM as two events). The FE poll returns on the first new `event_id`; a single combined event is the deliberate v1 choice.
 - Any SSE/stream coupling (explicitly rejected — FE spec §8).
 - Tuning rule magnitudes (kept as-is for v1).
+- Renaming the misleading `ema_inertia` / "EMA" identifiers to "gain" — the math is documented (§1, §5) but a rename would break the deployed `EMA_INERTIA` fly secret and struct/param names; deferred.
 
 ---
 
@@ -227,7 +253,7 @@ Because both FE surfaces are fed by `persist_with_event`, writing real combined 
 
 - **core** (`affinity.rs`): existing `apply_deltas` / clamp / label tests cover the math. Add a focused test that a combined (rule + llm) delta sums then gains/clamps as expected (pure function, no LLM).
 - **post_process** (`post_process.rs`): unit-test the evaluator JSON parse + per-axis clamp + "patience ignored" + failure-returns-default, deterministically (mirrors the existing `parse_facts` / `find_json_block` tests). The live LLM call itself is not unit-tested (consistent with `extract_facts`).
-- **store** (`affinity.rs`): existing `persist_with_event` tests already assert pre/post-EMA `deltas`/`effective_deltas` and clamping — unchanged.
+- **store** (`affinity.rs`): existing `persist_with_event` tests already assert pre/post-EMA `deltas`/`effective_deltas` and clamping. **Add a concurrency test** (`sqlx::test`): two overlapping `persist_with_event` calls on the same session each apply their increment (final = sum of both, no lost update) — guards the §6.2 locking.
 - **prompt** (`prompt.rs`): snapshot/format test that `affinity_eval_prompt` includes the six current values and the turn exchange.
 - **Stage labels**: a test that a turn pushing `warmth`/`intimacy` over thresholds flips `relationship_label` (via `infer_label`, already covered) — confirms the now-live axes drive labels.
 

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -39,6 +39,18 @@ model = "anthropic/claude-haiku-4.5"
 temperature = 0.35
 max_tokens = 200
 
+# Per-turn six-axis affinity evaluation (post-process, semantic axes).
+# Scores how a single chat turn should move warmth/trust/intimacy plus the
+# content nudges to intrigue/tension, as small per-turn deltas. Runs only on
+# Reply turns, after the SSE stream — never blocks the chat response. Haiku
+# 4.5 is fast with reliable structured JSON; gemini-flash-lite +
+# deepseek-v4-flash keep it alive if Anthropic is down.
+[tasks.affinity_evaluation]
+model = "anthropic/claude-haiku-4.5"
+fallback = ["google/gemini-3.1-flash-lite", "deepseek/deepseek-v4-flash"]
+temperature = 0.3
+max_tokens = 250
+
 # Reserved — not consumed by current code. `VoyageClient` reads
 # `VOYAGE_API_KEY` directly and hard-codes `voyage-3-lite` (512 dims).
 # This entry exists for future generalisation if we ever support a

--- a/fly.toml
+++ b/fly.toml
@@ -17,7 +17,7 @@ primary_region = "nrt"
 [env]
   BIND_ADDR = "0.0.0.0:8080"
   EXPOSE_AFFINITY_DEBUG = "true"
-  EMA_INERTIA = "0.8"
+  EMA_INERTIA = "0.5"
   MODEL_CONFIG_PATH = "/etc/eros-engine/model_config.toml"
   RUST_LOG = "info"
 


### PR DESCRIPTION
## Summary

Makes all six affinity axes (`warmth`, `trust`, `intrigue`, `intimacy`, `patience`, `tension`) actually move during chat. Previously only the deterministic rule deltas wrote `intrigue`/`patience`/`tension`, so `warmth`/`trust`/`intimacy` were frozen and stage labels never changed.

- **LLM evaluator** (`affinity_evaluation` haiku task) runs in `post_process` after the SSE stream (fire-and-forget), scores the semantic axes per Reply turn as small per-turn changes, clamps each to ±0.15, and sums onto the existing rule deltas — one combined event per turn. Any LLM/parse failure degrades to rule-only deltas; the affinity write never fails because the evaluator failed.
- **Concurrency fix**: `persist_with_event` now does the affinity read-modify-write inside the transaction under `SELECT ... FOR UPDATE`, with time-decay computed from the locked row. This prevents lost updates when two same-session post-process tasks overlap (a real bug once deltas became meaningful + LLM latency widened the window).
- **Evaluator reason** is stored in the event `context` JSONB (`affinity_reason`) for debugging.
- **v1 pacing**: `EMA_INERTIA=0.5` (gain 0.5 → ≤0.075/turn on a hot axis → a clear shift every ~3-5 turns), consistent across `fly.toml`, `.env.example`, and the code fallback.

Engine-only change. No SSE/protocol change, no new endpoint, no migration, no FE change. The new model task is added to `examples/model_config.toml` (the deployed config the Dockerfile ships).

Design spec: `docs/superpowers/specs/2026-05-20-six-axis-affinity-activation-design.md`.

Out of scope (deferred per spec §7): time-decay for warmth/trust/intimacy; eval for Proactive/GiftReaction turns; two-phase UI; rule-magnitude tuning; `ema_inertia`→"gain" rename.

## Test plan

- [x] `cargo test --workspace` — 274 pass / 0 fail (core 32, llm 39, server 148, store 55)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] New: `parse_affinity_eval` ×6 (clamp / patience-ignored / garbage→default / fenced-block), `merge_deltas`, core combined-apply math, `affinity_eval_prompt` format, committed-config regression, **concurrent `persist_with_event` no-lost-update**, label-flip via now-live axes
- [ ] Manual: confirm meters move and a stage label flips over ~3-5 strong turns against a live model

🤖 Generated with [Claude Code](https://claude.com/claude-code)