### PR TITLE
feat: per-request memory_scope & affinity_scope flags (#40)

### DIFF
--- a/crates/eros-engine-core/src/lib.rs
+++ b/crates/eros-engine-core/src/lib.rs
@@ -5,4 +5,5 @@ pub mod affinity;
 pub mod ghost;
 pub mod pde;
 pub mod persona;
+pub mod scope;
 pub mod types;

--- a/crates/eros-engine-core/src/pde.rs
+++ b/crates/eros-engine-core/src/pde.rs
@@ -209,6 +209,8 @@ mod tests {
             prompt_traits: Vec::new(),
             audit: None,
             tier: None,
+            memory_scope: Default::default(),
+            affinity_scope: Default::default(),
         }
     }
 

--- a/crates/eros-engine-core/src/scope.rs
+++ b/crates/eros-engine-core/src/scope.rs
@@ -128,6 +128,16 @@ impl AffinityScope {
         }
         s
     }
+    pub fn contains(self, axis: AffinityAxis) -> bool {
+        match axis {
+            AffinityAxis::Warmth => self.warmth,
+            AffinityAxis::Trust => self.trust,
+            AffinityAxis::Intrigue => self.intrigue,
+            AffinityAxis::Intimacy => self.intimacy,
+            AffinityAxis::Patience => self.patience,
+            AffinityAxis::Tension => self.tension,
+        }
+    }
     pub fn is_empty(self) -> bool {
         !(self.warmth
             || self.trust
@@ -155,13 +165,7 @@ impl AffinityScope {
 }
 
 fn clamp01(x: f64) -> f64 {
-    if x < 0.0 {
-        0.0
-    } else if x > 1.0 {
-        1.0
-    } else {
-        x
-    }
+    x.clamp(0.0, 1.0)
 }
 
 #[cfg(test)]
@@ -170,7 +174,14 @@ mod tests {
     use chrono::Utc;
     use uuid::Uuid;
 
-    fn affinity(warmth: f64, trust: f64, intrigue: f64, intimacy: f64, patience: f64, tension: f64) -> Affinity {
+    fn affinity(
+        warmth: f64,
+        trust: f64,
+        intrigue: f64,
+        intimacy: f64,
+        patience: f64,
+        tension: f64,
+    ) -> Affinity {
         let now = Utc::now();
         Affinity {
             id: Uuid::new_v4(),
@@ -196,7 +207,10 @@ mod tests {
     fn memory_scope_resolution_table() {
         use InsightMode::*;
         assert_eq!(MemoryScope::Full.resolve(), (Full, true, true));
-        assert_eq!(MemoryScope::NeutralAndRelationship.resolve(), (Neutral, true, true));
+        assert_eq!(
+            MemoryScope::NeutralAndRelationship.resolve(),
+            (Neutral, true, true)
+        );
         assert_eq!(MemoryScope::RelationshipOnly.resolve(), (Off, false, true));
         assert_eq!(MemoryScope::NeutralOnly.resolve(), (Neutral, false, false));
         assert_eq!(MemoryScope::InsightsOnly.resolve(), (Full, false, false));
@@ -212,7 +226,25 @@ mod tests {
     fn memory_scope_serde_snake_case() {
         let s: MemoryScope = serde_json::from_str("\"relationship_only\"").unwrap();
         assert_eq!(s, MemoryScope::RelationshipOnly);
+        // multi-word default variant round-trips
+        let n: MemoryScope = serde_json::from_str("\"neutral_and_relationship\"").unwrap();
+        assert_eq!(n, MemoryScope::NeutralAndRelationship);
+        assert_eq!(
+            serde_json::to_string(&MemoryScope::NeutralAndRelationship).unwrap(),
+            "\"neutral_and_relationship\""
+        );
         assert!(serde_json::from_str::<MemoryScope>("\"bogus\"").is_err());
+    }
+
+    #[test]
+    fn affinity_scope_contains_matches_fields() {
+        let s = AffinityScope::bond();
+        assert!(s.contains(AffinityAxis::Warmth));
+        assert!(s.contains(AffinityAxis::Intimacy));
+        assert!(s.contains(AffinityAxis::Tension));
+        assert!(!s.contains(AffinityAxis::Trust));
+        assert!(!s.contains(AffinityAxis::Intrigue));
+        assert!(!s.contains(AffinityAxis::Patience));
     }
 
     #[test]

--- a/crates/eros-engine-core/src/scope.rs
+++ b/crates/eros-engine-core/src/scope.rs
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! Per-request injection scope flags (issue #40). These gate prompt
+//! *injection* only — post-process writes (insight extraction, memory writes,
+//! six-axis affinity eval) are unaffected.
+
+use crate::affinity::Affinity;
+use serde::{Deserialize, Serialize};
+
+/// How much of the user-global structured profile ("基础画像") to inject.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InsightMode {
+    Off,
+    /// Drop the intimate fields: love_values / emotional_needs / interests.
+    Neutral,
+    Full,
+}
+
+/// Caller-supplied memory injection scope. Default narrows today's behavior
+/// (the #40 mitigation).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryScope {
+    Full,
+    #[default]
+    NeutralAndRelationship,
+    RelationshipOnly,
+    NeutralOnly,
+    InsightsOnly,
+    None,
+}
+
+impl MemoryScope {
+    /// Resolve to `(insight mode, inject global memory X, inject relationship memory Y)`.
+    pub fn resolve(self) -> (InsightMode, bool, bool) {
+        match self {
+            MemoryScope::Full => (InsightMode::Full, true, true),
+            MemoryScope::NeutralAndRelationship => (InsightMode::Neutral, true, true),
+            MemoryScope::RelationshipOnly => (InsightMode::Off, false, true),
+            MemoryScope::NeutralOnly => (InsightMode::Neutral, false, false),
+            MemoryScope::InsightsOnly => (InsightMode::Full, false, false),
+            MemoryScope::None => (InsightMode::Off, false, false),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AffinityAxis {
+    Warmth,
+    Trust,
+    Intrigue,
+    Intimacy,
+    Patience,
+    Tension,
+}
+
+/// Resolved set of affinity axes to inject. Default = `bond`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AffinityScope {
+    pub warmth: bool,
+    pub trust: bool,
+    pub intrigue: bool,
+    pub intimacy: bool,
+    pub patience: bool,
+    pub tension: bool,
+}
+
+impl Default for AffinityScope {
+    fn default() -> Self {
+        Self::bond()
+    }
+}
+
+impl AffinityScope {
+    pub fn none() -> Self {
+        Self {
+            warmth: false,
+            trust: false,
+            intrigue: false,
+            intimacy: false,
+            patience: false,
+            tension: false,
+        }
+    }
+    pub fn full() -> Self {
+        Self {
+            warmth: true,
+            trust: true,
+            intrigue: true,
+            intimacy: true,
+            patience: true,
+            tension: true,
+        }
+    }
+    /// 朋友感: warmth + intimacy + tension.
+    pub fn bond() -> Self {
+        Self {
+            warmth: true,
+            intimacy: true,
+            tension: true,
+            trust: false,
+            intrigue: false,
+            patience: false,
+        }
+    }
+    /// 暧昧感: trust + intrigue + patience.
+    pub fn chemistry() -> Self {
+        Self {
+            trust: true,
+            intrigue: true,
+            patience: true,
+            warmth: false,
+            intimacy: false,
+            tension: false,
+        }
+    }
+    pub fn from_axes(axes: &[AffinityAxis]) -> Self {
+        let mut s = Self::none();
+        for a in axes {
+            match a {
+                AffinityAxis::Warmth => s.warmth = true,
+                AffinityAxis::Trust => s.trust = true,
+                AffinityAxis::Intrigue => s.intrigue = true,
+                AffinityAxis::Intimacy => s.intimacy = true,
+                AffinityAxis::Patience => s.patience = true,
+                AffinityAxis::Tension => s.tension = true,
+            }
+        }
+        s
+    }
+    pub fn is_empty(self) -> bool {
+        !(self.warmth
+            || self.trust
+            || self.intrigue
+            || self.intimacy
+            || self.patience
+            || self.tension)
+    }
+
+    /// Composite length score per the #40 spec. `None` when no axis is in scope
+    /// (caller falls back to the strictest tier, matching `affinity = None`).
+    pub fn length_score(self, a: &Affinity) -> Option<f64> {
+        let warm01 = clamp01((a.warmth + 1.0) / 2.0);
+        let bond = clamp01((warm01 + a.intimacy + a.tension) / 3.0);
+        let chemistry = clamp01((a.trust + a.intrigue + a.patience) / 3.0);
+        let bond_active = self.warmth || self.intimacy || self.tension;
+        let chem_active = self.trust || self.intrigue || self.patience;
+        match (bond_active, chem_active) {
+            (true, true) => Some((bond + chemistry) / 2.0),
+            (true, false) => Some(bond),
+            (false, true) => Some(chemistry),
+            (false, false) => None,
+        }
+    }
+}
+
+fn clamp01(x: f64) -> f64 {
+    if x < 0.0 {
+        0.0
+    } else if x > 1.0 {
+        1.0
+    } else {
+        x
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use uuid::Uuid;
+
+    fn affinity(warmth: f64, trust: f64, intrigue: f64, intimacy: f64, patience: f64, tension: f64) -> Affinity {
+        let now = Utc::now();
+        Affinity {
+            id: Uuid::new_v4(),
+            session_id: Uuid::new_v4(),
+            user_id: Uuid::new_v4(),
+            instance_id: Uuid::new_v4(),
+            warmth,
+            trust,
+            intrigue,
+            intimacy,
+            patience,
+            tension,
+            ghost_streak: 0,
+            last_ghost_at: None,
+            total_ghosts: 0,
+            relationship_label: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    #[test]
+    fn memory_scope_resolution_table() {
+        use InsightMode::*;
+        assert_eq!(MemoryScope::Full.resolve(), (Full, true, true));
+        assert_eq!(MemoryScope::NeutralAndRelationship.resolve(), (Neutral, true, true));
+        assert_eq!(MemoryScope::RelationshipOnly.resolve(), (Off, false, true));
+        assert_eq!(MemoryScope::NeutralOnly.resolve(), (Neutral, false, false));
+        assert_eq!(MemoryScope::InsightsOnly.resolve(), (Full, false, false));
+        assert_eq!(MemoryScope::None.resolve(), (Off, false, false));
+    }
+
+    #[test]
+    fn memory_scope_default_is_neutral_and_relationship() {
+        assert_eq!(MemoryScope::default(), MemoryScope::NeutralAndRelationship);
+    }
+
+    #[test]
+    fn memory_scope_serde_snake_case() {
+        let s: MemoryScope = serde_json::from_str("\"relationship_only\"").unwrap();
+        assert_eq!(s, MemoryScope::RelationshipOnly);
+        assert!(serde_json::from_str::<MemoryScope>("\"bogus\"").is_err());
+    }
+
+    #[test]
+    fn affinity_scope_default_is_bond() {
+        let d = AffinityScope::default();
+        assert_eq!(d, AffinityScope::bond());
+        assert!(d.warmth && d.intimacy && d.tension);
+        assert!(!d.trust && !d.intrigue && !d.patience);
+    }
+
+    #[test]
+    fn affinity_scope_chemistry_and_full() {
+        let c = AffinityScope::chemistry();
+        assert!(c.trust && c.intrigue && c.patience);
+        assert!(!c.warmth && !c.intimacy && !c.tension);
+        let f = AffinityScope::full();
+        assert!(!f.is_empty());
+        assert!(f.warmth && f.trust && f.intrigue && f.intimacy && f.patience && f.tension);
+    }
+
+    #[test]
+    fn affinity_scope_from_axes_and_empty() {
+        let s = AffinityScope::from_axes(&[AffinityAxis::Warmth, AffinityAxis::Trust]);
+        assert!(s.warmth && s.trust);
+        assert!(!s.intrigue && !s.intimacy && !s.patience && !s.tension);
+        assert!(AffinityScope::from_axes(&[]).is_empty());
+        assert!(AffinityScope::none().is_empty());
+    }
+
+    #[test]
+    fn affinity_axis_serde_snake_case() {
+        let a: AffinityAxis = serde_json::from_str("\"warmth\"").unwrap();
+        assert_eq!(a, AffinityAxis::Warmth);
+        assert!(serde_json::from_str::<AffinityAxis>("\"warm\"").is_err());
+    }
+
+    #[test]
+    fn length_score_named_cases() {
+        // warmth=0 → warm01=0.5; intimacy=0.5; tension=0.5 → bond=0.5
+        // trust=0.9; intrigue=0.9; patience=0.9 → chemistry=0.9
+        let a = affinity(0.0, 0.9, 0.9, 0.5, 0.9, 0.5);
+        let bond = AffinityScope::bond().length_score(&a).unwrap();
+        let chem = AffinityScope::chemistry().length_score(&a).unwrap();
+        let full = AffinityScope::full().length_score(&a).unwrap();
+        assert!((bond - 0.5).abs() < 1e-9);
+        assert!((chem - 0.9).abs() < 1e-9);
+        assert!((full - 0.7).abs() < 1e-9); // (0.5 + 0.9) / 2
+        assert_eq!(AffinityScope::none().length_score(&a), None);
+    }
+
+    #[test]
+    fn length_score_array_activates_both_triads() {
+        let a = affinity(0.0, 0.9, 0.9, 0.5, 0.9, 0.5);
+        // warmth ∈ bond, trust ∈ chemistry → both active → avg
+        let s = AffinityScope::from_axes(&[AffinityAxis::Warmth, AffinityAxis::Trust]);
+        assert!((s.length_score(&a).unwrap() - 0.7).abs() < 1e-9);
+    }
+}

--- a/crates/eros-engine-core/src/scope.rs
+++ b/crates/eros-engine-core/src/scope.rs
@@ -147,6 +147,21 @@ impl AffinityScope {
             || self.tension)
     }
 
+    /// Number of axes that are active (0..=6). Used for observability tracing.
+    pub fn active_count(self) -> usize {
+        [
+            self.warmth,
+            self.trust,
+            self.intrigue,
+            self.intimacy,
+            self.patience,
+            self.tension,
+        ]
+        .iter()
+        .filter(|b| **b)
+        .count()
+    }
+
     /// Composite length score per the #40 spec. `None` when no axis is in scope
     /// (caller falls back to the strictest tier, matching `affinity = None`).
     pub fn length_score(self, a: &Affinity) -> Option<f64> {
@@ -272,6 +287,15 @@ mod tests {
         assert!(!s.intrigue && !s.intimacy && !s.patience && !s.tension);
         assert!(AffinityScope::from_axes(&[]).is_empty());
         assert!(AffinityScope::none().is_empty());
+    }
+
+    #[test]
+    fn affinity_scope_active_count() {
+        assert_eq!(AffinityScope::none().active_count(), 0);
+        assert_eq!(AffinityScope::bond().active_count(), 3);
+        assert_eq!(AffinityScope::full().active_count(), 6);
+        let one = AffinityScope::from_axes(&[AffinityAxis::Warmth]);
+        assert_eq!(one.active_count(), 1);
     }
 
     #[test]

--- a/crates/eros-engine-core/src/scope.rs
+++ b/crates/eros-engine-core/src/scope.rs
@@ -157,8 +157,8 @@ impl AffinityScope {
             self.patience,
             self.tension,
         ]
-        .iter()
-        .filter(|b| **b)
+        .into_iter()
+        .filter(|b| *b)
         .count()
     }
 

--- a/crates/eros-engine-core/src/types.rs
+++ b/crates/eros-engine-core/src/types.rs
@@ -6,6 +6,7 @@ use uuid::Uuid;
 
 use crate::affinity::{Affinity, AffinityDeltas};
 use crate::persona::CompanionPersona;
+use crate::scope::{AffinityScope, MemoryScope};
 
 /// A caller-supplied system-prompt fragment. The engine treats `text` as
 /// opaque — it is inserted verbatim under the `【附加指引】` section of
@@ -54,6 +55,14 @@ pub enum Event {
         /// `model_config.resolve` to pick the per-tier model + allow_traits.
         #[serde(default)]
         tier: Option<String>,
+        /// Optional caller-supplied memory injection scope (#40). Defaults to
+        /// `neutral_and_relationship` when absent.
+        #[serde(default)]
+        memory_scope: MemoryScope,
+        /// Optional caller-supplied affinity-axis injection scope (#40).
+        /// Defaults to `bond` when absent.
+        #[serde(default)]
+        affinity_scope: AffinityScope,
     },
     Gift {
         gift_id: Uuid,
@@ -190,6 +199,26 @@ mod tests {
         match ev {
             Event::UserMessage { tier, .. } => {
                 assert!(tier.is_none(), "missing tier must default to None")
+            }
+            _ => panic!("expected UserMessage"),
+        }
+    }
+
+    #[test]
+    fn user_message_defaults_scopes_when_absent() {
+        let raw = r#"{"UserMessage":{"content":"hi","message_id":"00000000-0000-0000-0000-000000000001"}}"#;
+        let ev: Event = serde_json::from_str(raw).unwrap();
+        match ev {
+            Event::UserMessage {
+                memory_scope,
+                affinity_scope,
+                ..
+            } => {
+                assert_eq!(
+                    memory_scope,
+                    crate::scope::MemoryScope::NeutralAndRelationship
+                );
+                assert_eq!(affinity_scope, crate::scope::AffinityScope::bond());
             }
             _ => panic!("expected UserMessage"),
         }

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -1003,6 +1003,29 @@
           }
         }
       },
+      "AffinityScopeDto": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/AffinityScopeName"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "AffinityScopeName": {
+        "type": "string",
+        "enum": [
+          "full",
+          "bond_and_chemistry",
+          "bond",
+          "chemistry",
+          "none"
+        ]
+      },
       "AffinitySnapshot": {
         "type": "object",
         "description": "Point-in-time projection of a session's `Affinity`. Same field set\nas the historical `AffinityDebugResponse`; renamed because it now\nflows through non-debug surfaces too.",
@@ -1680,6 +1703,16 @@
           "client_msg_id"
         ],
         "properties": {
+          "affinity_scope": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/AffinityScopeDto"
+              }
+            ]
+          },
           "audit": {
             "oneOf": [
               {
@@ -1695,6 +1728,12 @@
           },
           "content": {
             "type": "string"
+          },
+          "memory_scope": {
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "prompt_traits": {
             "type": [

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -461,6 +461,13 @@ pub(super) async fn build_reply_request(
         _ => (MemoryScope::default(), AffinityScope::default()),
     };
     let (mem_mode, x_on, y_on) = memory_scope.resolve();
+    tracing::info!(
+        memory_scope = ?memory_scope,
+        affinity_axes = affinity_scope.active_count(),
+        x_on,
+        y_on,
+        "chat scopes resolved"
+    );
 
     let (mut profile_groups, relationship_facts) =
         recall_memory(state, user_id, instance_id, query_text, x_on, y_on).await;

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -342,10 +342,13 @@ fn insights_to_bullets(insights: &Value) -> Vec<String> {
 /// `InsightMode::Full` reproduces the legacy output byte-for-byte. `Neutral`
 /// drops the intimate fields (love_values / emotional_needs / interests).
 /// Matching-only columns (preferred_gender / age / deal_breakers) are never
-/// rendered.
+/// rendered. `Off` → empty (defensive; loaders gate it before calling).
 // wired into the recall path in Task 5
 #[allow(dead_code)]
 fn human_insights_to_bullets(row: &HumanInsightsRow, mode: InsightMode) -> Vec<String> {
+    if matches!(mode, InsightMode::Off) {
+        return vec![];
+    }
     let mut out = Vec::new();
     let push_str = |out: &mut Vec<String>, val: &Option<String>, label: &str| {
         if let Some(s) = val {
@@ -1121,9 +1124,37 @@ mod tests {
                 "性格特质：温柔"
             ]
         );
-        assert!(bullets
-            .iter()
-            .all(|b| !b.contains("female") && !b.contains("抽烟")));
+        // matching-only columns (preferred_gender / age / deal_breakers) are
+        // never rendered in any mode — proven by the exact vec above.
+    }
+
+    #[test]
+    fn human_insights_full_matches_companion_insights_renderer() {
+        // The byte-identical parity contract: Full mode over a human_insights row
+        // must equal insights_to_bullets over the equivalent companion_insights JSON.
+        let row = sample_human_row();
+        let equivalent = serde_json::json!({
+            "city": "上海",
+            "occupation": "设计师",
+            "mbti_guess": "INFP",
+            "love_values": "慢热",
+            "interests": ["登山", "摄影"],
+            "emotional_needs": "被理解",
+            "life_rhythm": "夜猫子",
+            "personality_traits": ["温柔"],
+            // matching-only fields exist in JSON too but neither renderer emits them
+            "matching_preferences": { "preferred_gender": "female", "age_range": [25, 35] }
+        });
+        assert_eq!(
+            human_insights_to_bullets(&row, InsightMode::Full),
+            insights_to_bullets(&equivalent)
+        );
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn load_human_insight_bullets_returns_empty_for_unknown_user(pool: PgPool) {
+        let bullets = load_human_insight_bullets(&pool, Uuid::new_v4(), InsightMode::Full).await;
+        assert!(bullets.is_empty());
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -463,6 +463,11 @@ pub(super) async fn build_reply_request(
         );
     }
 
+    let affinity_scope = match &input.event {
+        Event::UserMessage { affinity_scope, .. } => *affinity_scope,
+        _ => eros_engine_core::scope::AffinityScope::default(),
+    };
+
     let system_prompt = build_prompt(
         &input.persona,
         &profile_groups,
@@ -473,6 +478,7 @@ pub(super) async fn build_reply_request(
         plan.reply_style,
         &plan.context_hints,
         &kept_traits,
+        affinity_scope,
     );
 
     Ok(assemble_chat_request(
@@ -531,6 +537,7 @@ pub(super) async fn build_gift_request(
         plan.reply_style,
         &plan.context_hints,
         &[],
+        eros_engine_core::scope::AffinityScope::full(),
     );
 
     Ok(assemble_chat_request(

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -461,13 +461,23 @@ pub(super) async fn build_reply_request(
         _ => (MemoryScope::default(), AffinityScope::default()),
     };
     let (mem_mode, x_on, y_on) = memory_scope.resolve();
-    tracing::info!(
-        memory_scope = ?memory_scope,
-        affinity_axes = affinity_scope.active_count(),
-        x_on,
-        y_on,
-        "chat scopes resolved"
-    );
+    // Routine turns use the defaults — keep those at debug. Surface only
+    // caller-overridden scopes at info, where they're actually notable.
+    if memory_scope != MemoryScope::default() || affinity_scope != AffinityScope::default() {
+        tracing::info!(
+            memory_scope = ?memory_scope,
+            affinity_axes_active = affinity_scope.active_count(),
+            x_on,
+            y_on,
+            "chat scopes resolved (non-default)"
+        );
+    } else {
+        tracing::debug!(
+            memory_scope = ?memory_scope,
+            affinity_axes_active = affinity_scope.active_count(),
+            "chat scopes resolved (defaults)"
+        );
+    }
 
     let (mut profile_groups, relationship_facts) =
         recall_memory(state, user_id, instance_id, query_text, x_on, y_on).await;

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -22,10 +22,12 @@ use sqlx::PgPool;
 use uuid::Uuid;
 
 use eros_engine_core::affinity::AffinityDeltas;
+use eros_engine_core::scope::InsightMode;
 use eros_engine_core::types::{ActionPlan, DecisionInput, Event, LlmAudit, PromptTrait};
 use eros_engine_llm::model_config::ResolvedModel;
 use eros_engine_llm::openrouter::{ChatMessage, ChatRequest};
 use eros_engine_store::chat::ChatRepo;
+use eros_engine_store::human_insight::{HumanInsightRepo, HumanInsightsRow};
 use eros_engine_store::insight::InsightRepo;
 use eros_engine_store::memory::MemoryRepo;
 
@@ -333,6 +335,71 @@ fn insights_to_bullets(insights: &Value) -> Vec<String> {
     push_arr(&mut out, "personality_traits", "性格特质");
 
     out
+}
+
+/// Render a `human_insights` row as 基础画像 bullets. Mirrors
+/// `insights_to_bullets`' labels / order / trim / empty-skip exactly so that
+/// `InsightMode::Full` reproduces the legacy output byte-for-byte. `Neutral`
+/// drops the intimate fields (love_values / emotional_needs / interests).
+/// Matching-only columns (preferred_gender / age / deal_breakers) are never
+/// rendered.
+// wired into the recall path in Task 5
+#[allow(dead_code)]
+fn human_insights_to_bullets(row: &HumanInsightsRow, mode: InsightMode) -> Vec<String> {
+    let mut out = Vec::new();
+    let push_str = |out: &mut Vec<String>, val: &Option<String>, label: &str| {
+        if let Some(s) = val {
+            let s = s.trim();
+            if !s.is_empty() {
+                out.push(format!("{label}：{s}"));
+            }
+        }
+    };
+    let push_arr = |out: &mut Vec<String>, val: &[String], label: &str| {
+        let parts: Vec<&str> = val
+            .iter()
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .collect();
+        if !parts.is_empty() {
+            out.push(format!("{label}：{}", parts.join("、")));
+        }
+    };
+    let intimate = matches!(mode, InsightMode::Full);
+
+    push_str(&mut out, &row.city, "城市");
+    push_str(&mut out, &row.occupation, "职业");
+    push_str(&mut out, &row.mbti_guess, "MBTI");
+    if intimate {
+        push_str(&mut out, &row.love_values, "感情观");
+        push_arr(&mut out, &row.interests, "兴趣");
+        push_str(&mut out, &row.emotional_needs, "情感需求");
+    }
+    push_str(&mut out, &row.life_rhythm, "作息");
+    push_arr(&mut out, &row.personality_traits, "性格特质");
+    out
+}
+
+/// Load + render 基础画像 from the flat `human_insights` mirror. `Off` → empty.
+// wired into the recall path in Task 5
+#[allow(dead_code)]
+async fn load_human_insight_bullets(
+    pool: &PgPool,
+    user_id: Uuid,
+    mode: InsightMode,
+) -> Vec<String> {
+    if matches!(mode, InsightMode::Off) {
+        return vec![];
+    }
+    let repo = HumanInsightRepo { pool };
+    match repo.load(user_id).await {
+        Ok(Some(row)) => human_insights_to_bullets(&row, mode),
+        Ok(None) => vec![],
+        Err(e) => {
+            tracing::warn!("human_insights load failed: {e}");
+            vec![]
+        }
+    }
 }
 
 // ─── Reply ──────────────────────────────────────────────────────────
@@ -701,6 +768,7 @@ mod tests {
     // either need a live Voyage key or a trait-mock indirection that
     // doesn't justify its weight for a single thin function.
 
+    use eros_engine_store::human_insight::HumanInsightRepo;
     use eros_engine_store::insight::InsightRepo;
     use eros_engine_store::memory::{MemoryLayer, MemoryRepo};
     use sqlx::PgPool;
@@ -999,6 +1067,89 @@ mod tests {
                 "兴趣：登山、精酿".to_string(),
             ]
         );
+    }
+
+    // ─── human_insights_to_bullets ──────────────────────────────────────
+
+    fn sample_human_row() -> HumanInsightsRow {
+        HumanInsightsRow {
+            user_id: Uuid::new_v4(),
+            city: Some("上海".into()),
+            occupation: Some("设计师".into()),
+            mbti_guess: Some("INFP".into()),
+            love_values: Some("慢热".into()),
+            emotional_needs: Some("被理解".into()),
+            life_rhythm: Some("夜猫子".into()),
+            interests: vec!["登山".into(), "摄影".into()],
+            personality_traits: vec!["温柔".into()],
+            preferred_gender: Some("female".into()),
+            age_min: Some(25),
+            age_max: Some(35),
+            deal_breakers: vec!["抽烟".into()],
+            updated_at: chrono::Utc::now(),
+        }
+    }
+
+    #[test]
+    fn human_insights_full_renders_all_eight_fields_in_order() {
+        let bullets = human_insights_to_bullets(&sample_human_row(), InsightMode::Full);
+        assert_eq!(
+            bullets,
+            vec![
+                "城市：上海",
+                "职业：设计师",
+                "MBTI：INFP",
+                "感情观：慢热",
+                "兴趣：登山、摄影",
+                "情感需求：被理解",
+                "作息：夜猫子",
+                "性格特质：温柔",
+            ]
+        );
+    }
+
+    #[test]
+    fn human_insights_neutral_drops_intimate_fields() {
+        let bullets = human_insights_to_bullets(&sample_human_row(), InsightMode::Neutral);
+        assert_eq!(
+            bullets,
+            vec![
+                "城市：上海",
+                "职业：设计师",
+                "MBTI：INFP",
+                "作息：夜猫子",
+                "性格特质：温柔"
+            ]
+        );
+        assert!(bullets
+            .iter()
+            .all(|b| !b.contains("female") && !b.contains("抽烟")));
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn load_human_insight_bullets_neutral_vs_full(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let insights = serde_json::json!({
+            "city": "北京", "occupation": "工程师",
+            "love_values": "认真", "interests": ["爬山"], "emotional_needs": "陪伴"
+        });
+        HumanInsightRepo { pool: &pool }
+            .project_from_insights(user_id, &insights)
+            .await
+            .unwrap();
+
+        let full = load_human_insight_bullets(&pool, user_id, InsightMode::Full).await;
+        assert!(full.iter().any(|b| b == "感情观：认真"));
+        assert!(full.iter().any(|b| b == "兴趣：爬山"));
+
+        let neutral = load_human_insight_bullets(&pool, user_id, InsightMode::Neutral).await;
+        assert!(neutral.iter().any(|b| b == "城市：北京"));
+        assert!(neutral
+            .iter()
+            .all(|b| !b.contains("认真") && !b.contains("爬山") && !b.contains("陪伴")));
+
+        let off = load_human_insight_bullets(&pool, user_id, InsightMode::Off).await;
+        assert!(off.is_empty());
     }
 
     // ─── audit_from_event ───────────────────────────────────────────────

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -22,7 +22,7 @@ use sqlx::PgPool;
 use uuid::Uuid;
 
 use eros_engine_core::affinity::AffinityDeltas;
-use eros_engine_core::scope::InsightMode;
+use eros_engine_core::scope::{AffinityScope, InsightMode, MemoryScope};
 use eros_engine_core::types::{ActionPlan, DecisionInput, Event, LlmAudit, PromptTrait};
 use eros_engine_llm::model_config::ResolvedModel;
 use eros_engine_llm::openrouter::{ChatMessage, ChatRequest};
@@ -142,17 +142,19 @@ fn assemble_chat_request(
 // ─── Memory recall + insight injection helpers ────────────────────
 
 /// Embed `query_text` once, then delegate to `recall_memory_with_embedding`.
-/// Empty query → returns (empty, empty) without hitting Voyage. Voyage
-/// failure also degrades silently to (empty, empty) — recall failure must
-/// never block a chat reply (the persona just looks slightly less "with
-/// it" for that turn).
+/// Returns (empty, empty) without hitting Voyage when both layers are off or
+/// the query is blank. Voyage failure also degrades silently to (empty, empty)
+/// — recall failure must never block a chat reply (the persona just looks
+/// slightly less "with it" for that turn).
 async fn recall_memory(
     state: &AppState,
     user_id: Uuid,
     instance_id: Uuid,
     query_text: &str,
+    x_on: bool,
+    y_on: bool,
 ) -> (Vec<(String, Vec<String>)>, Vec<String>) {
-    if query_text.trim().is_empty() {
+    if (!x_on && !y_on) || query_text.trim().is_empty() {
         return (vec![], vec![]);
     }
     let embedding = match state.voyage.embed_query(query_text).await {
@@ -162,53 +164,78 @@ async fn recall_memory(
             return (vec![], vec![]);
         }
     };
-    // Observation hook for recall-quality investigation (RUST_LOG=...=debug).
-    // Cheap fields only: scalars + lengths, no content / no PII.
     tracing::debug!(
         user_id = %user_id,
         query_len = query_text.chars().count(),
         embedding_dim = embedding.len(),
+        x_on,
+        y_on,
         "recall_memory: embedded query, dispatching pgvector search"
     );
-    recall_memory_with_embedding(&state.pool, user_id, instance_id, &embedding).await
+    recall_memory_with_embedding(&state.pool, user_id, instance_id, &embedding, x_on, y_on).await
 }
 
-/// Pure-DB inner half of memory recall. Takes a pre-computed embedding,
-/// fans out to profile (categorised + raw fallback) + relationship layers
-/// in parallel via `tokio::join!`, and returns:
+/// Pure-DB inner half of memory recall. Takes a pre-computed embedding and
+/// layer-enable flags, then returns:
 /// - profile_groups: `Vec<(label, bullets)>` — categorised rows grouped by
 ///   `category` if any exist; otherwise a single `("近况", raw_rows)` group
 ///   so users with no classified sessions yet still get profile context.
+///   Empty when `x_on` is false.
 /// - relationship: flat `Vec<String>` — relationship rows are full turn
-///   dumps and not categorised by the dreaming-lite pass.
+///   dumps and not categorised by the dreaming-lite pass. Empty when `y_on`
+///   is false.
+///
+/// Hot path (`x_on` ⇒ `y_on`): the three profile + relationship searches run
+/// in parallel via `tokio::join!`. Relationship-only (`!x_on && y_on`): only
+/// the relationship search runs. Both off: no DB round-trip.
 async fn recall_memory_with_embedding(
     pool: &PgPool,
     user_id: Uuid,
     instance_id: Uuid,
     embedding: &[f32],
+    x_on: bool,
+    y_on: bool,
 ) -> (Vec<(String, Vec<String>)>, Vec<String>) {
     let repo = MemoryRepo { pool };
-    let (grouped_res, raw_res, rel_res) = tokio::join!(
-        repo.search_profile_grouped(user_id, embedding, K_PER_CATEGORY),
-        repo.search(user_id, None, embedding, PROFILE_RECALL_K),
-        repo.search(user_id, Some(instance_id), embedding, RELATIONSHIP_RECALL_K),
-    );
-    let grouped_rows = grouped_res.unwrap_or_else(|e| {
-        tracing::warn!("profile-layer grouped search failed: {e}");
-        vec![]
-    });
-    let raw_rows = raw_res.unwrap_or_else(|e| {
-        tracing::warn!("profile-layer raw search failed: {e}");
-        vec![]
-    });
-    let profile_groups = build_profile_groups(grouped_rows, raw_rows);
 
-    let relationship: Vec<String> = match rel_res {
-        Ok(rows) => rows.into_iter().map(|r| r.content).collect(),
-        Err(e) => {
-            tracing::warn!("relationship-layer memory search failed: {e}");
+    let (profile_groups, relationship): (Vec<(String, Vec<String>)>, Vec<String>) = if x_on {
+        // X on ⇒ Y on: original three-way parallel recall (hot path).
+        let (grouped_res, raw_res, rel_res) = tokio::join!(
+            repo.search_profile_grouped(user_id, embedding, K_PER_CATEGORY),
+            repo.search(user_id, None, embedding, PROFILE_RECALL_K),
+            repo.search(user_id, Some(instance_id), embedding, RELATIONSHIP_RECALL_K),
+        );
+        let grouped_rows = grouped_res.unwrap_or_else(|e| {
+            tracing::warn!("profile-layer grouped search failed: {e}");
             vec![]
-        }
+        });
+        let raw_rows = raw_res.unwrap_or_else(|e| {
+            tracing::warn!("profile-layer raw search failed: {e}");
+            vec![]
+        });
+        let rel = match rel_res {
+            Ok(rows) => rows.into_iter().map(|r| r.content).collect(),
+            Err(e) => {
+                tracing::warn!("relationship-layer memory search failed: {e}");
+                vec![]
+            }
+        };
+        (build_profile_groups(grouped_rows, raw_rows), rel)
+    } else if y_on {
+        // relationship_only: skip both profile-layer searches.
+        let rel = match repo
+            .search(user_id, Some(instance_id), embedding, RELATIONSHIP_RECALL_K)
+            .await
+        {
+            Ok(rows) => rows.into_iter().map(|r| r.content).collect(),
+            Err(e) => {
+                tracing::warn!("relationship-layer memory search failed: {e}");
+                vec![]
+            }
+        };
+        (vec![], rel)
+    } else {
+        (vec![], vec![])
     };
 
     let profile_total_chars: usize = profile_groups
@@ -343,8 +370,6 @@ fn insights_to_bullets(insights: &Value) -> Vec<String> {
 /// drops the intimate fields (love_values / emotional_needs / interests).
 /// Matching-only columns (preferred_gender / age / deal_breakers) are never
 /// rendered. `Off` → empty (defensive; loaders gate it before calling).
-// wired into the recall path in Task 5
-#[allow(dead_code)]
 fn human_insights_to_bullets(row: &HumanInsightsRow, mode: InsightMode) -> Vec<String> {
     if matches!(mode, InsightMode::Off) {
         return vec![];
@@ -384,8 +409,6 @@ fn human_insights_to_bullets(row: &HumanInsightsRow, mode: InsightMode) -> Vec<S
 }
 
 /// Load + render 基础画像 from the flat `human_insights` mirror. `Off` → empty.
-// wired into the recall path in Task 5
-#[allow(dead_code)]
 async fn load_human_insight_bullets(
     pool: &PgPool,
     user_id: Uuid,
@@ -425,10 +448,20 @@ pub(super) async fn build_reply_request(
         _ => "",
     };
 
-    let (mut profile_groups, relationship_facts) =
-        recall_memory(state, user_id, instance_id, query_text).await;
+    let (memory_scope, affinity_scope) = match &input.event {
+        Event::UserMessage {
+            memory_scope,
+            affinity_scope,
+            ..
+        } => (*memory_scope, *affinity_scope),
+        _ => (MemoryScope::default(), AffinityScope::default()),
+    };
+    let (mem_mode, x_on, y_on) = memory_scope.resolve();
 
-    let insight_bullets = load_insight_bullets(&state.pool, user_id).await;
+    let (mut profile_groups, relationship_facts) =
+        recall_memory(state, user_id, instance_id, query_text, x_on, y_on).await;
+
+    let insight_bullets = load_human_insight_bullets(&state.pool, user_id, mem_mode).await;
     if !insight_bullets.is_empty() {
         profile_groups.insert(0, ("基础画像".into(), insight_bullets));
     }
@@ -462,11 +495,6 @@ pub(super) async fn build_reply_request(
             "prompt_traits: dropped tags not allowed for tier"
         );
     }
-
-    let affinity_scope = match &input.event {
-        Event::UserMessage { affinity_scope, .. } => *affinity_scope,
-        _ => eros_engine_core::scope::AffinityScope::default(),
-    };
 
     let system_prompt = build_prompt(
         &input.persona,
@@ -511,7 +539,7 @@ pub(super) async fn build_gift_request(
         .unwrap_or("");
 
     let (mut profile_groups, relationship_facts) =
-        recall_memory(state, user_id, instance_id, query_text).await;
+        recall_memory(state, user_id, instance_id, query_text, true, true).await;
 
     let insight_bullets = load_insight_bullets(&state.pool, user_id).await;
     if !insight_bullets.is_empty() {
@@ -809,8 +837,15 @@ mod tests {
     async fn recall_memory_with_embedding_empty_db_returns_empty(pool: PgPool) {
         let user_id = Uuid::new_v4();
         let instance_id = Uuid::new_v4();
-        let (profile, relationship) =
-            recall_memory_with_embedding(&pool, user_id, instance_id, &unit_embedding(7)).await;
+        let (profile, relationship) = recall_memory_with_embedding(
+            &pool,
+            user_id,
+            instance_id,
+            &unit_embedding(7),
+            true,
+            true,
+        )
+        .await;
         assert!(profile.is_empty());
         assert!(relationship.is_empty());
     }
@@ -849,8 +884,15 @@ mod tests {
         .await
         .unwrap();
 
-        let (profile_groups, relationship) =
-            recall_memory_with_embedding(&pool, user_id, instance_id, &unit_embedding(11)).await;
+        let (profile_groups, relationship) = recall_memory_with_embedding(
+            &pool,
+            user_id,
+            instance_id,
+            &unit_embedding(11),
+            true,
+            true,
+        )
+        .await;
         assert_eq!(
             profile_groups,
             vec![("近况".to_string(), vec!["profile fact".to_string()])]
@@ -902,8 +944,15 @@ mod tests {
         .await
         .unwrap();
 
-        let (profile_groups, _relationship) =
-            recall_memory_with_embedding(&pool, user_id, instance_id, &unit_embedding(7)).await;
+        let (profile_groups, _relationship) = recall_memory_with_embedding(
+            &pool,
+            user_id,
+            instance_id,
+            &unit_embedding(7),
+            true,
+            true,
+        )
+        .await;
 
         // Categorised rows surfaced; raw row dropped because grouped path won.
         let labels: Vec<&str> = profile_groups.iter().map(|(l, _)| l.as_str()).collect();
@@ -957,8 +1006,15 @@ mod tests {
             .unwrap();
         }
 
-        let (profile_groups, relationship) =
-            recall_memory_with_embedding(&pool, user_id, instance_id, &unit_embedding(100)).await;
+        let (profile_groups, relationship) = recall_memory_with_embedding(
+            &pool,
+            user_id,
+            instance_id,
+            &unit_embedding(100),
+            true,
+            true,
+        )
+        .await;
 
         // No categorised rows exist → raw fallback fires under "近况"
         // with PROFILE_RECALL_K entries from the cosine top-K.
@@ -1028,8 +1084,15 @@ mod tests {
         // Query embedding hits the profile target seed exactly. All rows
         // here are uncategorised, so the raw fallback fires under "近况"
         // and its first item is the cosine-nearest one.
-        let (profile_groups, _relationship) =
-            recall_memory_with_embedding(&pool, user_id, instance_id, &unit_embedding(42)).await;
+        let (profile_groups, _relationship) = recall_memory_with_embedding(
+            &pool,
+            user_id,
+            instance_id,
+            &unit_embedding(42),
+            true,
+            true,
+        )
+        .await;
         assert_eq!(profile_groups.len(), 1);
         assert_eq!(profile_groups[0].0, "近况");
         assert_eq!(
@@ -1038,12 +1101,86 @@ mod tests {
         );
 
         // Query at the relationship target seed.
-        let (_profile2, relationship2) =
-            recall_memory_with_embedding(&pool, user_id, instance_id, &unit_embedding(99)).await;
+        let (_profile2, relationship2) = recall_memory_with_embedding(
+            &pool,
+            user_id,
+            instance_id,
+            &unit_embedding(99),
+            true,
+            true,
+        )
+        .await;
         assert_eq!(
             relationship2.first().map(String::as_str),
             Some("relationship target"),
         );
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn recall_gating_skips_layers_per_flags(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let instance_id = Uuid::new_v4();
+        let session_id = make_session(&pool, user_id, Some(instance_id)).await;
+        let repo = MemoryRepo { pool: &pool };
+        repo.upsert(
+            MemoryLayer::Profile,
+            session_id,
+            user_id,
+            None,
+            "profile fact",
+            &unit_embedding(11),
+            None,
+        )
+        .await
+        .unwrap();
+        repo.upsert(
+            MemoryLayer::Relationship,
+            session_id,
+            user_id,
+            Some(instance_id),
+            "relationship fact",
+            &unit_embedding(11),
+            None,
+        )
+        .await
+        .unwrap();
+
+        // relationship_only: x off, y on → profile groups empty, relationship present
+        let (prof, rel) = recall_memory_with_embedding(
+            &pool,
+            user_id,
+            instance_id,
+            &unit_embedding(11),
+            false,
+            true,
+        )
+        .await;
+        assert!(prof.is_empty(), "profile groups must be empty when X off");
+        assert_eq!(rel, vec!["relationship fact".to_string()]);
+
+        // both off → nothing
+        let (prof2, rel2) = recall_memory_with_embedding(
+            &pool,
+            user_id,
+            instance_id,
+            &unit_embedding(11),
+            false,
+            false,
+        )
+        .await;
+        assert!(prof2.is_empty() && rel2.is_empty());
+
+        // both on → both layers (sanity that the hot path still works)
+        let (prof3, rel3) = recall_memory_with_embedding(
+            &pool,
+            user_id,
+            instance_id,
+            &unit_embedding(11),
+            true,
+            true,
+        )
+        .await;
+        assert!(!prof3.is_empty() && !rel3.is_empty());
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -235,6 +235,8 @@ async fn recall_memory_with_embedding(
         };
         (vec![], rel)
     } else {
+        // Unreachable via MemoryScope::resolve() (x_on ⇒ y_on); defensive for
+        // any direct caller that passes both layers off.
         (vec![], vec![])
     };
 
@@ -245,6 +247,8 @@ async fn recall_memory_with_embedding(
     tracing::debug!(
         user_id = %user_id,
         instance_id = %instance_id,
+        x_on,
+        y_on,
         profile_groups = profile_groups.len(),
         profile_total_chars,
         relationship_hits = relationship.len(),
@@ -1180,7 +1184,11 @@ mod tests {
             true,
         )
         .await;
-        assert!(!prof3.is_empty() && !rel3.is_empty());
+        assert!(
+            !prof3.is_empty(),
+            "profile groups should be present when X on"
+        );
+        assert!(!rel3.is_empty(), "relationship should be present when Y on");
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -1018,6 +1018,8 @@ mod tests {
             prompt_traits: vec![],
             audit: Some(audit.clone()),
             tier: None,
+            memory_scope: Default::default(),
+            affinity_scope: Default::default(),
         };
         let extracted = audit_from_event(&ev);
         assert_eq!(extracted, Some(&audit));

--- a/crates/eros-engine-server/src/pipeline/post_process.rs
+++ b/crates/eros-engine-server/src/pipeline/post_process.rs
@@ -737,6 +737,8 @@ mod tests {
                 metadata: Some(metadata),
             }),
             tier: None,
+            memory_scope: Default::default(),
+            affinity_scope: Default::default(),
         };
         // Only `user` is taken; session_id/metadata are ignored by design.
         assert_eq!(client_id_from_event(&event).as_deref(), Some("u_abc"));
@@ -750,6 +752,8 @@ mod tests {
             prompt_traits: Vec::new(),
             audit: None,
             tier: None,
+            memory_scope: Default::default(),
+            affinity_scope: Default::default(),
         };
         assert_eq!(client_id_from_event(&event), None);
     }

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -251,6 +251,8 @@ pub struct PersistedUserMessage {
     pub prompt_traits: Vec<eros_engine_core::types::PromptTrait>,
     pub audit: Option<eros_engine_core::types::LlmAudit>,
     pub tier: Option<String>,
+    pub memory_scope: eros_engine_core::scope::MemoryScope,
+    pub affinity_scope: eros_engine_core::scope::AffinityScope,
 }
 
 /// Produce a stream of `ProtocolFrame` events for a single burst. The
@@ -317,6 +319,8 @@ pub fn run_stream(
                 prompt_traits: user_msg.prompt_traits.clone(),
                 audit: user_msg.audit.clone(),
                 tier: user_msg.tier.clone(),
+                memory_scope: user_msg.memory_scope,
+                affinity_scope: user_msg.affinity_scope,
             },
             affinity: affinity.clone(),
             persona,
@@ -434,6 +438,8 @@ pub fn run_stream(
                     prompt_traits: user_msg.prompt_traits.clone(),
                     audit: user_msg.audit.clone(),
                     tier: user_msg.tier.clone(),
+                    memory_scope: user_msg.memory_scope,
+                    affinity_scope: user_msg.affinity_scope,
                 };
                 let user_id_bg = user_msg.user_id;
                 let instance_id_bg = user_msg.instance_id;
@@ -741,6 +747,8 @@ mod tests {
                 prompt_traits: vec![],
                 audit: None,
                 tier: None,
+                memory_scope: Default::default(),
+                affinity_scope: Default::default(),
             },
         )
         .collect()
@@ -863,6 +871,8 @@ data: [DONE]\n\n";
                 prompt_traits: vec![],
                 audit: None,
                 tier: None,
+                memory_scope: Default::default(),
+                affinity_scope: Default::default(),
             },
         )
         .collect()
@@ -937,6 +947,8 @@ data: [DONE]\n\n";
                 prompt_traits: vec![],
                 audit: None,
                 tier: None,
+                memory_scope: Default::default(),
+                affinity_scope: Default::default(),
             },
         )
         .collect()

--- a/crates/eros-engine-server/src/prompt.rs
+++ b/crates/eros-engine-server/src/prompt.rs
@@ -98,7 +98,8 @@ fn now_context_at(now: chrono::DateTime<Utc>, timezone: Option<&str>) -> String 
 
 /// Reply-length rule for 铁律①, graduated by the affinity-scope composite
 /// score (0~1). No in-scope axis (or no affinity yet) → strictest tier.
-/// Thresholds intentionally coarse (0.25 / 0.55) — tunable.
+/// Thresholds (0.25 / 0.55) carry over from the single-intimacy era; the
+/// composite averages land on similar tier boundaries in practice — tunable.
 fn length_rule(affinity: Option<&Affinity>, scope: AffinityScope) -> &'static str {
     let score = affinity.and_then(|a| scope.length_score(a)).unwrap_or(0.0);
     if score < 0.25 {
@@ -1196,6 +1197,10 @@ mod tests {
         );
         assert!(p.contains("warmth=") && p.contains("intimacy=") && p.contains("tension="));
         assert!(!p.contains("trust=") && !p.contains("intrigue=") && !p.contains("patience="));
+        // attitude directives are gated by the same axis set: bond-axis directives
+        // present, chemistry-axis directives (trust/intrigue/patience) suppressed.
+        assert!(p.contains("语气温暖"));
+        assert!(!p.contains("私密") && !p.contains("好奇") && !p.contains("有耐心"));
     }
 
     #[test]

--- a/crates/eros-engine-server/src/prompt.rs
+++ b/crates/eros-engine-server/src/prompt.rs
@@ -27,6 +27,7 @@ use chrono::{Datelike, Timelike, Utc, Weekday};
 
 use eros_engine_core::affinity::Affinity;
 use eros_engine_core::persona::CompanionPersona;
+use eros_engine_core::scope::AffinityScope;
 use eros_engine_core::types::PromptTrait;
 use eros_engine_core::types::ReplyStyle;
 
@@ -95,14 +96,14 @@ fn now_context_at(now: chrono::DateTime<Utc>, timezone: Option<&str>) -> String 
     )
 }
 
-/// Reply-length rule for 铁律①, graduated by `intimacy` (0~1). Looser as the
-/// relationship deepens; `None` affinity (no data yet) → strictest tier.
+/// Reply-length rule for 铁律①, graduated by the affinity-scope composite
+/// score (0~1). No in-scope axis (or no affinity yet) → strictest tier.
 /// Thresholds intentionally coarse (0.25 / 0.55) — tunable.
-fn length_rule(affinity: Option<&Affinity>) -> &'static str {
-    let intimacy = affinity.map(|a| a.intimacy).unwrap_or(0.0);
-    if intimacy < 0.25 {
+fn length_rule(affinity: Option<&Affinity>, scope: AffinityScope) -> &'static str {
+    let score = affinity.and_then(|a| scope.length_score(a)).unwrap_or(0.0);
+    if score < 0.25 {
         "刚认识，每次回复 1~2 句，绝对不超过 2 句；单条消息严格不超过 40 字"
-    } else if intimacy < 0.55 {
+    } else if score < 0.55 {
         "每次回复 1~3 句；单条消息不超过 60 字"
     } else {
         "每次回复 1~5 句（最多 5 句）；单条消息不超过 100 字"
@@ -110,42 +111,50 @@ fn length_rule(affinity: Option<&Affinity>) -> &'static str {
 }
 
 /// Attitude directives derived from the affinity state.
-pub fn affinity_to_attitude_prompt(a: &Affinity) -> String {
+pub fn affinity_to_attitude_prompt(a: &Affinity, scope: AffinityScope) -> String {
     let mut directives: Vec<&str> = Vec::new();
 
-    if a.warmth > 0.6 {
-        directives.push("语气温暖，可以用一些亲昵的称呼");
-    } else if a.warmth > 0.3 {
-        directives.push("语气友善自然");
-    } else if a.warmth > 0.0 {
-        directives.push("语气平淡，保持礼貌但不热络");
-    } else {
-        directives.push("语气冷淡，回复简短，不主动延伸话题");
+    if scope.warmth {
+        if a.warmth > 0.6 {
+            directives.push("语气温暖，可以用一些亲昵的称呼");
+        } else if a.warmth > 0.3 {
+            directives.push("语气友善自然");
+        } else if a.warmth > 0.0 {
+            directives.push("语气平淡，保持礼貌但不热络");
+        } else {
+            directives.push("语气冷淡，回复简短，不主动延伸话题");
+        }
     }
 
-    if a.trust > 0.6 {
-        directives.push("可以分享更私密的想法和小秘密");
-    } else if a.trust < 0.3 {
-        directives.push("保持一定距离感，不轻易透露内心想法");
+    if scope.trust {
+        if a.trust > 0.6 {
+            directives.push("可以分享更私密的想法和小秘密");
+        } else if a.trust < 0.3 {
+            directives.push("保持一定距离感，不轻易透露内心想法");
+        }
     }
 
-    if a.intrigue > 0.7 {
-        directives.push("你对他很好奇，主动问问题，想了解更多");
-    } else if a.intrigue < 0.3 {
-        directives.push("你对他兴趣不大，不会主动找话题");
+    if scope.intrigue {
+        if a.intrigue > 0.7 {
+            directives.push("你对他很好奇，主动问问题，想了解更多");
+        } else if a.intrigue < 0.3 {
+            directives.push("你对他兴趣不大，不会主动找话题");
+        }
     }
 
-    if a.intimacy > 0.5 {
+    if scope.intimacy && a.intimacy > 0.5 {
         directives.push("可以引用之前聊过的事情，有默契感，用你们之间的梗");
     }
 
-    if a.patience < 0.3 {
-        directives.push("你有点不耐烦了，回复可以更敷衍、更短");
-    } else if a.patience > 0.7 {
-        directives.push("你很有耐心，愿意陪他聊");
+    if scope.patience {
+        if a.patience < 0.3 {
+            directives.push("你有点不耐烦了，回复可以更敷衍、更短");
+        } else if a.patience > 0.7 {
+            directives.push("你很有耐心，愿意陪他聊");
+        }
     }
 
-    if a.tension > 0.5 {
+    if scope.tension && a.tension > 0.5 {
         directives.push("带点小傲娇，不要太好说话，适度推拉");
     }
 
@@ -327,6 +336,7 @@ pub fn build_prompt(
     style: ReplyStyle,
     hints: &[String],
     prompt_traits: &[PromptTrait],
+    affinity_scope: AffinityScope,
 ) -> String {
     let name = persona.genome.name.as_str();
     let age = meta_i32(persona, "age")
@@ -404,15 +414,37 @@ pub fn build_prompt(
     };
 
     let attitude = affinity
-        .map(affinity_to_attitude_prompt)
+        .map(|a| affinity_to_attitude_prompt(a, affinity_scope))
         .unwrap_or_default();
     let state = affinity
         .map(|a| {
-            format!(
-                "\n【你对他的内心感受】（绝对不要在回复中提及这些数值，这是隐藏参数）\n\
-             warmth={:.2}, trust={:.2}, intrigue={:.2}, intimacy={:.2}, patience={:.2}, tension={:.2}",
-                a.warmth, a.trust, a.intrigue, a.intimacy, a.patience, a.tension
-            )
+            let mut parts: Vec<String> = Vec::new();
+            if affinity_scope.warmth {
+                parts.push(format!("warmth={:.2}", a.warmth));
+            }
+            if affinity_scope.trust {
+                parts.push(format!("trust={:.2}", a.trust));
+            }
+            if affinity_scope.intrigue {
+                parts.push(format!("intrigue={:.2}", a.intrigue));
+            }
+            if affinity_scope.intimacy {
+                parts.push(format!("intimacy={:.2}", a.intimacy));
+            }
+            if affinity_scope.patience {
+                parts.push(format!("patience={:.2}", a.patience));
+            }
+            if affinity_scope.tension {
+                parts.push(format!("tension={:.2}", a.tension));
+            }
+            if parts.is_empty() {
+                String::new()
+            } else {
+                format!(
+                    "\n【你对他的内心感受】（绝对不要在回复中提及这些数值，这是隐藏参数）\n{}",
+                    parts.join(", ")
+                )
+            }
         })
         .unwrap_or_default();
     let gift = gift_reaction_context(pending_gifts, tip_personality);
@@ -474,7 +506,7 @@ pub fn build_prompt(
          \n\
          【输出】直接输出回复文字（纯文本，不要 JSON，不要 markdown，不要 quote 符号）",
         tc = now_context(timezone),
-        lr = length_rule(affinity),
+        lr = length_rule(affinity, affinity_scope),
     )
 }
 
@@ -646,6 +678,7 @@ mod tests {
             ReplyStyle::Neutral,
             &[],
             &[],
+            AffinityScope::full(),
         );
         assert!(
             !p.contains("【附加指引】"),
@@ -680,6 +713,7 @@ mod tests {
             ReplyStyle::Neutral,
             &[],
             &traits,
+            AffinityScope::full(),
         );
         assert!(p.contains("【附加指引】"), "section header present");
         assert!(p.contains("- be more daring"));
@@ -706,6 +740,7 @@ mod tests {
             ReplyStyle::Neutral,
             &[],
             &traits,
+            AffinityScope::full(),
         );
         let topics = p.find("【擅长话题】").expect("topics");
         let traits_i = p.find("【附加指引】").expect("traits");
@@ -728,6 +763,7 @@ mod tests {
             ReplyStyle::Neutral,
             &[],
             &[],
+            AffinityScope::full(),
         );
         let pos = |h: &str| s.find(h).unwrap_or_else(|| panic!("missing {h} in:\n{s}"));
         let order = [
@@ -776,6 +812,7 @@ mod tests {
             ReplyStyle::Neutral,
             &[],
             &[],
+            AffinityScope::full(),
         );
         assert!(
             s.starts_with("AUTHORED HEAD\n\n你是 "),
@@ -797,6 +834,7 @@ mod tests {
             ReplyStyle::Neutral,
             &[],
             &[],
+            AffinityScope::full(),
         );
         assert!(
             s.starts_with("你是 "),
@@ -818,6 +856,7 @@ mod tests {
             ReplyStyle::Neutral,
             &[],
             &[],
+            AffinityScope::full(),
         );
         assert!(s.contains("你是 Aria，男性，24 岁，INFP 性格。"), "{s}");
         assert!(s.contains("⑧ 你是男性，严格遵守自己的性别"), "{s}");
@@ -837,6 +876,7 @@ mod tests {
             ReplyStyle::Neutral,
             &[],
             &[],
+            AffinityScope::full(),
         );
         assert!(
             s.contains("你是 Aria，non-binary，24 岁"),
@@ -861,6 +901,7 @@ mod tests {
             ReplyStyle::Neutral,
             &[],
             &[],
+            AffinityScope::full(),
         );
         assert!(s.contains("你是 Aria，24 岁，INFP 性格。"), "{s}");
         assert!(!s.contains("⑧"), "no gender → no ⑧: {s}");
@@ -880,6 +921,7 @@ mod tests {
             ReplyStyle::Neutral,
             &[],
             &[],
+            AffinityScope::full(),
         );
         // blank gender must not produce a double comma or a ⑧ rule
         assert!(s.contains("你是 Aria，24 岁，INFP 性格。"), "{s}");
@@ -904,6 +946,7 @@ mod tests {
             ReplyStyle::Neutral,
             &[],
             &[],
+            AffinityScope::full(),
         );
         assert!(s.contains("你所在时区：Asia/Tokyo。"), "{s}");
     }
@@ -924,6 +967,7 @@ mod tests {
             ReplyStyle::Neutral,
             &[],
             &[],
+            AffinityScope::full(),
         );
         let groups = vec![("基础画像".to_string(), vec!["住在上海".to_string()])];
         let b = build_prompt(
@@ -936,6 +980,7 @@ mod tests {
             ReplyStyle::Warm,
             &["想他".to_string()],
             &[],
+            AffinityScope::full(),
         );
         let cut = a.find("【本轮风格】").expect("turn-style header present");
         assert_eq!(
@@ -968,6 +1013,7 @@ mod tests {
             ReplyStyle::Neutral,
             &[],
             &t1,
+            AffinityScope::full(),
         );
         let b = build_prompt(
             &p,
@@ -979,6 +1025,7 @@ mod tests {
             ReplyStyle::Neutral,
             &[],
             &t2,
+            AffinityScope::full(),
         );
         let cut = a.find("【附加指引】").expect("traits header present");
         assert_eq!(
@@ -1092,35 +1139,82 @@ mod tests {
         assert!(p.contains("\"mbti_guess\": \"INFP\""));
     }
 
-    #[test]
-    fn length_rule_tiers_by_intimacy() {
-        use eros_engine_core::affinity::Affinity;
+    fn make_affinity(
+        warmth: f64,
+        trust: f64,
+        intrigue: f64,
+        intimacy: f64,
+        patience: f64,
+        tension: f64,
+    ) -> eros_engine_core::affinity::Affinity {
         let now = chrono::Utc::now();
-        let mut a = Affinity {
-            id: uuid::Uuid::nil(),
-            session_id: uuid::Uuid::nil(),
-            user_id: uuid::Uuid::nil(),
-            instance_id: uuid::Uuid::nil(),
-            warmth: 0.0,
-            trust: 0.0,
-            intrigue: 0.0,
-            intimacy: 0.1,
-            patience: 0.0,
-            tension: 0.0,
+        eros_engine_core::affinity::Affinity {
+            id: uuid::Uuid::new_v4(),
+            session_id: uuid::Uuid::new_v4(),
+            user_id: uuid::Uuid::new_v4(),
+            instance_id: uuid::Uuid::new_v4(),
+            warmth,
+            trust,
+            intrigue,
+            intimacy,
+            patience,
+            tension,
             ghost_streak: 0,
             last_ghost_at: None,
             total_ghosts: 0,
             relationship_label: None,
             created_at: now,
             updated_at: now,
-        };
-        assert!(length_rule(Some(&a)).contains("绝对不超过 2 句"));
-        a.intimacy = 0.4;
-        assert!(length_rule(Some(&a)).contains("1~3 句"));
-        a.intimacy = 0.8;
-        assert!(length_rule(Some(&a)).contains("最多 5 句"));
-        // No affinity → strictest tier.
-        assert!(length_rule(None).contains("绝对不超过 2 句"));
+        }
+    }
+
+    #[test]
+    fn length_rule_uses_scope_composite() {
+        // warmth=0 → warm01=0.5; intimacy=0.5; tension=0.5 → bond=0.5
+        // trust=0.9; intrigue=0.9; patience=0.9 → chemistry=0.9
+        let a = make_affinity(0.0, 0.9, 0.9, 0.5, 0.9, 0.5);
+        assert!(length_rule(Some(&a), AffinityScope::bond()).contains("1~3 句"));
+        assert!(length_rule(Some(&a), AffinityScope::chemistry()).contains("最多 5 句"));
+        assert!(length_rule(Some(&a), AffinityScope::none()).contains("绝对不超过 2 句"));
+        assert!(length_rule(None, AffinityScope::full()).contains("绝对不超过 2 句"));
+    }
+
+    #[test]
+    fn bond_scope_injects_only_bond_axes() {
+        let a = make_affinity(0.8, 0.8, 0.8, 0.8, 0.8, 0.8);
+        let p = build_prompt(
+            &fixture_persona(),
+            &[],
+            &[],
+            Some(&a),
+            &[],
+            "normal",
+            ReplyStyle::Neutral,
+            &[],
+            &[],
+            AffinityScope::bond(),
+        );
+        assert!(p.contains("warmth=") && p.contains("intimacy=") && p.contains("tension="));
+        assert!(!p.contains("trust=") && !p.contains("intrigue=") && !p.contains("patience="));
+    }
+
+    #[test]
+    fn none_scope_omits_affinity_blocks() {
+        let a = make_affinity(0.8, 0.8, 0.8, 0.8, 0.8, 0.8);
+        let p = build_prompt(
+            &fixture_persona(),
+            &[],
+            &[],
+            Some(&a),
+            &[],
+            "normal",
+            ReplyStyle::Neutral,
+            &[],
+            &[],
+            AffinityScope::none(),
+        );
+        assert!(!p.contains("【你对他的内心感受】"));
+        assert!(!p.contains("【你此刻的心情】"));
     }
 
     #[test]

--- a/crates/eros-engine-server/src/routes/companion_stream.rs
+++ b/crates/eros-engine-server/src/routes/companion_stream.rs
@@ -55,6 +55,8 @@ pub enum AffinityScopeDto {
 impl AffinityScopeDto {
     fn resolve(&self) -> AffinityScope {
         match self {
+            // bond (warmth+intimacy+tension) ∪ chemistry (trust+intrigue+patience)
+            // covers all six axes — identical to Full.
             AffinityScopeDto::Named(AffinityScopeName::Full)
             | AffinityScopeDto::Named(AffinityScopeName::BondAndChemistry) => AffinityScope::full(),
             AffinityScopeDto::Named(AffinityScopeName::Bond) => AffinityScope::bond(),
@@ -365,6 +367,14 @@ mod tests {
     fn affinity_scope_dto_resolves_named_and_array() {
         let named: AffinityScopeDto = serde_json::from_str("\"chemistry\"").unwrap();
         assert_eq!(named.resolve(), AffinityScope::chemistry());
+        let bond: AffinityScopeDto = serde_json::from_str("\"bond\"").unwrap();
+        assert_eq!(bond.resolve(), AffinityScope::bond());
+        let full: AffinityScopeDto = serde_json::from_str("\"full\"").unwrap();
+        assert_eq!(full.resolve(), AffinityScope::full());
+        let bac: AffinityScopeDto = serde_json::from_str("\"bond_and_chemistry\"").unwrap();
+        assert_eq!(bac.resolve(), AffinityScope::full());
+        let none: AffinityScopeDto = serde_json::from_str("\"none\"").unwrap();
+        assert!(none.resolve().is_empty());
         let arr: AffinityScopeDto = serde_json::from_str("[\"warmth\",\"trust\"]").unwrap();
         assert_eq!(
             arr.resolve(),

--- a/crates/eros-engine-server/src/routes/companion_stream.rs
+++ b/crates/eros-engine-server/src/routes/companion_stream.rs
@@ -15,6 +15,7 @@ use std::time::Duration;
 use utoipa_axum::{router::OpenApiRouter, routes};
 use uuid::Uuid;
 
+use eros_engine_core::scope::{AffinityAxis, AffinityScope, MemoryScope};
 use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
 use eros_engine_store::persona::PersonaRepo;
 
@@ -34,6 +35,37 @@ const CONCURRENT_STREAMS_PER_USER: u32 = 3;
 const SSE_KEEPALIVE_SECS: u64 = 15;
 
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AffinityScopeName {
+    Full,
+    BondAndChemistry,
+    Bond,
+    Chemistry,
+    None,
+}
+
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
+#[serde(untagged)]
+pub enum AffinityScopeDto {
+    Named(AffinityScopeName),
+    #[schema(value_type = Vec<String>)]
+    Axes(Vec<AffinityAxis>),
+}
+
+impl AffinityScopeDto {
+    fn resolve(&self) -> AffinityScope {
+        match self {
+            AffinityScopeDto::Named(AffinityScopeName::Full)
+            | AffinityScopeDto::Named(AffinityScopeName::BondAndChemistry) => AffinityScope::full(),
+            AffinityScopeDto::Named(AffinityScopeName::Bond) => AffinityScope::bond(),
+            AffinityScopeDto::Named(AffinityScopeName::Chemistry) => AffinityScope::chemistry(),
+            AffinityScopeDto::Named(AffinityScopeName::None) => AffinityScope::none(),
+            AffinityScopeDto::Axes(axes) => AffinityScope::from_axes(axes),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct StreamSendRequest {
     pub content: String,
     pub client_msg_id: String,
@@ -43,6 +75,11 @@ pub struct StreamSendRequest {
     pub audit: Option<LlmAuditDto>,
     #[serde(default)]
     pub tier: Option<String>,
+    #[serde(default)]
+    #[schema(value_type = Option<String>)]
+    pub memory_scope: Option<MemoryScope>,
+    #[serde(default)]
+    pub affinity_scope: Option<AffinityScopeDto>,
 }
 
 /// Pre-stream error body per spec §1.3. Schema-only struct for utoipa;
@@ -227,6 +264,12 @@ pub async fn send_message_stream(
         match outcome {
             UpsertUserOutcome::Inserted { message_id } => {
                 let state_arc = Arc::new(state.clone());
+                let memory_scope = req.memory_scope.unwrap_or_default();
+                let affinity_scope = req
+                    .affinity_scope
+                    .as_ref()
+                    .map(AffinityScopeDto::resolve)
+                    .unwrap_or_default();
                 let user_msg = PersistedUserMessage {
                     user_message_id: message_id,
                     session_id,
@@ -236,6 +279,8 @@ pub async fn send_message_stream(
                     prompt_traits: prompt_traits.clone(),
                     audit: audit.clone(),
                     tier: req.tier.clone(),
+                    memory_scope,
+                    affinity_scope,
                 };
                 Box::pin(run_stream(state_arc, user_msg))
             }
@@ -311,7 +356,23 @@ mod tests {
             prompt_traits: None,
             audit: None,
             tier: tier.map(String::from),
+            memory_scope: None,
+            affinity_scope: None,
         }
+    }
+
+    #[test]
+    fn affinity_scope_dto_resolves_named_and_array() {
+        let named: AffinityScopeDto = serde_json::from_str("\"chemistry\"").unwrap();
+        assert_eq!(named.resolve(), AffinityScope::chemistry());
+        let arr: AffinityScopeDto = serde_json::from_str("[\"warmth\",\"trust\"]").unwrap();
+        assert_eq!(
+            arr.resolve(),
+            AffinityScope::from_axes(&[AffinityAxis::Warmth, AffinityAxis::Trust])
+        );
+        let empty: AffinityScopeDto = serde_json::from_str("[]").unwrap();
+        assert!(empty.resolve().is_empty());
+        assert!(serde_json::from_str::<AffinityScopeDto>("\"bogus\"").is_err());
     }
 
     #[test]

--- a/crates/eros-engine-store/migrations/0018_backfill_human_insights.sql
+++ b/crates/eros-engine-store/migrations/0018_backfill_human_insights.sql
@@ -1,0 +1,42 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- One-time backfill: project existing companion_insights JSONB into the flat
+-- human_insights mirror for users missing a row. Idempotent — only fills gaps
+-- (ON CONFLICT DO NOTHING); write-through keeps fresher rows authoritative.
+-- Mirrors the Rust project_columns() projection (human_insight.rs).
+INSERT INTO engine.human_insights (
+    user_id, city, occupation, mbti_guess, love_values, emotional_needs,
+    life_rhythm, interests, personality_traits, preferred_gender,
+    age_min, age_max, deal_breakers, updated_at
+)
+SELECT
+    ci.user_id,
+    ci.insights->>'city',
+    ci.insights->>'occupation',
+    ci.insights->>'mbti_guess',
+    ci.insights->>'love_values',
+    ci.insights->>'emotional_needs',
+    ci.insights->>'life_rhythm',
+    COALESCE(
+        ARRAY(SELECT jsonb_array_elements_text(ci.insights->'interests')),
+        '{}'
+    ),
+    COALESCE(
+        ARRAY(SELECT jsonb_array_elements_text(ci.insights->'personality_traits')),
+        '{}'
+    ),
+    ci.insights->'matching_preferences'->>'preferred_gender',
+    CASE
+        WHEN jsonb_typeof(ci.insights->'matching_preferences'->'age_range'->0) = 'number'
+        THEN (ci.insights->'matching_preferences'->'age_range'->>0)::int
+    END,
+    CASE
+        WHEN jsonb_typeof(ci.insights->'matching_preferences'->'age_range'->1) = 'number'
+        THEN (ci.insights->'matching_preferences'->'age_range'->>1)::int
+    END,
+    COALESCE(
+        ARRAY(SELECT jsonb_array_elements_text(ci.insights->'matching_preferences'->'deal_breakers')),
+        '{}'
+    ),
+    now()
+FROM engine.companion_insights ci
+ON CONFLICT (user_id) DO NOTHING;

--- a/crates/eros-engine-store/migrations/0018_backfill_human_insights.sql
+++ b/crates/eros-engine-store/migrations/0018_backfill_human_insights.sql
@@ -17,11 +17,13 @@ SELECT
     ci.insights->>'emotional_needs',
     ci.insights->>'life_rhythm',
     COALESCE(
-        ARRAY(SELECT jsonb_array_elements_text(ci.insights->'interests')),
+        CASE WHEN jsonb_typeof(ci.insights->'interests') = 'array'
+             THEN ARRAY(SELECT jsonb_array_elements_text(ci.insights->'interests')) END,
         '{}'
     ),
     COALESCE(
-        ARRAY(SELECT jsonb_array_elements_text(ci.insights->'personality_traits')),
+        CASE WHEN jsonb_typeof(ci.insights->'personality_traits') = 'array'
+             THEN ARRAY(SELECT jsonb_array_elements_text(ci.insights->'personality_traits')) END,
         '{}'
     ),
     ci.insights->'matching_preferences'->>'preferred_gender',
@@ -34,7 +36,8 @@ SELECT
         THEN (ci.insights->'matching_preferences'->'age_range'->>1)::int
     END,
     COALESCE(
-        ARRAY(SELECT jsonb_array_elements_text(ci.insights->'matching_preferences'->'deal_breakers')),
+        CASE WHEN jsonb_typeof(ci.insights->'matching_preferences'->'deal_breakers') = 'array'
+             THEN ARRAY(SELECT jsonb_array_elements_text(ci.insights->'matching_preferences'->'deal_breakers')) END,
         '{}'
     ),
     now()

--- a/crates/eros-engine-store/src/human_insight.rs
+++ b/crates/eros-engine-store/src/human_insight.rs
@@ -317,6 +317,10 @@ mod tests {
         assert!(repo.load(Uuid::new_v4()).await.unwrap().is_none());
     }
 
+    /// The canonical backfill SQL, embedded from the migration file so the test
+    /// always exercises the real statement (no drift between test and migration).
+    const BACKFILL_SQL: &str = include_str!("../migrations/0018_backfill_human_insights.sql");
+
     #[sqlx::test(migrations = "./migrations")]
     async fn backfill_sql_projects_companion_insights(pool: PgPool) {
         let user_id = Uuid::new_v4();
@@ -334,30 +338,8 @@ mod tests {
             .await
             .unwrap();
 
-        // Run the backfill statement (same body as 0018_backfill_human_insights.sql).
-        sqlx::query(
-            "INSERT INTO engine.human_insights ( \
-                user_id, city, occupation, mbti_guess, love_values, emotional_needs, \
-                life_rhythm, interests, personality_traits, preferred_gender, \
-                age_min, age_max, deal_breakers, updated_at) \
-             SELECT ci.user_id, ci.insights->>'city', ci.insights->>'occupation', \
-                ci.insights->>'mbti_guess', ci.insights->>'love_values', \
-                ci.insights->>'emotional_needs', ci.insights->>'life_rhythm', \
-                COALESCE(ARRAY(SELECT jsonb_array_elements_text(ci.insights->'interests')), '{}'), \
-                COALESCE(ARRAY(SELECT jsonb_array_elements_text(ci.insights->'personality_traits')), '{}'), \
-                ci.insights->'matching_preferences'->>'preferred_gender', \
-                CASE WHEN jsonb_typeof(ci.insights->'matching_preferences'->'age_range'->0) = 'number' \
-                     THEN (ci.insights->'matching_preferences'->'age_range'->>0)::int END, \
-                CASE WHEN jsonb_typeof(ci.insights->'matching_preferences'->'age_range'->1) = 'number' \
-                     THEN (ci.insights->'matching_preferences'->'age_range'->>1)::int END, \
-                COALESCE(ARRAY(SELECT jsonb_array_elements_text(ci.insights->'matching_preferences'->'deal_breakers')), '{}'), \
-                now() \
-             FROM engine.companion_insights ci \
-             ON CONFLICT (user_id) DO NOTHING",
-        )
-        .execute(&pool)
-        .await
-        .unwrap();
+        // Re-run the canonical migration (idempotent) now that a row exists.
+        sqlx::query(BACKFILL_SQL).execute(&pool).await.unwrap();
 
         let row = HumanInsightRepo { pool: &pool }
             .load(user_id)
@@ -374,31 +356,26 @@ mod tests {
     }
 
     #[sqlx::test(migrations = "./migrations")]
-    async fn backfill_sql_tolerates_malformed_age_range(pool: PgPool) {
+    async fn backfill_sql_tolerates_malformed_fields(pool: PgPool) {
         let user_id = Uuid::new_v4();
+        // Non-array scalars where arrays are expected (would crash
+        // jsonb_array_elements_text without the jsonb_typeof guards), plus a
+        // non-array age_range — all degrade to NULL / empty, no abort.
         sqlx::query("INSERT INTO engine.companion_insights (user_id, insights) VALUES ($1, $2)")
             .bind(user_id)
             .bind(serde_json::json!({
                 "city": "深圳",
-                "matching_preferences": { "age_range": "not-an-array" }
+                "interests": "游泳、读书",
+                "personality_traits": "开朗",
+                "matching_preferences": { "age_range": "not-an-array", "deal_breakers": "抽烟" }
             }))
             .execute(&pool)
             .await
             .unwrap();
-        // Same backfill statement — must NOT error on the malformed age_range.
-        sqlx::query(
-            "INSERT INTO engine.human_insights (user_id, city, age_min, age_max, updated_at) \
-             SELECT ci.user_id, ci.insights->>'city', \
-                CASE WHEN jsonb_typeof(ci.insights->'matching_preferences'->'age_range'->0) = 'number' \
-                     THEN (ci.insights->'matching_preferences'->'age_range'->>0)::int END, \
-                CASE WHEN jsonb_typeof(ci.insights->'matching_preferences'->'age_range'->1) = 'number' \
-                     THEN (ci.insights->'matching_preferences'->'age_range'->>1)::int END, \
-                now() \
-             FROM engine.companion_insights ci ON CONFLICT (user_id) DO NOTHING",
-        )
-        .execute(&pool)
-        .await
-        .unwrap();
+
+        // The canonical migration must NOT error on these malformed fields.
+        sqlx::query(BACKFILL_SQL).execute(&pool).await.unwrap();
+
         let row = HumanInsightRepo { pool: &pool }
             .load(user_id)
             .await
@@ -407,5 +384,8 @@ mod tests {
         assert_eq!(row.city.as_deref(), Some("深圳"));
         assert_eq!(row.age_min, None);
         assert_eq!(row.age_max, None);
+        assert!(row.interests.is_empty());
+        assert!(row.personality_traits.is_empty());
+        assert!(row.deal_breakers.is_empty());
     }
 }

--- a/crates/eros-engine-store/src/human_insight.rs
+++ b/crates/eros-engine-store/src/human_insight.rs
@@ -316,4 +316,96 @@ mod tests {
         let repo = HumanInsightRepo { pool: &pool };
         assert!(repo.load(Uuid::new_v4()).await.unwrap().is_none());
     }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn backfill_sql_projects_companion_insights(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        // Seed a companion_insights row directly (simulating a legacy user with
+        // no human_insights mirror yet).
+        sqlx::query("INSERT INTO engine.companion_insights (user_id, insights) VALUES ($1, $2)")
+            .bind(user_id)
+            .bind(serde_json::json!({
+                "city": "广州",
+                "interests": ["游泳", "读书"],
+                "personality_traits": ["开朗"],
+                "matching_preferences": { "age_range": [22, 30], "preferred_gender": "female", "deal_breakers": ["抽烟"] }
+            }))
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        // Run the backfill statement (same body as 0018_backfill_human_insights.sql).
+        sqlx::query(
+            "INSERT INTO engine.human_insights ( \
+                user_id, city, occupation, mbti_guess, love_values, emotional_needs, \
+                life_rhythm, interests, personality_traits, preferred_gender, \
+                age_min, age_max, deal_breakers, updated_at) \
+             SELECT ci.user_id, ci.insights->>'city', ci.insights->>'occupation', \
+                ci.insights->>'mbti_guess', ci.insights->>'love_values', \
+                ci.insights->>'emotional_needs', ci.insights->>'life_rhythm', \
+                COALESCE(ARRAY(SELECT jsonb_array_elements_text(ci.insights->'interests')), '{}'), \
+                COALESCE(ARRAY(SELECT jsonb_array_elements_text(ci.insights->'personality_traits')), '{}'), \
+                ci.insights->'matching_preferences'->>'preferred_gender', \
+                CASE WHEN jsonb_typeof(ci.insights->'matching_preferences'->'age_range'->0) = 'number' \
+                     THEN (ci.insights->'matching_preferences'->'age_range'->>0)::int END, \
+                CASE WHEN jsonb_typeof(ci.insights->'matching_preferences'->'age_range'->1) = 'number' \
+                     THEN (ci.insights->'matching_preferences'->'age_range'->>1)::int END, \
+                COALESCE(ARRAY(SELECT jsonb_array_elements_text(ci.insights->'matching_preferences'->'deal_breakers')), '{}'), \
+                now() \
+             FROM engine.companion_insights ci \
+             ON CONFLICT (user_id) DO NOTHING",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let row = HumanInsightRepo { pool: &pool }
+            .load(user_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.city.as_deref(), Some("广州"));
+        assert_eq!(row.interests, vec!["游泳".to_string(), "读书".to_string()]);
+        assert_eq!(row.personality_traits, vec!["开朗".to_string()]);
+        assert_eq!(row.age_min, Some(22));
+        assert_eq!(row.age_max, Some(30));
+        assert_eq!(row.preferred_gender.as_deref(), Some("female"));
+        assert_eq!(row.deal_breakers, vec!["抽烟".to_string()]);
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn backfill_sql_tolerates_malformed_age_range(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        sqlx::query("INSERT INTO engine.companion_insights (user_id, insights) VALUES ($1, $2)")
+            .bind(user_id)
+            .bind(serde_json::json!({
+                "city": "深圳",
+                "matching_preferences": { "age_range": "not-an-array" }
+            }))
+            .execute(&pool)
+            .await
+            .unwrap();
+        // Same backfill statement — must NOT error on the malformed age_range.
+        sqlx::query(
+            "INSERT INTO engine.human_insights (user_id, city, age_min, age_max, updated_at) \
+             SELECT ci.user_id, ci.insights->>'city', \
+                CASE WHEN jsonb_typeof(ci.insights->'matching_preferences'->'age_range'->0) = 'number' \
+                     THEN (ci.insights->'matching_preferences'->'age_range'->>0)::int END, \
+                CASE WHEN jsonb_typeof(ci.insights->'matching_preferences'->'age_range'->1) = 'number' \
+                     THEN (ci.insights->'matching_preferences'->'age_range'->>1)::int END, \
+                now() \
+             FROM engine.companion_insights ci ON CONFLICT (user_id) DO NOTHING",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        let row = HumanInsightRepo { pool: &pool }
+            .load(user_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.city.as_deref(), Some("深圳"));
+        assert_eq!(row.age_min, None);
+        assert_eq!(row.age_max, None);
+    }
 }

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -162,6 +162,52 @@ curl -N -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/js
 Limits: ≤ 8 entries, `tag` matches `[a-z0-9_]{1,32}`, `text` ≤ 2000 chars
 (non-blank). Violations return `400 BadRequest` as a pre-stream error.
 
+**Optional: memory injection scope.** The body may include a `memory_scope`
+string to control which memory layers are injected into the prompt. Accepted
+values:
+
+| Value | Injected |
+|-------|----------|
+| `full` | Full user profile (including intimate fields) + relationship memory |
+| `neutral_and_relationship` | Neutral profile (city/occupation/MBTI only) + relationship memory **(default)** |
+| `relationship_only` | Relationship memory only; no profile |
+| `neutral_only` | Neutral profile only; no relationship memory |
+| `insights_only` | Full user profile only (intimate fields included); no relationship memory |
+| `none` | No memory injection |
+
+> **Important (#40 mitigation):** The default `neutral_and_relationship` is
+> intentionally narrower than the pre-#40 behavior (which injected everything).
+> Omitting `memory_scope` is **not** equivalent to the old behavior — it
+> applies the narrowed default. Use `full` explicitly if you need the
+> full-injection behavior.
+
+**Optional: affinity injection scope.** The body may include an
+`affinity_scope` value to control which of the six affinity axes are injected
+into the prompt. Accepted values:
+
+- Named presets: `"bond"` **(default)** — warmth + intimacy + tension;
+  `"chemistry"` — trust + intrigue + patience; `"bond_and_chemistry"` / `"full"` — all six axes; `"none"` — no affinity injection.
+- Axis array: any subset of `["warmth", "trust", "intrigue", "intimacy", "patience", "tension"]`.
+
+> **Important (#40 mitigation):** The default `bond` (3 axes) is intentionally
+> narrower than the pre-#40 behavior (which injected all six axes). Omitting
+> `affinity_scope` is **not** equivalent to the old behavior. Use
+> `"bond_and_chemistry"` or `"full"` explicitly if you need all axes.
+
+Example using both fields:
+
+```bash
+curl -N -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json" \
+  -H "Accept: text/event-stream" \
+  -d '{
+        "content": "hi",
+        "client_msg_id": "01J3333333333333333333333A",
+        "memory_scope": "full",
+        "affinity_scope": "bond_and_chemistry"
+      }' \
+  http://localhost:8080/comp/chat/<session_id>/message/stream
+```
+
 **Optional: OpenRouter audit passthrough.** The body may include an
 `audit` object that rides directly to OpenRouter as wire-level `user` /
 `session_id` / `metadata` — see [llm-audit.md](llm-audit.md). Example:

--- a/docs/api-reference.zh.md
+++ b/docs/api-reference.zh.md
@@ -157,6 +157,47 @@ curl -N -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/js
 限制：最多 8 条，`tag` 满足 `[a-z0-9_]{1,32}`，`text` ≤ 2000 字符
 （trim 后非空）。违反作为 pre-stream 错误返回 `400 BadRequest`。
 
+**可选：记忆注入范围。** 请求体可附加 `memory_scope` 字符串，控制哪些
+记忆层会被注入到 prompt 中。接受值：
+
+| 值 | 注入内容 |
+|-------|----------|
+| `full` | 完整用户画像（含亲密字段）+ 关系记忆 |
+| `neutral_and_relationship` | 中性画像（仅城市/职业/MBTI）+ 关系记忆 **（默认）** |
+| `relationship_only` | 仅关系记忆；不含画像 |
+| `neutral_only` | 仅中性画像；不含关系记忆 |
+| `insights_only` | 仅完整用户画像（含亲密字段）；不含关系记忆 |
+| `none` | 不注入任何记忆 |
+
+> **重要（#40 缓解措施）：** 默认的 `neutral_and_relationship` 有意比
+> #40 之前的行为更窄（旧行为注入全部内容）。**省略 `memory_scope` 并不
+> 等同于旧行为**——会应用收窄后的默认值。如需完整注入，请显式指定 `full`。
+
+**可选：好感度注入范围。** 请求体可附加 `affinity_scope` 值，控制六个
+好感度轴中哪些会被注入到 prompt 中。接受值：
+
+- 具名预设：`"bond"` **（默认）** — warmth + intimacy + tension；
+  `"chemistry"` — trust + intrigue + patience；`"bond_and_chemistry"` / `"full"` — 全部六轴；`"none"` — 不注入好感度。
+- 轴数组：`["warmth", "trust", "intrigue", "intimacy", "patience", "tension"]` 的任意子集。
+
+> **重要（#40 缓解措施）：** 默认的 `bond`（3 轴）有意比 #40 之前的行为
+> 更窄（旧行为注入全部六轴）。**省略 `affinity_scope` 并不等同于旧行为**。
+> 如需全轴注入，请显式指定 `"bond_and_chemistry"` 或 `"full"`。
+
+同时使用两个字段的示例：
+
+```bash
+curl -N -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json" \
+  -H "Accept: text/event-stream" \
+  -d '{
+        "content": "hi",
+        "client_msg_id": "01J3333333333333333333333A",
+        "memory_scope": "full",
+        "affinity_scope": "bond_and_chemistry"
+      }' \
+  http://localhost:8080/comp/chat/<session_id>/message/stream
+```
+
 **可选：OpenRouter audit 透传。** 请求体可附加 `audit` 对象，
 原样作为 wire 级别的 `user` / `session_id` / `metadata` 发送给
 OpenRouter —— 详见 [llm-audit.zh.md](llm-audit.zh.md)。示例：

--- a/docs/superpowers/specs/2026-05-24-memory-affinity-scope-flags-design.md
+++ b/docs/superpowers/specs/2026-05-24-memory-affinity-scope-flags-design.md
@@ -1,0 +1,403 @@
+# Per-Request `memory_scope` & `affinity_scope` Flags — Design
+
+**Status:** Draft for review
+**Date:** 2026-05-24
+**Owner:** @enriquephl
+**Issue:** #40 (cross-companion bleed of intimate/NSFW user insights)
+
+## Problem
+
+Issue #40: a male persona surfaces a user's NSFW/intimate preferences that were
+only ever established in chats with *other* personas. Two engine-level causes:
+
+1. **`companion_insights` ("基础画像") is user-global** and injected into every
+   persona's prompt — its intimate fields (感情观/情感需求/兴趣) bleed across
+   personas, every turn, regardless of relevance.
+2. **The `companion_memories` profile layer (`instance_id IS NULL`) is also
+   user-global** and recalled into every persona's prompt. Same bleed, just
+   query-relevance gated rather than dumped every turn. (Not named in #40, but
+   the same class of leak.)
+
+This spec implements the **caller-driven interim** from the issue thread: the
+calling app already knows the user's gender/orientation and the persona's gender,
+so it decides per request how much memory and which affinity axes to inject, and
+tells the engine via two optional flags. The engine treats them as opaque inputs
+— no engine↔consumer schema coupling.
+
+## Non-Goals
+
+- **No `user_orientation` field / orientation 铁律.** The complementary
+  deterministic romance-gating guardrail from #40 is a separate change.
+- **No sensitivity tagging of memories.** The precise end-state (tag each
+  insight/memory as neutral vs intimate, route intimate to per-instance scope)
+  is deferred. This flag is the coarse interim; `affinity_scope` + the
+  neutral-default mitigate the worst bleed now.
+- **No change to the post-process pipeline.** Regardless of either flag, after
+  every turn the engine still extracts insights, writes both memory layers, and
+  evaluates + persists all six affinity axes exactly as today. **These flags gate
+  prompt *injection* only — never *write* behavior.**
+- **No new persistence.** Both flags are re-sent per request; nothing is stored.
+
+## Compatibility — IMPORTANT: defaults change behavior
+
+Unlike `prompt_traits`, **omitting these fields does NOT preserve today's
+output.** That is intentional — the new defaults are the #40 mitigation:
+
+| Flag | Omitted-default | vs. today |
+|------|-----------------|-----------|
+| `memory_scope` | `neutral_and_relationship` | drops intimate insights + global memory layer from the default prompt |
+| `affinity_scope` | `bond` | injects 3 axes (warmth/intimacy/tension) instead of all 6 |
+
+Byte-for-byte parity with today is reachable explicitly: `memory_scope:"full"`
+**and** `affinity_scope:"bond_and_chemistry"` (≡ `"full"`) together reproduce the
+current system prompt. A golden test pins this (see Tests).
+
+## Current injection map (baseline)
+
+Memory-related prompt sections built in `build_prompt` (`prompt.rs:447-478`):
+
+- **① 【你对他的了解（通用画像）】** (`prompt.rs:458`) = `profile_groups`, which
+  blends two **user-global** sources (`handlers.rs:358-364`):
+  - `基础画像` — `companion_insights` bullets (`load_insight_bullets`,
+    `handlers.rs:281-292`; rendered by `insights_to_bullets`,
+    `handlers.rs:298-336`).
+  - profile-layer memory recalls — `companion_memories WHERE instance_id IS NULL`
+    (`handlers.rs:190-202`).
+- **② 【你们之间的事（只有你和他知道）】** (`prompt.rs:460`) = `relationship_facts`
+  = `companion_memories WHERE instance_id = <persona>` (`handlers.rs:192,204`).
+  Instance-scoped; no bleed.
+
+Affinity-related injection:
+
+- **③ 【你此刻的心情】** attitude directives — `affinity_to_attitude_prompt`
+  (`prompt.rs:113-163`), per-axis thresholds.
+- **④ 【你对他的内心感受】** raw six-axis numbers (`prompt.rs:409-417`).
+- **⑤ 铁律① reply length** — `length_rule` (`prompt.rs:98-110`), keyed on
+  `intimacy`.
+
+## Building blocks & taxonomy
+
+Authoritative definitions agreed for this spec:
+
+| Block | Meaning | Source (read path) |
+|-------|---------|--------------------|
+| **W**  | full profile facts | `human_insights` row, all 8 rendered fields |
+| **W'** | neutral profile facts | `human_insights` row minus `love_values`, `emotional_needs`, `interests` → `city`, `occupation`, `mbti_guess`, `life_rhythm`, `personality_traits` |
+| **X**  | global memory recall | `companion_memories` `instance_id IS NULL` |
+| **Y**  | relationship memory recall | `companion_memories` `instance_id = <persona>` |
+
+`U` (section ①) = W/W' + X; `V` (section ②) = Y.
+
+**Read-path change:** W/W' are read from the flat `human_insights` table
+(`HumanInsightRepo::load`, `human_insight.rs:165`) — direct column SELECT, no
+JSONB flattening. **Write path is unchanged:** post-process still writes the
+authoritative `companion_insights` first, then mirrors to `human_insights` via
+`project_from_insights` (`human_insight.rs:120`). The matching-only columns
+(`preferred_gender`, `age_min/max`, `deal_breakers`) are **never** rendered into
+the prompt.
+
+The intimate fields {`love_values`, `emotional_needs`, `interests`} are only ever
+injected via W (i.e. `full` / `insights_only`).
+
+## `memory_scope` design
+
+### Wire values & mapping
+
+```jsonc
+"memory_scope": "full" | "neutral_and_relationship" | "relationship_only"
+              | "neutral_only" | "insights_only" | "none"   // optional
+```
+
+| scope | 基础画像 | X (global mem) | Y (relationship mem) | U | V |
+|-------|----------|----------------|----------------------|------|-----|
+| `full` | W full | on | on | W+X | Y |
+| `neutral_and_relationship` *(default)* | W' neutral | on | on | W'+X | Y |
+| `relationship_only` | off | off | on | ∅ | Y |
+| `neutral_only` | W' neutral | off | off | W' | ∅ |
+| `insights_only` | W full | off | off | W | ∅ |
+| `none` | off | off | off | ∅ | ∅ |
+
+`insights_only` can still bleed (full user-global insights, no memory) — kept for
+enum completeness; callers should prefer the others.
+
+Resolution helper (core): `MemoryScope → (InsightMode, x_on, y_on)` where
+`InsightMode ∈ { Off, Neutral, Full }`.
+
+### Recall short-circuit (efficiency, not semantics)
+
+Across all six scopes, **X-on ⟹ Y-on**, so:
+
+- `x_on || y_on == false` (`neutral_only`, `insights_only`, `none`) → skip the
+  embedding call **and** all vector searches in `recall_memory`.
+- `x_off && y_on` (`relationship_only`) → compute embedding, run **only** the
+  relationship-layer search; skip both profile-layer searches.
+- `x_on` (`full`, `neutral_and_relationship`) → full recall (current behavior).
+
+The `human_insights` read is independent, gated by `InsightMode`; `Off` skips it.
+
+## `affinity_scope` design
+
+### Wire values
+
+```jsonc
+"affinity_scope": "full" | "bond_and_chemistry" | "bond" | "chemistry" | "none"
+                | ["warmth","trust", ...]            // optional
+```
+
+Axis names are the `Affinity` struct fields (`eros-engine-core/src/affinity.rs`):
+`warmth, trust, intrigue, intimacy, patience, tension`.
+
+| named scope | axis set |
+|-------------|----------|
+| `bond` *(default)* | `{warmth, intimacy, tension}` |
+| `chemistry` | `{trust, intrigue, patience}` |
+| `full` ≡ `bond_and_chemistry` | all six |
+| `none` | `{}` |
+| array | the listed axes (subset of the six) |
+
+Resolution helper (core): `AffinityScope → AxisSet`.
+
+### What the axis set gates
+
+The resolved axis set governs **③ + ④** per-axis:
+
+- **③ attitude directives** (`affinity_to_attitude_prompt`): for an axis not in
+  the set, its directive block is skipped entirely. Empty set → no
+  【你此刻的心情】 section.
+- **④ raw numbers**: print only in-set axes. Empty set → omit the
+  【你对他的内心感受】 block entirely.
+
+### ⑤ `length_rule` — composite-driven
+
+`length_rule` is recomputed from a composite score selected by the axis set.
+Composite formula (all six raw values are always available — the scope gates
+injection, not the affinity record):
+
+```
+warm01    = clamp01((warmth + 1) / 2)
+bond      = clamp01((warm01 + intimacy + tension) / 3)
+chemistry = clamp01((trust + intrigue + patience) / 3)
+
+bond_active = axisset ∩ {warmth, intimacy, tension} ≠ ∅
+chem_active = axisset ∩ {trust, intrigue, patience} ≠ ∅
+
+score =
+  (bond_active && chem_active) → (bond + chemistry) / 2
+  (bond_active)                → bond
+  (chem_active)                → chemistry
+  (neither)                    → DEFAULT (no score)
+```
+
+This reduces exactly to the named cases (`full`→avg, `bond`→bond,
+`chemistry`→chemistry, `none`→default) and generalizes the array form.
+
+Tier thresholds reuse the existing `0.25 / 0.55` (the composite is also in
+`[0,1]`; thresholds tunable, comment to say so). The "DEFAULT (no score)" branch
+maps to the current `affinity = None` tier — strictest: `刚认识，1~2 句，≤40 字`.
+So `affinity_scope:"none"` and "no affinity data yet" share the strictest tier.
+
+## Type plumbing
+
+### `eros-engine-core/src/types.rs`
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryScope {
+    Full,
+    #[default]
+    NeutralAndRelationship,
+    RelationshipOnly,
+    NeutralOnly,
+    InsightsOnly,
+    None,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AffinityAxis { Warmth, Trust, Intrigue, Intimacy, Patience, Tension }
+
+// Resolved axis set carried on the event (route resolves DTO → this).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AffinityScope { /* 6-bool mask or EnumSet */ }
+```
+
+- `MemoryScope::resolve() -> (InsightMode, bool /*x*/, bool /*y*/)`.
+- `AffinityScope::contains(axis)`, `::is_empty()`, and the composite helper for
+  length live here (pure, unit-tested without a DB).
+- Default for `AffinityScope` when the field is omitted = `bond` triad.
+
+Extend `Event::UserMessage` (mirrors the existing `tier`/`audit` pattern,
+`types.rs:38-57`):
+
+```rust
+UserMessage {
+    content: String,
+    message_id: Uuid,
+    #[serde(default)] prompt_traits: Vec<PromptTrait>,
+    #[serde(default)] audit: Option<LlmAudit>,
+    #[serde(default)] tier: Option<String>,
+    #[serde(default)] memory_scope: MemoryScope,      // NEW (defaults via Default)
+    #[serde(default)] affinity_scope: AffinityScope,  // NEW (defaults to bond)
+}
+```
+
+### `eros-engine-server/src/routes/companion_stream.rs`
+
+`StreamSendRequest` (`:36-46`) gains two optional fields + a DTO for the
+string|array affinity form:
+
+```rust
+#[derive(Deserialize, ToSchema)]
+#[serde(untagged)]
+pub enum AffinityScopeDto {
+    Named(AffinityScopeName),     // full|bond_and_chemistry|bond|chemistry|none
+    Axes(Vec<AffinityAxis>),      // ["warmth", ...]
+}
+
+pub struct StreamSendRequest {
+    // ... existing ...
+    #[serde(default)] pub memory_scope: Option<MemoryScope>,
+    #[serde(default)] pub affinity_scope: Option<AffinityScopeDto>,
+}
+```
+
+Handler (`:139-240`): resolve `None → default`; convert `AffinityScopeDto →
+AffinityScope` (expand named → triads; `[]` → empty set ≡ `none`). Validation is
+deserialize-driven:
+
+| input | result |
+|-------|--------|
+| unknown `memory_scope` string | `400 BadRequest` (serde) |
+| unknown axis name in array | `400 BadRequest` (serde, untagged fails both arms) |
+| unknown `affinity_scope` string | `400 BadRequest` |
+| `affinity_scope: []` | empty set ≡ `none` |
+| field omitted | per-flag default |
+
+### `eros-engine-server/src/pipeline/stream.rs`
+
+`PersistedUserMessage` (`:245-254`) gains `memory_scope: MemoryScope` and
+`affinity_scope: AffinityScope`. `run_stream` (`:313-324`) forwards both into
+`Event::UserMessage`. The three test construction sites (`:735,857,931`) get the
+defaults.
+
+### `eros-engine-server/src/pipeline/handlers.rs`
+
+`build_reply_request` (`:342-364`):
+
+```rust
+let (mem_mode, x_on, y_on) = memory_scope.resolve();
+
+let (mut profile_groups, relationship_facts) =
+    recall_memory_gated(state, user_id, instance_id, query_text, x_on, y_on).await;
+    // both off → returns (vec![], vec![]) without embedding/search
+
+if mem_mode != InsightMode::Off {
+    let bullets = load_human_insight_bullets(&state.pool, user_id, mem_mode).await;
+    if !bullets.is_empty() { profile_groups.insert(0, ("基础画像".into(), bullets)); }
+}
+// ... build_prompt(..., affinity_scope) ...
+```
+
+- New `load_human_insight_bullets(pool, user_id, mode)` reads
+  `HumanInsightRepo::load` and renders bullets from columns, **replicating
+  `insights_to_bullets`' label/order/trim/empty-skip logic** (`Full` = 8 fields;
+  `Neutral` = drop the 3 intimate fields). Order pinned to match today:
+  城市, 职业, MBTI, 感情观, 兴趣, 情感需求, 作息, 性格特质.
+- `recall_memory` / `recall_memory_with_embedding` gain `x_on`/`y_on` (or a new
+  gated wrapper) implementing the short-circuit above.
+
+### `eros-engine-server/src/prompt.rs`
+
+`build_prompt` gains an `affinity_scope: AffinityScope` parameter (already
+`#[allow(clippy::too_many_arguments)]`). It threads to:
+
+- `affinity_to_attitude_prompt(a, scope)` — skip out-of-scope axis directives;
+  empty → "".
+- raw-values block — filter to in-scope axes; empty → "".
+- `length_rule(affinity, scope)` — composite score per above.
+
+## Observability
+
+In the stream pipeline's existing tracing, append:
+`memory_scope=<...> affinity_axes=<n>` (counts/enum only; never insight or memory
+content).
+
+## OpenAPI
+
+`StreamSendRequest`, `MemoryScope`, `AffinityScopeDto`, `AffinityAxis` derive
+`ToSchema`. The repo has a CI snapshot drift check — regenerate the snapshot or
+CI fails.
+
+## Tests
+
+### Core (`eros-engine-core`, unit, no DB)
+
+- `memory_scope_resolves_to_expected_switches` — table test of all 6 →
+  `(InsightMode, x, y)`.
+- `affinity_scope_named_expands_to_triads` — bond/chemistry/full/none + array.
+- `affinity_scope_defaults_to_bond`; `memory_scope_defaults_to_neutral_and_relationship`.
+- `length_composite_matches_named_cases` — full→avg, bond→bond, chemistry→
+  chemistry, none→default; plus an array case activating both.
+- `clamp01_and_warm01_mapping`.
+
+### Prompt (`prompt.rs`, unit)
+
+- `full_scope_matches_current_output` — golden: `memory_scope=full` +
+  `affinity_scope=bond_and_chemistry` reproduces today's prompt byte-for-byte
+  (note: W comes from a `human_insights`-shaped fixture identical to the
+  `companion_insights` fixture).
+- `neutral_only_drops_intimate_fields` — 感情观/情感需求/兴趣 absent; 城市/职业
+  present.
+- `attitude_and_values_filter_by_axis_set` — bond shows only warmth/intimacy/
+  tension in ③ and ④; `none` omits both blocks.
+- `length_rule_uses_chemistry_composite_when_scoped`.
+
+### Routes / pipeline (`sqlx::test`)
+
+- `defaults_when_flags_omitted` — body without flags →
+  neutral_and_relationship + bond (assert intimate insight + global-memory blocks
+  absent, neutral facts + relationship present).
+- `relationship_only_skips_profile_and_insights`.
+- `none_skips_all_memory_and_affinity_blocks`.
+- `invalid_memory_scope_400`; `invalid_affinity_axis_400`;
+  `empty_affinity_array_equals_none`.
+- `flags_do_not_change_post_process` — after a turn with `memory_scope:"none"`,
+  insights + both memory layers + all six affinity axes are still written.
+
+## Risks / Open Questions
+
+1. **`human_insights` backfill.** The read path now depends on every active user
+   having a mirrored `human_insights` row. The table was added 2026-05-21; users
+   who haven't chatted since may lack a row → empty 基础画像 until their next
+   post-process. **Mitigation (recommended):** one-time backfill migration
+   projecting all `companion_insights` → `human_insights`. **Alternative:**
+   fallback to `companion_insights` when the row is missing. Decide before ship.
+2. **Byte-identical `full` via `human_insights`.** Switching W's source could
+   diverge from today if the projection normalizes a value differently
+   (whitespace, empty handling). Mitigated by replicating `insights_to_bullets`'
+   trim/skip logic in the new renderer + the golden test. If divergence is found,
+   reconsider sourcing W from `companion_insights` while keeping W' from
+   `human_insights`.
+3. **Default behavior change is a prod-visible shift.** Existing callers that
+   send neither flag will immediately get the narrowed default. This is the
+   intended #40 mitigation, but coordinate the rollout with eros-chat so the
+   change is expected.
+4. **Length thresholds reused as-is.** `0.25 / 0.55` were tuned for raw
+   `intimacy`; the composite distribution differs slightly. Shipped as tunable;
+   revisit if reply lengths feel off.
+5. **`affinity_scope:"none"` length.** Falls to the strictest tier (≤40 字). If a
+   caller wants "no affinity expressed but normal length," that's not
+   expressible — acceptable for the interim.
+
+## Acceptance Criteria
+
+- [ ] `cargo test -p eros-engine-server -p eros-engine-core` green
+- [ ] OpenAPI snapshot regenerated; CI drift check green
+- [ ] `full` + `bond_and_chemistry` reproduces today's prompt byte-for-byte
+- [ ] Omitted flags → `neutral_and_relationship` + `bond` (verified: no intimate
+      insight block, no global-memory block, neutral facts + relationship + 3-axis
+      affinity present)
+- [ ] Post-process writes (insights, both memory layers, all six affinity axes)
+      unchanged under every scope, including `none`
+- [ ] `human_insights` backfill decision made and (if chosen) migration landed

--- a/docs/superpowers/specs/2026-05-24-memory-affinity-scope-flags-design.md
+++ b/docs/superpowers/specs/2026-05-24-memory-affinity-scope-flags-design.md
@@ -45,7 +45,7 @@ output.** That is intentional — the new defaults are the #40 mitigation:
 
 | Flag | Omitted-default | vs. today |
 |------|-----------------|-----------|
-| `memory_scope` | `neutral_and_relationship` | drops intimate insights + global memory layer from the default prompt |
+| `memory_scope` | `neutral_and_relationship` | drops the intimate insight *fields* (W→W') from the default prompt; global memory recall (X) stays ON — use `relationship_only` to also stop global cross-persona bleed |
 | `affinity_scope` | `bond` | injects 3 axes (warmth/intimacy/tension) instead of all 6 |
 
 Byte-for-byte parity with today is reachable explicitly: `memory_scope:"full"`


### PR DESCRIPTION
## Summary

Caller-driven interim fix for #40 (cross-companion bleed of intimate/NSFW user insights). Adds two optional per-request flags to `POST /comp/chat/{session_id}/message/stream` that gate prompt **injection only** — the post-process pipeline (insight extraction, memory writes, six-axis affinity eval) is untouched.

- **`memory_scope`** (default `neutral_and_relationship`): resolves to an insight mode + global(X)/relationship(Y) memory switches. The 基础画像 block is now read from the flat `human_insights` mirror; neutral mode drops the intimate fields (love_values / emotional_needs / interests). Recall short-circuits (skips embedding + searches) when layers are off; the hot-path 3-way `tokio::join!` is preserved.
- **`affinity_scope`** (default `bond`): resolves to an axis set that gates the 【你此刻的心情】 attitude directives, the 【你对他的内心感受】 raw six-axis numbers, and a bond/chemistry **composite** reply-length rule. Accepts named presets or an explicit axis array.
- **`0018` backfill migration**: projects existing `companion_insights` → `human_insights` (`ON CONFLICT DO NOTHING`), guarded against non-array JSONB so a malformed legacy row can't abort the migration.

**Important:** the defaults intentionally *narrow* today's injection (this is the #40 mitigation) — omitting the fields is **not** equivalent to pre-#40 behavior. Byte-for-byte parity is reachable explicitly via `memory_scope:"full"` + `affinity_scope:"bond_and_chemistry"`. See `docs/superpowers/specs/2026-05-24-memory-affinity-scope-flags-design.md`.

Gift path is unchanged (still companion_insights + both memory layers + full six-axis affinity).

## Test plan

- [ ] CI green: fmt, `clippy -D warnings`, workspace tests, OpenAPI snapshot drift
- [x] 362 tests pass locally (scope unit tests, byte-identical parity test, recall gating, backfill projection + malformed-field tolerance, axis-gating)
- [x] `full` + `bond_and_chemistry` reproduces the pre-#40 system prompt (golden + parity tests)
- [x] OpenAPI snapshot regenerated and drift-clean
- [ ] Post-merge: confirm `0018` backfill ran at deploy (legacy users get 基础画像 from human_insights)

🤖 Generated with [Claude Code](https://claude.com/claude-code)