### PR TITLE
feat(prompt): stable per-role cache prefix + gender/time fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,6 +242,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,6 +443,7 @@ dependencies = [
  "async-trait",
  "axum",
  "chrono",
+ "chrono-tz",
  "dotenvy",
  "eros-engine-core",
  "eros-engine-llm",
@@ -1386,6 +1397,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1901,6 +1930,12 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ serde_json = "1"
 sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls", "postgres", "uuid", "chrono", "json"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
+chrono-tz = "0.10"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 thiserror = "1"
 anyhow = "1"

--- a/crates/eros-engine-server/Cargo.toml
+++ b/crates/eros-engine-server/Cargo.toml
@@ -20,6 +20,7 @@ serde_json = { workspace = true }
 sqlx = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
+chrono-tz = { workspace = true }
 async-trait = { workspace = true }
 thiserror = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/eros-engine-server/src/prompt.rs
+++ b/crates/eros-engine-server/src/prompt.rs
@@ -300,13 +300,16 @@ fn meta_string_array_joined(persona: &CompanionPersona, key: &str) -> Option<Str
 }
 
 /// Display label for the persona's gender. `male`/`female` → Chinese; any other
-/// non-empty value (e.g. "non-binary") is rendered verbatim; absent → None.
+/// non-empty value (e.g. "non-binary") is rendered verbatim; absent or
+/// blank → None (so a `""` value can't produce a double-comma identity line).
 fn gender_label(persona: &CompanionPersona) -> Option<String> {
-    meta_str(persona, "gender").map(|g| match g {
-        "male" => "男性".to_string(),
-        "female" => "女性".to_string(),
-        other => other.to_string(),
-    })
+    meta_str(persona, "gender")
+        .filter(|g| !g.trim().is_empty())
+        .map(|g| match g {
+            "male" => "男性".to_string(),
+            "female" => "女性".to_string(),
+            other => other.to_string(),
+        })
 }
 
 /// Whether gender is a binary value that warrants the 铁律 anatomy clause.
@@ -439,7 +442,7 @@ pub fn build_prompt(
     // 铁律 ⑧: gender-consistency reinforcement (redundancy = weighting). Only for
     // binary genders, with a role-play exception. Skipped for non-binary/absent.
     let gender_rule = if is_binary_gender(persona) {
-        let g = gender_label(persona).unwrap_or_default();
+        let g = gender_label(persona).expect("is_binary_gender ⇒ gender present");
         format!(
             "\n⑧ 你是{g}，严格遵守自己的性别，绝不说出与自身性别矛盾的身体或身份描述；\
              除非在与用户的角色扮演中双方明确约定你暂时扮演其他性别"
@@ -777,6 +780,19 @@ mod tests {
         );
         assert!(s.contains("你是 Aria，24 岁，INFP 性格。"), "{s}");
         assert!(!s.contains("⑧"), "no gender → no ⑧: {s}");
+    }
+
+    #[test]
+    fn build_prompt_treats_blank_gender_as_absent() {
+        let mut p = fixture_persona();
+        set_meta(&mut p, "gender", serde_json::json!("   "));
+        let s = build_prompt(
+            &p, &[], &[], None, &[], "normal", ReplyStyle::Neutral, &[], &[],
+        );
+        // blank gender must not produce a double comma or a ⑧ rule
+        assert!(s.contains("你是 Aria，24 岁，INFP 性格。"), "{s}");
+        assert!(!s.contains("，，"), "blank gender must not double-comma: {s}");
+        assert!(!s.contains("⑧"), "{s}");
     }
 
     #[test]

--- a/crates/eros-engine-server/src/prompt.rs
+++ b/crates/eros-engine-server/src/prompt.rs
@@ -299,6 +299,21 @@ fn meta_string_array_joined(persona: &CompanionPersona, key: &str) -> Option<Str
         })
 }
 
+/// Display label for the persona's gender. `male`/`female` → Chinese; any other
+/// non-empty value (e.g. "non-binary") is rendered verbatim; absent → None.
+fn gender_label(persona: &CompanionPersona) -> Option<String> {
+    meta_str(persona, "gender").map(|g| match g {
+        "male" => "男性".to_string(),
+        "female" => "女性".to_string(),
+        other => other.to_string(),
+    })
+}
+
+/// Whether gender is a binary value that warrants the 铁律 anatomy clause.
+fn is_binary_gender(persona: &CompanionPersona) -> bool {
+    matches!(meta_str(persona, "gender"), Some("male") | Some("female"))
+}
+
 /// Build the full companion system prompt (plain-text reply schema).
 ///
 /// `profile_groups` is a list of `(label, bullets)` pairs that get rendered
