### PR TITLE
feat: human_insights matching-table projection

### DIFF
--- a/crates/eros-engine-server/src/main.rs
+++ b/crates/eros-engine-server/src/main.rs
@@ -43,6 +43,10 @@ async fn main() -> Result<()> {
     //                                     (Fly.io release_command)
     //   eros-engine seed-personas <dir>   load every *.toml in <dir> as a
     //                                     persona genome (idempotent on name)
+    //   eros-engine backfill-human-insights  project every companion_insights
+    //                                     row into engine.human_insights
+    //                                     (idempotent UPSERT; manual, never
+    //                                     in release_command)
     //   eros-engine print-openapi         dump the OpenAPI spec to stdout and
     //                                     exit (no DB, no env). Used by the
     //                                     CI drift check.
@@ -55,11 +59,12 @@ async fn main() -> Result<()> {
                 .unwrap_or_else(|| "/etc/eros-engine/personas".to_string());
             run_seed_personas(&dir).await
         }
+        Some("backfill-human-insights") => run_backfill_human_insights().await,
         Some("print-openapi") => run_print_openapi(),
         Some("serve") | None => run_server().await,
         Some(other) => {
             eprintln!("unknown subcommand: {other}");
-            eprintln!("usage: eros-engine [serve|migrate|seed-personas <dir>|print-openapi]");
+            eprintln!("usage: eros-engine [serve|migrate|seed-personas <dir>|backfill-human-insights|print-openapi]");
             std::process::exit(2);
         }
     }
@@ -137,6 +142,38 @@ async fn run_seed_personas(dir: &str) -> Result<()> {
         }
     }
     tracing::info!(inserted, skipped, "seed-personas complete");
+    Ok(())
+}
+
+/// Project every existing `companion_insights` row into `engine.human_insights`.
+/// Idempotent (UPSERT), so re-running is safe. Manual maintenance command —
+/// deliberately NOT wired into the Fly release_command.
+async fn run_backfill_human_insights() -> Result<()> {
+    let database_url = std::env::var("DATABASE_URL").context("DATABASE_URL is required")?;
+    let pool = eros_engine_store::pool::build(&database_url)
+        .await
+        .context("failed to connect to DATABASE_URL")?;
+    let human_repo = eros_engine_store::human_insight::HumanInsightRepo { pool: &pool };
+
+    let rows: Vec<(uuid::Uuid, serde_json::Value)> =
+        sqlx::query_as("SELECT user_id, insights FROM engine.companion_insights")
+            .fetch_all(&pool)
+            .await
+            .context("load companion_insights for backfill")?;
+
+    let total = rows.len();
+    let mut ok = 0u32;
+    let mut failed = 0u32;
+    for (user_id, insights) in rows {
+        match human_repo.project_from_insights(user_id, &insights).await {
+            Ok(()) => ok += 1,
+            Err(e) => {
+                tracing::warn!(%user_id, "backfill projection failed: {e}");
+                failed += 1;
+            }
+        }
+    }
+    tracing::info!(total, ok, failed, "backfill-human-insights complete");
     Ok(())
 }
 

