### PR TITLE
feat: BFF message ids + per-task reasoning control

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Install sqlx-cli
-        run: cargo install sqlx-cli --no-default-features --features postgres
+        # Pin to 0.8.x: it matches the workspace's `sqlx = "0.8"` and builds on
+        # the repo's pinned rustc (rust-toolchain.toml = 1.88). Unpinned would
+        # grab sqlx-cli 0.9+, which requires rustc 1.94 and fails to install.
+        run: cargo install sqlx-cli --no-default-features --features postgres --version ^0.8
       - name: Run migrations
         run: sqlx migrate run --source crates/eros-engine-store/migrations
       - run: cargo test --workspace --all-features

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -769,4 +769,26 @@ reasoning = { exclude = true }
             ]
         );
     }
+
+    #[test]
+    fn committed_example_chat_companion_disables_reasoning() {
+        let text = include_str!("../../../examples/model_config.toml");
+        let cfg = ModelConfig::from_toml_str(text).expect("examples/model_config.toml must parse");
+        let disabled = ReasoningConfig {
+            enabled: Some(false),
+            exclude: None,
+        };
+        // Disabled for the default block...
+        assert_eq!(
+            cfg.resolve("chat_companion", None).reasoning,
+            Some(disabled.clone())
+        );
+        // ...and inherited by the free tier (no per-tier override).
+        assert_eq!(
+            cfg.resolve("chat_companion", Some("free")).reasoning,
+            Some(disabled)
+        );
+        // Untouched tasks stay at model default.
+        assert_eq!(cfg.resolve("insight_extraction", None).reasoning, None);
+    }
 }

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //! TOML-driven model orchestration config.
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -29,6 +29,20 @@ impl FallbackSpec {
             FallbackSpec::Multiple(v) => v.into_iter().filter(|s| !s.is_empty()).collect(),
         }
     }
+}
+
+/// Mirror of OpenRouter's `reasoning` request object. Parsed from TOML and
+/// forwarded to the wire unchanged, so operators control reasoning in the
+/// same shape OpenRouter documents. Every field optional; absent fields are
+/// omitted from the wire. Common uses: `{ enabled = false }` to disable
+/// reasoning entirely, or `{ exclude = true }` to keep reasoning but drop it
+/// from the response. (Extend with `effort`/`max_tokens` here if ever needed.)
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct ReasoningConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exclude: Option<bool>,
 }
 
 /// One tier's overrides for a task. Every field is optional; an absent