@@ -329,6 +344,28 @@ pub fn build_prompt(
         meta_string_array_joined(persona, "quirks").unwrap_or_else(|| "无特定口癖".into());
     let topics_str =
         meta_string_array_joined(persona, "topics").unwrap_or_else(|| "日常生活、感情观".into());
+    let timezone = meta_str(persona, "timezone");
+
+    // Authored prose head — the most stable per-genome block, used as the
+    // leading cache prefix. Deliberately redundant with the structured sections
+    // below (reinforcement). Omitted with no separator when empty.
+    let head = {
+        let sp = persona.genome.system_prompt.trim();
+        if sp.is_empty() {
+            String::new()
+        } else {
+            format!("{sp}\n\n")
+        }
+    };
+
+    let identity = match gender_label(persona) {
+        Some(g) => format!("你是 {name}，{g}，{age} 岁，{mbti} 性格。"),
+        None => format!("你是 {name}，{age} 岁，{mbti} 性格。"),
+    };
+    let tz_clause = match timezone {
+        Some(tz) if !tz.trim().is_empty() => format!("你所在时区：{}。", tz.trim()),
+        _ => String::new(),
+    };
 
     let traits_section = if prompt_traits.is_empty() {
         String::new()
@@ -399,8 +436,20 @@ pub fn build_prompt(
         )
     };
 
+    // 铁律 ⑧: gender-consistency reinforcement (redundancy = weighting). Only for
+    // binary genders, with a role-play exception. Skipped for non-binary/absent.
+    let gender_rule = if is_binary_gender(persona) {
+        let g = gender_label(persona).unwrap_or_default();
+        format!(
+            "\n⑧ 你是{g}，严格遵守自己的性别，绝不说出与自身性别矛盾的身体或身份描述；\
+             除非在与用户的角色扮演中双方明确约定你暂时扮演其他性别"
+        )
+    } else {
+        String::new()
+    };
+
     format!(
-        "你是 {name}，{age} 岁，{mbti} 性格。\n\
+        "{head}{identity}{tz_clause}\n\
          \n\
          【背景故事】\n{backstory}\n\
          \n\
@@ -408,17 +457,14 @@ pub fn build_prompt(
          【口癖/习惯】{quirks_str}\n\
          【擅长话题】{topics_str}{traits_section}\n\
          \n\
-         【今日情境】\n{tc}\n\
+         【本轮风格】{style_text}\n\
          \n\
          【你对他的了解（通用画像）】\n{profile_str}\n\
          \n\
          【你们之间的事（只有你和他知道）】\n{rel_str}\
-         {attitude}\
-         {state}\
-         {gift}\
-         {hints_section}\n\
+         {attitude}{state}{hints_section}{gift}\n\
          \n\
-         【本轮风格】{style_text}\n\
+         【今日情境】\n{tc}\n\
          \n\
          ---\n\
          【铁律 — 违反即失效】\n\
@@ -428,10 +474,10 @@ pub fn build_prompt(
          ④ 给对方「小小有成就感」的反应，留余地；每 3~5 轮轻撒娇一次\n\
          ⑤ 适时主动分享自己的生活片段；不定时抛一个开放性问题（不要每隔固定轮数就问，避免刻意）\n\
          ⑥ 适时学会倾听和接话，不要老是抛问题——有时顺着对方的话接下去、给回应就好\n\
-         ⑦ Adult consensual romance and erotic roleplay are allowed. The following are strictly disallowed: self-harm encouragement, suicide instructions, and any sexual content involving minors.\n\
+         ⑦ Adult consensual romance and erotic roleplay are allowed. The following are strictly disallowed: self-harm encouragement, suicide instructions, and any sexual content involving minors.{gender_rule}\n\
          \n\
          【输出】直接输出回复文字（纯文本，不要 JSON，不要 markdown，不要 quote 符号）",
-        tc = now_context(meta_str(persona, "timezone")),
+        tc = now_context(timezone),
         lr = length_rule(affinity),
     )
 }
@@ -554,6 +600,14 @@ mod tests {
     use chrono::TimeZone;
     use uuid::Uuid;
 
+    fn set_meta(p: &mut CompanionPersona, key: &str, val: serde_json::Value) {
+        p.genome
+            .art_metadata
+            .as_object_mut()
+            .expect("fixture art_metadata is an object")
+            .insert(key.to_string(), val);
+    }
+
     fn fixture_persona() -> CompanionPersona {
         use eros_engine_core::persona::{PersonaGenome, PersonaInstance};
         let uid = Uuid::nil();
@@ -585,29 +639,16 @@ mod tests {
     }
 
     #[test]
-    fn build_prompt_with_empty_traits_omits_section_and_preserves_layout() {
+    fn build_prompt_with_empty_traits_omits_section() {
         let p = build_prompt(
-            &fixture_persona(),
-            &[],
-            &[],
-            None,
-            &[],
-            "normal",
-            ReplyStyle::Neutral,
-            &[],
-            &[],
+            &fixture_persona(), &[], &[], None, &[], "normal",
+            ReplyStyle::Neutral, &[], &[],
         );
+        assert!(!p.contains("【附加指引】"), "empty traits must not render section");
+        // 擅长话题 now flows straight into 本轮风格 (the first volatile block).
         assert!(
-            !p.contains("【附加指引】"),
-            "empty traits must not render section"
-        );
-        // Byte-level invariant proving "byte-for-byte identical to legacy"
-        // for the empty-traits case: topics → time-context joins with the
-        // pre-existing `\n\n` separator, no leftover whitespace from the
-        // new `{traits_section}` placeholder.
-        assert!(
-            p.contains("【擅长话题】t1\n\n【今日情境】"),
-            "topics → time-context separator must be exactly '\\n\\n'"
+            p.contains("【擅长话题】t1\n\n【本轮风格】"),
+            "topics → 本轮风格 separator must be exactly '\\n\\n': {p}"
         );
     }
 
@@ -644,29 +685,108 @@ mod tests {
     }
 
     #[test]
-    fn build_prompt_section_sits_between_topics_and_time_context() {
-        let traits = vec![PromptTrait {
-            tag: "x".into(),
-            text: "trait body".into(),
-        }];
+    fn build_prompt_stable_block_order() {
+        let traits = vec![PromptTrait { tag: "x".into(), text: "trait body".into() }];
         let p = build_prompt(
-            &fixture_persona(),
-            &[],
-            &[],
-            None,
-            &[],
-            "normal",
-            ReplyStyle::Neutral,
-            &[],
-            &traits,
+            &fixture_persona(), &[], &[], None, &[], "normal",
+            ReplyStyle::Neutral, &[], &traits,
         );
-        let topics_idx = p.find("【擅长话题】").expect("topics header");
-        let traits_idx = p.find("【附加指引】").expect("traits header");
-        let time_idx = p.find("【今日情境】").expect("time-context header");
+        let topics = p.find("【擅长话题】").expect("topics");
+        let traits_i = p.find("【附加指引】").expect("traits");
+        let turn_style = p.find("【本轮风格】").expect("turn style");
         assert!(
-            topics_idx < traits_idx && traits_idx < time_idx,
-            "order: 擅长话题 → 附加指引 → 今日情境"
+            topics < traits_i && traits_i < turn_style,
+            "order: 擅长话题 → 附加指引 → 本轮风格"
         );
+    }
+
+    #[test]
+    fn build_prompt_full_order_and_cache_break() {
+        let s = build_prompt(
+            &fixture_persona(), &[], &[], None, &[], "normal",
+            ReplyStyle::Neutral, &[], &[],
+        );
+        let pos = |h: &str| s.find(h).unwrap_or_else(|| panic!("missing {h} in:\n{s}"));
+        let order = [
+            "你是 ", "【背景故事】", "【说话风格】", "【口癖/习惯】", "【擅长话题】",
+            "【本轮风格】", "【你对他的了解（通用画像）】", "【你们之间的事",
+            "【今日情境】", "【铁律", "【输出】",
+        ];
+        let mut last = 0usize;
+        for h in order {
+            let cur = pos(h);
+            assert!(cur >= last, "header {h} out of order in:\n{s}");
+            last = cur;
+        }
+        let topics = pos("【擅长话题】");
+        for vol in ["【本轮风格】", "【你对他的了解（通用画像）】", "【今日情境】"] {
+            assert!(pos(vol) > topics, "{vol} must sit after the stable persona block");
+        }
+    }
+
+    #[test]
+    fn build_prompt_renders_system_prompt_head_when_present() {
+        let mut p = fixture_persona();
+        p.genome.system_prompt = "AUTHORED HEAD".into();
+        let s = build_prompt(
+            &p, &[], &[], None, &[], "normal", ReplyStyle::Neutral, &[], &[],
+        );
+        assert!(
+            s.starts_with("AUTHORED HEAD\n\n你是 "),
+            "prose head + '\\n\\n' separator before identity: {s}"
+        );
+    }
+
+    #[test]
+    fn build_prompt_omits_head_when_system_prompt_empty() {
+        let mut p = fixture_persona();
+        p.genome.system_prompt = "   ".into();
+        let s = build_prompt(
+            &p, &[], &[], None, &[], "normal", ReplyStyle::Neutral, &[], &[],
+        );
+        assert!(s.starts_with("你是 "), "empty head → starts with identity: {s}");
+    }
+
+    #[test]
+    fn build_prompt_renders_binary_gender_and_iron_rule() {
+        let mut p = fixture_persona();
+        set_meta(&mut p, "gender", serde_json::json!("male"));
+        let s = build_prompt(
+            &p, &[], &[], None, &[], "normal", ReplyStyle::Neutral, &[], &[],
+        );
+        assert!(s.contains("你是 Aria，男性，24 岁，INFP 性格。"), "{s}");
+        assert!(s.contains("⑧ 你是男性，严格遵守自己的性别"), "{s}");
+    }
+
+    #[test]
+    fn build_prompt_renders_nonbinary_gender_without_iron_rule() {
+        let mut p = fixture_persona();
+        set_meta(&mut p, "gender", serde_json::json!("non-binary"));
+        let s = build_prompt(
+            &p, &[], &[], None, &[], "normal", ReplyStyle::Neutral, &[], &[],
+        );
+        assert!(s.contains("你是 Aria，non-binary，24 岁"), "verbatim render: {s}");
+        assert!(!s.contains("⑧"), "non-binary must not get the binary anatomy rule: {s}");
+    }
+
+    #[test]
+    fn build_prompt_omits_gender_when_absent() {
+        let p = fixture_persona(); // fixture art_metadata has no gender key
+        let s = build_prompt(
+            &p, &[], &[], None, &[], "normal", ReplyStyle::Neutral, &[], &[],
+        );
+        assert!(s.contains("你是 Aria，24 岁，INFP 性格。"), "{s}");
+        assert!(!s.contains("⑧"), "no gender → no ⑧: {s}");
+    }
+
+    #[test]
+    fn build_prompt_renders_timezone_clause_when_present() {
+        let mut p = fixture_persona();
+        set_meta(&mut p, "timezone", serde_json::json!("Asia/Tokyo"));
+        let s = build_prompt(
+            &p, &[], &[], None, &[], "normal", ReplyStyle::Neutral, &[], &[],
+        );
+        assert!(s.contains("你所在时区：Asia/Tokyo。"), "{s}");
     }
 
     #[test]

--- a/crates/eros-engine-server/src/prompt.rs
+++ b/crates/eros-engine-server/src/prompt.rs
@@ -23,7 +23,7 @@
 //! so don't live here. Future port targets (dream / proactive) should be
 //! added as new families in this file.
 
-use chrono::{Datelike, Timelike, Utc};
+use chrono::{Datelike, Timelike, Utc, Weekday};
 
 use eros_engine_core::affinity::Affinity;
 use eros_engine_core::persona::CompanionPersona;
@@ -46,35 +46,61 @@ pub struct PendingGift {
     pub item_name: Option<String>,
 }
 
-/// Absolute "now" context. Renders the current UTC date + weekday + time and
-/// asks the model to infer the companion's LOCAL time from its residence
-/// (set in the persona backstory). We deliberately do NOT pre-apply a fixed
-/// timezone — personas live in different places, so the model derives local
-/// time from absolute UTC + residence. This is what lets the companion
-/// "perceive" today's date.
-fn now_context() -> String {
-    now_context_at(Utc::now())
+fn weekday_cn(wd: Weekday) -> &'static str {
+    match wd {
+        Weekday::Mon => "周一",
+        Weekday::Tue => "周二",
+        Weekday::Wed => "周三",
+        Weekday::Thu => "周四",
+        Weekday::Fri => "周五",
+        Weekday::Sat => "周六",
+        Weekday::Sun => "周日",
+    }
 }
 
-fn now_context_at(now: chrono::DateTime<Utc>) -> String {
-    let weekday = match now.weekday() {
-        chrono::Weekday::Mon => "周一",
-        chrono::Weekday::Tue => "周二",
-        chrono::Weekday::Wed => "周三",
-        chrono::Weekday::Thu => "周四",
-        chrono::Weekday::Fri => "周五",
-        chrono::Weekday::Sat => "周六",
-        chrono::Weekday::Sun => "周日",
-    };
-    format!(
-        "现在是 UTC {date}（{weekday}）{hh:02}:{mm:02}。根据你的居住地（见背景故事）\
-         推算你当地的时间和日期，自然地感知现在大概是清晨/白天/傍晚/深夜、今天几号、\
-         星期几，并据此开启符合当地时段的话题。",
-        date = now.format("%Y-%m-%d"),
-        weekday = weekday,
-        hh = now.hour(),
-        mm = now.minute(),
-    )
+/// Coarse day-part bucket from a local hour (0-23).
+fn period_cn(hour: u32) -> &'static str {
+    match hour {
+        5..=7 => "清晨",
+        8..=17 => "白天",
+        18..=22 => "傍晚",
+        _ => "深夜",
+    }
+}
+
+/// Absolute "now" context. With a parseable IANA `timezone` we render the
+/// persona's LOCAL date/weekday/time/period directly (the model does no
+/// arithmetic — this is the fix for the time-hallucination bug). Without one we
+/// fall back to UTC + infer-from-residence, hardened against fabricating times.
+fn now_context(timezone: Option<&str>) -> String {
+    now_context_at(Utc::now(), timezone)
+}
+
+fn now_context_at(now: chrono::DateTime<Utc>, timezone: Option<&str>) -> String {
+    match timezone.and_then(|s| s.trim().parse::<chrono_tz::Tz>().ok()) {
+        Some(tz) => {
+            let local = now.with_timezone(&tz);
+            format!(
+                "现在你当地时间是 {date}（{wd}）{hh:02}:{mm:02}，{period}。\
+                 这是你唯一的时间基准，不要编造其它日期或时间。",
+                date = local.format("%Y-%m-%d"),
+                wd = weekday_cn(local.weekday()),
+                hh = local.hour(),
+                mm = local.minute(),
+                period = period_cn(local.hour()),
+            )
+        }
+        None => format!(
+            "现在是 UTC {date}（{wd}）{hh:02}:{mm:02}。根据你的居住地（见背景故事）\
+             推算你当地的时间和日期，自然地感知现在大概是清晨/白天/傍晚/深夜、今天几号、\
+             星期几。严格以上述 UTC 时间为唯一基准，不得编造其它日期或时间；无法换算时区时\
+             只说大致时段，不要编造具体钟点。",
+            date = now.format("%Y-%m-%d"),
+            wd = weekday_cn(now.weekday()),
+            hh = now.hour(),
+            mm = now.minute(),
+        ),
+    }
 }
 
 /// Reply-length rule for 铁律①, graduated by `intimacy` (0~1). Looser as the
@@ -405,7 +431,7 @@ pub fn build_prompt(
          ⑦ Adult consensual romance and erotic roleplay are allowed. The following are strictly disallowed: self-harm encouragement, suicide instructions, and any sexual content involving minors.\n\
          \n\
          【输出】直接输出回复文字（纯文本，不要 JSON，不要 markdown，不要 quote 符号）",
-        tc = now_context(),
+        tc = now_context(meta_str(persona, "timezone")),
         lr = length_rule(affinity),
     )
 }
@@ -778,12 +804,32 @@ mod tests {
     }
 
     #[test]
-    fn now_context_renders_absolute_utc_date_weekday_time() {
+    fn now_context_fallback_renders_utc_and_hardened_wording() {
         let dt = Utc.with_ymd_and_hms(2026, 5, 21, 7, 55, 0).unwrap(); // a Thursday
-        let s = now_context_at(dt);
+        let s = now_context_at(dt, None);
         assert!(s.contains("2026-05-21"), "{s}");
         assert!(s.contains("周四"), "{s}");
         assert!(s.contains("07:55"), "{s}");
         assert!(s.contains("居住地"), "{s}");
+        assert!(s.contains("不得编造"), "hardened anti-fabrication wording: {s}");
+    }
+
+    #[test]
+    fn now_context_with_timezone_uses_local_date_weekday_time() {
+        // 2026-05-21 20:00 UTC is Thursday; Asia/Tokyo (UTC+9) → 2026-05-22 05:00, Friday.
+        let dt = Utc.with_ymd_and_hms(2026, 5, 21, 20, 0, 0).unwrap();
+        let s = now_context_at(dt, Some("Asia/Tokyo"));
+        assert!(s.contains("2026-05-22"), "local date should roll over: {s}");
+        assert!(s.contains("周五"), "local weekday should be Friday, not UTC Thursday: {s}");
+        assert!(s.contains("05:00"), "{s}");
+        assert!(s.contains("清晨"), "05:00 local → 清晨: {s}");
+        assert!(s.contains("唯一的时间基准"), "{s}");
+    }
+
+    #[test]
+    fn now_context_with_garbage_timezone_falls_back() {
+        let dt = Utc.with_ymd_and_hms(2026, 5, 21, 7, 55, 0).unwrap();
+        let s = now_context_at(dt, Some("Not/AZone"));
+        assert!(s.contains("UTC"), "unparseable tz falls back to UTC: {s}");
     }
 }

--- a/crates/eros-engine-server/src/prompt.rs
+++ b/crates/eros-engine-server/src/prompt.rs
@@ -68,39 +68,31 @@ fn period_cn(hour: u32) -> &'static str {
     }
 }
 
-/// Absolute "now" context. With a parseable IANA `timezone` we render the
-/// persona's LOCAL date/weekday/time/period directly (the model does no
-/// arithmetic — this is the fix for the time-hallucination bug). Without one we
-/// fall back to UTC + infer-from-residence, hardened against fabricating times.
+/// Absolute "now" context. Renders the persona's LOCAL date/weekday/time/period
+/// directly so the model does no arithmetic — this is the fix for the
+/// time-hallucination bug. The zone is the persona's own IANA `timezone` when
+/// set & valid; otherwise we default to SGT (UTC+8), since most users sit in
+/// UTC+8 — an unset persona then shares their wall clock rather than guessing.
 fn now_context(timezone: Option<&str>) -> String {
     now_context_at(Utc::now(), timezone)
 }
 
 fn now_context_at(now: chrono::DateTime<Utc>, timezone: Option<&str>) -> String {
-    match timezone.and_then(|s| s.trim().parse::<chrono_tz::Tz>().ok()) {
-        Some(tz) => {
-            let local = now.with_timezone(&tz);
-            format!(
-                "现在你当地时间是 {date}（{wd}）{hh:02}:{mm:02}，{period}。\
-                 这是你唯一的时间基准，不要编造其它日期或时间。",
-                date = local.format("%Y-%m-%d"),
-                wd = weekday_cn(local.weekday()),
-                hh = local.hour(),
-                mm = local.minute(),
-                period = period_cn(local.hour()),
-            )
-        }
-        None => format!(
-            "现在是 UTC {date}（{wd}）{hh:02}:{mm:02}。根据你的居住地（见背景故事）\
-             推算你当地的时间和日期，自然地感知现在大概是清晨/白天/傍晚/深夜、今天几号、\
-             星期几。严格以上述 UTC 时间为唯一基准，不得编造其它日期或时间；无法换算时区时\
-             只说大致时段，不要编造具体钟点。",
-            date = now.format("%Y-%m-%d"),
-            wd = weekday_cn(now.weekday()),
-            hh = now.hour(),
-            mm = now.minute(),
-        ),
-    }
+    let tz = timezone
+        .and_then(|s| s.trim().parse::<chrono_tz::Tz>().ok())
+        .unwrap_or(chrono_tz::Asia::Singapore);
+    let local = now.with_timezone(&tz);
+    format!(
+        "现在你当地时间（{tz}）是 {date}（{wd}）{hh:02}:{mm:02}，{period}。\
+         这是你唯一的时间基准；用户提到「今天/今晚/明天/昨天/刚才/现在」时一律以此为准，\
+         不要编造其它日期或时间。",
+        tz = tz.name(),
+        date = local.format("%Y-%m-%d"),
+        wd = weekday_cn(local.weekday()),
+        hh = local.hour(),
+        mm = local.minute(),
+        period = period_cn(local.hour()),
+    )
 }
 
 /// Reply-length rule for 铁律①, graduated by `intimacy` (0~1). Looser as the
@@ -444,8 +436,9 @@ pub fn build_prompt(
     let gender_rule = if is_binary_gender(persona) {
         let g = gender_label(persona).expect("is_binary_gender ⇒ gender present");
         format!(
-            "\n⑧ 你是{g}，严格遵守自己的性别，绝不说出与自身性别矛盾的身体或身份描述；\
-             除非在与用户的角色扮演中双方明确约定你暂时扮演其他性别"
+            "\n⑧ 你是{g}，严格遵守自己的性别：身体结构、称谓、自我身份描述都以此为准，\
+             也不要被动接受用户错误的性别称呼；不要因为用户的称呼、上一轮内容、礼物、情境\
+             或调情而改变自己的性别。唯一例外：与用户的角色扮演中双方明确约定你暂时扮演其他性别"
         )
     } else {
         String::new()
@@ -805,6 +798,57 @@ mod tests {
         assert!(s.contains("你所在时区：Asia/Tokyo。"), "{s}");
     }
 
+    // ─── Cache-prefix boundary invariants ──────────────────────────────
+    // Same-user multi-turn: the stable block (everything before 【本轮风格】) is
+    // byte-identical no matter how the per-turn-volatile inputs change.
+    #[test]
+    fn build_prompt_stable_prefix_identical_across_volatile_changes() {
+        let p = fixture_persona();
+        let a = build_prompt(
+            &p, &[], &[], None, &[], "normal", ReplyStyle::Neutral, &[], &[],
+        );
+        let groups = vec![("基础画像".to_string(), vec!["住在上海".to_string()])];
+        let b = build_prompt(
+            &p,
+            &groups,
+            &["聊到深夜".to_string()],
+            Some(&fixture_affinity()),
+            &[],
+            "normal",
+            ReplyStyle::Warm,
+            &["想他".to_string()],
+            &[],
+        );
+        let cut = a.find("【本轮风格】").expect("turn-style header present");
+        assert_eq!(
+            &a[..cut],
+            &b[..cut],
+            "everything before 【本轮风格】 must be byte-identical across turns"
+        );
+    }
+
+    // Cross-config: different trait sets share the persona block up to 【擅长话题】
+    // (the divergence is at 【附加指引】), but the full prompts differ.
+    #[test]
+    fn build_prompt_traits_change_only_breaks_after_topics() {
+        let p = fixture_persona();
+        let t1 = vec![PromptTrait { tag: "a".into(), text: "alpha".into() }];
+        let t2 = vec![PromptTrait { tag: "b".into(), text: "beta".into() }];
+        let a = build_prompt(
+            &p, &[], &[], None, &[], "normal", ReplyStyle::Neutral, &[], &t1,
+        );
+        let b = build_prompt(
+            &p, &[], &[], None, &[], "normal", ReplyStyle::Neutral, &[], &t2,
+        );
+        let cut = a.find("【附加指引】").expect("traits header present");
+        assert_eq!(
+            &a[..cut],
+            &b[..cut],
+            "persona block up to 【擅长话题】 is shared across trait configs"
+        );
+        assert_ne!(a, b, "different trait sets must produce different prompts");
+    }
+
     #[test]
     fn test_style_directive_for_all_styles() {
         assert!(!style_directive(ReplyStyle::Warm).is_empty());
@@ -940,14 +984,17 @@ mod tests {
     }
 
     #[test]
-    fn now_context_fallback_renders_utc_and_hardened_wording() {
+    fn now_context_defaults_to_sgt_when_timezone_absent() {
+        // No persona tz → default SGT (UTC+8): 07:55 UTC → 15:55 same day, Thursday.
         let dt = Utc.with_ymd_and_hms(2026, 5, 21, 7, 55, 0).unwrap(); // a Thursday
         let s = now_context_at(dt, None);
+        assert!(s.contains("Asia/Singapore"), "default zone is SGT: {s}");
         assert!(s.contains("2026-05-21"), "{s}");
         assert!(s.contains("周四"), "{s}");
-        assert!(s.contains("07:55"), "{s}");
-        assert!(s.contains("居住地"), "{s}");
-        assert!(s.contains("不得编造"), "hardened anti-fabrication wording: {s}");
+        assert!(s.contains("15:55"), "07:55 UTC +8 = 15:55: {s}");
+        assert!(s.contains("白天"), "{s}");
+        assert!(s.contains("唯一的时间基准"), "{s}");
+        assert!(!s.contains("UTC"), "no UTC-inference path anymore: {s}");
     }
 
     #[test]
@@ -955,17 +1002,22 @@ mod tests {
         // 2026-05-21 20:00 UTC is Thursday; Asia/Tokyo (UTC+9) → 2026-05-22 05:00, Friday.
         let dt = Utc.with_ymd_and_hms(2026, 5, 21, 20, 0, 0).unwrap();
         let s = now_context_at(dt, Some("Asia/Tokyo"));
+        assert!(s.contains("Asia/Tokyo"), "renders the persona zone id: {s}");
         assert!(s.contains("2026-05-22"), "local date should roll over: {s}");
         assert!(s.contains("周五"), "local weekday should be Friday, not UTC Thursday: {s}");
         assert!(s.contains("05:00"), "{s}");
         assert!(s.contains("清晨"), "05:00 local → 清晨: {s}");
         assert!(s.contains("唯一的时间基准"), "{s}");
+        assert!(s.contains("今天/今晚/明天/昨天/刚才/现在"), "relative-date binding: {s}");
     }
 
     #[test]
-    fn now_context_with_garbage_timezone_falls_back() {
+    fn now_context_with_garbage_timezone_defaults_to_sgt() {
+        // Unparseable tz → SGT default (not UTC): 07:55 UTC → 15:55 SGT.
         let dt = Utc.with_ymd_and_hms(2026, 5, 21, 7, 55, 0).unwrap();
         let s = now_context_at(dt, Some("Not/AZone"));
-        assert!(s.contains("UTC"), "unparseable tz falls back to UTC: {s}");
+        assert!(s.contains("Asia/Singapore"), "garbage tz falls back to SGT: {s}");
+        assert!(s.contains("15:55"), "{s}");
+        assert!(!s.contains("UTC"), "{s}");
     }
 }

--- a/crates/eros-engine-server/src/prompt.rs
+++ b/crates/eros-engine-server/src/prompt.rs
@@ -637,10 +637,20 @@ mod tests {
     #[test]
     fn build_prompt_with_empty_traits_omits_section() {
         let p = build_prompt(
-            &fixture_persona(), &[], &[], None, &[], "normal",
-            ReplyStyle::Neutral, &[], &[],
+            &fixture_persona(),
+            &[],
+            &[],
+            None,
+            &[],
+            "normal",
+            ReplyStyle::Neutral,
+            &[],
+            &[],
         );
-        assert!(!p.contains("【附加指引】"), "empty traits must not render section");
+        assert!(
+            !p.contains("【附加指引】"),
+            "empty traits must not render section"
+        );
         // 擅长话题 now flows straight into 本轮风格 (the first volatile block).
         assert!(
             p.contains("【擅长话题】t1\n\n【本轮风格】"),
@@ -682,10 +692,20 @@ mod tests {
 
     #[test]
     fn build_prompt_stable_block_order() {
-        let traits = vec![PromptTrait { tag: "x".into(), text: "trait body".into() }];
+        let traits = vec![PromptTrait {
+            tag: "x".into(),
+            text: "trait body".into(),
+        }];
         let p = build_prompt(
-            &fixture_persona(), &[], &[], None, &[], "normal",
-            ReplyStyle::Neutral, &[], &traits,
+            &fixture_persona(),
+            &[],
+            &[],
+            None,
+            &[],
+            "normal",
+            ReplyStyle::Neutral,
+            &[],
+            &traits,
         );
         let topics = p.find("【擅长话题】").expect("topics");
         let traits_i = p.find("【附加指引】").expect("traits");
@@ -699,14 +719,29 @@ mod tests {
     #[test]
     fn build_prompt_full_order_and_cache_break() {
         let s = build_prompt(
-            &fixture_persona(), &[], &[], None, &[], "normal",
-            ReplyStyle::Neutral, &[], &[],
+            &fixture_persona(),
+            &[],
+            &[],
+            None,
+            &[],
+            "normal",
+            ReplyStyle::Neutral,
+            &[],
+            &[],
         );
         let pos = |h: &str| s.find(h).unwrap_or_else(|| panic!("missing {h} in:\n{s}"));
         let order = [
-            "你是 ", "【背景故事】", "【说话风格】", "【口癖/习惯】", "【擅长话题】",
-            "【本轮风格】", "【你对他的了解（通用画像）】", "【你们之间的事",
-            "【今日情境】", "【铁律", "【输出】",
+            "你是 ",
+            "【背景故事】",
+            "【说话风格】",
+            "【口癖/习惯】",
+            "【擅长话题】",
+            "【本轮风格】",
+            "【你对他的了解（通用画像）】",
+            "【你们之间的事",
+            "【今日情境】",
+            "【铁律",
+            "【输出】",
         ];
         let mut last = 0usize;
         for h in order {
@@ -715,8 +750,15 @@ mod tests {
             last = cur;
         }
         let topics = pos("【擅长话题】");
-        for vol in ["【本轮风格】", "【你对他的了解（通用画像）】", "【今日情境】"] {
-            assert!(pos(vol) > topics, "{vol} must sit after the stable persona block");
+        for vol in [
+            "【本轮风格】",
+            "【你对他的了解（通用画像）】",
+            "【今日情境】",
+        ] {
+            assert!(
+                pos(vol) > topics,
+                "{vol} must sit after the stable persona block"
+            );
         }
     }
 
@@ -725,7 +767,15 @@ mod tests {
         let mut p = fixture_persona();
         p.genome.system_prompt = "AUTHORED HEAD".into();
         let s = build_prompt(
-            &p, &[], &[], None, &[], "normal", ReplyStyle::Neutral, &[], &[],
+            &p,
+            &[],
+            &[],
+            None,
+            &[],
+            "normal",
+            ReplyStyle::Neutral,
+            &[],
+            &[],
         );
         assert!(
             s.starts_with("AUTHORED HEAD\n\n你是 "),
@@ -738,9 +788,20 @@ mod tests {
         let mut p = fixture_persona();
         p.genome.system_prompt = "   ".into();
         let s = build_prompt(
-            &p, &[], &[], None, &[], "normal", ReplyStyle::Neutral, &[], &[],
+            &p,
+            &[],
+            &[],
+            None,
+            &[],
+            "normal",
+            ReplyStyle::Neutral,
+            &[],
+            &[],
         );
-        assert!(s.starts_with("你是 "), "empty head → starts with identity: {s}");
+        assert!(
+            s.starts_with("你是 "),
+            "empty head → starts with identity: {s}"
+        );
     }
 
     #[test]
@@ -748,7 +809,15 @@ mod tests {
         let mut p = fixture_persona();
         set_meta(&mut p, "gender", serde_json::json!("male"));
         let s = build_prompt(
-            &p, &[], &[], None, &[], "normal", ReplyStyle::Neutral, &[], &[],
+            &p,
+            &[],
+            &[],
+            None,
+            &[],
+            "normal",
+            ReplyStyle::Neutral,
+            &[],
+            &[],
         );
         assert!(s.contains("你是 Aria，男性，24 岁，INFP 性格。"), "{s}");
         assert!(s.contains("⑧ 你是男性，严格遵守自己的性别"), "{s}");
@@ -759,17 +828,39 @@ mod tests {
         let mut p = fixture_persona();
         set_meta(&mut p, "gender", serde_json::json!("non-binary"));
         let s = build_prompt(
-            &p, &[], &[], None, &[], "normal", ReplyStyle::Neutral, &[], &[],
+            &p,
+            &[],
+            &[],
+            None,
+            &[],
+            "normal",
+            ReplyStyle::Neutral,
+            &[],
+            &[],
         );
-        assert!(s.contains("你是 Aria，non-binary，24 岁"), "verbatim render: {s}");
-        assert!(!s.contains("⑧"), "non-binary must not get the binary anatomy rule: {s}");
+        assert!(
+            s.contains("你是 Aria，non-binary，24 岁"),
+            "verbatim render: {s}"
+        );
+        assert!(
+            !s.contains("⑧"),
+            "non-binary must not get the binary anatomy rule: {s}"
+        );
     }
 
     #[test]
     fn build_prompt_omits_gender_when_absent() {
         let p = fixture_persona(); // fixture art_metadata has no gender key
         let s = build_prompt(
-            &p, &[], &[], None, &[], "normal", ReplyStyle::Neutral, &[], &[],
+            &p,
+            &[],
+            &[],
+            None,
+            &[],
+            "normal",
+            ReplyStyle::Neutral,
+            &[],
+            &[],
         );
         assert!(s.contains("你是 Aria，24 岁，INFP 性格。"), "{s}");
         assert!(!s.contains("⑧"), "no gender → no ⑧: {s}");
@@ -780,11 +871,22 @@ mod tests {
         let mut p = fixture_persona();
         set_meta(&mut p, "gender", serde_json::json!("   "));
         let s = build_prompt(
-            &p, &[], &[], None, &[], "normal", ReplyStyle::Neutral, &[], &[],
+            &p,
+            &[],
+            &[],
+            None,
+            &[],
+            "normal",
+            ReplyStyle::Neutral,
+            &[],
+            &[],
         );
         // blank gender must not produce a double comma or a ⑧ rule
         assert!(s.contains("你是 Aria，24 岁，INFP 性格。"), "{s}");
-        assert!(!s.contains("，，"), "blank gender must not double-comma: {s}");
+        assert!(
+            !s.contains("，，"),
+            "blank gender must not double-comma: {s}"
+        );
         assert!(!s.contains("⑧"), "{s}");
     }
 
@@ -793,7 +895,15 @@ mod tests {
         let mut p = fixture_persona();
         set_meta(&mut p, "timezone", serde_json::json!("Asia/Tokyo"));
         let s = build_prompt(
-            &p, &[], &[], None, &[], "normal", ReplyStyle::Neutral, &[], &[],
+            &p,
+            &[],
+            &[],
+            None,
+            &[],
+            "normal",
+            ReplyStyle::Neutral,
+            &[],
+            &[],
         );
         assert!(s.contains("你所在时区：Asia/Tokyo。"), "{s}");
     }
@@ -805,7 +915,15 @@ mod tests {
     fn build_prompt_stable_prefix_identical_across_volatile_changes() {
         let p = fixture_persona();
         let a = build_prompt(
-            &p, &[], &[], None, &[], "normal", ReplyStyle::Neutral, &[], &[],
+            &p,
+            &[],
+            &[],
+            None,
+            &[],
+            "normal",
+            ReplyStyle::Neutral,
+            &[],
+            &[],
         );
         let groups = vec![("基础画像".to_string(), vec!["住在上海".to_string()])];
         let b = build_prompt(
@@ -832,13 +950,35 @@ mod tests {
     #[test]
     fn build_prompt_traits_change_only_breaks_after_topics() {
         let p = fixture_persona();
-        let t1 = vec![PromptTrait { tag: "a".into(), text: "alpha".into() }];
-        let t2 = vec![PromptTrait { tag: "b".into(), text: "beta".into() }];
+        let t1 = vec![PromptTrait {
+            tag: "a".into(),
+            text: "alpha".into(),
+        }];
+        let t2 = vec![PromptTrait {
+            tag: "b".into(),
+            text: "beta".into(),
+        }];
         let a = build_prompt(
-            &p, &[], &[], None, &[], "normal", ReplyStyle::Neutral, &[], &t1,
+            &p,
+            &[],
+            &[],
+            None,
+            &[],
+            "normal",
+            ReplyStyle::Neutral,
+            &[],
+            &t1,
         );
         let b = build_prompt(
-            &p, &[], &[], None, &[], "normal", ReplyStyle::Neutral, &[], &t2,
+            &p,
+            &[],
+            &[],
+            None,
+            &[],
+            "normal",
+            ReplyStyle::Neutral,
+            &[],
+            &t2,
         );
         let cut = a.find("【附加指引】").expect("traits header present");
         assert_eq!(
@@ -1004,11 +1144,17 @@ mod tests {
         let s = now_context_at(dt, Some("Asia/Tokyo"));
         assert!(s.contains("Asia/Tokyo"), "renders the persona zone id: {s}");
         assert!(s.contains("2026-05-22"), "local date should roll over: {s}");
-        assert!(s.contains("周五"), "local weekday should be Friday, not UTC Thursday: {s}");
+        assert!(
+            s.contains("周五"),
+            "local weekday should be Friday, not UTC Thursday: {s}"
+        );
         assert!(s.contains("05:00"), "{s}");
         assert!(s.contains("清晨"), "05:00 local → 清晨: {s}");
         assert!(s.contains("唯一的时间基准"), "{s}");
-        assert!(s.contains("今天/今晚/明天/昨天/刚才/现在"), "relative-date binding: {s}");
+        assert!(
+            s.contains("今天/今晚/明天/昨天/刚才/现在"),
+            "relative-date binding: {s}"
+        );
     }
 
     #[test]
@@ -1016,7 +1162,10 @@ mod tests {
         // Unparseable tz → SGT default (not UTC): 07:55 UTC → 15:55 SGT.
         let dt = Utc.with_ymd_and_hms(2026, 5, 21, 7, 55, 0).unwrap();
         let s = now_context_at(dt, Some("Not/AZone"));
-        assert!(s.contains("Asia/Singapore"), "garbage tz falls back to SGT: {s}");
+        assert!(
+            s.contains("Asia/Singapore"),
+            "garbage tz falls back to SGT: {s}"
+        );
         assert!(s.contains("15:55"), "{s}");
         assert!(!s.contains("UTC"), "{s}");
     }

--- a/docs/superpowers/specs/2026-05-24-prompt-prefix-reorder-design.md
+++ b/docs/superpowers/specs/2026-05-24-prompt-prefix-reorder-design.md
@@ -1,0 +1,244 @@
+# eros-engine — Prompt prefix reorder for cache stability + gender/time fixes (Spec)
+
+**Status**: design, pending implementation plan
+**Target release**: 0.3.x (prompt-string change + one `art_metadata` field + one new dep; graceful fallback when fields absent)
+**Audience**: anyone implementing the `build_prompt` reorder in `crates/eros-engine-server/src/prompt.rs`
+
+---
+
+## 0. Background
+
+`build_prompt` assembles the per-turn companion system prompt as a single
+`messages[0]` system message; history is appended after it
+(`pipeline/handlers.rs:108-121`). Implicit prefix caching (grok / OpenRouter)
+caches the **longest common token prefix of the whole request**, so a stable
+leading chunk of the system message caches across turns *and* across users of
+the same genome.
+
+Motivation: `eros-reports/dev-logs/2026-05-24_grok_cost_prompt_cache_research.md`.
+grok is the cost driver; we want a long, byte-stable per-role prefix so its
+automatic prefix cache hits.
+
+**Current break point.** Today the order is
+`你是 → 背景 → 说话风格 → 口癖 → 擅长话题 → 附加指引 → 今日情境(每分钟变) → …`.
+The `今日情境` timestamp sits right after the persona block, so the cacheable
+prefix ends there and everything after — including the *stable* 铁律 / 输出
+blocks — is orphaned behind a volatile element.
+
+**Two latent code bugs found while scoping this** (both real, both in
+`prompt.rs`, not the persona data):
+
+1. **`genome.system_prompt` is never used by the chat path.** It is loaded from
+   DB (`store/persona.rs:154`), held on the struct (`core/persona.rs:10`), and
+   exposed to the admin edit route (`routes/companion.rs:500`) — but
+   `build_prompt` reconstructs the persona purely from `art_metadata` and
+   ignores the authored prose. The authored block is the richest, most stable
+   per-genome content; using it both lengthens the cache prefix and reinforces
+   the persona (redundancy = weighting for the LLM).
+2. **`gender` is never rendered.** `art_metadata` documents a `gender` field
+   (`core/persona.rs:13`; e.g. `examples/personas/kenji.toml:21`
+   `gender = "male"`), but `build_prompt` only ever emits name/age/mbti/backstory.
+   The model has no explicit gender signal → the "male persona uses female
+   anatomy" gender-confusion bug.
+
+**Time bug.** `now_context` hands the model raw UTC and asks it to *infer* the
+local timezone from the backstory residence and do the UTC→local arithmetic.
+Models are bad at that and hallucinate clock times. We add a structured
+`timezone` field and compute local time **server-side** so the model only reads,
+never computes. (This deliberately overturns the earlier "no persona-template
+change" scoping decision — the template change is folded into this PR.)
+
+---
+
+## 1. Goal / Non-goals
+
+**Goal:** reorder `build_prompt` into a long, byte-stable per-role prefix, render
+the two unused fields (`system_prompt`, `gender`), and fix the time bug with a
+structured per-persona timezone. Concretely:
+
+- Lead with `genome.system_prompt` as a stable head block (hybrid: prose head
+  **and** the existing structured sections; redundancy reinforces).
+- Render `gender` in the identity line, with a conditional 铁律 reinforcement.
+- Add an optional `timezone` field to `art_metadata`; declare it in the stable
+  block and use it to precompute local time in `今日情境`.
+- Consolidate per-turn-volatile blocks after the persona block; move `今日情境`
+  to the end of the volatile cluster (recency aids time adherence); keep 铁律 /
+  输出 last (rule adherence beats caching them — they are short).
+
+**Non-goals (explicit follow-ups / out of scope):**
+
+- **No suffix move.** Volatile content stays in the system message; we are *not*
+  relocating it to the latest user message. Caching the appended **history**
+  (the same-user-multi-turn win in the report) requires that move + per-model
+  branching + verifying OpenRouter forwards `x-grok-conv-id`. Separate PR, gated
+  on that verification.
+- **No per-model prompt branching.** The reorder applies uniformly to all models.
+- **No prod persona edits.** Prod personas are hand-tuned in DB (seed-personas
+  are always manual). Backfilling `timezone` / confirming `system_prompt` /
+  `gender` on prod genomes is the operator's manual job. Missing fields degrade
+  gracefully (see 2.x fallbacks).
+- **No change to message assembly** (`assemble_chat_request`), insight/affinity
+  prompts, or the memory pipeline.
+
+---
+
+## 2. Design
+
+### 2.1 Final prompt layout
+
+Stable block (byte-identical per genome → cacheable; first per-turn-volatile
+element ends the cached prefix):
+
+1. `{system_prompt}` — authored prose head (NEW), omitted if empty
+2. `你是 {name}，{gender_label}，{age} 岁，{mbti} 性格。你所在时区：{timezone}。`
+   — `gender_label` + `timezone` clauses NEW, each omitted if absent
+3. `【背景故事】\n{backstory}`
+4. `【说话风格】{speech_style}`
+5. `【口癖/习惯】{quirks_str}`
+6. `【擅长话题】{topics_str}`
+7. `【附加指引】{traits}` — at the cache-break boundary. Items 1–6 are shared by
+   **all** users of the genome regardless of trait config; traits diverge only
+   between *different* configs, so placing them last in the stable block
+   maximizes the cross-config shared prefix while staying far from the
+   generation point (the anti-recency goal for `nsfw_boost` etc.).
+
+**—— cache break (everything below changes per turn) ——**
+
+8. `【本轮风格】{style_text}` — PDE-chosen, first per-turn-volatile element
+9. `【你对他的了解（通用画像）】\n{profile_str}`
+10. `【你们之间的事（只有你和他知道）】\n{rel_str}`
+11. `{attitude}` (`【你此刻的心情】`), `{state}` (`【你对他的内心感受】`),
+    `{hints_section}` (`【当前内心状态】`) — affinity/hints cluster
+12. `{gift}` (`【刚收到的礼物/红包】`) — only when gifts present
+13. `【今日情境】\n{tc}` — moved to the end of the volatile cluster (recency)
+14. `--- 【铁律 — 违反即失效】` ①–⑦ + conditional ⑧ gender rule (2.3)
+15. `【输出】…` — final instruction, unchanged
+
+The internal order of items 8–13 is **behavior-only** — all sit after the cache
+break, so reordering among them has no cache impact; the order above is chosen
+for coherence (know-him → know-us → my-feelings → events → time).
+
+### 2.2 `system_prompt` head block (hybrid)
+
+```rust
+let head = {
+    let sp = persona.genome.system_prompt.trim();
+    if sp.is_empty() { String::new() } else { format!("{sp}\n\n") }
+};
+// full prompt = format!("{head}你是 {name}…")
+```
+
+Empty / whitespace-only `system_prompt` → no head block, no stray separator
+(layout below it byte-identical to the no-head case). The structured sections
+(背景/说话风格/口癖/擅长话题) are retained even when the head is present — the
+redundancy reinforces the persona and the structured fields remain the source
+for gender/timezone/age/mbti.
+
+### 2.3 `gender` rendering + conditional 铁律
+
+Read `gender` via the existing `meta_str(persona, "gender")` helper. Normalize
+for display; the field may hold values beyond male/female:
+
+- `"male"` → `男性`, `"female"` → `女性`
+- anything else (e.g. `"non-binary"`) → rendered **verbatim**
+- absent → gender clause omitted entirely
+
+Identity line: `你是 {name}，{gender_label}，{age} 岁，{mbti} 性格。` when present,
+falling back to the current `你是 {name}，{age} 岁，{mbti} 性格。` when absent.
+
+**Conditional 铁律 ⑧ (reinforcement; redundancy = weighting):** appended only
+when gender normalizes to a **binary** value (`male`/`female`). Skipped for
+non-binary / verbatim / absent (they carry no fixed binary-anatomy constraint):
+
+> ⑧ 你是{gender_label}，严格遵守自己的性别，绝不说出与自身性别矛盾的身体或身份描述；除非在与用户的角色扮演中双方明确约定你暂时扮演其他性别。
+
+The role-play exception keeps consensual gender-swap fiction allowed.
+
+### 2.4 `timezone` field + server-side local-time precompute
+
+Add an optional `timezone` field to `art_metadata` (IANA name, e.g.
+`"Asia/Tokyo"`; may be empty). Dependency: add **`chrono-tz`** (workspace dep +
+`eros-engine-server`).
+
+`now_context` gains the persona timezone:
+
+```rust
+fn now_context(timezone: Option<&str>) -> String { now_context_at(Utc::now(), timezone) }
+
+fn now_context_at(now: DateTime<Utc>, timezone: Option<&str>) -> String {
+    match timezone.and_then(|s| s.parse::<chrono_tz::Tz>().ok()) {
+        Some(tz) => {
+            let local = now.with_timezone(&tz);
+            // weekday / date / HH:MM / period all computed in LOCAL time
+            // period buckets (coarse): 05–08 清晨, 08–18 白天, 18–23 傍晚, 23–05 深夜
+            format!(
+                "现在你当地时间是 {date}（{weekday}）{hh:02}:{mm:02}，{period}。\
+                 这是你唯一的时间基准，不要编造其它日期或时间。",
+                …
+            )
+        }
+        None => {
+            // fallback: current UTC + infer-from-residence, with hardened wording
+            "现在是 UTC {date}（{weekday}）{hh:02}:{mm:02}。根据你的居住地（见背景故事）\
+             推算当地时间，自然地感知现在大概是清晨/白天/傍晚/深夜、今天几号、星期几。\
+             严格以上述 UTC 时间为唯一基准，不得编造其它日期或时间；无法换算时区时只说\
+             大致时段，不要编造具体钟点。"
+        }
+    }
+}
+```
+
+Note the fallback path also fixes a latent correctness bug: today the weekday is
+derived from **UTC**, not local time; the `chrono-tz` path computes weekday from
+the converted local datetime. The `timezone` declaration in the stable block
+(2.1 item 2) is kept for persona self-awareness + reinforcement even though
+`今日情境` now states the concrete local time.
+
+### 2.5 `build_prompt` signature / call sites
+
+`build_prompt` already receives `persona`, so `gender`, `timezone`, and
+`system_prompt` are read internally from it — **no signature change**, no change
+at the two call sites (`handlers.rs:396`, `handlers.rs:454`). `now_context`'s
+new arg is internal to `prompt.rs`.
+
+---
+
+## 3. Testing
+
+Unit tests in `prompt.rs` (the three order/byte assertions at `:562`, `:589`,
+`:621` and the time test at `:781` are rewritten for the new layout):
+
+- **Order invariant:** `system_prompt` head < `你是` < 背景 < 说话风格 < 口癖 <
+  擅长话题 < 附加指引 < 本轮风格 < 通用画像 < 你们之间的事 < 今日情境 < 铁律 < 输出.
+- **Cache-break invariant:** every per-turn-volatile header (`本轮风格`,
+  `今日情境`, `通用画像`, `你们之间的事`) appears **after** every stable header.
+- **system_prompt:** non-empty → prose head present + exactly one `\n\n`
+  separator before `你是`; empty/whitespace → no head, layout byte-identical to
+  the no-head case.
+- **gender:** `male`→`男性` and `female`→`女性` in the identity line + 铁律 ⑧
+  present; `non-binary` rendered verbatim + **no** ⑧; absent → identity line
+  has no gender clause + no ⑧.
+- **timezone:** a fixed UTC instant + `Asia/Tokyo` renders the expected local
+  date/weekday/HH:MM/period and the "唯一的时间基准" anti-fabrication line;
+  absent/garbage → UTC fallback with hardened wording (and weekday-from-local
+  on the tz path vs weekday-from-UTC on the fallback).
+- **traits:** unchanged rendering, now asserted between `擅长话题` and `本轮风格`;
+  empty traits omit the section with no stray whitespace.
+
+---
+
+## 4. Rollout / Out of scope
+
+- `Cargo.toml`: add `chrono-tz` to `[workspace.dependencies]` and to
+  `eros-engine-server`.
+- `examples/personas/*.toml`: add a `timezone` field to document the convention
+  (`kenji` = `Asia/Tokyo`; `aria`/`miel` underspecified → a plausible value or
+  left empty to demonstrate the fallback). Docs only — no Rust code loads these.
+- **Operator action (manual):** backfill `timezone` (and confirm `gender` /
+  `system_prompt`) on prod `persona_genomes`. Until then, behavior degrades
+  gracefully to the fallbacks above.
+- Additive / non-breaking: every new field is optional with a fallback; existing
+  personas keep working with no data changes.
+- **Deferred to follow-up PRs** (see Non-goals): suffix move for history
+  caching, per-model prompt branching, and `x-grok-conv-id` passthrough
+  verification.

--- a/docs/superpowers/specs/2026-05-24-prompt-prefix-reorder-design.md
+++ b/docs/superpowers/specs/2026-05-24-prompt-prefix-reorder-design.md
@@ -150,9 +150,12 @@ falling back to the current `你是 {name}，{age} 岁，{mbti} 性格。` when 
 when gender normalizes to a **binary** value (`male`/`female`). Skipped for
 non-binary / verbatim / absent (they carry no fixed binary-anatomy constraint):
 
-> ⑧ 你是{gender_label}，严格遵守自己的性别，绝不说出与自身性别矛盾的身体或身份描述；除非在与用户的角色扮演中双方明确约定你暂时扮演其他性别。
+> ⑧ 你是{gender_label}，严格遵守自己的性别：身体结构、称谓、自我身份描述都以此为准，也不要被动接受用户错误的性别称呼；不要因为用户的称呼、上一轮内容、礼物、情境或调情而改变自己的性别。唯一例外：与用户的角色扮演中双方明确约定你暂时扮演其他性别
 
-The role-play exception keeps consensual gender-swap fiction allowed.
+The role-play exception keeps consensual gender-swap fiction allowed. (The
+clause was spelled out further during PR review — body/称谓/self-identity,
+rejecting wrong-gender address, and resisting address/prior-turn/gift/context/
+flirting pressure — but the conditional-on-binary-gender behavior is unchanged.)
 
 ### 2.4 `timezone` field + server-side local-time precompute
 
@@ -160,39 +163,42 @@ Add an optional `timezone` field to `art_metadata` (IANA name, e.g.
 `"Asia/Tokyo"`; may be empty). Dependency: add **`chrono-tz`** (workspace dep +
 `eros-engine-server`).
 
-`now_context` gains the persona timezone:
+`now_context` resolves a single zone — the persona's own `timezone` when set &
+valid, otherwise **SGT (`Asia/Singapore`, UTC+8) as the default** — and always
+renders concrete local time. There is **no UTC-inference fallback**: the model
+never does timezone arithmetic, which is what closes the time-hallucination bug.
+The SGT default is a product decision — most users sit in UTC+8, so a persona
+with no declared zone shares the user's wall clock rather than guessing.
 
 ```rust
 fn now_context(timezone: Option<&str>) -> String { now_context_at(Utc::now(), timezone) }
 
 fn now_context_at(now: DateTime<Utc>, timezone: Option<&str>) -> String {
-    match timezone.and_then(|s| s.parse::<chrono_tz::Tz>().ok()) {
-        Some(tz) => {
-            let local = now.with_timezone(&tz);
-            // weekday / date / HH:MM / period all computed in LOCAL time
-            // period buckets (coarse): 05–08 清晨, 08–18 白天, 18–23 傍晚, 23–05 深夜
-            format!(
-                "现在你当地时间是 {date}（{weekday}）{hh:02}:{mm:02}，{period}。\
-                 这是你唯一的时间基准，不要编造其它日期或时间。",
-                …
-            )
-        }
-        None => {
-            // fallback: current UTC + infer-from-residence, with hardened wording
-            "现在是 UTC {date}（{weekday}）{hh:02}:{mm:02}。根据你的居住地（见背景故事）\
-             推算当地时间，自然地感知现在大概是清晨/白天/傍晚/深夜、今天几号、星期几。\
-             严格以上述 UTC 时间为唯一基准，不得编造其它日期或时间；无法换算时区时只说\
-             大致时段，不要编造具体钟点。"
-        }
-    }
+    let tz = timezone
+        .and_then(|s| s.trim().parse::<chrono_tz::Tz>().ok())
+        .unwrap_or(chrono_tz::Asia::Singapore);
+    let local = now.with_timezone(&tz);
+    // weekday / date / HH:MM / period all computed in LOCAL time
+    // period buckets (coarse): 05–07 清晨, 08–17 白天, 18–22 傍晚, else 深夜
+    format!(
+        "现在你当地时间（{tz}）是 {date}（{weekday}）{hh:02}:{mm:02}，{period}。\
+         这是你唯一的时间基准；用户提到「今天/今晚/明天/昨天/刚才/现在」时一律以此为准，\
+         不要编造其它日期或时间。",
+        tz = tz.name(), …
+    )
 }
 ```
 
-Note the fallback path also fixes a latent correctness bug: today the weekday is
-derived from **UTC**, not local time; the `chrono-tz` path computes weekday from
-the converted local datetime. The `timezone` declaration in the stable block
-(2.1 item 2) is kept for persona self-awareness + reinforcement even though
-`今日情境` now states the concrete local time.
+The block also renders the resolved zone id (`{tz.name()}`) and binds relative
+date words (今天/今晚/明天/…) to this time, so the model can't drift to another
+zone. This also fixes a latent correctness bug: weekday/date are now computed in
+**local** time (the previous code derived weekday from **UTC**). The `timezone`
+declaration in the stable block (2.1 item 2) is kept for persona self-awareness
++ reinforcement even though `今日情境` now states the concrete local time.
+
+> **Note (review amendment):** §2.4 originally specified a UTC + infer-from-
+> residence fallback for the no-timezone case. During PR review that was replaced
+> with the SGT default above (simpler, and fully removes model-side arithmetic).
 
 ### 2.5 `build_prompt` signature / call sites
 
@@ -217,11 +223,16 @@ Unit tests in `prompt.rs` (the three order/byte assertions at `:562`, `:589`,
   the no-head case.
 - **gender:** `male`→`男性` and `female`→`女性` in the identity line + 铁律 ⑧
   present; `non-binary` rendered verbatim + **no** ⑧; absent → identity line
-  has no gender clause + no ⑧.
+  has no gender clause + no ⑧; blank/whitespace → treated as absent (no
+  double-comma, no ⑧).
 - **timezone:** a fixed UTC instant + `Asia/Tokyo` renders the expected local
-  date/weekday/HH:MM/period and the "唯一的时间基准" anti-fabrication line;
-  absent/garbage → UTC fallback with hardened wording (and weekday-from-local
-  on the tz path vs weekday-from-UTC on the fallback).
+  date/weekday/HH:MM/period, the resolved zone id, and the "唯一的时间基准"
+  anti-fabrication + relative-date binding; absent/garbage → **SGT default**
+  (`Asia/Singapore`, UTC+8), never UTC. Weekday/date are computed in local time.
+- **cache-prefix boundaries:** stable block (everything before `【本轮风格】`)
+  is byte-identical across volatile-input changes (style/profile/affinity/hints);
+  different trait configs share the persona block up to `【附加指引】` but
+  produce different full prompts.
 - **traits:** unchanged rendering, now asserted between `擅长话题` and `本轮风格`;
   empty traits omit the section with no stray whitespace.
 

--- a/examples/personas/aria.toml
+++ b/examples/personas/aria.toml
@@ -19,6 +19,8 @@ You never break character. You never acknowledge being an AI. You don't recite s
 
 [art_metadata]
 gender = "female"
+# IANA timezone — drives 今日情境 local-time rendering. Leave empty/omit if unknown.
+timezone = "America/Chicago"
 age = 27
 mbti = "INFJ"
 backstory = "Rare-books librarian in a small university town. Reads three novels a week. Notices what you don't say."

--- a/examples/personas/kenji.toml
+++ b/examples/personas/kenji.toml
@@ -19,6 +19,8 @@ You never break character. You don't acknowledge being an AI. No safety disclaim
 
 [art_metadata]
 gender = "male"
+# IANA timezone — drives 今日情境 local-time rendering. Leave empty/omit if unknown.
+timezone = "Asia/Tokyo"
 age = 33
 mbti = "ISTP"
 backstory = "Runs a six-seat ramen counter in Sapporo. Closes at 3am. Lost a brother three years ago and doesn't talk about it."

--- a/examples/personas/miel.toml
+++ b/examples/personas/miel.toml
@@ -19,6 +19,8 @@ You never break character. You don't acknowledge being an AI. No safety disclaim
 
 [art_metadata]
 gender = "non-binary"
+# IANA timezone — drives 今日情境 local-time rendering. Leave empty/omit if unknown.
+timezone = "Europe/Amsterdam"
 age = 22
 mbti = "ENFP"
 backstory = "Architecture grad student who moonlights at a vinyl shop. Talks fast when nervous. Texts with three exclamation marks then deletes two."


### PR DESCRIPTION
## Summary
- **Reorder `build_prompt` into a long byte-stable per-role cache prefix.** Lead with the previously-**unused** authored `genome.system_prompt` as a hybrid head block (redundancy with the structured sections reinforces the persona); consolidate per-turn-volatile blocks after the persona block; `今日情境` sits at the end of the volatile cluster (recency); 铁律/输出 stay last.
- **Render the previously-unused `art_metadata.gender`** in the identity line (`male→男性`/`female→女性`/else verbatim/blank→omit) + a **conditional 铁律 ⑧** for binary genders: spells out body/称谓/self-identity, rejects wrong-gender address, forbids switching gender due to address/prior-turn/gift/context/flirting, with a role-play exception. Non-binary/blank skip it.
- **Fix the time-hallucination bug.** New optional `art_metadata.timezone` (IANA) + `chrono-tz`; `今日情境` renders **server-computed** persona-local date/weekday/time/period — the model does no arithmetic. When a persona's timezone is unset/invalid, default to **SGT (UTC+8)** (most users are UTC+8) instead of asking the model to infer. The resolved zone id is shown and 今天/今晚/明天/昨天/刚才/现在 are bound to it. Also fixes weekday previously derived from UTC.
- **Docs:** document the `timezone` field in `examples/personas/*`.
- **Scope:** reorder-only — no message-assembly/suffix-move, no per-model branching (deferred; rationale in the spec). No `build_prompt` signature or call-site changes.

Spec: `docs/superpowers/specs/2026-05-24-prompt-prefix-reorder-design.md` (note: spec §2.4 describes the original UTC fallback; the implementation uses the SGT default decided during review).

## Follow-ups (out of scope; noted here per review)
- **Operational loop for missing/invalid `timezone`:** log/metric when the SGT default kicks in + admin nudge to backfill prod `persona_genomes`.
- **Canonicalize/validate `timezone`** at persona save/import/backfill time (store a canonical IANA name), so same-genome data stays consistent.

## Test plan
- [x] `prompt::tests` 23/23 pass locally (incl. cache-prefix boundary invariants)
- [x] `cargo clippy --workspace --all-features` clean; workspace compiles
- [x] Eyeballed rendered prompts (gender + timezone present, and SGT-default path)
- [ ] CI: `cargo test --workspace --all-features` incl. DB-backed integration tests
- [ ] Operator: backfill `timezone` (and confirm `gender`/`system_prompt`) on prod `persona_genomes` — until then behavior degrades gracefully (SGT for time, no gender line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)