--- a/crates/eros-engine-server/src/pipeline/post_process.rs
+++ b/crates/eros-engine-server/src/pipeline/post_process.rs
@@ -540,7 +540,10 @@ async fn extract_insights(
             // matching table. No extra read — merge returned the merged row.
             // Failure only warns; it must not break the chat turn.
             let human_repo = HumanInsightRepo { pool: &state.pool };
-            if let Err(e) = human_repo.project_from_insights(user_id, &row.insights).await {
+            if let Err(e) = human_repo
+                .project_from_insights(user_id, &row.insights)
+                .await
+            {
                 tracing::warn!("human_insights projection failed: {e}");
             }
         }

--- a/crates/eros-engine-server/src/pipeline/post_process.rs
+++ b/crates/eros-engine-server/src/pipeline/post_process.rs
@@ -24,6 +24,7 @@ use eros_engine_llm::openrouter::{ChatMessage, ChatRequest, OpenRouterClient};
 use eros_engine_llm::voyage::VoyageClient;
 use eros_engine_store::affinity::AffinityRepo;
 use eros_engine_store::chat::ChatRepo;
+use eros_engine_store::human_insight::HumanInsightRepo;
 use eros_engine_store::insight::InsightRepo;
 use eros_engine_store::memory::{MemoryLayer, MemoryRepo};
 use eros_engine_store::persona::PersonaRepo;
@@ -533,8 +534,17 @@ async fn extract_insights(
         return;
     }
 
-    if let Err(e) = insights_repo.merge(user_id, new_insights).await {
-        tracing::warn!("companion_insights merge failed: {e}");
+    match insights_repo.merge(user_id, new_insights).await {
+        Ok(row) => {
+            // Write-through: project the just-merged JSONB into the flat
+            // matching table. No extra read — merge returned the merged row.
+            // Failure only warns; it must not break the chat turn.
+            let human_repo = HumanInsightRepo { pool: &state.pool };
+            if let Err(e) = human_repo.project_from_insights(user_id, &row.insights).await {
+                tracing::warn!("human_insights projection failed: {e}");
+            }
+        }
+        Err(e) => tracing::warn!("companion_insights merge failed: {e}"),
     }
 }
 

--- a/crates/eros-engine-store/migrations/0015_human_insights.sql
+++ b/crates/eros-engine-store/migrations/0015_human_insights.sql
@@ -1,0 +1,49 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Flat, typed projection of the soft (conversation-derived) user profile,
+-- shaped for user<->user matching. companion_insights stays the source of
+-- truth (JSONB); this table is a derived mirror written by write-through.
+--
+-- Hard-filter attributes (own gender/age/geo) are intentionally NOT here:
+-- they live in the user-self-filled profile table owned outside engine.*
+-- and are joined at match time.
+CREATE TABLE engine.human_insights (
+    user_id            UUID PRIMARY KEY,
+
+    -- soft scalar signal (free text; context / future embedding, not filtered)
+    city               TEXT,
+    occupation         TEXT,
+    mbti_guess         TEXT,
+    love_values        TEXT,
+    emotional_needs    TEXT,
+    life_rhythm        TEXT,
+
+    -- array signal — core matching dimensions (set overlap via &&)
+    interests          TEXT[] NOT NULL DEFAULT '{}',
+    personality_traits TEXT[] NOT NULL DEFAULT '{}',
+
+    -- flattened matching_preferences: "what the user wants"
+    preferred_gender   TEXT,
+    age_min            INT,
+    age_max            INT,
+    deal_breakers      TEXT[] NOT NULL DEFAULT '{}',
+
+    updated_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Only the array-overlap dimensions get indexes. No city index — geo
+-- hard-filtering is the profile table's job.
+CREATE INDEX idx_human_insights_interests ON engine.human_insights USING GIN(interests);
+CREATE INDEX idx_human_insights_traits    ON engine.human_insights USING GIN(personality_traits);
+
+-- Supabase lockdown (mirror of 0013) for the new table.
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
+        REVOKE ALL ON engine.human_insights FROM anon;
+    END IF;
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+        REVOKE ALL ON engine.human_insights FROM authenticated;
+    END IF;
+END
+$$;
+ALTER TABLE engine.human_insights ENABLE ROW LEVEL SECURITY;

--- a/crates/eros-engine-store/src/human_insight.rs
+++ b/crates/eros-engine-store/src/human_insight.rs
@@ -45,15 +45,20 @@ fn str_array(v: &serde_json::Value, key: &str) -> Vec<String> {
 }
 
 /// Parse `matching_preferences.age_range` ([min, max]) into two i32s. Any
-/// shape other than a 2-element all-integer array yields `(None, None)`.
+/// shape other than a 2-element array of in-range integers yields `(None,
+/// None)` — including values outside i32 range, which degrade to NULL rather
+/// than wrapping silently.
 fn parse_age_range(prefs: Option<&serde_json::Value>) -> (Option<i32>, Option<i32>) {
     prefs
         .and_then(|p| p.get("age_range"))
         .and_then(|a| a.as_array())
         .and_then(|arr| {
             if arr.len() == 2 {
-                match (arr[0].as_i64(), arr[1].as_i64()) {
-                    (Some(lo), Some(hi)) => Some((Some(lo as i32), Some(hi as i32))),
+                match (
+                    arr[0].as_i64().and_then(|n| i32::try_from(n).ok()),
+                    arr[1].as_i64().and_then(|n| i32::try_from(n).ok()),
+                ) {
+                    (Some(lo), Some(hi)) => Some((Some(lo), Some(hi))),
                     _ => None,
                 }
             } else {
@@ -218,6 +223,7 @@ mod tests {
             serde_json::json!([18]),
             serde_json::json!([18, 30, 40]),
             serde_json::json!(["a", "b"]),
+            serde_json::json!([i64::MAX, 30]),
         ] {
             let v = serde_json::json!({ "matching_preferences": { "age_range": bad } });
             let c = project_columns(&v);

--- a/crates/eros-engine-store/src/human_insight.rs
+++ b/crates/eros-engine-store/src/human_insight.rs
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! Flat, typed projection of the soft (conversation-derived) profile for
+//! user<->user matching. The JSONB->columns mapping lives ONLY in
+//! `project_columns` so the source/trigger can be repointed later without
+//! touching callers. `companion_insights` remains the source of truth.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+/// The parsed, typed columns ready to UPSERT. Owned values so the caller can
+/// move them straight into `.bind(...)`.
+#[derive(Debug, Default, PartialEq)]
+pub struct ProjectedColumns {
+    pub city: Option<String>,
+    pub occupation: Option<String>,
+    pub mbti_guess: Option<String>,
+    pub love_values: Option<String>,
+    pub emotional_needs: Option<String>,
+    pub life_rhythm: Option<String>,
+    pub interests: Vec<String>,
+    pub personality_traits: Vec<String>,
+    pub preferred_gender: Option<String>,
+    pub age_min: Option<i32>,
+    pub age_max: Option<i32>,
+    pub deal_breakers: Vec<String>,
+}
+
+fn str_field(v: &serde_json::Value, key: &str) -> Option<String> {
+    v.get(key).and_then(|x| x.as_str()).map(String::from)
+}
+
+/// Collect a JSON array under `key` into the string items only. Missing /
+/// non-array / non-string items are dropped, yielding `[]` rather than an error.
+fn str_array(v: &serde_json::Value, key: &str) -> Vec<String> {
+    v.get(key)
+        .and_then(|a| a.as_array())
+        .map(|arr| arr.iter().filter_map(|x| x.as_str().map(String::from)).collect())
+        .unwrap_or_default()
+}
+
+/// Parse `matching_preferences.age_range` ([min, max]) into two i32s. Any
+/// shape other than a 2-element all-integer array yields `(None, None)`.
+fn parse_age_range(prefs: Option<&serde_json::Value>) -> (Option<i32>, Option<i32>) {
+    prefs
+        .and_then(|p| p.get("age_range"))
+        .and_then(|a| a.as_array())
+        .and_then(|arr| {
+            if arr.len() == 2 {
+                match (arr[0].as_i64(), arr[1].as_i64()) {
+                    (Some(lo), Some(hi)) => Some((Some(lo as i32), Some(hi as i32))),
+                    _ => None,
+                }
+            } else {
+                None
+            }
+        })
+        .unwrap_or((None, None))
+}
+
+/// The single definition of the companion_insights JSONB -> human_insights
+/// columns mapping. Pure; unit-tested without a database.
+pub fn project_columns(insights: &serde_json::Value) -> ProjectedColumns {
+    let prefs = insights.get("matching_preferences");
+    let (age_min, age_max) = parse_age_range(prefs);
+    ProjectedColumns {
+        city: str_field(insights, "city"),
+        occupation: str_field(insights, "occupation"),
+        mbti_guess: str_field(insights, "mbti_guess"),
+        love_values: str_field(insights, "love_values"),
+        emotional_needs: str_field(insights, "emotional_needs"),
+        life_rhythm: str_field(insights, "life_rhythm"),
+        interests: str_array(insights, "interests"),
+        personality_traits: str_array(insights, "personality_traits"),
+        preferred_gender: prefs.and_then(|p| str_field(p, "preferred_gender")),
+        age_min,
+        age_max,
+        deal_breakers: prefs.map(|p| str_array(p, "deal_breakers")).unwrap_or_default(),
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct HumanInsightsRow {
+    pub user_id: Uuid,
+    pub city: Option<String>,
+    pub occupation: Option<String>,
+    pub mbti_guess: Option<String>,
+    pub love_values: Option<String>,
+    pub emotional_needs: Option<String>,
+    pub life_rhythm: Option<String>,
+    pub interests: Vec<String>,
+    pub personality_traits: Vec<String>,
+    pub preferred_gender: Option<String>,
+    pub age_min: Option<i32>,
+    pub age_max: Option<i32>,
+    pub deal_breakers: Vec<String>,
+    pub updated_at: DateTime<Utc>,
+}
+
+pub struct HumanInsightRepo<'a> {
+    pub pool: &'a PgPool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn project_columns_full_blob() {
+        let v = serde_json::json!({
+            "city": "Shanghai",
+            "occupation": "engineer",
+            "mbti_guess": "INFP",
+            "love_values": "slow burn",
+            "emotional_needs": "validation",
+            "life_rhythm": "night owl",
+            "interests": ["coffee", "hiking"],
+            "personality_traits": ["curious", "calm"],
+            "matching_preferences": {
+                "preferred_gender": "any",
+                "age_range": [18, 30],
+                "deal_breakers": ["smoking"]
+            }
+        });
+        let c = project_columns(&v);
+        assert_eq!(c.city.as_deref(), Some("Shanghai"));
+        assert_eq!(c.mbti_guess.as_deref(), Some("INFP"));
+        assert_eq!(c.interests, vec!["coffee", "hiking"]);
+        assert_eq!(c.personality_traits, vec!["curious", "calm"]);
+        assert_eq!(c.preferred_gender.as_deref(), Some("any"));
+        assert_eq!(c.age_min, Some(18));
+        assert_eq!(c.age_max, Some(30));
+        assert_eq!(c.deal_breakers, vec!["smoking"]);
+    }
+
+    #[test]
+    fn project_columns_missing_fields_are_null_and_empty() {
+        let c = project_columns(&serde_json::json!({}));
+        assert_eq!(c.city, None);
+        assert_eq!(c.preferred_gender, None);
+        assert_eq!(c.age_min, None);
+        assert_eq!(c.age_max, None);
+        assert!(c.interests.is_empty());
+        assert!(c.personality_traits.is_empty());
+        assert!(c.deal_breakers.is_empty());
+    }
+
+    #[test]
+    fn project_columns_malformed_age_range_is_null() {
+        for bad in [
+            serde_json::json!("18-30"),
+            serde_json::json!([18]),
+            serde_json::json!([18, 30, 40]),
+            serde_json::json!(["a", "b"]),
+        ] {
+            let v = serde_json::json!({ "matching_preferences": { "age_range": bad } });
+            let c = project_columns(&v);
+            assert_eq!(c.age_min, None, "age_min for {bad:?}");
+            assert_eq!(c.age_max, None, "age_max for {bad:?}");
+        }
+    }
+
+    #[test]
+    fn project_columns_array_drops_non_strings() {
+        let v = serde_json::json!({ "interests": ["coffee", 1, null, "tea"] });
+        let c = project_columns(&v);
+        assert_eq!(c.interests, vec!["coffee", "tea"]);
+    }
+}

--- a/crates/eros-engine-store/src/human_insight.rs
+++ b/crates/eros-engine-store/src/human_insight.rs
@@ -102,6 +102,65 @@ pub struct HumanInsightRepo<'a> {
     pub pool: &'a PgPool,
 }
 
+impl<'a> HumanInsightRepo<'a> {
+    /// Project a companion_insights JSONB blob into the flat matching row and
+    /// UPSERT. Full-overwrite (not field-merge): companion_insights already
+    /// holds the cumulatively merged state, so each call writes it whole.
+    pub async fn project_from_insights(
+        &self,
+        user_id: Uuid,
+        insights: &serde_json::Value,
+    ) -> Result<(), sqlx::Error> {
+        let c = project_columns(insights);
+        sqlx::query(
+            "INSERT INTO engine.human_insights \
+                (user_id, city, occupation, mbti_guess, love_values, emotional_needs, \
+                 life_rhythm, interests, personality_traits, preferred_gender, \
+                 age_min, age_max, deal_breakers) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13) \
+             ON CONFLICT (user_id) DO UPDATE SET \
+                 city               = EXCLUDED.city, \
+                 occupation         = EXCLUDED.occupation, \
+                 mbti_guess         = EXCLUDED.mbti_guess, \
+                 love_values        = EXCLUDED.love_values, \
+                 emotional_needs    = EXCLUDED.emotional_needs, \
+                 life_rhythm        = EXCLUDED.life_rhythm, \
+                 interests          = EXCLUDED.interests, \
+                 personality_traits = EXCLUDED.personality_traits, \
+                 preferred_gender   = EXCLUDED.preferred_gender, \
+                 age_min            = EXCLUDED.age_min, \
+                 age_max            = EXCLUDED.age_max, \
+                 deal_breakers      = EXCLUDED.deal_breakers, \
+                 updated_at         = now()",
+        )
+        .bind(user_id)
+        .bind(c.city)
+        .bind(c.occupation)
+        .bind(c.mbti_guess)
+        .bind(c.love_values)
+        .bind(c.emotional_needs)
+        .bind(c.life_rhythm)
+        .bind(c.interests)
+        .bind(c.personality_traits)
+        .bind(c.preferred_gender)
+        .bind(c.age_min)
+        .bind(c.age_max)
+        .bind(c.deal_breakers)
+        .execute(self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn load(&self, user_id: Uuid) -> Result<Option<HumanInsightsRow>, sqlx::Error> {
+        sqlx::query_as::<_, HumanInsightsRow>(
+            "SELECT * FROM engine.human_insights WHERE user_id = $1",
+        )
+        .bind(user_id)
+        .fetch_optional(self.pool)
+        .await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -166,5 +225,81 @@ mod tests {
         let v = serde_json::json!({ "interests": ["coffee", 1, null, "tea"] });
         let c = project_columns(&v);
         assert_eq!(c.interests, vec!["coffee", "tea"]);
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn project_creates_then_overwrites(pool: PgPool) {
+        let repo = HumanInsightRepo { pool: &pool };
+        let user_id = Uuid::new_v4();
+
+        repo.project_from_insights(
+            user_id,
+            &serde_json::json!({ "city": "Shanghai", "interests": ["coffee"] }),
+        )
+        .await
+        .unwrap();
+        let first = repo.load(user_id).await.unwrap().unwrap();
+        assert_eq!(first.city.as_deref(), Some("Shanghai"));
+        assert_eq!(first.interests, vec!["coffee"]);
+
+        // Full-overwrite: a field absent in the new blob becomes NULL.
+        repo.project_from_insights(
+            user_id,
+            &serde_json::json!({ "interests": ["tea", "wine"] }),
+        )
+        .await
+        .unwrap();
+        let second = repo.load(user_id).await.unwrap().unwrap();
+        assert_eq!(second.city, None, "absent field overwrites to NULL");
+        assert_eq!(second.interests, vec!["tea", "wine"]);
+        assert!(second.updated_at >= first.updated_at);
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn arrays_roundtrip(pool: PgPool) {
+        let repo = HumanInsightRepo { pool: &pool };
+        let user_id = Uuid::new_v4();
+        repo.project_from_insights(
+            user_id,
+            &serde_json::json!({
+                "interests": ["a", "b"],
+                "personality_traits": ["x"],
+                "matching_preferences": { "deal_breakers": ["d1", "d2"] }
+            }),
+        )
+        .await
+        .unwrap();
+        let row = repo.load(user_id).await.unwrap().unwrap();
+        assert_eq!(row.interests, vec!["a", "b"]);
+        assert_eq!(row.personality_traits, vec!["x"]);
+        assert_eq!(row.deal_breakers, vec!["d1", "d2"]);
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn gin_overlap_query_matches(pool: PgPool) {
+        let repo = HumanInsightRepo { pool: &pool };
+        let want = Uuid::new_v4();
+        let other = Uuid::new_v4();
+        repo.project_from_insights(want, &serde_json::json!({ "interests": ["coffee", "hiking"] }))
+            .await
+            .unwrap();
+        repo.project_from_insights(other, &serde_json::json!({ "interests": ["gaming"] }))
+            .await
+            .unwrap();
+
+        let hits: Vec<Uuid> = sqlx::query_scalar(
+            "SELECT user_id FROM engine.human_insights WHERE interests && $1",
+        )
+        .bind(vec!["coffee".to_string()])
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+        assert_eq!(hits, vec![want]);
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn load_returns_none_for_unknown_user(pool: PgPool) {
+        let repo = HumanInsightRepo { pool: &pool };
+        assert!(repo.load(Uuid::new_v4()).await.unwrap().is_none());
     }
 }

--- a/crates/eros-engine-store/src/human_insight.rs
+++ b/crates/eros-engine-store/src/human_insight.rs
@@ -36,7 +36,11 @@ fn str_field(v: &serde_json::Value, key: &str) -> Option<String> {
 fn str_array(v: &serde_json::Value, key: &str) -> Vec<String> {
     v.get(key)
         .and_then(|a| a.as_array())
-        .map(|arr| arr.iter().filter_map(|x| x.as_str().map(String::from)).collect())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|x| x.as_str().map(String::from))
+                .collect()
+        })
         .unwrap_or_default()
 }
 
@@ -76,7 +80,9 @@ pub fn project_columns(insights: &serde_json::Value) -> ProjectedColumns {
         preferred_gender: prefs.and_then(|p| str_field(p, "preferred_gender")),
         age_min,
         age_max,
-        deal_breakers: prefs.map(|p| str_array(p, "deal_breakers")).unwrap_or_default(),
+        deal_breakers: prefs
+            .map(|p| str_array(p, "deal_breakers"))
+            .unwrap_or_default(),
     }
 }
 
@@ -280,20 +286,22 @@ mod tests {
         let repo = HumanInsightRepo { pool: &pool };
         let want = Uuid::new_v4();
         let other = Uuid::new_v4();
-        repo.project_from_insights(want, &serde_json::json!({ "interests": ["coffee", "hiking"] }))
-            .await
-            .unwrap();
+        repo.project_from_insights(
+            want,
+            &serde_json::json!({ "interests": ["coffee", "hiking"] }),
+        )
+        .await
+        .unwrap();
         repo.project_from_insights(other, &serde_json::json!({ "interests": ["gaming"] }))
             .await
             .unwrap();
 
-        let hits: Vec<Uuid> = sqlx::query_scalar(
-            "SELECT user_id FROM engine.human_insights WHERE interests && $1",
-        )
-        .bind(vec!["coffee".to_string()])
-        .fetch_all(&pool)
-        .await
-        .unwrap();
+        let hits: Vec<Uuid> =
+            sqlx::query_scalar("SELECT user_id FROM engine.human_insights WHERE interests && $1")
+                .bind(vec!["coffee".to_string()])
+                .fetch_all(&pool)
+                .await
+                .unwrap();
         assert_eq!(hits, vec![want]);
     }
 

--- a/crates/eros-engine-store/src/lib.rs
+++ b/crates/eros-engine-store/src/lib.rs
@@ -113,4 +113,16 @@ mod migration_tests {
         .await;
         assert!(dup_res.is_err(), "duplicate asset_id must be rejected");
     }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn human_insights_has_rls_enabled(pool: PgPool) {
+        let enabled: bool = sqlx::query_scalar(
+            "SELECT relrowsecurity FROM pg_class \
+             WHERE oid = 'engine.human_insights'::regclass",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("query relrowsecurity for human_insights");
+        assert!(enabled, "RLS must be enabled on engine.human_insights");
+    }
 }

--- a/crates/eros-engine-store/src/lib.rs
+++ b/crates/eros-engine-store/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod affinity;
 pub mod chat;
+pub mod human_insight;
 pub mod insight;
 pub mod memory;
 pub mod ownership;

--- a/docs/superpowers/specs/2026-05-21-human-insights-matching-table-design.md
+++ b/docs/superpowers/specs/2026-05-21-human-insights-matching-table-design.md
@@ -1,0 +1,336 @@
+# Human Insights Matching Table — Design
+
+**Status:** Draft for review
+**Date:** 2026-05-21
+**Owner:** @enriquephl
+
+## Problem
+
+The structured user profile mined from conversations lives only in
+`engine.companion_insights` as a single JSONB blob (`insights`) keyed by
+`user_id`, written each turn by the `insight_extraction` pipeline
+(`post_process.rs:496` → `InsightRepo::merge`). That shape is perfect for
+the prompt-rendering read path (bullet list back into the system prompt) but
+useless for **user↔user matching**: you cannot index a JSONB blob's nested
+fields for array-overlap or range queries without bolting on expression
+indexes, and the blob mixes free text, scalars, arrays, and a nested
+`matching_preferences` object.
+
+We want a second table, `engine.human_insights`, that is a **flat, typed
+projection** of the soft (conversation-derived) signal, shaped for matching
+queries. It is read for matching, **not** rendered to frontend users.
+
+## Non-Goals
+
+- **Don't touch `companion_insights`.** It runs smoothly and stays the
+  source of truth. The LLM merge hot path is not modified beyond capturing
+  its already-returned row (see Write-Through).
+- **No hard-filter attributes.** Gender / age / geography hard filters are
+  the job of the **user-self-filled profile table** (owned elsewhere, not in
+  `engine`), which is authoritative and structured. `human_insights` carries
+  **only** conversation-derived soft signal. We deliberately do **not** add
+  `own_gender` / `own_age` columns, and "later change the update mechanism"
+  will never add hard-attribute extraction here.
+- **No matching algorithm.** This spec ships the table + projection + sync,
+  not a ranking/recommendation query. Matching will JOIN the profile table
+  (hard `WHERE` filter) against `human_insights` (GIN overlap / soft score).
+- **No new LLM extraction.** Phase 1 mirrors the existing
+  `companion_insights` JSONB. A dedicated human-matching extractor is future
+  work, deferred to "later change the update mechanism".
+- **No API / OpenAPI surface.** No HTTP route reads or writes this table in
+  v1. It is an internal store primitive.
+
+## High-Level Design
+
+```
+insight_extraction (per turn, post_process.rs)
+   │
+   ▼
+InsightRepo::merge(user_id, new_insights)  ── writes companion_insights JSONB
+   │   returns CompanionInsightsRow { insights, .. }   (today: discarded)
+   ▼
+HumanInsightRepo::project_from_insights(user_id, &row.insights)   ── NEW write-through
+   │   parse JSONB → typed columns
+   ▼
+engine.human_insights  (flat, indexed for matching)
+```
+
+`companion_insights` stays canonical. `human_insights` is a derived mirror
+in Phase 1. The projection logic is isolated in one function
+(`project_from_insights`) so the trigger and the source can be swapped later
+without touching callers.
+
+## Data Model
+
+New migration `crates/eros-engine-store/migrations/0015_human_insights.sql`.
+
+```sql
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Flat, typed projection of the soft (conversation-derived) user profile,
+-- shaped for user<->user matching. companion_insights stays the source of
+-- truth (JSONB); this table is a derived mirror in Phase 1.
+--
+-- Hard-filter attributes (own gender/age/geo) are NOT here by design — they
+-- live in the user-self-filled profile table owned outside engine.* and are
+-- joined at match time.
+CREATE TABLE engine.human_insights (
+    user_id            UUID PRIMARY KEY,
+
+    -- soft scalar signal (free text; carried for context / future embedding,
+    -- not used for hard filtering)
+    city               TEXT,            -- conversational mention only; geo
+                                        -- hard-filter lives in profile table
+    occupation         TEXT,
+    mbti_guess         TEXT,
+    love_values        TEXT,
+    emotional_needs    TEXT,
+    life_rhythm        TEXT,
+
+    -- array signal — the core matching dimensions (set overlap via &&)
+    interests          TEXT[] NOT NULL DEFAULT '{}',
+    personality_traits TEXT[] NOT NULL DEFAULT '{}',
+
+    -- flattened matching_preferences: "what the user wants" (complements the
+    -- self-filled "what the user is" in the profile table)
+    preferred_gender   TEXT,
+    age_min            INT,
+    age_max            INT,
+    deal_breakers      TEXT[] NOT NULL DEFAULT '{}',
+
+    updated_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Only the array-overlap dimensions get indexes. No city index — geo
+-- filtering is the profile table's job.
+CREATE INDEX idx_human_insights_interests ON engine.human_insights USING GIN(interests);
+CREATE INDEX idx_human_insights_traits    ON engine.human_insights USING GIN(personality_traits);
+```
+
+### Supabase lockdown (mandatory)
+
+Migration `0013_supabase_lockdown.sql` REVOKEs grants + enables RLS on every
+`engine.*` table. A new table that skips this would be a hole, so the same
+migration must append, guarded by the same `pg_roles` existence checks as
+0013:
+
+```sql
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
+        REVOKE ALL ON engine.human_insights FROM anon;
+    END IF;
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+        REVOKE ALL ON engine.human_insights FROM authenticated;
+    END IF;
+END
+$$;
+ALTER TABLE engine.human_insights ENABLE ROW LEVEL SECURITY;
+```
+
+(Schema USAGE for anon/authenticated is already revoked by 0013 and is not
+re-granted, so no USAGE handling is needed here.)
+
+### Field mapping (companion_insights JSONB → columns)
+
+| JSONB path                            | Column              | Type      | Rule |
+|---------------------------------------|---------------------|-----------|------|
+| `city`                                | `city`              | TEXT      | string or NULL |
+| `occupation`                          | `occupation`        | TEXT      | string or NULL |
+| `mbti_guess`                          | `mbti_guess`        | TEXT      | string or NULL |
+| `love_values`                         | `love_values`       | TEXT      | string or NULL |
+| `emotional_needs`                     | `emotional_needs`   | TEXT      | string or NULL |
+| `life_rhythm`                         | `life_rhythm`       | TEXT      | string or NULL |
+| `interests` (array)                   | `interests`         | TEXT[]    | string items only; missing → `{}` |
+| `personality_traits` (array)          | `personality_traits`| TEXT[]    | string items only; missing → `{}` |
+| `matching_preferences.preferred_gender` | `preferred_gender`| TEXT      | string or NULL |
+| `matching_preferences.age_range[0]`   | `age_min`           | INT       | int or NULL; malformed → NULL |
+| `matching_preferences.age_range[1]`   | `age_max`           | INT       | int or NULL; malformed → NULL |
+| `matching_preferences.deal_breakers`  | `deal_breakers`     | TEXT[]    | string items only; missing → `{}` |
+
+`age_range` is `[min_int, max_int]` per `COMPANION_INSIGHTS_SCHEMA`
+(`prompt.rs:404`). A non-array, wrong-length, or non-integer `age_range`
+yields `age_min = age_max = NULL` rather than failing the projection.
+
+## Store Layer
+
+New file `crates/eros-engine-store/src/human_insight.rs`; register
+`pub mod human_insight;` in `crates/eros-engine-store/src/lib.rs`.
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct HumanInsightsRow {
+    pub user_id: Uuid,
+    pub city: Option<String>,
+    pub occupation: Option<String>,
+    pub mbti_guess: Option<String>,
+    pub love_values: Option<String>,
+    pub emotional_needs: Option<String>,
+    pub life_rhythm: Option<String>,
+    pub interests: Vec<String>,
+    pub personality_traits: Vec<String>,
+    pub preferred_gender: Option<String>,
+    pub age_min: Option<i32>,
+    pub age_max: Option<i32>,
+    pub deal_breakers: Vec<String>,
+    pub updated_at: DateTime<Utc>,
+}
+
+pub struct HumanInsightRepo<'a> {
+    pub pool: &'a PgPool,
+}
+
+impl<'a> HumanInsightRepo<'a> {
+    /// Project a companion_insights JSONB blob into the flat matching row and
+    /// UPSERT. This is the ONLY place that knows the JSONB→columns mapping, so
+    /// the source/trigger can be repointed later without touching callers.
+    pub async fn project_from_insights(
+        &self,
+        user_id: Uuid,
+        insights: &serde_json::Value,
+    ) -> Result<(), sqlx::Error> { /* parse → INSERT ... ON CONFLICT DO UPDATE */ }
+
+    pub async fn load(&self, user_id: Uuid) -> Result<Option<HumanInsightsRow>, sqlx::Error> { /* ... */ }
+}
+```
+
+Parsing is a pure helper (`fn project_columns(insights: &Value) -> ProjectedColumns`)
+unit-tested without a DB. The UPSERT writes all columns + `updated_at = now()`:
+
+```sql
+INSERT INTO engine.human_insights
+    (user_id, city, occupation, mbti_guess, love_values, emotional_needs,
+     life_rhythm, interests, personality_traits, preferred_gender,
+     age_min, age_max, deal_breakers)
+VALUES ($1, $2, ..., $13)
+ON CONFLICT (user_id) DO UPDATE SET
+    city = EXCLUDED.city, ..., deal_breakers = EXCLUDED.deal_breakers,
+    updated_at = now()
+```
+
+Full-overwrite semantics (not field-merge): `companion_insights` already
+holds the cumulatively-merged blob, so each projection writes the complete
+current state. No merge logic is duplicated here.
+
+## Write-Through
+
+In `post_process.rs::extract_insights` (around line 536). Today:
+
+```rust
+if let Err(e) = insights_repo.merge(user_id, new_insights).await {
+    tracing::warn!("companion_insights merge failed: {e}");
+}
+```
+
+`InsightRepo::merge` already returns the merged `CompanionInsightsRow`
+(`insight.rs:84`), currently discarded. Capture it and project — **no extra
+DB read**:
+
+```rust
+match insights_repo.merge(user_id, new_insights).await {
+    Ok(row) => {
+        let human_repo = HumanInsightRepo { pool: &state.pool };
+        if let Err(e) = human_repo.project_from_insights(user_id, &row.insights).await {
+            tracing::warn!("human_insights projection failed: {e}");
+        }
+    }
+    Err(e) => tracing::warn!("companion_insights merge failed: {e}"),
+}
+```
+
+Projection failure only warns — it never breaks the turn, matching the
+existing fire-and-forget post-process style. Projection runs only when there
+were new insights to merge (the `extract_insights` early-returns already
+gate that).
+
+## Backfill (manual command)
+
+A `eros-engine backfill-human-insights` subcommand in `main.rs`, mirroring
+the `seed-personas` pattern (`main.rs:52`). Following the project rule that
+data-mutating maintenance stays manual (never wired into `release_command`),
+this is operator-run, not automatic:
+
+```rust
+Some("backfill-human-insights") => run_backfill_human_insights().await,
+```
+
+It streams `companion_insights` and projects each row:
+
+```sql
+-- Conceptually; implemented by looping rows through project_from_insights so
+-- the JSONB→columns mapping has exactly one definition.
+SELECT user_id, insights FROM engine.companion_insights;
+```
+
+Each row → `HumanInsightRepo::project_from_insights`. Idempotent (UPSERT), so
+re-running is safe. Logs `backfilled`/`skipped` counts like seed-personas.
+
+Update the usage string at `main.rs:62` and the subcommand doc comment block
+at `main.rs:40`.
+
+## Tests
+
+### `human_insight.rs` (unit — no DB)
+
+- `project_columns_full_blob` — every field populated → all columns set,
+  arrays preserved in order.
+- `project_columns_missing_fields_are_null_and_empty` — `{}` → all scalars
+  NULL, all arrays `[]`.
+- `project_columns_age_range_parsed` — `matching_preferences.age_range:[18,30]`
+  → `age_min=18, age_max=30`.
+- `project_columns_malformed_age_range_is_null` — `age_range:"18-30"`,
+  `[18]`, `[18,30,40]`, `["a","b"]` each → both NULL.
+- `project_columns_array_drops_non_strings` — `interests:["coffee",1,null]`
+  → `["coffee"]`.
+
+### `human_insight.rs` (`#[sqlx::test(migrations = "./migrations")]`)
+
+- `project_creates_then_overwrites` — first project creates the row; a second
+  project with changed fields overwrites (full state, not merge), `updated_at`
+  advances.
+- `arrays_roundtrip` — `interests` / `personality_traits` / `deal_breakers`
+  written and read back identical.
+- `gin_overlap_query_matches` — insert two users with overlapping
+  `interests`, assert `WHERE interests && ARRAY['coffee']` returns the right
+  set (exercises the GIN index path).
+- `load_returns_none_for_unknown_user`.
+
+### `migrations` lockdown (extend `lib.rs` migration_tests)
+
+- `human_insights_has_rls_enabled` — assert `relrowsecurity` is true for
+  `engine.human_insights` (mirrors the 0013 guarantee for the new table).
+
+## Risks / Open Questions
+
+1. **Phase-1 mirror is throwaway scaffolding.** When the dedicated
+   human-matching extractor lands ("later change the update mechanism"), the
+   write-through from `merge` is removed and `project_from_insights` is
+   repointed at the new source. Because the JSONB→columns mapping is isolated
+   in one function, this is a localized change. Accepted.
+2. **No referential integrity to a users table.** `companion_insights` itself
+   has no FK on `user_id` (it's a bare PK), so `human_insights` follows the
+   same convention — `user_id` is an `auth.users` id from the shared realm,
+   not FK-enforced in `engine`.
+3. **Preference vs. attribute split must stay clean.** `preferred_gender` /
+   `age_range` here are the *querying* user's wants, matched against
+   *candidate* users' self-filled profile attributes. Keeping "wants" in
+   `human_insights` and "is" in the profile table is the whole design;
+   blurring it (e.g. someone later adds `own_gender` here) re-creates the
+   ambiguity this split removes. Documented to prevent drift.
+4. **City column with no index.** Carried as soft conversational context; if a
+   future query wants to weakly boost same-city matches it can still read the
+   column. Geo hard-filtering remains the profile table's job. If it proves
+   genuinely unused, drop the column in a later migration (YAGNI either way —
+   keeping it costs ~nothing).
+
+## Acceptance Criteria
+
+- [ ] `cargo test -p eros-engine-store -p eros-engine-server` green
+- [ ] `0015_human_insights.sql` creates the table + 2 GIN indexes and applies
+      the lockdown REVOKE/RLS for the new table
+- [ ] `human_insights_has_rls_enabled` passes
+- [ ] Per-turn chat flow projects into `human_insights` with no extra DB read
+      (verified by the write-through using `merge`'s returned row)
+- [ ] `eros-engine backfill-human-insights` populates existing
+      `companion_insights` users idempotently
+- [ ] `companion_insights` write path behaviour is byte-identical except for
+      capturing the previously-discarded `merge` return value


### PR DESCRIPTION
## Summary
- Adds `engine.human_insights` — a flat, typed projection of the conversation-derived user profile (stored as JSONB in `engine.companion_insights`) shaped for future user↔user matching. `interests`/`personality_traits` are `text[]` with GIN indexes; `matching_preferences` is flattened to `preferred_gender`/`age_min`/`age_max`/`deal_breakers`.
- `companion_insights` stays the source of truth and is functionally unchanged — the only change to its write path is capturing the row `InsightRepo::merge` already returns (no extra DB read) and writing through to the new table via `HumanInsightRepo::project_from_insights`.
- The JSONB→columns mapping lives in exactly one place (`project_columns`) so the source/trigger can be repointed later.
- Hard-filter attributes (own gender/age/geo) are intentionally **not** stored here — they belong to the user-self-filled profile table and are joined at match time. No `city` index for the same reason.
- New migration `0015_human_insights.sql` applies the Supabase lockdown (REVOKE anon/authenticated + ENABLE ROW LEVEL SECURITY) for the new table, mirroring `0013`.
- Manual `eros-engine backfill-human-insights` CLI subcommand projects existing rows (idempotent UPSERT); deliberately **not** wired into any automatic release/migration step.
- Design spec: `docs/superpowers/specs/2026-05-21-human-insights-matching-table-design.md`.

## Test Plan
- [x] `cargo test -p eros-engine-store` — 64 passed (incl. RLS migration test + projection/UPSERT/GIN sqlx tests)
- [x] `cargo test -p eros-engine-server` — 148 passed
- [x] `cargo clippy -p eros-engine-store -p eros-engine-server --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `backfill-human-insights` smoke-tested against a local DB (idempotent, no SQL error)
- [ ] Reviewer: confirm INSERT bind order matches column list and `HumanInsightsRow` matches table columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)