@@ -77,12 +91,12 @@ pub struct TaskConfig {
     /// semantics as `TierConfig::allow_traits`.
     #[serde(default)]
     pub allow_traits: Option<Vec<String>>,
-    /// Task-level reasoning toggle. Tri-state: absent → omit the OpenRouter
-    /// `reasoning` param (model default); `false` → send `{enabled:false}`
-    /// (disable); `true` → `{enabled:true}`. Task-level only — tiers inherit,
-    /// like `temperature`/`max_tokens`.
+    /// Task-level reasoning config (OpenRouter `reasoning` object). Absent →
+    /// omit the param (model default); present → forwarded to the wire (e.g.
+    /// `reasoning = { enabled = false }` to disable). Task-level only — tiers
+    /// inherit, like `temperature`/`max_tokens`.
     #[serde(default)]
-    pub reasoning: Option<bool>,
+    pub reasoning: Option<ReasoningConfig>,
     /// Per-tier overrides keyed by tier name. Empty for tasks that don't tier.
     #[serde(default)]
     pub tiers: HashMap<String, TierConfig>,
@@ -111,9 +125,9 @@ pub struct ResolvedModel {
     /// Resolved trait allow-list. `None` → no gating; `Some(set)` → the chat
     /// handler keeps only `prompt_traits` whose tag is in `set`.
     pub allow_traits: Option<Vec<String>>,
-    /// Resolved reasoning toggle (see `TaskConfig::reasoning`). `None` → omit
-    /// the wire param; `Some(b)` → send `reasoning:{enabled:b}`.
-    pub reasoning: Option<bool>,
+    /// Resolved reasoning config (see `TaskConfig::reasoning`). `None` → omit
+    /// the wire param; `Some(cfg)` → forwarded as the `reasoning` object.
+    pub reasoning: Option<ReasoningConfig>,
 }
 
 impl ModelConfig {
@@ -192,7 +206,7 @@ impl ModelConfig {
             .unwrap_or(FALLBACK_MAX_TOKENS);
 
         // Task-level only (tiers inherit), mirroring temperature/max_tokens.
-        let reasoning = task_cfg.and_then(|t| t.reasoning);
+        let reasoning = task_cfg.and_then(|t| t.reasoning.clone());
 
         ResolvedModel {
             model,
@@ -686,18 +700,25 @@ fallback = ""
         let toml = r#"
 [tasks.chat_companion]
 model = "m"
-reasoning = false
+reasoning = { enabled = false }
 
 [tasks.chat_companion.tiers.free]
 model = "free-m"
 "#;
         let cfg = ModelConfig::from_toml_str(toml).unwrap();
+        let expected = ReasoningConfig {
+            enabled: Some(false),
+            exclude: None,
+        };
         // Task-level value applies with no tier...
-        assert_eq!(cfg.resolve("chat_companion", None).reasoning, Some(false));
+        assert_eq!(
+            cfg.resolve("chat_companion", None).reasoning,
+            Some(expected.clone())
+        );
         // ...and a tier that doesn't override it inherits the task value.
         assert_eq!(
             cfg.resolve("chat_companion", Some("free")).reasoning,
-            Some(false)
+            Some(expected)
         );
     }
 
@@ -712,14 +733,20 @@ model = "m"
     }
 
     #[test]
-    fn resolve_reasoning_true_is_some_true() {
+    fn resolve_reasoning_parses_exclude_field() {
         let toml = r#"
 [tasks.chat_companion]
 model = "m"
-reasoning = true
+reasoning = { exclude = true }
 "#;
         let cfg = ModelConfig::from_toml_str(toml).unwrap();
-        assert_eq!(cfg.resolve("chat_companion", None).reasoning, Some(true));
+        assert_eq!(
+            cfg.resolve("chat_companion", None).reasoning,
+            Some(ReasoningConfig {
+                enabled: None,
+                exclude: Some(true),
+            })
+        );
     }
 
     // Regression: the committed deployed config (examples/model_config.toml,

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -137,7 +137,8 @@ impl ModelConfig {
 
     /// Resolve a task's model. Priority for `model`/`fallback`/`allow_traits`:
     /// matched tier block > task default block > `[defaults]` > compiled-in.
-    /// `temperature`/`max_tokens` are task-level only (no per-tier override).
+    /// `temperature`/`max_tokens`/`reasoning` are task-level only (no per-tier
+    /// override).
     pub fn resolve(&self, task: &str, tier: Option<&str>) -> ResolvedModel {
         let task_cfg = self.tasks.get(task);
         if task_cfg.is_none() {

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -677,7 +677,7 @@ fallback = ""
         let cfg = ModelConfig::from_toml_str(text).expect("examples/model_config.toml must parse");
         let r = cfg.resolve("affinity_evaluation", None);
         assert_eq!(r.model, "anthropic/claude-haiku-4.5");
-        assert_eq!(r.max_tokens, 250);
+        assert_eq!(r.max_tokens, 400);
         assert!((r.temperature - 0.3).abs() < 1e-9);
         assert_eq!(
             r.fallback_model,

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -77,6 +77,12 @@ pub struct TaskConfig {
     /// semantics as `TierConfig::allow_traits`.
     #[serde(default)]
     pub allow_traits: Option<Vec<String>>,
+    /// Task-level reasoning toggle. Tri-state: absent → omit the OpenRouter
+    /// `reasoning` param (model default); `false` → send `{enabled:false}`
+    /// (disable); `true` → `{enabled:true}`. Task-level only — tiers inherit,
+    /// like `temperature`/`max_tokens`.
+    #[serde(default)]
+    pub reasoning: Option<bool>,
     /// Per-tier overrides keyed by tier name. Empty for tasks that don't tier.
     #[serde(default)]
     pub tiers: HashMap<String, TierConfig>,
@@ -105,6 +111,9 @@ pub struct ResolvedModel {
     /// Resolved trait allow-list. `None` → no gating; `Some(set)` → the chat
     /// handler keeps only `prompt_traits` whose tag is in `set`.
     pub allow_traits: Option<Vec<String>>,
+    /// Resolved reasoning toggle (see `TaskConfig::reasoning`). `None` → omit
+    /// the wire param; `Some(b)` → send `reasoning:{enabled:b}`.
+    pub reasoning: Option<bool>,
 }
 
 impl ModelConfig {
@@ -181,12 +190,16 @@ impl ModelConfig {
             .or(self.defaults.fallback_max_tokens)
             .unwrap_or(FALLBACK_MAX_TOKENS);
 
+        // Task-level only (tiers inherit), mirroring temperature/max_tokens.
+        let reasoning = task_cfg.and_then(|t| t.reasoning);
+
         ResolvedModel {
             model,
             fallback_model,
             temperature,
             max_tokens,
             allow_traits,
+            reasoning,
         }
     }
 }
@@ -665,6 +678,47 @@ fallback = ""
             "explicit empty string must suppress defaults; got {:?}",
             r.fallback_model
         );
+    }
+
+    #[test]
+    fn resolve_reads_task_level_reasoning_and_tiers_inherit() {
+        let toml = r#"
+[tasks.chat_companion]
+model = "m"
+reasoning = false
+
+[tasks.chat_companion.tiers.free]
+model = "free-m"
+"#;
+        let cfg = ModelConfig::from_toml_str(toml).unwrap();
+        // Task-level value applies with no tier...
+        assert_eq!(cfg.resolve("chat_companion", None).reasoning, Some(false));
+        // ...and a tier that doesn't override it inherits the task value.
+        assert_eq!(
+            cfg.resolve("chat_companion", Some("free")).reasoning,
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn resolve_reasoning_absent_is_none() {
+        let toml = r#"
+[tasks.chat_companion]
+model = "m"
+"#;
+        let cfg = ModelConfig::from_toml_str(toml).unwrap();
+        assert_eq!(cfg.resolve("chat_companion", None).reasoning, None);
+    }
+
+    #[test]
+    fn resolve_reasoning_true_is_some_true() {
+        let toml = r#"
+[tasks.chat_companion]
+model = "m"
+reasoning = true
+"#;
+        let cfg = ModelConfig::from_toml_str(toml).unwrap();
+        assert_eq!(cfg.resolve("chat_companion", None).reasoning, Some(true));
     }
 
     // Regression: the committed deployed config (examples/model_config.toml,

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -7,6 +7,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::error::LlmError;
+use crate::model_config::ReasoningConfig;
 
 const BASE_URL: &str = "https://openrouter.ai/api/v1/chat/completions";
 
@@ -45,9 +46,9 @@ pub struct ChatRequest {
     /// (≤16 keys, key ≤64 chars, value ≤512 chars) are enforced at the
     /// HTTP boundary, not here.
     pub metadata: Option<serde_json::Map<String, serde_json::Value>>,
-    /// Reasoning toggle forwarded to OpenRouter. `None` → omit the param;
-    /// `Some(b)` → send `reasoning:{enabled:b}`.
-    pub reasoning: Option<bool>,
+    /// Reasoning config forwarded to OpenRouter. `None` → omit the param;
+    /// `Some(cfg)` → send the `reasoning` object verbatim.
+    pub reasoning: Option<ReasoningConfig>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -67,11 +68,6 @@ fn is_false(b: &bool) -> bool {
 }
 
 #[derive(Debug, Serialize)]
-struct WireReasoning {
-    enabled: bool,
-}
-
-#[derive(Debug, Serialize)]
 struct WireRequest<'a> {
     model: &'a str,
     messages: &'a [ChatMessage],
@@ -86,7 +82,7 @@ struct WireRequest<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     metadata: Option<&'a serde_json::Map<String, serde_json::Value>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    reasoning: Option<WireReasoning>,
+    reasoning: Option<&'a ReasoningConfig>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -282,7 +278,7 @@ impl OpenRouterClient {
                     req.user.as_deref(),
                     req.session_id.as_deref(),
                     req.metadata.as_ref(),
-                    req.reasoning,
+                    req.reasoning.as_ref(),
                 )
                 .await
             {
@@ -331,7 +327,7 @@ impl OpenRouterClient {
         req_user: Option<&str>,
         req_session_id: Option<&str>,
         req_metadata: Option<&serde_json::Map<String, serde_json::Value>>,
-        req_reasoning: Option<bool>,
+        req_reasoning: Option<&ReasoningConfig>,
     ) -> Result<ChatResponse, LlmError> {
         if self.api_key.is_empty() {
             return Err(LlmError::Config("openrouter: api key not set".into()));
@@ -346,7 +342,7 @@ impl OpenRouterClient {
             user: req_user,
             session_id: req_session_id,
             metadata: req_metadata,
-            reasoning: req_reasoning.map(|enabled| WireReasoning { enabled }),
+            reasoning: req_reasoning,
         };
 
         let resp = self
@@ -405,7 +401,7 @@ impl OpenRouterClient {
             user: req.user.as_deref(),
             session_id: req.session_id.as_deref(),
             metadata: req.metadata.as_ref(),
-            reasoning: req.reasoning.map(|enabled| WireReasoning { enabled }),
+            reasoning: req.reasoning.as_ref(),
         };
 
         let resp = self
@@ -1169,7 +1165,11 @@ data: [DONE]\n\n";
             role: "user".into(),
             content: "hi".into(),
         }];
-        // Some(false) -> nested {enabled:false}
+        // Some(cfg) -> nested object; absent inner fields are omitted.
+        let cfg = ReasoningConfig {
+            enabled: Some(false),
+            exclude: None,
+        };
         let wire = WireRequest {
             model: "m",
             messages: &messages,
@@ -1179,12 +1179,12 @@ data: [DONE]\n\n";
             user: None,
             session_id: None,
             metadata: None,
-            reasoning: Some(WireReasoning { enabled: false }),
+            reasoning: Some(&cfg),
         };
         let s = serde_json::to_string(&wire).unwrap();
         assert!(
             s.contains("\"reasoning\":{\"enabled\":false}"),
-            "reasoning must serialize as a nested enabled flag: {s}"
+            "reasoning must serialize as a nested object: {s}"
         );
 
         // None -> key omitted entirely

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -45,6 +45,9 @@ pub struct ChatRequest {
     /// (≤16 keys, key ≤64 chars, value ≤512 chars) are enforced at the
     /// HTTP boundary, not here.
     pub metadata: Option<serde_json::Map<String, serde_json::Value>>,
+    /// Reasoning toggle forwarded to OpenRouter. `None` → omit the param;
+    /// `Some(b)` → send `reasoning:{enabled:b}`.
+    pub reasoning: Option<bool>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -64,6 +67,11 @@ fn is_false(b: &bool) -> bool {
 }
 
 #[derive(Debug, Serialize)]
+struct WireReasoning {
+    enabled: bool,
+}
+
+#[derive(Debug, Serialize)]
 struct WireRequest<'a> {
     model: &'a str,
     messages: &'a [ChatMessage],
@@ -77,6 +85,8 @@ struct WireRequest<'a> {
     session_id: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     metadata: Option<&'a serde_json::Map<String, serde_json::Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reasoning: Option<WireReasoning>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -272,6 +282,7 @@ impl OpenRouterClient {
                     req.user.as_deref(),
                     req.session_id.as_deref(),
                     req.metadata.as_ref(),
+                    req.reasoning,
                 )
                 .await
             {
@@ -320,6 +331,7 @@ impl OpenRouterClient {
         req_user: Option<&str>,
         req_session_id: Option<&str>,
         req_metadata: Option<&serde_json::Map<String, serde_json::Value>>,
+        req_reasoning: Option<bool>,
     ) -> Result<ChatResponse, LlmError> {
         if self.api_key.is_empty() {
             return Err(LlmError::Config("openrouter: api key not set".into()));
@@ -334,6 +346,7 @@ impl OpenRouterClient {
             user: req_user,
             session_id: req_session_id,
             metadata: req_metadata,
+            reasoning: req_reasoning.map(|enabled| WireReasoning { enabled }),
         };
 
         let resp = self
@@ -392,6 +405,7 @@ impl OpenRouterClient {
             user: req.user.as_deref(),
             session_id: req.session_id.as_deref(),
             metadata: req.metadata.as_ref(),
+            reasoning: req.reasoning.map(|enabled| WireReasoning { enabled }),
         };
 
         let resp = self
@@ -642,6 +656,7 @@ mod tests {
             user: req.user.as_deref(),
             session_id: req.session_id.as_deref(),
             metadata: req.metadata.as_ref(),
+            reasoning: None,
         };
         let s = serde_json::to_string(&wire).unwrap();
         assert!(!s.contains("\"user\":"), "user key must be absent: {s}");
@@ -681,6 +696,7 @@ mod tests {
             user: req.user.as_deref(),
             session_id: req.session_id.as_deref(),
             metadata: req.metadata.as_ref(),
+            reasoning: None,
         };
         let s = serde_json::to_string(&wire).unwrap();
         assert!(s.contains("\"user\":\"u_abc\""), "{s}");
@@ -1144,6 +1160,49 @@ data: [DONE]\n\n";
         assert!(
             matches!(err, LlmError::Status(s, _) if s.as_u16() == 429),
             "expected Status(429), got {err:?}"
+        );
+    }
+
+    #[test]
+    fn wire_request_serializes_reasoning_enabled_flag() {
+        let messages = vec![ChatMessage {
+            role: "user".into(),
+            content: "hi".into(),
+        }];
+        // Some(false) -> nested {enabled:false}
+        let wire = WireRequest {
+            model: "m",
+            messages: &messages,
+            temperature: 0.0,
+            max_tokens: 16,
+            stream: false,
+            user: None,
+            session_id: None,
+            metadata: None,
+            reasoning: Some(WireReasoning { enabled: false }),
+        };
+        let s = serde_json::to_string(&wire).unwrap();
+        assert!(
+            s.contains("\"reasoning\":{\"enabled\":false}"),
+            "reasoning must serialize as a nested enabled flag: {s}"
+        );
+
+        // None -> key omitted entirely
+        let wire_none = WireRequest {
+            model: "m",
+            messages: &messages,
+            temperature: 0.0,
+            max_tokens: 16,
+            stream: false,
+            user: None,
+            session_id: None,
+            metadata: None,
+            reasoning: None,
+        };
+        let s_none = serde_json::to_string(&wire_none).unwrap();
+        assert!(
+            !s_none.contains("\"reasoning\""),
+            "absent reasoning must be omitted: {s_none}"
         );
     }
 

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -1104,12 +1104,8 @@ data: [DONE]\n\n";
             .expect("stream opens");
         while stream.next().await.is_some() {}
 
-        let reqs = server
-            .received_requests()
-            .await
-            .expect("requests recorded");
-        let body: serde_json::Value =
-            serde_json::from_slice(&reqs[0].body).expect("body is json");
+        let reqs = server.received_requests().await.expect("requests recorded");
+        let body: serde_json::Value = serde_json::from_slice(&reqs[0].body).expect("body is json");
         let obj = body.as_object().expect("body is a json object");
         assert_eq!(obj.get("stream"), Some(&serde_json::Value::Bool(true)));
         assert!(

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0-only",
       "identifier": "AGPL-3.0-only"
     },
-    "version": "0.3.0"
+    "version": "0.3.1"
   },
   "servers": [
     {
@@ -1114,13 +1114,26 @@
       "BffHistoryEntry": {
         "type": "object",
         "required": [
+          "id",
           "role",
           "content",
           "sent_at"
         ],
         "properties": {
+          "client_msg_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Client-supplied message id forwarded during streaming (the\n`client_msg_id` the FE sent on send). NULL for rows that never carried\none, e.g. assistant turns. Lets the FE reconcile an optimistic local\nmessage with its persisted row."
+          },
           "content": {
             "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Stable message id — the `engine.chat_messages` row primary key (UUID)."
           },
           "role": {
             "type": "string",

--- a/crates/eros-engine-server/src/pipeline/dreaming.rs
+++ b/crates/eros-engine-server/src/pipeline/dreaming.rs
@@ -178,6 +178,7 @@ async fn classify_session(
         temperature: resolved.temperature as f32,
         max_tokens: resolved.max_tokens,
         user: Some(SYSTEM_AUDIT_USER.into()),
+        reasoning: resolved.reasoning,
         ..Default::default()
     };
     let raw = state

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -133,6 +133,7 @@ fn assemble_chat_request(
         user: audit_user,
         session_id: audit_session,
         metadata: audit_metadata,
+        reasoning: resolved.reasoning,
     }
 }
 

--- a/crates/eros-engine-server/src/pipeline/post_process.rs
+++ b/crates/eros-engine-server/src/pipeline/post_process.rs
@@ -485,6 +485,7 @@ async fn evaluate_affinity(
         temperature: resolved.temperature as f32,
         max_tokens: resolved.max_tokens,
         user: audit_user.map(String::from),
+        reasoning: resolved.reasoning,
         ..Default::default()
     };
 
@@ -598,6 +599,7 @@ async fn extract_facts(
         temperature: resolved.temperature as f32,
         max_tokens: resolved.max_tokens,
         user: audit_user.map(String::from),
+        reasoning: resolved.reasoning,
         ..Default::default()
     };
 
@@ -663,6 +665,7 @@ async fn extract_structured_insights(
         temperature: resolved.temperature as f32,
         max_tokens: resolved.max_tokens,
         user: audit_user.map(String::from),
+        reasoning: resolved.reasoning,
         ..Default::default()
     };
 

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -77,10 +77,11 @@ pub fn ulid_string(u: Ulid) -> String {
     u.to_string()
 }
 
-/// Maximum number of model attempts per streaming burst. Spec §5 chose 2
-/// (= 1 primary + 1 fallback) because streaming exposes each fallback as
-/// a separate visible bubble; depth > 2 starts feeling like a bug to users.
-pub const MAX_STREAM_FALLBACK_DEPTH: usize = 2;
+/// Maximum number of model attempts per streaming burst (= 1 primary + up to
+/// 2 fallbacks). Each attempt surfaces as a separate visible bubble; the
+/// frontend masks attempts beyond the first behind a "thinking" affordance, so
+/// a depth of 3 buys extra resilience without looking like a bug to users.
+pub const MAX_STREAM_FALLBACK_DEPTH: usize = 3;
 
 use std::sync::Arc;
 use uuid::Uuid;

--- a/crates/eros-engine-server/src/routes/bff/companion.rs
+++ b/crates/eros-engine-server/src/routes/bff/companion.rs
@@ -25,6 +25,13 @@ use crate::state::AppState;
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct BffHistoryEntry {
+    /// Stable message id — the `engine.chat_messages` row primary key (UUID).
+    pub id: Uuid,
+    /// Client-supplied message id forwarded during streaming (the
+    /// `client_msg_id` the FE sent on send). NULL for rows that never carried
+    /// one, e.g. assistant turns. Lets the FE reconcile an optimistic local
+    /// message with its persisted row.
+    pub client_msg_id: Option<String>,
     /// "user" | "assistant" | "gift_user" | "system_error"
     pub role: String,
     pub content: String,
@@ -114,6 +121,8 @@ async fn bff_get_history(
     let messages: Vec<BffHistoryEntry> = rows
         .into_iter()
         .map(|r| BffHistoryEntry {
+            id: r.id,
+            client_msg_id: r.client_msg_id,
             role: r.role,
             content: r.content,
             sent_at: r.sent_at,
@@ -165,6 +174,8 @@ async fn bff_start_chat(
     let history = rows
         .into_iter()
         .map(|r| BffHistoryEntry {
+            id: r.id,
+            client_msg_id: r.client_msg_id,
             role: r.role,
             content: r.content,
             sent_at: r.sent_at,
@@ -260,6 +271,62 @@ mod tests {
         // `total` reflects page count, not grand total.
         assert_eq!(body["total"], 3);
         assert_eq!(body["session_id"], json!(session_id.to_string()));
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn bff_history_entries_carry_row_id_and_client_msg_id(pool: PgPool) {
+        // The slim history must expose the engine's chat_messages primary key
+        // (`id`, a UUID) plus the stream-time `client_msg_id` (nullable), so the
+        // FE can reconcile persisted rows against both the DB key and its own
+        // optimistic message ids.
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+
+        let id_with = sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO engine.chat_messages (session_id, role, content, client_msg_id, sent_at) \
+             VALUES ($1, 'user', 'alpha', 'c_alpha', now() - interval '1 second') RETURNING id",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let id_without = sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO engine.chat_messages (session_id, role, content, sent_at) \
+             VALUES ($1, 'assistant', 'beta', now()) RETURNING id",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        let state = test_state(pool);
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        let (status, body) =
+            send_request(&mut app, bff_history_request(&token, session_id, "")).await;
+        assert_eq!(status, StatusCode::OK, "got body: {body}");
+
+        let messages = body["messages"].as_array().expect("messages array");
+        assert_eq!(messages.len(), 2);
+        // Oldest-first: the user row carrying a client_msg_id.
+        assert_eq!(
+            messages[0]["id"].as_str(),
+            Some(id_with.to_string().as_str()),
+            "id must be the raw chat_messages UUID; got {body}"
+        );
+        assert_eq!(messages[0]["client_msg_id"].as_str(), Some("c_alpha"));
+        // Assistant row had no client_msg_id → serialized as null.
+        assert_eq!(
+            messages[1]["id"].as_str(),
+            Some(id_without.to_string().as_str())
+        );
+        assert!(
+            messages[1]["client_msg_id"].is_null(),
+            "absent client_msg_id must be null; got {body}"
+        );
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -62,9 +62,13 @@ pub struct ChatMessage {
 /// Carries only the columns a chat-history viewer renders.
 #[derive(Debug, Clone, Serialize, sqlx::FromRow)]
 pub struct ChatMessageSlim {
+    pub id: Uuid,
     pub role: String,
     pub content: String,
     pub sent_at: DateTime<Utc>,
+    /// Client-supplied message id forwarded during streaming (idempotency
+    /// key). NULL for rows that never carried one (e.g. assistant turns).
+    pub client_msg_id: Option<String>,
 }
 
 pub struct ChatRepo<'a> {
@@ -197,7 +201,7 @@ impl<'a> ChatRepo<'a> {
         offset: i64,
     ) -> Result<Vec<ChatMessageSlim>, sqlx::Error> {
         let mut rows = sqlx::query_as::<_, ChatMessageSlim>(
-            "SELECT role, content, sent_at FROM engine.chat_messages \
+            "SELECT id, role, content, sent_at, client_msg_id FROM engine.chat_messages \
              WHERE session_id = $1 \
              ORDER BY sent_at DESC \
              LIMIT $2 OFFSET $3",

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -297,8 +297,8 @@ The body is the canonical start body plus one BFF-only field:
   "persona_name": "Aria",
   "is_new": false,
   "history": [
-    { "role": "user",      "content": "hello",   "sent_at": "…" },
-    { "role": "assistant", "content": "hi back", "sent_at": "…" }
+    { "id": "3cc06c53-…", "client_msg_id": "c_abc", "role": "user",      "content": "hello",   "sent_at": "…" },
+    { "id": "9f2e7a10-…", "client_msg_id": null,    "role": "assistant", "content": "hi back", "sent_at": "…" }
   ]
 }
 ```
@@ -309,8 +309,11 @@ independent of `EXPOSE_AFFINITY_DEBUG`.
 
 ### `GET /bff/v1/comp/chat/{session_id}/history?limit=50&offset=0`
 
-Slim history projection for the chat screen: `role` / `content` /
-`sent_at` only (no `extracted_facts`). Same auth, ownership check, and
+Slim history projection for the chat screen: `id` / `client_msg_id` /
+`role` / `content` / `sent_at` (no `extracted_facts`). `id` is the
+`chat_messages` row primary key (UUID); `client_msg_id` is the id the FE
+sent during streaming (`null` for rows that never carried one, e.g.
+assistant turns). Same auth, ownership check, and
 `limit ∈ [1, 50]` clamp as the canonical history route. **Intentional
 divergence:** the default `limit` is 50 (the canonical route defaults to 20),
 because the BFF exists for a cold mount that wants a full backscroll in one
@@ -320,8 +323,8 @@ round-trip.
 {
   "session_id": "…",
   "messages": [
-    { "role": "user",      "content": "alpha", "sent_at": "…" },
-    { "role": "assistant", "content": "beta",  "sent_at": "…" }
+    { "id": "3cc06c53-…", "client_msg_id": "c_abc", "role": "user",      "content": "alpha", "sent_at": "…" },
+    { "id": "9f2e7a10-…", "client_msg_id": null,    "role": "assistant", "content": "beta",  "sent_at": "…" }
   ],
   "total": 2
 }

--- a/docs/api-reference.zh.md
+++ b/docs/api-reference.zh.md
@@ -291,8 +291,8 @@ canonical `/comp/*` 路由永遠不會為了遷就前端而被改形狀——而
   "persona_name": "Aria",
   "is_new": false,
   "history": [
-    { "role": "user",      "content": "hello",   "sent_at": "…" },
-    { "role": "assistant", "content": "hi back", "sent_at": "…" }
+    { "id": "3cc06c53-…", "client_msg_id": "c_abc", "role": "user",      "content": "hello",   "sent_at": "…" },
+    { "id": "9f2e7a10-…", "client_msg_id": null,    "role": "assistant", "content": "hi back", "sent_at": "…" }
   ]
 }
 ```
@@ -302,8 +302,10 @@ canonical `/comp/*` 路由永遠不會為了遷就前端而被改形狀——而
 
 ### `GET /bff/v1/comp/chat/{session_id}/history?limit=50&offset=0`
 
-給聊天屏用的精簡歷史投影：只有 `role` / `content` / `sent_at`
-（不含 `extracted_facts`）。鑒權、ownership 檢查、`limit ∈ [1, 50]` 夾取
+給聊天屏用的精簡歷史投影：`id` / `client_msg_id` / `role` / `content` /
+`sent_at`（不含 `extracted_facts`）。`id` 是 `chat_messages` 行的主鍵（UUID）；
+`client_msg_id` 是前端串流時帶上的 id（沒帶的行為 `null`，例如 assistant 回合）。
+鑒權、ownership 檢查、`limit ∈ [1, 50]` 夾取
 都與 canonical history 路由相同。**刻意差異：** 默認 `limit` 是 50
 （canonical 默認 20），因為 BFF 是為「冷啟動一次拉一整屏 backscroll」設計的。
 
@@ -311,8 +313,8 @@ canonical `/comp/*` 路由永遠不會為了遷就前端而被改形狀——而
 {
   "session_id": "…",
   "messages": [
-    { "role": "user",      "content": "alpha", "sent_at": "…" },
-    { "role": "assistant", "content": "beta",  "sent_at": "…" }
+    { "id": "3cc06c53-…", "client_msg_id": "c_abc", "role": "user",      "content": "alpha", "sent_at": "…" },
+    { "id": "9f2e7a10-…", "client_msg_id": null,    "role": "assistant", "content": "beta",  "sent_at": "…" }
   ],
   "total": 2
 }

--- a/docs/superpowers/specs/2026-05-22-chat-reasoning-control-design.md
+++ b/docs/superpowers/specs/2026-05-22-chat-reasoning-control-design.md
@@ -40,12 +40,15 @@ on models that don't support it (no 4xx).
 
 ## 1. Goal / Non-goals
 
-**Goal:** a TOML-driven, task-level toggle that makes `tasks.chat_companion`
-send `reasoning:{enabled:false}` on every turn (all tiers).
+**Goal:** a TOML-driven, task-level reasoning config that makes
+`tasks.chat_companion` send `reasoning:{enabled:false}` on every turn (all
+tiers). The config mirrors OpenRouter's `reasoning` object so operators can
+also express e.g. `{ exclude = true }`.
 
 **Non-goals:**
 - Per-tier reasoning override (task-level only; tiers inherit).
-- Reasoning *effort*/*max_tokens* tuning (only the on/off `enabled` flag).
+- `effort`/`max_tokens` reasoning fields (the struct carries `enabled` +
+  `exclude` only; extend later if needed).
 - Changing reasoning for insight/affinity/memory tasks (left at model default).
 - Consuming/persisting reasoning tokens (the engine still ignores the
   `reasoning` channel).
@@ -54,73 +57,96 @@ send `reasoning:{enabled:false}` on every turn (all tiers).
 
 ## 2. Design
 
-### 2.1 Config (`TaskConfig`)
+### 2.1 Config object (`ReasoningConfig`)
 
-Add `reasoning: Option<bool>` to `TaskConfig` (not `TierConfig`). Three-state,
-mirroring how `temperature`/`max_tokens` are task-level only:
+A single struct mirrors OpenRouter's `reasoning` object — parsed from TOML and
+serialized to the wire unchanged, so config and request shape stay aligned:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct ReasoningConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exclude: Option<bool>,
+}
+```
+
+`TaskConfig.reasoning: Option<ReasoningConfig>` (not on `TierConfig`).
+Three-state, like `temperature`/`max_tokens` being task-level only:
 
 - absent → `None` → omit the wire param (model default; current behavior)
-- `false` → `Some(false)` → send `reasoning:{enabled:false}`
-- `true` → `Some(true)` → send `reasoning:{enabled:true}`
+- present → forwarded verbatim, inner absent fields omitted
 
 ```toml
 [tasks.chat_companion]
 model = "x-ai/grok-4.20"
-reasoning = false   # disables reasoning for ALL chat_companion turns (every tier)
+reasoning = { enabled = false }   # disables reasoning for ALL tiers
+# or: reasoning = { exclude = true }   # generate but hide it
 ```
 
 ### 2.2 Resolver (`ResolvedModel` + `resolve()`)
 
-Add `reasoning: Option<bool>` to `ResolvedModel`. In `resolve()` it is read
-straight from the task block: `task_cfg.and_then(|t| t.reasoning)`. It is
-**task-level only** — tiers inherit it unchanged (no `TierConfig` field, no
-per-tier override), exactly like `temperature`/`max_tokens`.
+Add `reasoning: Option<ReasoningConfig>` to `ResolvedModel`. In `resolve()` it
+is read (cloned) straight from the task block:
+`task_cfg.and_then(|t| t.reasoning.clone())`. **Task-level only** — tiers
+inherit it unchanged (no `TierConfig` field), exactly like
+`temperature`/`max_tokens`.
 
 ### 2.3 Request plumbing (`ChatRequest` + build sites)
 
-Add `reasoning: Option<bool>` to `ChatRequest` (derives `Default` → `None`).
-Thread `resolved.reasoning` into every `ChatRequest` build site
+Add `reasoning: Option<ReasoningConfig>` to `ChatRequest` (derives `Default` →
+`None`). Thread `resolved.reasoning` into every `ChatRequest` build site
 (`assemble_chat_request` for chat, plus the affinity / insight / memory
 builders). Tasks with no `reasoning` in config resolve to `None` → field
 omitted → behavior unchanged.
 
 ### 2.4 Wire serialization (`openrouter.rs`)
 
-Add to `WireRequest`:
+`ChatRequest.reasoning: Option<ReasoningConfig>` is forwarded directly — no
+bespoke wire struct. `WireRequest` borrows it:
 
 ```rust
-#[derive(Debug, Serialize)]
-struct WireReasoning { enabled: bool }
-
-// in WireRequest:
 #[serde(skip_serializing_if = "Option::is_none")]
-reasoning: Option<WireReasoning>,
+reasoning: Option<&'a ReasoningConfig>,
 ```
 
-Map `ChatRequest.reasoning: Option<bool>` → `Option<WireReasoning>`
-(`Some(b) => Some(WireReasoning{enabled:b})`, `None => None`). Because the
+set from `req.reasoning.as_ref()` (streaming) and the `req_reasoning` param
+(sync `call_once`, passed `req.reasoning.as_ref()` by `execute`). Because the
 streaming and sync paths were unified onto `WireRequest` (the 2026-05-22
-`user: null` bugfix), this single field covers **both** paths — no separate
-`json!` edit.
+`user: null` bugfix), this single field covers **both** paths.
+
+### 2.5 Streaming retry depth + fallback guidance
+
+Raise `MAX_STREAM_FALLBACK_DEPTH` 2 → 3 (1 primary + up to 2 fallbacks). The
+frontend masks attempts beyond the first behind a "thinking" affordance, so the
+extra attempt adds resilience without looking buggy. Correspondingly, the
+example config recommends `fallback` ≤ 2 entries (primary + 2 = the cap);
+entries past the third are never tried on the chat path.
 
 ---
 
 ## 3. Testing
 
-- **model_config resolve:** task `reasoning=false` → `Some(false)`; absent →
-  `None`; a tier with no override inherits the task's `reasoning`.
-- **openrouter wire:** `WireRequest` with `reasoning=Some(false)` serializes
-  `"reasoning":{"enabled":false}`; `None` omits the key entirely.
-- **committed example config:** `resolve("chat_companion", …)` →
-  `reasoning == Some(false)`.
+- **model_config resolve:** task `reasoning = { enabled = false }` →
+  `Some(ReasoningConfig{enabled:Some(false),..})` (and a no-override tier
+  inherits it); absent → `None`; `{ exclude = true }` parses into the struct.
+- **openrouter wire:** `WireRequest` with a `Some(&ReasoningConfig{enabled:
+  Some(false),..})` serializes `"reasoning":{"enabled":false}`; `None` omits
+  the key entirely.
+- **committed example config:** `resolve("chat_companion", …)` (and the free
+  tier) → `reasoning == Some({enabled:false})`; `insight_extraction` → `None`.
 
 ---
 
 ## 4. Rollout
 
-- `examples/model_config.toml`: add `reasoning = false` to
-  `[tasks.chat_companion]`.
+- `examples/model_config.toml`: add `reasoning = { enabled = false }` to
+  `[tasks.chat_companion]`; trim default `fallback` to ≤ 2 entries and document
+  the guidance.
+- `MAX_STREAM_FALLBACK_DEPTH` 2 → 3.
 - Regenerate the committed OpenAPI snapshot only if any `ToSchema` type
-  changed (it does not — `ChatRequest`/`WireRequest` are not exposed schemas).
+  changed (it does not — `ChatRequest`/`WireRequest`/`ReasoningConfig` are not
+  exposed schemas).
 - Additive and non-breaking: existing configs without `reasoning` keep
   model-default behavior.

--- a/docs/superpowers/specs/2026-05-22-chat-reasoning-control-design.md
+++ b/docs/superpowers/specs/2026-05-22-chat-reasoning-control-design.md
@@ -1,0 +1,126 @@
+# eros-engine — Per-task reasoning control (Spec)
+
+**Status**: design, pending implementation plan
+**Target release**: 0.3.x patch (additive, non-breaking)
+**Audience**: anyone implementing the engine-side reasoning toggle for `tasks.chat_companion`
+
+---
+
+## 0. Background
+
+`tasks.chat_companion` can resolve to reasoning-capable models (e.g.
+`qwen/qwen3.6-flash`, the `z-ai/glm-*` family). On those models OpenRouter
+emits a `reasoning` token stream that the engine's chat path does **not**
+consume — it only accumulates `delta.content`. The reasoning tokens add
+latency and cost to every companion turn while contributing nothing to the
+visible reply.
+
+We want a config knob to turn reasoning **off** for the chat task, without
+touching the structured-extraction tasks (insight/affinity/memory) that may
+legitimately benefit from it later.
+
+### OpenRouter API (empirically confirmed 2026-05-22)
+
+The request accepts a `reasoning` object. Probed against the engine's own
+key at `max_tokens=400`:
+
+| request | `reasoning` chars | outcome |
+|---|---|---|
+| qwen, no `reasoning` param | 3110 | model default — heavy reasoning |
+| qwen, `reasoning:{enabled:false}` | 0 | content present, `finish=stop` — **truly disabled** |
+| qwen, `reasoning:{exclude:true}` | 0 in stream | still generated server-side (hidden, still billed) — *not* what we want |
+| cydonia (non-reasoning), `reasoning:{enabled:false}` | 0 | HTTP 200, no error — harmless no-op |
+| minimax-m2-her, `reasoning:{enabled:false}` | 0 | HTTP 200 — harmless |
+
+**Conclusion:** `reasoning: { "enabled": false }` is the correct primitive.
+It suppresses reasoning on reasoning-capable models and is a harmless no-op
+on models that don't support it (no 4xx).
+
+---
+
+## 1. Goal / Non-goals
+
+**Goal:** a TOML-driven, task-level toggle that makes `tasks.chat_companion`
+send `reasoning:{enabled:false}` on every turn (all tiers).
+
+**Non-goals:**
+- Per-tier reasoning override (task-level only; tiers inherit).
+- Reasoning *effort*/*max_tokens* tuning (only the on/off `enabled` flag).
+- Changing reasoning for insight/affinity/memory tasks (left at model default).
+- Consuming/persisting reasoning tokens (the engine still ignores the
+  `reasoning` channel).
+
+---
+
+## 2. Design
+
+### 2.1 Config (`TaskConfig`)
+
+Add `reasoning: Option<bool>` to `TaskConfig` (not `TierConfig`). Three-state,
+mirroring how `temperature`/`max_tokens` are task-level only:
+
+- absent → `None` → omit the wire param (model default; current behavior)
+- `false` → `Some(false)` → send `reasoning:{enabled:false}`
+- `true` → `Some(true)` → send `reasoning:{enabled:true}`
+
+```toml
+[tasks.chat_companion]
+model = "x-ai/grok-4.20"
+reasoning = false   # disables reasoning for ALL chat_companion turns (every tier)
+```
+
+### 2.2 Resolver (`ResolvedModel` + `resolve()`)
+
+Add `reasoning: Option<bool>` to `ResolvedModel`. In `resolve()` it is read
+straight from the task block: `task_cfg.and_then(|t| t.reasoning)`. It is
+**task-level only** — tiers inherit it unchanged (no `TierConfig` field, no
+per-tier override), exactly like `temperature`/`max_tokens`.
+
+### 2.3 Request plumbing (`ChatRequest` + build sites)
+
+Add `reasoning: Option<bool>` to `ChatRequest` (derives `Default` → `None`).
+Thread `resolved.reasoning` into every `ChatRequest` build site
+(`assemble_chat_request` for chat, plus the affinity / insight / memory
+builders). Tasks with no `reasoning` in config resolve to `None` → field
+omitted → behavior unchanged.
+
+### 2.4 Wire serialization (`openrouter.rs`)
+
+Add to `WireRequest`:
+
+```rust
+#[derive(Debug, Serialize)]
+struct WireReasoning { enabled: bool }
+
+// in WireRequest:
+#[serde(skip_serializing_if = "Option::is_none")]
+reasoning: Option<WireReasoning>,
+```
+
+Map `ChatRequest.reasoning: Option<bool>` → `Option<WireReasoning>`
+(`Some(b) => Some(WireReasoning{enabled:b})`, `None => None`). Because the
+streaming and sync paths were unified onto `WireRequest` (the 2026-05-22
+`user: null` bugfix), this single field covers **both** paths — no separate
+`json!` edit.
+
+---
+
+## 3. Testing
+
+- **model_config resolve:** task `reasoning=false` → `Some(false)`; absent →
+  `None`; a tier with no override inherits the task's `reasoning`.
+- **openrouter wire:** `WireRequest` with `reasoning=Some(false)` serializes
+  `"reasoning":{"enabled":false}`; `None` omits the key entirely.
+- **committed example config:** `resolve("chat_companion", …)` →
+  `reasoning == Some(false)`.
+
+---
+
+## 4. Rollout
+
+- `examples/model_config.toml`: add `reasoning = false` to
+  `[tasks.chat_companion]`.
+- Regenerate the committed OpenAPI snapshot only if any `ToSchema` type
+  changed (it does not — `ChatRequest`/`WireRequest` are not exposed schemas).
+- Additive and non-breaking: existing configs without `reasoning` keep
+  model-default behavior.

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -7,10 +7,18 @@
 # ids in preference order. The chain is tried sequentially; first success
 # wins. An explicit empty value (`""` or `[]`) opts out of the defaults
 # block's fallback for this task.
+# Recommendation: keep `fallback` to at most 2 entries. The streaming chat
+# burst caps attempts at MAX_STREAM_FALLBACK_DEPTH (3 = primary + 2 fallbacks);
+# anything past the third entry is never tried on the chat path.
 model = "x-ai/grok-4.20"
-fallback = ["thedrummer/cydonia-24b-v4.1", "x-ai/grok-4.3", "z-ai/glm-4.7-flash"]
+fallback = ["thedrummer/cydonia-24b-v4.1", "minimax/minimax-m2-her"]
 temperature = 0.8
 max_tokens = 1500
+# Companion replies only render `content`; the reasoning channel is ignored,
+# so disable it to save latency/cost. Same shape as OpenRouter's `reasoning`
+# object — set `{ exclude = true }` instead if you want it generated but hidden.
+# Inherited by every tier below.
+reasoning = { enabled = false }
 # Default-block trait allow-list: used when no tier is sent or the tier is
 # unknown. Tier sub-tables below override model/fallback/allow_traits per tier.
 allow_traits = ["nsfw_boost","politics_open"]


### PR DESCRIPTION
## Summary

Two related engine changes for the `eros-engine-web` chat surface, plus supporting cleanup.

**1. BFF slim history now carries stable ids** (`/bff/v1/comp/chat/start` history + `/bff/v1/comp/chat/{sid}/history` messages):
- `id` — the `engine.chat_messages` row primary key (UUID).
- `client_msg_id` — the nullable stream-time client id.
- Lets the FE reconcile persisted rows against both the DB key and its own optimistic message ids. Adds the columns to the `ChatMessageSlim` projection + `history_slim` query; refreshes the OpenAPI snapshot and the en/zh API reference.

**2. Per-task reasoning control** (`tasks.chat_companion`):
- New `reasoning` config object mirroring OpenRouter's request shape: `reasoning = { enabled = false }` (or `{ exclude = true }`). Parsed from TOML and forwarded verbatim to the wire on both the sync and streaming paths via the shared `WireRequest`.
- Task-level only (tiers inherit). Companion turns ignore the reasoning channel, so the example config disables it to save latency/cost.
- Empirically confirmed `reasoning:{enabled:false}` disables reasoning on reasoning-capable models and is a harmless no-op on the rest (see spec §0).

**3. Streaming retry depth 2 → 3** (`MAX_STREAM_FALLBACK_DEPTH`): 1 primary + up to 2 fallbacks; the FE masks attempts past the first behind a "thinking" affordance. Example config documents the matching "≤2 fallbacks" guidance.

Design spec: `docs/superpowers/specs/2026-05-22-chat-reasoning-control-design.md`.

> Note: the related `user: null` streaming-wire bugfix and the model_config fallback retune are already on `main` (merged earlier), so they are not part of this PR's diff.

## Test plan
- [x] `cargo test --workspace` — 310 pass (server 162, store 66, llm 49, core 33)
- [x] `cargo clippy --workspace` — clean
- [x] New regression tests: BFF id/client_msg_id projection; reasoning resolve (enabled/exclude/absent + tier inheritance); wire serialization; committed-config asserts chat_companion reasoning disabled
- [x] codex review — no issues
- [ ] Reviewer: confirm BFF `id` UUID format + `client_msg_id` nullability match eros-engine-web expectations

🤖 Generated with [Claude Code](https://claude.com/claude-code)