### PR TITLE
feat: model_name_display_override + remove dead sync pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,18 +41,25 @@ Embeddings use Voyage `voyage-3-lite` with 512-dimensional vectors. Retrieval ru
 
 ### Six-dimensional affinity
 
-Each chat session has a relationship vector:
+Each chat session carries a six-dimensional relationship vector. The six axes — the dimensions of the vector — are:
 
 | Axis | Range | Controls |
 |---|---:|---|
 | `warmth` | -1.0 to 1.0 | Tone and address, from distant to affectionate. |
 | `trust` | 0.0 to 1.0 | Topic depth and willingness to disclose. |
-| `intrigue` | 0.0 to 1.0 | Curiosity and follow-up behavior. |
 | `intimacy` | 0.0 to 1.0 | Nicknames, inside jokes, and callbacks. |
+| `intrigue` | 0.0 to 1.0 | Curiosity and follow-up behavior. |
 | `patience` | 0.0 to 1.0 | Tolerance for low-effort or repeated messages. |
 | `tension` | 0.0 to 1.0 | Push-pull, friction, and playful resistance. |
 
-Updates are smoothed with exponential moving average (EMA), so the persona does not jump between emotional states. `intrigue`, `patience`, and `tension` also decay or recover with real time.
+Two **composite scores** summarize this vector for prompt-shaping — each is the mean of a disjoint triplet of axes (`warmth` is rescaled to 0–1 first):
+
+- **bond** (朋友感, how close it feels) = mean(`warmth`, `intimacy`, `tension`)
+- **chemistry** (来电感, how charged it feels) = mean(`trust`, `intrigue`, `patience`)
+
+Updates are smoothed with exponential moving average (EMA), so the persona does not jump between emotional states. `intrigue`, `patience`, and `tension` also decay or recover with real time. The smoothing strength is set by `EMA_INERTIA` (default `0.8`): each turn applies only `1 − inertia` of the evaluated delta, so a higher value makes the relationship build (and cool) more slowly — in effect a difficulty dial — while `0` applies every delta in full.
+
+A per-request `affinity_scope` flag selects which composite shapes the prompt: `bond` (default), `chemistry`, `bond_and_chemistry` (≡ `full`, all six axes), `none`, or an explicit axis subset like `["warmth", "trust"]`. It gates prompt injection only — all six axes are always persisted and updated regardless.
 
 Relationship labels such as `stranger`, `slow_burn`, `friend`, `frenemy`, and `romantic` emerge from threshold rules. They are internal state, not user-facing badges.
 
@@ -226,7 +233,7 @@ for frame layout and error semantics.
 | Env var | Required | Notes |
 |---|---|---|
 | `DATABASE_URL` | yes | Postgres with `pgvector`; tables are created under `engine.*`. |
-| `OPENROUTER_API_KEY` | yes | Chat completions, routed by `examples/model_config.toml.example` unless overridden. |
+| `OPENROUTER_API_KEY` | yes | Chat completions, routed by `examples/model_config.toml` unless overridden. |
 | `OPENROUTER_APP_REFERER` | no | When set, sent as `HTTP-Referer` on every outbound OpenRouter call. Shows up on OpenRouter's app analytics dashboard. |
 | `OPENROUTER_APP_TITLE` | no | When set, sent as `X-Title`. Display name in OpenRouter app analytics. Pairs with `OPENROUTER_APP_REFERER`; both optional. |
 | `OPENROUTER_USAGE_HIDDEN_KEYS` | no | Comma-separated list of top-level keys to strip from the `usage` object on the SSE streaming `done` frame. Useful for hiding wholesale `cost` / `cost_details` from downstream customers. The full usage is still persisted and traced server-side. |
@@ -235,8 +242,8 @@ for frame layout and error semantics.
 | `SUPABASE_JWT_SECRET` | yes | JWT signing secret for default auth. |
 | `BIND_ADDR` | no | Defaults to `0.0.0.0:8080`. |
 | `EXPOSE_AFFINITY_DEBUG` | no | Set `true` to enable `/comp/affinity/{session_id}`. |
-| `EMA_INERTIA` | no | Defaults to `0.8`. |
-| `MODEL_CONFIG_PATH` | no | Defaults to `examples/model_config.toml.example`. |
+| `EMA_INERTIA` | no | EMA smoothing for affinity updates, in `[0, 1]`; defaults to `0.8`. Each turn applies `1 − inertia` of the evaluated delta, so a higher value moves the affinity vector less per turn (slower to build or lose) — a relationship-difficulty dial; `0` applies every delta in full. |
+| `MODEL_CONFIG_PATH` | no | Defaults to `examples/model_config.toml`. |
 | `RUST_LOG` | no | Defaults to `info`. |
 | `MARKETPLACE_SVC_URL` | no | Base URL of eros-marketplace-svc. When set, the engine pulls /since cursors every 5 min as a self-heal recovery path. Requires `MARKETPLACE_SVC_S2S_SECRET`. |
 | `MARKETPLACE_SVC_S2S_SECRET` | no | HMAC secret shared with eros-marketplace-svc. Gates the `/s2s/*` routes the svc pushes into. Without it, `/s2s/*` always 401s. |

--- a/README.zh.md
+++ b/README.zh.md
@@ -37,18 +37,25 @@ Embedding 使用 Voyage `voyage-3-lite`，512 維向量。檢索走 pgvector IVF
 
 ### 六維好感度
 
-每個 chat session 都有一條關係向量：
+每個 chat session 都有一條六維關係向量。六個維度（向量的各軸）如下：
 
 | 維度 | 範圍 | 控制 |
 |---|---:|---|
 | `warmth` | -1.0 到 1.0 | 語氣與稱呼，從疏離到親近。 |
 | `trust` | 0.0 到 1.0 | 話題深度，以及 persona 是否願意透露自己。 |
-| `intrigue` | 0.0 到 1.0 | 好奇心與追問傾向。 |
 | `intimacy` | 0.0 到 1.0 | 暱稱、內部梗、對過往細節的呼應。 |
+| `intrigue` | 0.0 到 1.0 | 好奇心與追問傾向。 |
 | `patience` | 0.0 到 1.0 | 對低 effort 或重複消息的容忍度。 |
 | `tension` | 0.0 到 1.0 | 推拉、摩擦、玩鬧式抵抗。 |
 
-更新使用指數移動平均（EMA），避免 persona 在情緒狀態間突然跳變。`intrigue`、`patience`、`tension` 也會隨真實時間自然衰退或恢復。
+兩個**复合指标**把這條向量壓成便於 prompt 塑形的摘要——各是一組互斥三維的平均（`warmth` 先線性縮放到 0–1）：
+
+- **bond**（朋友感，關係有多近）= mean(`warmth`、`intimacy`、`tension`)
+- **chemistry**（来电感，張力有多強）= mean(`trust`、`intrigue`、`patience`)
+
+更新使用指數移動平均（EMA），避免 persona 在情緒狀態間突然跳變。`intrigue`、`patience`、`tension` 也會隨真實時間自然衰退或恢復。平滑强度由 `EMA_INERTIA`（默认 `0.8`）控制：每轮只施加 `1 − inertia` 比例的评估增量，所以值越高、关系升温（与降温）越慢——相当于一个难度旋钮；设为 `0` 则每次增量全额生效。
+
+每個 request 可帶 `affinity_scope` flag，決定哪一個复合指标參與 prompt 注入：`bond`（默認）、`chemistry`、`bond_and_chemistry`（≡ `full`，全部六維）、`none`，或像 `["warmth", "trust"]` 這樣的顯式維度子集。它只 gate prompt 注入——六個維度始終照常持久化與更新。
 
 `stranger`、`slow_burn`、`friend`、`frenemy`、`romantic` 這些關係標籤由閾值規則從向量中推導出來。它們是內部狀態，不是展示給用戶看的 badge。
 
@@ -170,7 +177,7 @@ Server 默認監聽 `0.0.0.0:8080`。Scalar API docs 在 `/docs`，OpenAPI JSON 
 | 環境變量 | 必要 | 說明 |
 |---|---|---|
 | `DATABASE_URL` | 是 | 帶 `pgvector` 的 Postgres；表建在 `engine.*`。 |
-| `OPENROUTER_API_KEY` | 是 | Chat completions；默認由 `examples/model_config.toml.example` 路由。 |
+| `OPENROUTER_API_KEY` | 是 | Chat completions；默認由 `examples/model_config.toml` 路由。 |
 | `OPENROUTER_APP_REFERER` | 否 | 設了之後每次出站 OpenRouter 調用都帶 `HTTP-Referer`。會出現在 OpenRouter 的 app 分析面板上。 |
 | `OPENROUTER_APP_TITLE` | 否 | 設了之後帶 `X-Title`。OpenRouter app analytics 顯示名稱。和 `OPENROUTER_APP_REFERER` 一對；兩個都可選。 |
 | `OPENROUTER_USAGE_HIDDEN_KEYS` | 否 | 逗号分隔的顶层 key 列表，从 `usage` 对象里剔除 —— 在 SSE 流式 `done` 帧上生效。常用于把批发 `cost` / `cost_details` 隐藏起来不外泄给下游客户。完整 usage 仍会落库并写入服务器端 tracing。 |
@@ -179,8 +186,8 @@ Server 默認監聽 `0.0.0.0:8080`。Scalar API docs 在 `/docs`，OpenAPI JSON 
 | `SUPABASE_JWT_SECRET` | 是 | 默認 auth 使用的 JWT signing secret。 |
 | `BIND_ADDR` | 否 | 默認 `0.0.0.0:8080`。 |
 | `EXPOSE_AFFINITY_DEBUG` | 否 | 設為 `true` 會開啟 `/comp/affinity/{session_id}`。 |
-| `EMA_INERTIA` | 否 | 默認 `0.8`。 |
-| `MODEL_CONFIG_PATH` | 否 | 默認 `examples/model_config.toml.example`。 |
+| `EMA_INERTIA` | 否 | affinity 更新的 EMA 平滑系数，范围 `[0, 1]`，默认 `0.8`。每轮只施加 `1 − inertia` 比例的增量，值越高则关系向量每轮移动越小（升温/降温都更慢）——相当于关系难度旋钮；`0` 表示每次增量全额生效。 |
+| `MODEL_CONFIG_PATH` | 否 | 默認 `examples/model_config.toml`。 |
 | `RUST_LOG` | 否 | 默認 `info`。 |
 
 ## 刻意不包含的東西

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -941,7 +941,7 @@ reasoning = { exclude = true }
     // depends on — otherwise resolve() silently falls back to the wrong model.
     #[test]
     fn committed_example_config_parses_and_has_affinity_task() {
-        let text = include_str!("../../../examples/model_config.toml.example");
+        let text = include_str!("../../../examples/model_config.toml");
         let cfg = ModelConfig::from_toml_str(text)
             .expect("examples/model_config.toml.example must parse");
         let r = cfg.resolve("affinity_evaluation", None);
@@ -959,7 +959,7 @@ reasoning = { exclude = true }
 
     #[test]
     fn committed_example_chat_companion_disables_reasoning() {
-        let text = include_str!("../../../examples/model_config.toml.example");
+        let text = include_str!("../../../examples/model_config.toml");
         let cfg = ModelConfig::from_toml_str(text)
             .expect("examples/model_config.toml.example must parse");
         let disabled = ReasoningConfig {

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -133,6 +133,40 @@ impl ModelSpec {
     }
 }
 
+/// Client-facing model-name display override (chat `meta.model`). Four TOML
+/// shapes, unambiguous to serde: `false`/`true` (bool), `"name"` (string),
+/// `["a","b"]` (array → random per emit), or `{ "id" = "name", default =
+/// "name" }` (map keyed by the real id; reserved `default` key). Affects ONLY
+/// what the client sees — never the OpenRouter call or the persisted row.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(untagged)]
+pub enum DisplayOverride {
+    Bool(bool),
+    Fixed(String),
+    Random(Vec<String>),
+    Map(HashMap<String, String>),
+}
+
+impl DisplayOverride {
+    /// Map the real model id to the value shown to the client. `None` means
+    /// "omit the `model` field". `false`, an empty string, an empty array, and
+    /// a map miss with no `default` all yield `None`.
+    pub fn display(&self, actual_model: &str) -> Option<String> {
+        match self {
+            DisplayOverride::Bool(false) => None,
+            DisplayOverride::Bool(true) => Some(actual_model.to_string()),
+            DisplayOverride::Fixed(s) if s.is_empty() => None,
+            DisplayOverride::Fixed(s) => Some(s.clone()),
+            DisplayOverride::Random(v) if v.is_empty() => None,
+            DisplayOverride::Random(v) => {
+                let i = rand::thread_rng().gen_range(0..v.len());
+                Some(v[i].clone())
+            }
+            DisplayOverride::Map(m) => m.get(actual_model).or_else(|| m.get("default")).cloned(),
+        }
+    }
+}
+
 /// Mirror of OpenRouter's `reasoning` request object. Parsed from TOML and
 /// forwarded to the wire unchanged, so operators control reasoning in the
 /// same shape OpenRouter documents. Every field optional; absent fields are
@@ -199,6 +233,11 @@ pub struct TaskConfig {
     /// inherit, like `temperature`/`max_tokens`.
     #[serde(default)]
     pub reasoning: Option<ReasoningConfig>,
+    /// Client-facing display override for `meta.model` (chat task only).
+    /// Task-level; tiers inherit. Absent → `None` (treated as `false` → the
+    /// `model` field is omitted from chat `meta` frames). See `DisplayOverride`.
+    #[serde(default)]
+    pub model_name_display_override: Option<DisplayOverride>,
     /// Per-tier overrides keyed by tier name. Empty for tasks that don't tier.
     #[serde(default)]
     pub tiers: HashMap<String, TierConfig>,
@@ -334,6 +373,16 @@ impl ModelConfig {
             allow_traits,
             reasoning,
         }
+    }
+
+    /// Task-level display override, read WITHOUT running model selection — so
+    /// the replay path can read it without advancing round-robin / weighted
+    /// cursors. Tier-independent (the field is task-level; tiers inherit it).
+    /// `None` when the task is unknown or sets no override.
+    pub fn display_override(&self, task: &str) -> Option<DisplayOverride> {
+        self.tasks
+            .get(task)
+            .and_then(|t| t.model_name_display_override.clone())
     }
 }
 
@@ -1061,5 +1110,102 @@ model = []
 "#;
         let cfg = ModelConfig::from_toml_str(toml).unwrap();
         assert_eq!(cfg.resolve("t", None).model, "fb");
+    }
+
+    #[test]
+    fn display_override_parses_all_four_forms() {
+        let toml = r#"
+[tasks.b_false]
+model = "m"
+model_name_display_override = false
+[tasks.b_true]
+model = "m"
+model_name_display_override = true
+[tasks.s]
+model = "m"
+model_name_display_override = "Aria"
+[tasks.arr]
+model = "m"
+model_name_display_override = ["Aria", "Nova"]
+[tasks.map]
+model = "m"
+model_name_display_override = { "deepseek/x" = "Aria", default = "Companion" }
+"#;
+        let cfg = ModelConfig::from_toml_str(toml).unwrap();
+        assert_eq!(
+            cfg.tasks["b_false"].model_name_display_override,
+            Some(DisplayOverride::Bool(false))
+        );
+        assert_eq!(
+            cfg.tasks["b_true"].model_name_display_override,
+            Some(DisplayOverride::Bool(true))
+        );
+        assert_eq!(
+            cfg.tasks["s"].model_name_display_override,
+            Some(DisplayOverride::Fixed("Aria".into()))
+        );
+        assert_eq!(
+            cfg.tasks["arr"].model_name_display_override,
+            Some(DisplayOverride::Random(vec!["Aria".into(), "Nova".into()]))
+        );
+        let map = match &cfg.tasks["map"].model_name_display_override {
+            Some(DisplayOverride::Map(m)) => m.clone(),
+            other => panic!("expected Map, got {other:?}"),
+        };
+        assert_eq!(map.get("deepseek/x").map(String::as_str), Some("Aria"));
+        assert_eq!(map.get("default").map(String::as_str), Some("Companion"));
+    }
+
+    #[test]
+    fn display_method_truth_table() {
+        assert_eq!(DisplayOverride::Bool(false).display("m"), None);
+        assert_eq!(
+            DisplayOverride::Bool(true).display("m"),
+            Some("m".to_string())
+        );
+        assert_eq!(
+            DisplayOverride::Fixed("Aria".into()).display("m"),
+            Some("Aria".to_string())
+        );
+        assert_eq!(DisplayOverride::Fixed(String::new()).display("m"), None);
+        assert_eq!(DisplayOverride::Random(vec![]).display("m"), None);
+        assert_eq!(
+            DisplayOverride::Random(vec!["only".into()]).display("m"),
+            Some("only".to_string())
+        );
+
+        let mut map = std::collections::HashMap::new();
+        map.insert("m1".to_string(), "n1".to_string());
+        map.insert("default".to_string(), "nd".to_string());
+        let ov = DisplayOverride::Map(map);
+        assert_eq!(ov.display("m1"), Some("n1".to_string()));
+        assert_eq!(ov.display("zzz"), Some("nd".to_string()));
+
+        let mut map2 = std::collections::HashMap::new();
+        map2.insert("m1".to_string(), "n1".to_string());
+        let ov2 = DisplayOverride::Map(map2);
+        assert_eq!(ov2.display("zzz"), None);
+    }
+
+    #[test]
+    fn display_override_accessor_is_tier_independent_and_absent_is_none() {
+        let toml = r#"
+[tasks.chat_companion]
+model = "m"
+model_name_display_override = "Aria"
+
+[tasks.chat_companion.tiers.gold]
+model = "g"
+
+[tasks.other]
+model = "m"
+"#;
+        let cfg = ModelConfig::from_toml_str(toml).unwrap();
+        assert_eq!(
+            cfg.display_override("chat_companion"),
+            Some(DisplayOverride::Fixed("Aria".into()))
+        );
+        assert_eq!(cfg.display_override("other"), None);
+        assert_eq!(cfg.display_override("nonexistent"), None);
     }
 }

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -238,14 +238,14 @@ impl ModelConfig {
     }
 
     /// Library-side convenience: load the config from `MODEL_CONFIG_PATH`,
-    /// or fall back to `examples/model_config.toml.example` to match the
+    /// or fall back to `examples/model_config.toml` to match the
     /// `eros-engine-server` boot default. The server binary itself reads
     /// the file inline via `from_toml_str` rather than calling this; this
     /// method is provided for embedders who want the same behaviour in
     /// one call.
     pub fn load() -> Result<Arc<Self>, LlmError> {
         let path = std::env::var("MODEL_CONFIG_PATH")
-            .unwrap_or_else(|_| "examples/model_config.toml.example".to_string());
+            .unwrap_or_else(|_| "examples/model_config.toml".to_string());
         let text = std::fs::read_to_string(&path)?;
         let cfg = Self::from_toml_str(&text)?;
         Ok(Arc::new(cfg))
@@ -943,7 +943,7 @@ reasoning = { exclude = true }
     fn committed_example_config_parses_and_has_affinity_task() {
         let text = include_str!("../../../examples/model_config.toml");
         let cfg = ModelConfig::from_toml_str(text)
-            .expect("examples/model_config.toml.example must parse");
+            .expect("examples/model_config.toml must parse");
         let r = cfg.resolve("affinity_evaluation", None);
         assert_eq!(r.model, "anthropic/claude-haiku-4.5");
         assert_eq!(r.max_tokens, 400);
@@ -961,7 +961,7 @@ reasoning = { exclude = true }
     fn committed_example_chat_companion_disables_reasoning() {
         let text = include_str!("../../../examples/model_config.toml");
         let cfg = ModelConfig::from_toml_str(text)
-            .expect("examples/model_config.toml.example must parse");
+            .expect("examples/model_config.toml must parse");
         let disabled = ReasoningConfig {
             enabled: Some(false),
             exclude: None,

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -991,8 +991,7 @@ reasoning = { exclude = true }
     #[test]
     fn committed_example_config_parses_and_has_affinity_task() {
         let text = include_str!("../../../examples/model_config.toml");
-        let cfg = ModelConfig::from_toml_str(text)
-            .expect("examples/model_config.toml must parse");
+        let cfg = ModelConfig::from_toml_str(text).expect("examples/model_config.toml must parse");
         let r = cfg.resolve("affinity_evaluation", None);
         assert_eq!(r.model, "anthropic/claude-haiku-4.5");
         assert_eq!(r.max_tokens, 400);
@@ -1009,8 +1008,7 @@ reasoning = { exclude = true }
     #[test]
     fn committed_example_chat_companion_disables_reasoning() {
         let text = include_str!("../../../examples/model_config.toml");
-        let cfg = ModelConfig::from_toml_str(text)
-            .expect("examples/model_config.toml must parse");
+        let cfg = ModelConfig::from_toml_str(text).expect("examples/model_config.toml must parse");
         let disabled = ReasoningConfig {
             enabled: Some(false),
             exclude: None,

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -1208,4 +1208,22 @@ model = "m"
         assert_eq!(cfg.display_override("other"), None);
         assert_eq!(cfg.display_override("nonexistent"), None);
     }
+
+    #[test]
+    fn committed_example_chat_companion_shows_real_model() {
+        let text = include_str!("../../../examples/model_config.toml");
+        let cfg = ModelConfig::from_toml_str(text).expect("example must parse");
+        // The shipped example opts into showing the real id (today's behavior).
+        assert_eq!(
+            cfg.display_override("chat_companion"),
+            Some(DisplayOverride::Bool(true))
+        );
+        assert_eq!(
+            cfg.display_override("chat_companion")
+                .and_then(|d| d.display("deepseek/deepseek-v4-flash")),
+            Some("deepseek/deepseek-v4-flash".to_string())
+        );
+        // A task without the field stays None (omit).
+        assert_eq!(cfg.display_override("insight_extraction"), None);
+    }
 }

--- a/crates/eros-engine-server/src/main.rs
+++ b/crates/eros-engine-server/src/main.rs
@@ -261,11 +261,11 @@ async fn run_server() -> Result<()> {
     }
     let auth: Arc<dyn AuthValidator> = Arc::new(validator);
 
-    // model_config: env override > examples/model_config.toml.example dev default.
+    // model_config: env override > examples/model_config.toml dev default.
     // The committed example is sanitized; the real config is opted into via
     // MODEL_CONFIG_PATH (the docker/Dockerfile.fly image bakes it in for prod).
     let model_config_path = std::env::var("MODEL_CONFIG_PATH")
-        .unwrap_or_else(|_| "examples/model_config.toml.example".into());
+        .unwrap_or_else(|_| "examples/model_config.toml".into());
     let model_config_text = std::fs::read_to_string(&model_config_path)
         .with_context(|| format!("model_config read failed: {model_config_path}"))?;
     let model_config = Arc::new(

--- a/crates/eros-engine-server/src/main.rs
+++ b/crates/eros-engine-server/src/main.rs
@@ -264,8 +264,8 @@ async fn run_server() -> Result<()> {
     // model_config: env override > examples/model_config.toml dev default.
     // The committed example is sanitized; the real config is opted into via
     // MODEL_CONFIG_PATH (the docker/Dockerfile.fly image bakes it in for prod).
-    let model_config_path = std::env::var("MODEL_CONFIG_PATH")
-        .unwrap_or_else(|_| "examples/model_config.toml".into());
+    let model_config_path =
+        std::env::var("MODEL_CONFIG_PATH").unwrap_or_else(|_| "examples/model_config.toml".into());
     let model_config_text = std::fs::read_to_string(&model_config_path)
         .with_context(|| format!("model_config read failed: {model_config_path}"))?;
     let model_config = Arc::new(

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -1,27 +1,15 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-//! Action handlers — one per ActionType. Each assembles a ChatRequest
-//! (or None if no LLM call is needed) based on the PDE's ActionPlan.
+//! Chat request builders — assemble an `eros_engine_llm::openrouter::ChatRequest`
+//! for the streaming pipeline based on the PDE's `ActionPlan`.
 //!
-//! Ported from `eros-gateway/src/engine/handlers/{reply,ghost,gift,proactive}.rs`
-//! with these OSS-specific changes:
-//!
-//! - All handlers go through `eros_engine_store::chat::ChatRepo` rather than
-//!   inline `sqlx::query_as` against `chat_messages`.
-//! - `ChatRequest` is built around the OSS `eros_engine_llm::openrouter::ChatRequest`
-//!   shape (`model` / `fallback_model` / `messages` / `temperature` / `max_tokens`),
-//!   resolved via `state.model_config` at handler time. The resolver takes
-//!   `task: &str` + the request's `tier: Option<&str>` and returns the
-//!   per-tier model / fallback / allow_traits.
-//! - `GiftHandler` carries `deltas: AffinityDeltas` directly — there is
-//!   no shop item / gift-record lookup since the OSS engine has no
-//!   credit ledger.
+//! OSS specifics: all DB I/O goes through `eros_engine_store` repos, and the
+//! model / fallback / allow_traits are resolved via `state.model_config`
+//! (task + per-request tier).
 
-use async_trait::async_trait;
 use serde_json::Value;
 use sqlx::PgPool;
 use uuid::Uuid;
 
-use eros_engine_core::affinity::AffinityDeltas;
 use eros_engine_core::scope::{AffinityScope, InsightMode, MemoryScope};
 use eros_engine_core::types::{ActionPlan, DecisionInput, Event, LlmAudit, PromptTrait};
 use eros_engine_llm::model_config::ResolvedModel;
@@ -49,18 +37,6 @@ const CHAT_TASK: &str = "chat_companion";
 
 /// Maximum number of recent messages pulled into the prompt.
 const HISTORY_WINDOW: i64 = 20;
-
-#[async_trait]
-pub trait ActionHandler: Send + Sync {
-    // Dispatched only by the retained-but-unreached sync `pipeline::run`
-    // (the sync `/message` handler was removed); see pipeline/mod.rs note.
-    #[allow(dead_code)]
-    async fn handle(
-        &self,
-        input: &DecisionInput,
-        plan: &ActionPlan,
-    ) -> Result<Option<ChatRequest>, AppError>;
-}
 
 /// Partition caller traits by a tier's resolved allow-list.
 /// - `allow == None` → no gating: all kept, none dropped.
@@ -595,124 +571,6 @@ pub(super) async fn build_gift_request(
         history,
         None,
     ))
-}
-
-pub struct ReplyHandler<'a> {
-    pub state: &'a AppState,
-    pub session_id: Uuid,
-    pub user_id: Uuid,
-    pub instance_id: Uuid,
-}
-
-#[async_trait]
-impl<'a> ActionHandler for ReplyHandler<'a> {
-    async fn handle(
-        &self,
-        input: &DecisionInput,
-        plan: &ActionPlan,
-    ) -> Result<Option<ChatRequest>, AppError> {
-        let req = build_reply_request(
-            self.state,
-            input,
-            plan,
-            self.session_id,
-            self.user_id,
-            self.instance_id,
-        )
-        .await?;
-        Ok(Some(req))
-    }
-}
-
-// ─── Ghost ──────────────────────────────────────────────────────────
-
-/// Ghost handler is intentionally a no-op at the chat-request layer:
-/// the affinity row update happens in `pipeline::post_process`. The
-/// `state` / `session_id` fields are kept for future tracing hooks and
-/// for symmetry with the other handlers.
-#[allow(dead_code)]
-pub struct GhostHandler<'a> {
-    pub state: &'a AppState,
-    pub session_id: Uuid,
-}
-
-#[async_trait]
-impl<'a> ActionHandler for GhostHandler<'a> {
-    async fn handle(
-        &self,
-        _input: &DecisionInput,
-        _plan: &ActionPlan,
-    ) -> Result<Option<ChatRequest>, AppError> {
-        tracing::info!("Ghost decision: session={}", self.session_id);
-        // Affinity mutation and DB write happen in pipeline::post_process,
-        // which sees ActionType::Ghost and calls AffinityRepo::record_ghost.
-        Ok(None)
-    }
-}
-
-// ─── Gift ───────────────────────────────────────────────────────────
-
-/// Gift reaction handler.
-///
-/// Replaces the gateway's shop-item / gift-record lookup. The OSS engine
-/// has no credit ledger — the gift event endpoint (T11) injects the
-/// affinity deltas and an optional pending-gift list directly.
-pub struct GiftHandler<'a> {
-    pub state: &'a AppState,
-    pub session_id: Uuid,
-    pub user_id: Uuid,
-    pub instance_id: Uuid,
-    /// Caller-supplied deltas — passed through to the post-process step
-    /// via the ActionPlan / event channel; not consumed inside `handle()`.
-    #[allow(dead_code)]
-    pub deltas: AffinityDeltas,
-    /// Caller-supplied pending gifts (possibly empty) for prompt context.
-    pub pending: Vec<PendingGift>,
-}
-
-#[async_trait]
-impl<'a> ActionHandler for GiftHandler<'a> {
-    async fn handle(
-        &self,
-        input: &DecisionInput,
-        plan: &ActionPlan,
-    ) -> Result<Option<ChatRequest>, AppError> {
-        let req = build_gift_request(
-            self.state,
-            input,
-            plan,
-            self.session_id,
-            self.user_id,
-            self.instance_id,
-            &self.pending,
-        )
-        .await?;
-        Ok(Some(req))
-    }
-}
-
-// ─── Proactive ──────────────────────────────────────────────────────
-
-/// Proactive handler is a stub today — Phase 6 in the gateway / a
-/// later OSS milestone produces an outbound message here. Fields kept
-/// for the eventual implementation.
-#[allow(dead_code)]
-pub struct ProactiveHandler<'a> {
-    pub state: &'a AppState,
-    pub session_id: Uuid,
-}
-
-#[async_trait]
-impl<'a> ActionHandler for ProactiveHandler<'a> {
-    async fn handle(
-        &self,
-        _input: &DecisionInput,
-        _plan: &ActionPlan,
-    ) -> Result<Option<ChatRequest>, AppError> {
-        // Stub — Phase 6 in the gateway / a later OSS milestone will
-        // produce an outbound message here.
-        Ok(None)
-    }
 }
 
 #[cfg(test)]

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -410,8 +410,8 @@ async fn load_human_insight_bullets(
 
 // ─── Reply ──────────────────────────────────────────────────────────
 
-/// Build a ChatRequest for the Reply action. Shared by the sync
-/// `ReplyHandler` and the streaming `pipeline::stream::run_stream`.
+/// Build a ChatRequest for the Reply action. Called by the streaming
+/// pipeline (`pipeline::stream::run_stream`).
 pub(super) async fn build_reply_request(
     state: &AppState,
     input: &DecisionInput,
@@ -514,8 +514,8 @@ pub(super) async fn build_reply_request(
     ))
 }
 
-/// Build a ChatRequest for the GiftReaction action. Shared by the sync
-/// `GiftHandler` and the streaming `pipeline::stream::run_stream`.
+/// Build a ChatRequest for the GiftReaction action. Called by the streaming
+/// pipeline (`pipeline::stream::run_stream`).
 pub(super) async fn build_gift_request(
     state: &AppState,
     input: &DecisionInput,

--- a/crates/eros-engine-server/src/pipeline/mod.rs
+++ b/crates/eros-engine-server/src/pipeline/mod.rs
@@ -1,24 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// NOTE: the synchronous orchestrator `run` (+ its sync-only helpers and the
-// `ActionHandler` dispatch it drives) is currently unreached from the binary:
-// its only HTTP caller, the sync `POST /comp/chat/{session_id}/message`
-// handler, was removed in favour of the SSE streaming endpoint
-// (`stream::run_stream`). It's retained for now as the canonical
-// host-app-driven path pending a separate decision to delete it. The dead
-// items carry targeted `#[allow(dead_code)]` so the rest of the `pipeline`
-// module keeps its normal dead-code warnings (no module-wide suppression).
-//! Pipeline orchestrator — pre-process → PDE → handler dispatch → chat
-//! exec → save assistant message → spawn post-process.
-//!
-//! Ported from `eros-gateway/src/engine/main.rs` with these OSS changes:
-//!
-//! - All DB I/O routed through `eros-engine-store` repos.
-//! - Ghost-streak reset on Reply / Proactive / GiftReaction is performed
-//!   here before persistence; the store crate's `persist_with_event`
-//!   intentionally does not touch the streak.
-//! - Ghost path calls `AffinityRepo::record_ghost` rather than going
-//!   through `persist_with_event`.
-//! - `state.chat_engine` → `state.openrouter`.
+//! Pipeline module — shared helpers (`compute_signals_for_session`,
+//! `log_openrouter_usage`) plus the chat / post-process / dreaming
+//! submodules. The streaming chat entry point is `stream::run_stream`.
 
 pub mod dreaming;
 pub mod handlers;
@@ -29,198 +12,9 @@ pub mod sync;
 use uuid::Uuid;
 
 use eros_engine_core::affinity::Affinity;
-use eros_engine_core::types::{
-    ActionType, ChatResponse, ConversationSignals, DecisionInput, Event,
-};
-use eros_engine_core::{pde, persona::CompanionPersona};
-use eros_engine_store::affinity::AffinityRepo;
-use eros_engine_store::chat::ChatRepo;
-use eros_engine_store::persona::PersonaRepo;
+use eros_engine_core::types::ConversationSignals;
 
 use crate::error::AppError;
-use crate::state::AppState;
-use handlers::{ActionHandler, GhostHandler, GiftHandler, ProactiveHandler, ReplyHandler};
-
-/// Primary entry point for the companion engine.
-// Unreached from the binary since the sync `/message` handler was removed; see
-// the module note above. Retained pending a separate decision to delete it.
-#[allow(dead_code)]
-pub async fn run(
-    state: &AppState,
-    session_id: Uuid,
-    event: Event,
-) -> Result<Option<ChatResponse>, AppError> {
-    // 1. Resolve user + persona instance for the session.
-    let (user_id, instance_id) = load_session_ids(state, session_id).await?;
-
-    // 2. Persona.
-    let persona_repo = PersonaRepo { pool: &state.pool };
-    let persona: CompanionPersona = persona_repo
-        .load_companion(instance_id)
-        .await?
-        .ok_or_else(|| AppError::NotFound("persona instance not found".into()))?;
-
-    // 3. Affinity (with time decay).
-    let affinity = load_affinity_with_decay(state, session_id, user_id, instance_id).await?;
-
-    // 4. Conversation signals.
-    let signals = compute_signals_for_session(&state.pool, session_id, &affinity).await?;
-
-    // 5. Build decision input.
-    let input = DecisionInput {
-        event: event.clone(),
-        affinity,
-        persona,
-        signals,
-    };
-
-    // 6. PDE decision (rules only for now). Ghost evaluation happens
-    // internally inside `pde::decide` via `eros_engine_core::ghost`.
-    let plan = pde::decide(&input);
-
-    tracing::info!(
-        "engine: session={session_id} action={:?} style={:?}",
-        plan.action_type,
-        plan.reply_style,
-    );
-
-    if let Event::UserMessage {
-        prompt_traits,
-        audit,
-        ..
-    } = &event
-    {
-        if !prompt_traits.is_empty() {
-            let tags: Vec<&str> = prompt_traits.iter().map(|t| t.tag.as_str()).collect();
-            tracing::info!(
-                session = %session_id,
-                traits_count = prompt_traits.len(),
-                trait_tags = ?tags,
-                "engine: prompt_traits applied"
-            );
-        }
-        if let Some(a) = audit {
-            let metadata_keys: Vec<&str> = a
-                .metadata
-                .as_ref()
-                .map(|m| m.keys().map(String::as_str).collect())
-                .unwrap_or_default();
-            tracing::info!(
-                session = %session_id,
-                audit_user_present = a.user.is_some(),
-                audit_session_present = a.session_id.is_some(),
-                audit_metadata_keys = ?metadata_keys,
-                "engine: llm audit applied"
-            );
-        }
-    }
-
-    // 7. Dispatch to handler. The Gift branch passes `plan.affinity_deltas`
-    // through; T11 will replace this with deltas supplied directly by the
-    // `/comp/chat/{id}/event/gift` route's request body, since the OSS
-    // engine has no credit ledger to look them up from.
-    let chat_req = match plan.action_type {
-        ActionType::Reply => {
-            ReplyHandler {
-                state,
-                session_id,
-                user_id,
-                instance_id,
-            }
-            .handle(&input, &plan)
-            .await?
-        }
-        ActionType::Ghost => {
-            GhostHandler { state, session_id }
-                .handle(&input, &plan)
-                .await?
-        }
-        ActionType::Proactive => {
-            ProactiveHandler { state, session_id }
-                .handle(&input, &plan)
-                .await?
-        }
-        ActionType::GiftReaction => {
-            GiftHandler {
-                state,
-                session_id,
-                user_id,
-                instance_id,
-                deltas: plan.affinity_deltas.clone(),
-                pending: vec![], // TODO(T11): inject from request body
-            }
-            .handle(&input, &plan)
-            .await?
-        }
-    };
-
-    // 8. Execute chat stage only if a handler produced a request.
-    // Convert the LLM crate's ChatResponse → core's ChatResponse so the
-    // engine's public API stays decoupled from the openrouter wire shape.
-    let response: Option<ChatResponse> = match chat_req {
-        Some(req) => {
-            let llm_resp = state
-                .openrouter
-                .execute(req)
-                .await
-                .map_err(|e| AppError::Internal(format!("openrouter: {e}")))?;
-
-            log_openrouter_usage("chat_companion", Some(session_id), &llm_resp);
-
-            let chat_repo = ChatRepo { pool: &state.pool };
-            chat_repo
-                .append_message(session_id, "assistant", &llm_resp.reply)
-                .await?;
-            Some(ChatResponse {
-                reply: llm_resp.reply,
-                generation_id: llm_resp.generation_id,
-                model: llm_resp.model,
-                usage: llm_resp.usage,
-            })
-        }
-        None => None,
-    };
-
-    // 9. Reset ghost streak — caller responsibility per store crate split.
-    // The store's `persist_with_event` intentionally doesn't touch the
-    // streak; the policy of "any non-Ghost action clears the streak" lives
-    // here in the pipeline. Ghost increments are handled by `record_ghost`
-    // inside post_process.
-    if !matches!(plan.action_type, ActionType::Ghost) {
-        if let Err(e) = clear_ghost_streak(state, session_id).await {
-            tracing::warn!("ghost streak reset failed: {e}");
-        }
-    }
-
-    // 10. Spawn post-process. Wrap the (at most one) assistant message into
-    // a single-element Vec so the post-process signature matches the
-    // streaming path's multi-message bursts.
-    let produced: Vec<post_process::ProducedMessage> = match &response {
-        Some(r) => vec![post_process::ProducedMessage {
-            message_id: Uuid::nil(), // sync path does not produce a streamable id
-            full_text: r.reply.clone(),
-            action: plan.action_type,
-        }],
-        None => vec![],
-    };
-    let state_bg = state.clone();
-    let plan_bg = plan.clone();
-    let event_bg = event;
-    tokio::spawn(async move {
-        post_process::run(
-            state_bg,
-            session_id,
-            user_id,
-            instance_id,
-            event_bg,
-            plan_bg,
-            produced,
-        )
-        .await;
-    });
-
-    Ok(response)
-}
 
 /// Emit one structured `openrouter: call completed` log line per call.
 /// Token / cost fields are best-effort parses off the opaque `usage`
@@ -257,34 +51,6 @@ pub(super) fn log_openrouter_usage(
         cost = ?cost,
         "openrouter: call completed"
     );
-}
-
-#[allow(dead_code)] // only used by the retained-but-unreached sync `run`
-async fn load_session_ids(state: &AppState, session_id: Uuid) -> Result<(Uuid, Uuid), AppError> {
-    let chat_repo = ChatRepo { pool: &state.pool };
-    let session = chat_repo
-        .get_session(session_id)
-        .await?
-        .ok_or_else(|| AppError::NotFound("session not found".into()))?;
-    let instance_id = session
-        .instance_id
-        .ok_or_else(|| AppError::Internal("session has no instance".into()))?;
-    Ok((session.user_id, instance_id))
-}
-
-#[allow(dead_code)] // only used by the retained-but-unreached sync `run`
-async fn load_affinity_with_decay(
-    state: &AppState,
-    session_id: Uuid,
-    user_id: Uuid,
-    instance_id: Uuid,
-) -> Result<Affinity, AppError> {
-    let repo = AffinityRepo { pool: &state.pool };
-    let mut affinity = repo
-        .load_or_create(session_id, user_id, instance_id)
-        .await?;
-    affinity.apply_time_decay();
-    Ok(affinity)
 }
 
 pub async fn compute_signals_for_session(
@@ -325,18 +91,3 @@ pub async fn compute_signals_for_session(
     })
 }
 
-/// Reset `ghost_streak` to 0 for the affinity row tied to this session.
-/// Idempotent: the WHERE clause skips the UPDATE when streak is already 0
-/// so the unconditional call from `pipeline::run` doesn't spam writes.
-#[allow(dead_code)] // only used by the retained-but-unreached sync `run`
-async fn clear_ghost_streak(state: &AppState, session_id: Uuid) -> Result<(), sqlx::Error> {
-    sqlx::query(
-        "UPDATE engine.companion_affinity \
-         SET ghost_streak = 0, updated_at = now() \
-         WHERE session_id = $1 AND ghost_streak <> 0",
-    )
-    .bind(session_id)
-    .execute(&state.pool)
-    .await?;
-    Ok(())
-}

--- a/crates/eros-engine-server/src/pipeline/mod.rs
+++ b/crates/eros-engine-server/src/pipeline/mod.rs
@@ -90,4 +90,3 @@ pub async fn compute_signals_for_session(
         hours_since_last_ghost,
     })
 }
-

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -41,7 +41,8 @@ pub enum ProtocolFrame {
     Meta {
         message_id: String,
         action_type: FrameActionType,
-        model: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        model: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         continues_from: Option<String>,
     },
@@ -142,7 +143,7 @@ fn drive_chat_burst(
             yield ProtocolFrame::Meta {
                 message_id: ulid_string(msg_ulid),
                 action_type: frame_action,
-                model: model_id.clone(),
+                model: Some(model_id.clone()),
                 continues_from: continues_from.map(ulid_string),
             };
 
@@ -342,7 +343,7 @@ pub fn run_stream(
                 yield ProtocolFrame::Meta {
                     message_id: ulid_string(msg_id),
                     action_type: FrameActionType::Ghost,
-                    model: String::new(),
+                    model: None,
                     continues_from: None,
                 };
                 yield ProtocolFrame::Done {
@@ -514,7 +515,7 @@ pub fn replay_stream(
             yield ProtocolFrame::Meta {
                 message_id: ulid_string(msg_id),
                 action_type: FrameActionType::Ghost,
-                model: String::new(),
+                model: None,
                 continues_from: None,
             };
             yield ProtocolFrame::Done {
@@ -534,7 +535,7 @@ pub fn replay_stream(
                 yield ProtocolFrame::Meta {
                     message_id: ulid_string(msg_ulid),
                     action_type: action,
-                    model: row.model.clone().unwrap_or_default(),
+                    model: row.model.clone(),
                     continues_from: prev_ulid.map(ulid_string),
                 };
                 if !row.content.is_empty() {
@@ -583,7 +584,7 @@ mod tests {
         let f = ProtocolFrame::Meta {
             message_id: ulid_string(id),
             action_type: FrameActionType::Reply,
-            model: "x-ai/grok-4-fast".into(),
+            model: Some("x-ai/grok-4-fast".into()),
             continues_from: None,
         };
         let s = serde_json::to_string(&f).unwrap();
@@ -604,11 +605,24 @@ mod tests {
         let f = ProtocolFrame::Meta {
             message_id: ulid_string(Ulid::new()),
             action_type: FrameActionType::Reply,
-            model: "x-ai/grok-4-fast".into(),
+            model: Some("x-ai/grok-4-fast".into()),
             continues_from: Some(prev.clone()),
         };
         let v: serde_json::Value = serde_json::to_value(&f).unwrap();
         assert_eq!(v["continues_from"], prev);
+    }
+
+    #[test]
+    fn meta_frame_omits_model_when_none() {
+        let f = ProtocolFrame::Meta {
+            message_id: ulid_string(Ulid::new()),
+            action_type: FrameActionType::Ghost,
+            model: None,
+            continues_from: None,
+        };
+        let v: serde_json::Value = serde_json::to_value(&f).unwrap();
+        assert_eq!(v["type"], "meta");
+        assert!(v.get("model").is_none(), "model must be omitted when None");
     }
 
     #[test]

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -513,6 +513,7 @@ pub fn replay_stream(
     rows: Vec<eros_engine_store::chat::ChatMessage>,
 ) -> impl futures_util::Stream<Item = ProtocolFrame> + Send + 'static {
     async_stream::stream! {
+        let display_override = state.model_config.display_override("chat_companion");
         if ghost {
             let msg_id = Ulid::new();
             yield ProtocolFrame::Meta {
@@ -538,7 +539,9 @@ pub fn replay_stream(
                 yield ProtocolFrame::Meta {
                     message_id: ulid_string(msg_ulid),
                     action_type: action,
-                    model: row.model.clone(),
+                    model: display_override
+                        .as_ref()
+                        .and_then(|d| d.display(row.model.as_deref().unwrap_or_default())),
                     continues_from: prev_ulid.map(ulid_string),
                 };
                 if !row.content.is_empty() {
@@ -1068,5 +1071,79 @@ data: [DONE]\n\n";
                 assert_eq!(*model, None, "override=false must omit meta.model");
             }
         }
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn replay_applies_display_override(pool: PgPool) {
+        use futures_util::StreamExt;
+
+        let user_id = Uuid::new_v4();
+        let (_g, _instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+
+        let row = eros_engine_store::chat::ChatMessage {
+            id: Uuid::new_v4(),
+            session_id,
+            role: "assistant".into(),
+            content: "hello".into(),
+            sent_at: chrono::Utc::now(),
+            client_msg_id: None,
+            ghost_decision: false,
+            user_message_id: None,
+            continues_from_message_id: None,
+            truncated: false,
+            model: Some("deepseek/x".into()),
+            usage: None,
+            generation_id: None,
+            assistant_action_type: Some("reply".into()),
+        };
+
+        let meta_model = |frames: &[ProtocolFrame]| -> Option<String> {
+            frames.iter().find_map(|f| match f {
+                ProtocolFrame::Meta { model, .. } => Some(model.clone()),
+                _ => None,
+            })?
+        };
+
+        // false -> omit
+        let mut s1 = crate::routes::companion::test_state(pool.clone());
+        s1.model_config = std::sync::Arc::new(
+            eros_engine_llm::model_config::ModelConfig::from_toml_str(
+                "[tasks.chat_companion]\nmodel = \"deepseek/x\"\nmodel_name_display_override = false\n",
+            )
+            .unwrap(),
+        );
+        let f1: Vec<ProtocolFrame> =
+            replay_stream(std::sync::Arc::new(s1), session_id, user_id, false, vec![row.clone()])
+                .collect()
+                .await;
+        assert_eq!(meta_model(&f1), None);
+
+        // pinned string -> that name
+        let mut s2 = crate::routes::companion::test_state(pool.clone());
+        s2.model_config = std::sync::Arc::new(
+            eros_engine_llm::model_config::ModelConfig::from_toml_str(
+                "[tasks.chat_companion]\nmodel = \"deepseek/x\"\nmodel_name_display_override = \"Aria\"\n",
+            )
+            .unwrap(),
+        );
+        let f2: Vec<ProtocolFrame> =
+            replay_stream(std::sync::Arc::new(s2), session_id, user_id, false, vec![row.clone()])
+                .collect()
+                .await;
+        assert_eq!(meta_model(&f2), Some("Aria".to_string()));
+
+        // map hit -> mapped name
+        let mut s3 = crate::routes::companion::test_state(pool.clone());
+        s3.model_config = std::sync::Arc::new(
+            eros_engine_llm::model_config::ModelConfig::from_toml_str(
+                "[tasks.chat_companion]\nmodel = \"deepseek/x\"\nmodel_name_display_override = { \"deepseek/x\" = \"Nova\", default = \"Companion\" }\n",
+            )
+            .unwrap(),
+        );
+        let f3: Vec<ProtocolFrame> =
+            replay_stream(std::sync::Arc::new(s3), session_id, user_id, false, vec![row.clone()])
+                .collect()
+                .await;
+        assert_eq!(meta_model(&f3), Some("Nova".to_string()));
     }
 }

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -111,6 +111,7 @@ fn drive_chat_burst(
     persist_action: &'static str, // "reply" | "gift_reaction"
     plan_action: ActionType,
     req: eros_engine_llm::openrouter::ChatRequest,
+    display_override: Option<eros_engine_llm::model_config::DisplayOverride>,
     produced_out: std::sync::Arc<
         std::sync::Mutex<Vec<crate::pipeline::post_process::ProducedMessage>>,
     >,
@@ -143,7 +144,7 @@ fn drive_chat_burst(
             yield ProtocolFrame::Meta {
                 message_id: ulid_string(msg_ulid),
                 action_type: frame_action,
-                model: Some(model_id.clone()),
+                model: display_override.as_ref().and_then(|d| d.display(model_id)),
                 continues_from: continues_from.map(ulid_string),
             };
 
@@ -389,6 +390,7 @@ pub fn run_stream(
 
                 let produced_out: std::sync::Arc<std::sync::Mutex<Vec<crate::pipeline::post_process::ProducedMessage>>> =
                     std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+                let display_override = state.model_config.display_override("chat_companion");
                 let burst = drive_chat_burst(
                     state.clone(),
                     user_msg.session_id,
@@ -397,6 +399,7 @@ pub fn run_stream(
                     persist_action,
                     plan_action,
                     req,
+                    display_override,
                     produced_out.clone(),
                 );
                 {
@@ -991,6 +994,79 @@ data: [DONE]\n\n";
                 saw_filtered_usage,
                 "a Reply burst ran but no Done frame carried usage to filter"
             );
+        }
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn live_burst_meta_omits_model_when_override_false(pool: PgPool) {
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+        use futures_util::StreamExt;
+        use wiremock::matchers::path as wm_path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        let body = "\
+data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1,\"total_tokens\":2},\"id\":\"g\",\"model\":\"primary\"}\n\n\
+data: [DONE]\n\n";
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+
+        let user_id = Uuid::new_v4();
+        let (_g, instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = std::sync::Arc::new(
+            eros_engine_llm::model_config::ModelConfig::from_toml_str(
+                "[tasks.chat_companion]\nmodel = \"deepseek/x\"\nmodel_name_display_override = false\n",
+            )
+            .unwrap(),
+        );
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                eros_engine_llm::openrouter::AppAttribution::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+
+        let chat_repo = ChatRepo { pool: &pool };
+        let user_message_id = match chat_repo
+            .upsert_user_message_idempotent(session_id, "hi", "01J4444444444444444444444A")
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
+
+        let frames: Vec<ProtocolFrame> = run_stream(
+            std::sync::Arc::new(state),
+            PersistedUserMessage {
+                user_message_id,
+                session_id,
+                user_id,
+                instance_id,
+                content: "hi".into(),
+                prompt_traits: vec![],
+                audit: None,
+                tier: None,
+                memory_scope: Default::default(),
+                affinity_scope: Default::default(),
+            },
+        )
+        .collect()
+        .await;
+
+        for f in &frames {
+            if let ProtocolFrame::Meta { model, .. } = f {
+                assert_eq!(*model, None, "override=false must omit meta.model");
+            }
         }
     }
 }

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -1112,10 +1112,15 @@ data: [DONE]\n\n";
             )
             .unwrap(),
         );
-        let f1: Vec<ProtocolFrame> =
-            replay_stream(std::sync::Arc::new(s1), session_id, user_id, false, vec![row.clone()])
-                .collect()
-                .await;
+        let f1: Vec<ProtocolFrame> = replay_stream(
+            std::sync::Arc::new(s1),
+            session_id,
+            user_id,
+            false,
+            vec![row.clone()],
+        )
+        .collect()
+        .await;
         assert_eq!(meta_model(&f1), None);
 
         // pinned string -> that name
@@ -1126,10 +1131,15 @@ data: [DONE]\n\n";
             )
             .unwrap(),
         );
-        let f2: Vec<ProtocolFrame> =
-            replay_stream(std::sync::Arc::new(s2), session_id, user_id, false, vec![row.clone()])
-                .collect()
-                .await;
+        let f2: Vec<ProtocolFrame> = replay_stream(
+            std::sync::Arc::new(s2),
+            session_id,
+            user_id,
+            false,
+            vec![row.clone()],
+        )
+        .collect()
+        .await;
         assert_eq!(meta_model(&f2), Some("Aria".to_string()));
 
         // map hit -> mapped name
@@ -1140,10 +1150,15 @@ data: [DONE]\n\n";
             )
             .unwrap(),
         );
-        let f3: Vec<ProtocolFrame> =
-            replay_stream(std::sync::Arc::new(s3), session_id, user_id, false, vec![row.clone()])
-                .collect()
-                .await;
+        let f3: Vec<ProtocolFrame> = replay_stream(
+            std::sync::Arc::new(s3),
+            session_id,
+            user_id,
+            false,
+            vec![row.clone()],
+        )
+        .collect()
+        .await;
         assert_eq!(meta_model(&f3), Some("Nova".to_string()));
     }
 }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,7 +39,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /eros-engine /usr/local/bin/eros-engine
-COPY examples/model_config.toml.example /etc/eros-engine/model_config.toml
+COPY examples/model_config.toml /etc/eros-engine/model_config.toml
 COPY examples/personas /etc/eros-engine/personas
 
 # sqlx::migrate!() embeds migration files at compile time, but the

--- a/docs/model-config.md
+++ b/docs/model-config.md
@@ -51,6 +51,24 @@ Field details:
 | `tasks.<name>.description` | `String` | no | Documentation field, ignored by code. |
 | `tasks.<name>.dimensions` | `u32` | no | Embedding-only. Ignored by chat / insight tasks. |
 
+### `model_name_display_override` (chat task only)
+
+Controls the `model` value sent to clients in chat SSE `meta` frames. Affects
+**only** the client display — never the OpenRouter request, the persisted
+assistant row, or usage logging. Task-level on `[tasks.chat_companion]`; every
+tier inherits it. Setting it on other tasks parses but has no effect.
+
+| Form | Example | Behavior |
+|---|---|---|
+| `false` *(default when absent)* | `false` | `model` is **omitted** from the frame |
+| `true` | `true` | the real model id is sent (pre-0.x behavior) |
+| string | `"Aria"` | always sends `"Aria"` |
+| array | `["Aria","Nova"]` | random pick per bubble (re-randomizes on replay) |
+| map | `{ "deepseek/x" = "Aria", default = "Companion" }` | maps the real id to a name; `default` when unlisted; omit if no `default` |
+
+Because the display name is never persisted, the **array** form re-randomizes on
+history replay; `bool`/`string`/`map` are deterministic.
+
 ## Task names
 
 | Name | Consumed by | Status |
@@ -140,6 +158,10 @@ What may still change without notice:
 ### Changelog note
 
 - **`persona_override` (`art_metadata.model`) is no longer read by the engine as of this version.** Use `[tasks.<name>.tiers.<tier>]` for per-tier model selection instead. The `model` field may still exist in a persona's JSONB `art_metadata` but is silently ignored.
+- `model_name_display_override` (optional, `[tasks.chat_companion]`): added in
+  0.x. When unset the chat `meta.model` field is **omitted** — a change from the
+  earlier "always present" behavior. The shipped example sets `= true` to keep
+  showing the real id.
 
 ## What this config does NOT control
 

--- a/docs/model-config.md
+++ b/docs/model-config.md
@@ -6,9 +6,9 @@ LLM model selection for the engine lives in a TOML file loaded at server start. 
 
 ## Where it lives
 
-- Default path: `examples/model_config.toml.example` (relative to the working directory). The committed file is a sanitized template; copy it (or point `MODEL_CONFIG_PATH` at your own) for real deployments.
+- Default path: `examples/model_config.toml` (relative to the working directory). The committed file is a sanitized template; copy it (or point `MODEL_CONFIG_PATH` at your own) for real deployments.
 - Override: `MODEL_CONFIG_PATH` environment variable
-- Loaded once at server start by `eros-engine-server/src/main.rs` (reads `MODEL_CONFIG_PATH` directly, then `ModelConfig::from_toml_str`). For library embedders, `ModelConfig::load()` in `crates/eros-engine-llm/src/model_config.rs` does the same with the same default path (`examples/model_config.toml.example`).
+- Loaded once at server start by `eros-engine-server/src/main.rs` (reads `MODEL_CONFIG_PATH` directly, then `ModelConfig::from_toml_str`). For library embedders, `ModelConfig::load()` in `crates/eros-engine-llm/src/model_config.rs` does the same with the same default path (`examples/model_config.toml`).
 - Held as `Arc<ModelConfig>` in `AppState`; shared across all chat / post-process turns
 - The server also calls `dotenvy::dotenv()` at startup, so `cp .env.example .env` works for the quickstart without an explicit `source .env`
 

--- a/docs/model-config.md
+++ b/docs/model-config.md
@@ -6,7 +6,7 @@ LLM model selection for the engine lives in a TOML file loaded at server start. 
 
 ## Where it lives
 
-- Default path: `examples/model_config.toml` (relative to the working directory). The committed file is a sanitized template; copy it (or point `MODEL_CONFIG_PATH` at your own) for real deployments.
+- Default path: `examples/model_config.toml` (relative to the working directory). The file under `examples/` is an illustrative template — adapt it to your own needs (or point `MODEL_CONFIG_PATH` at your own file).
 - Override: `MODEL_CONFIG_PATH` environment variable
 - Loaded once at server start by `eros-engine-server/src/main.rs` (reads `MODEL_CONFIG_PATH` directly, then `ModelConfig::from_toml_str`). For library embedders, `ModelConfig::load()` in `crates/eros-engine-llm/src/model_config.rs` does the same with the same default path (`examples/model_config.toml`).
 - Held as `Arc<ModelConfig>` in `AppState`; shared across all chat / post-process turns

--- a/docs/model-config.zh.md
+++ b/docs/model-config.zh.md
@@ -6,7 +6,7 @@
 
 ## 文件位置
 
-- 默认路径: `examples/model_config.toml`(相对于工作目录)。已提交的文件是脱敏模板；实际部署时复制一份（或用 `MODEL_CONFIG_PATH` 指向自己的文件）。
+- 默认路径: `examples/model_config.toml`(相对于工作目录)。examples 内的是示意模版，请依自身业务需求修改（或用 `MODEL_CONFIG_PATH` 指向自己的文件）。
 - 覆盖: `MODEL_CONFIG_PATH` 环境变量
 - 服务启动时由 `eros-engine-server/src/main.rs` 一次性载入(直接读 `MODEL_CONFIG_PATH` + `ModelConfig::from_toml_str`)。`crates/eros-engine-llm/src/model_config.rs` 里的 `ModelConfig::load()` 是给 library embedder 用的便利方法,默认路径同为 `examples/model_config.toml`
 - 以 `Arc<ModelConfig>` 形式挂在 `AppState` 上,所有 chat / post-process 轮共享

--- a/docs/model-config.zh.md
+++ b/docs/model-config.zh.md
@@ -6,9 +6,9 @@
 
 ## 文件位置
 
-- 默认路径: `examples/model_config.toml.example`(相对于工作目录)。已提交的文件是脱敏模板；实际部署时复制一份（或用 `MODEL_CONFIG_PATH` 指向自己的文件）。
+- 默认路径: `examples/model_config.toml`(相对于工作目录)。已提交的文件是脱敏模板；实际部署时复制一份（或用 `MODEL_CONFIG_PATH` 指向自己的文件）。
 - 覆盖: `MODEL_CONFIG_PATH` 环境变量
-- 服务启动时由 `eros-engine-server/src/main.rs` 一次性载入(直接读 `MODEL_CONFIG_PATH` + `ModelConfig::from_toml_str`)。`crates/eros-engine-llm/src/model_config.rs` 里的 `ModelConfig::load()` 是给 library embedder 用的便利方法,默认路径同为 `examples/model_config.toml.example`
+- 服务启动时由 `eros-engine-server/src/main.rs` 一次性载入(直接读 `MODEL_CONFIG_PATH` + `ModelConfig::from_toml_str`)。`crates/eros-engine-llm/src/model_config.rs` 里的 `ModelConfig::load()` 是给 library embedder 用的便利方法,默认路径同为 `examples/model_config.toml`
 - 以 `Arc<ModelConfig>` 形式挂在 `AppState` 上,所有 chat / post-process 轮共享
 - Server 启动时还会调一次 `dotenvy::dotenv()`,所以快速开始里 `cp .env.example .env` 之后可以直接 `cargo run`,不需要手动 `source .env`
 

--- a/docs/superpowers/specs/2026-05-19-sse-streaming-chat-0.2-design.md
+++ b/docs/superpowers/specs/2026-05-19-sse-streaming-chat-0.2-design.md
@@ -110,6 +110,11 @@ Every frame's JSON has a required `"type"` discriminator.
 }
 ```
 
+> **Update (2026-05-25):** `meta.model` is now optional — omitted when
+> `tasks.chat_companion.model_name_display_override` resolves to "hide"
+> (`false`/absent, or a map miss with no `default`). See
+> `2026-05-25-model-name-display-override-design.md`.
+
 #### `delta` — token chunk
 
 ```jsonc

--- a/docs/superpowers/specs/2026-05-25-model-name-display-override-design.md
+++ b/docs/superpowers/specs/2026-05-25-model-name-display-override-design.md
@@ -2,7 +2,7 @@
 
 **Status**: design, pending implementation plan
 **Target release**: 0.x patch (additive schema; **changes the default SSE wire behavior** — see §1)
-**Audience**: anyone implementing the engine-side `model_name_display_override` knob for `tasks.*`
+**Audience**: anyone implementing the engine-side `model_name_display_override` knob for `tasks.chat_companion`
 
 ---
 
@@ -32,9 +32,8 @@ Only the **streaming SSE path** (`crates/eros-engine-server/src/pipeline/stream.
 
 Not client-facing (left untouched):
 - `pipeline/mod.rs` sync `run` builds `ChatResponse.model` (~L177) but is
-  **unrouted dead code**; the gift route returns `reply: None`. We apply the
-  override there too (trivial, keeps the contract honest if re-wired) but it
-  has no live effect today.
+  **unrouted dead code**; the gift route returns `reply: None`. Out of scope —
+  not wired to the override (§1 non-goals).
 - Background tasks (affinity / memory / dreaming) build requests with the
   resolved model and never expose it to a client.
 
@@ -42,9 +41,16 @@ Not client-facing (left untouched):
 
 ## 1. Goal / Non-goals
 
-**Goal:** a TOML-driven, **task-level** `model_name_display_override` that
-controls the `model` value sent to clients in chat `meta` frames. Four forms:
-`boolean | string | array | dict`.
+**Goal:** a TOML-driven `model_name_display_override` on
+`[tasks.chat_companion]` that controls the `model` value sent to clients in
+chat `meta` frames. Four forms: `boolean | string | array | dict`. It is a
+top-level (default-block) field; tiers inherit it.
+
+**Scope: `chat_companion` only.** It is the only task that streams a `model`
+to a client, so the override is documented, exampled, and honored there alone.
+The field still lives on `TaskConfig` (the resolver is generic), so setting it
+on another task block parses without error but is **inert** — no task other
+than `chat_companion` ever reaches a `display_model()` call.
 
 **Default behavior change (approved):** the compiled-in / field-absent default
 is **`false` → omit the `model` field**. This flips today's "always show the
@@ -53,12 +59,16 @@ shipped `examples/model_config.toml.example` sets
 `model_name_display_override = true` on `chat_companion`.
 
 **Non-goals:**
+- Honoring the override on non-chat tasks (insight/affinity/memory/dreaming) —
+  they never stream a `model` to a client; the field is inert there.
 - Per-tier override (task-level only; tiers inherit, exactly like
   `reasoning`/`temperature`/`max_tokens`).
 - Changing the model sent to OpenRouter (`per_model_req.model`), the persisted
   `AssistantInsert.model`, or any usage logging — all keep the **real** id.
 - Persisting the display name (so the DB stays the source of truth for the
-  real model; see the replay note in §2.5).
+  real model; see the replay note in §2.6).
+- Wiring the override into the dead sync `pipeline::run` path (§0) — it is
+  unrouted; out of scope until/unless that path is revived.
 
 ---
 
@@ -170,9 +180,8 @@ In `stream.rs`:
   builds via `resolve(CHAT_TASK, None)` too), so one resolve covers all rows.
 - **Ghost** (both live and replay): `model: None`.
 
-In `pipeline/mod.rs` (currently dead sync path): apply
-`resolved.display_model(llm_resp.model.as_deref().unwrap_or(&resolved.model))`
-when building `ChatResponse.model`, for contract consistency.
+The dead sync `pipeline/mod.rs` path (`ChatResponse.model`, ~L177) is left
+unchanged — it is unrouted (§0) and out of scope.
 
 ### 2.6 Replay consistency (explicit consequence)
 
@@ -183,12 +192,14 @@ Because the display name is intentionally **not** persisted, the `array` form
 after a reload. `bool` / `string` / `dict` are deterministic across live and
 replay. This is acceptable for a cosmetic field.
 
-### 2.7 "All task types"
+### 2.7 Scope — `chat_companion` only
 
-The field is valid on every task block (it lives on `TaskConfig`) and is
-carried on every `ResolvedModel`, but it only has an **observable effect** for
-`chat_companion`, the only task that streams a model to a client. On
-background tasks it is inert.
+The field lives on `TaskConfig` and is carried on `ResolvedModel` (the resolver
+is generic), but `display_model()` is only ever called from the chat streaming
+path. No other task reaches an apply site, so the override is honored for
+`chat_companion` alone. Setting it on another task block parses without error
+and is silently inert — consistent with the absence of `deny_unknown_fields`
+elsewhere in the config.
 
 ---
 

--- a/docs/superpowers/specs/2026-05-25-model-name-display-override-design.md
+++ b/docs/superpowers/specs/2026-05-25-model-name-display-override-design.md
@@ -30,10 +30,10 @@ Only the **streaming SSE path** (`crates/eros-engine-server/src/pipeline/stream.
 | Replay Meta | `replay_stream`, ~L537 | DB `row.model` |
 | Ghost Meta (live + replay) | ~L345 / ~L517 | none — no model involved |
 
-Not client-facing (left untouched):
+Not client-facing:
 - `pipeline/mod.rs` sync `run` builds `ChatResponse.model` (~L177) but is
-  **unrouted dead code**; the gift route returns `reply: None`. Out of scope —
-  not wired to the override (§1 non-goals).
+  **unrouted dead code** (the gift route returns `reply: None`). It is
+  **removed** in this task as bundled cleanup — see §2.8.
 - Background tasks (affinity / memory / dreaming) build requests with the
   resolved model and never expose it to a client.
 
@@ -67,8 +67,9 @@ shipped `examples/model_config.toml.example` sets
   `AssistantInsert.model`, or any usage logging — all keep the **real** id.
 - Persisting the display name (so the DB stays the source of truth for the
   real model; see the replay note in §2.6).
-- Wiring the override into the dead sync `pipeline::run` path (§0) — it is
-  unrouted; out of scope until/unless that path is revived.
+- Reviving the sync `pipeline::run` path or supporting a non-streaming chat
+  response — instead it is removed as bundled cleanup (§2.8).
+- Removing core's public `ChatResponse` type — see §2.8.
 
 ---
 
@@ -180,8 +181,9 @@ In `stream.rs`:
   builds via `resolve(CHAT_TASK, None)` too), so one resolve covers all rows.
 - **Ghost** (both live and replay): `model: None`.
 
-The dead sync `pipeline/mod.rs` path (`ChatResponse.model`, ~L177) is left
-unchanged — it is unrouted (§0) and out of scope.
+There is no sync apply site: the dead `pipeline/mod.rs` chat path is removed in
+this task (§2.8), so the SSE Meta frames are the only place the override is
+applied.
 
 ### 2.6 Replay consistency (explicit consequence)
 
@@ -200,6 +202,36 @@ path. No other task reaches an apply site, so the override is honored for
 `chat_companion` alone. Setting it on another task block parses without error
 and is silently inert — consistent with the absence of `deny_unknown_fields`
 elsewhere in the config.
+
+### 2.8 Bundled cleanup — remove the dead sync orchestrator
+
+`pipeline::run` and the `ActionHandler` dispatch it drives have been unreached
+since the sync `POST /comp/chat/{id}/message` handler was replaced by the SSE
+endpoint (`stream::run_stream`). Remove them in this task rather than leave a
+dead apply-site for the override to reason about. **Do the removal first**, then
+build the feature on the slimmed-down stream path.
+
+**Remove (server crate only):**
+- `pipeline/mod.rs`: `run`, `load_session_ids`, `load_affinity_with_decay`,
+  `clear_ghost_streak` (all `#[allow(dead_code)]`, sync-only); the
+  `handlers::{ActionHandler, …}` import; the module-level note about the sync
+  orchestrator; and any imports left unused after the removal.
+- `pipeline/handlers.rs`: the `ActionHandler` trait and all four structs +
+  impls (`ReplyHandler`, `GhostHandler`, `GiftHandler`, `ProactiveHandler`);
+  the `async_trait` and `AffinityDeltas` imports; trim the module doc comment
+  that references them.
+
+**Keep (shared with the live SSE path — do NOT remove):**
+- `build_reply_request`, `build_gift_request`, `assemble_chat_request`,
+  `audit_from_event`, and every recall / insight / trait helper.
+- `compute_signals_for_session` and `log_openrouter_usage` in `mod.rs` (used by
+  `stream` / `post_process` / `dreaming`).
+- `pipeline/sync.rs` — an unrelated marketplace self-heal job, still spawned in
+  `main.rs`.
+
+**Out of scope:** core's public `ChatResponse` type (`eros-engine-core`) stays —
+it's library surface for embedders. Drop the `async_trait` crate dependency only
+if it turns out unused workspace-wide after the import is gone.
 
 ---
 
@@ -222,6 +254,9 @@ elsewhere in the config.
 - **Committed example config:** `resolve("chat_companion", …).display_model(id)`
   returns the real id (because the example sets `= true`); an untouched task
   with no override → `None`.
+- **Dead-path removal (§2.8):** the crate builds with no new dead-code warnings,
+  `cargo clippy` is clean, and the existing `pipeline` / `handlers` test suites
+  still pass (none of them exercise `run` or the removed handlers).
 
 ---
 
@@ -238,3 +273,5 @@ elsewhere in the config.
 - Additive TOML schema; **default wire behavior changes** (model omitted when
   unset) — the shipped example opts back into showing the real id so OSS users
   see no behavior change out of the box.
+- Bundled cleanup (§2.8): remove the dead sync `pipeline::run` orchestrator and
+  the `ActionHandler` trait/handlers as the first commit on the branch.

--- a/docs/superpowers/specs/2026-05-25-model-name-display-override-design.md
+++ b/docs/superpowers/specs/2026-05-25-model-name-display-override-design.md
@@ -1,0 +1,229 @@
+# eros-engine — Client-facing model name display override (Spec)
+
+**Status**: design, pending implementation plan
+**Target release**: 0.x patch (additive schema; **changes the default SSE wire behavior** — see §1)
+**Audience**: anyone implementing the engine-side `model_name_display_override` knob for `tasks.*`
+
+---
+
+## 0. Background
+
+The streaming chat path emits a `meta` frame per assistant bubble whose
+`model` field tells the client which model produced the reply. Today that
+field always carries the **real** OpenRouter model id — for every live
+attempt in the fallback chain, and again on history replay (read back from
+the DB).
+
+Operators want to control what the client *sees* here, independently of what
+the engine actually calls and stores: hide it entirely, pin it to a brand
+name, randomize across a pool, or remap specific ids to display names. This
+is purely cosmetic/branding — it must not touch the OpenRouter request, the
+persisted DB row, or any usage logging.
+
+### Where a model name reaches a client (confirmed)
+
+Only the **streaming SSE path** (`crates/eros-engine-server/src/pipeline/stream.rs`):
+
+| Site | Code | Key (real model id) used for lookup |
+|---|---|---|
+| Live burst Meta | `drive_chat_burst`, ~L142 | the attempted chain entry `model_id` |
+| Replay Meta | `replay_stream`, ~L537 | DB `row.model` |
+| Ghost Meta (live + replay) | ~L345 / ~L517 | none — no model involved |
+
+Not client-facing (left untouched):
+- `pipeline/mod.rs` sync `run` builds `ChatResponse.model` (~L177) but is
+  **unrouted dead code**; the gift route returns `reply: None`. We apply the
+  override there too (trivial, keeps the contract honest if re-wired) but it
+  has no live effect today.
+- Background tasks (affinity / memory / dreaming) build requests with the
+  resolved model and never expose it to a client.
+
+---
+
+## 1. Goal / Non-goals
+
+**Goal:** a TOML-driven, **task-level** `model_name_display_override` that
+controls the `model` value sent to clients in chat `meta` frames. Four forms:
+`boolean | string | array | dict`.
+
+**Default behavior change (approved):** the compiled-in / field-absent default
+is **`false` → omit the `model` field**. This flips today's "always show the
+real id" behavior. To preserve the current experience for OSS users, the
+shipped `examples/model_config.toml.example` sets
+`model_name_display_override = true` on `chat_companion`.
+
+**Non-goals:**
+- Per-tier override (task-level only; tiers inherit, exactly like
+  `reasoning`/`temperature`/`max_tokens`).
+- Changing the model sent to OpenRouter (`per_model_req.model`), the persisted
+  `AssistantInsert.model`, or any usage logging — all keep the **real** id.
+- Persisting the display name (so the DB stays the source of truth for the
+  real model; see the replay note in §2.5).
+
+---
+
+## 2. Design
+
+### 2.1 Config object (`DisplayOverride`)
+
+New untagged enum in `model_config.rs`, parsed the same way as `ModelSpec`
+(TOML bool vs string vs array vs inline-table are unambiguous to serde):
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(untagged)]
+pub enum DisplayOverride {
+    Bool(bool),                    // false → omit; true → real id
+    Fixed(String),                 // always this string
+    Random(Vec<String>),           // random pick per emit
+    Map(HashMap<String, String>),  // key = real id; reserved key "default"
+}
+```
+
+TOML forms (model ids contain `/` and `.`, so map keys must be quoted; the
+bareword `default` key is reserved):
+
+```toml
+[tasks.chat_companion]
+model = "deepseek/deepseek-v4-flash"
+
+# pick ONE of:
+model_name_display_override = false                       # omit model field
+model_name_display_override = true                        # real id (today's behavior)
+model_name_display_override = "Aria"                      # always "Aria"
+model_name_display_override = ["Aria", "Nova"]            # random per bubble
+model_name_display_override = { "deepseek/deepseek-v4-flash" = "Aria", "thedrummer/cydonia-24b-v4.1" = "Nova", default = "Companion" }
+```
+
+### 2.2 Resolver (`TaskConfig` + `ResolvedModel` + `resolve()`)
+
+- `TaskConfig.model_name_display_override: Option<DisplayOverride>`
+  (`#[serde(default)]`). **Not** on `TierConfig`.
+- Add `model_name_display_override: Option<DisplayOverride>` to
+  `ResolvedModel`. In `resolve()` read it straight from the task block:
+  `task_cfg.and_then(|t| t.model_name_display_override.clone())`.
+- **Task-level only — tiers inherit unchanged.** A consequence we rely on:
+  the resolved override value is **tier-independent**, so any code path that
+  lacks a tier (replay) can resolve with `(CHAT_TASK, None)` and still get the
+  correct override.
+
+### 2.3 Apply helper
+
+```rust
+impl ResolvedModel {
+    /// Map the real model id to the value sent to the client.
+    /// `None` => omit the `model` field from the frame.
+    pub fn display_model(&self, actual_model: &str) -> Option<String> { ... }
+}
+```
+
+| Config | Result |
+|---|---|
+| absent (`None`) / `false` | `None` → **omit field** |
+| `true` | `Some(actual_model.to_string())` |
+| `"Aria"` | `Some("Aria")` (empty string → `None`) |
+| `["a","b"]` | random `Some(..)`; empty list → `None` |
+| `{ "m1"="n1", default="nd" }` | `get(actual)` else `get("default")` else `None` |
+
+`default` is looked up by the literal key `"default"`. (Edge: a real model id
+literally named `default` is not a thing in OpenRouter's `vendor/model`
+namespace, so the collision is ignored.)
+
+### 2.4 Wire change (`ProtocolFrame::Meta.model`)
+
+`model` changes `String` → `Option<String>`:
+
+```rust
+Meta {
+    message_id: String,
+    action_type: FrameActionType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    continues_from: Option<String>,
+}
+```
+
+- When hidden, the `model` **key is absent** from the JSON (not `null`/`""`).
+- Ghost frames, previously `model: ""`, now pass `None` → omitted.
+- Frontend must tolerate a missing `model` field. (Sync `ChatResponse.model`
+  is already `Option<String>`.)
+
+This is a change to the SSE contract documented in
+`docs/superpowers/specs/2026-05-19-sse-streaming-chat-0.2-design.md` §1.5
+(`model` was always present). The TOML schema change is purely additive and
+within the stated 0.x stability commitments.
+
+### 2.5 Apply sites
+
+In `stream.rs`:
+
+- **Live burst** (`drive_chat_burst`): the resolved override is on the
+  `ResolvedModel` used to build `req`; thread it (or the `ResolvedModel`) into
+  the burst driver and emit
+  `model: resolved.display_model(model_id)` for each attempt's Meta. The
+  request still uses the real `model_id`; the persisted row still stores the
+  real `model_id`.
+- **Replay** (`replay_stream`): resolve `(CHAT_TASK, None)` once, then emit
+  `model: resolved.display_model(row.model.as_deref().unwrap_or_default())`
+  per row. Both `reply` and `gift_reaction` rows are `chat_companion` (gift
+  builds via `resolve(CHAT_TASK, None)` too), so one resolve covers all rows.
+- **Ghost** (both live and replay): `model: None`.
+
+In `pipeline/mod.rs` (currently dead sync path): apply
+`resolved.display_model(llm_resp.model.as_deref().unwrap_or(&resolved.model))`
+when building `ChatResponse.model`, for contract consistency.
+
+### 2.6 Replay consistency (explicit consequence)
+
+The override is **re-applied on replay** — otherwise a client reconnecting
+would read the real model id straight from the DB, defeating `false`/dict-hide.
+Because the display name is intentionally **not** persisted, the `array` form
+**re-randomizes** on replay: a bubble shown as `Aria` live may show `Nova`
+after a reload. `bool` / `string` / `dict` are deterministic across live and
+replay. This is acceptable for a cosmetic field.
+
+### 2.7 "All task types"
+
+The field is valid on every task block (it lives on `TaskConfig`) and is
+carried on every `ResolvedModel`, but it only has an **observable effect** for
+`chat_companion`, the only task that streams a model to a client. On
+background tasks it is inert.
+
+---
+
+## 3. Testing
+
+- **Parsing:** all four forms deserialize into the right `DisplayOverride`
+  variant; quoted map keys + bareword `default` parse.
+- **Resolve + inheritance:** task `model_name_display_override` resolves onto
+  `ResolvedModel`; a no-override tier inherits the task value; absent → `None`.
+- **`display_model`:** one assertion per row of the §2.3 table, including
+  dict-hit, dict-miss→default, dict-miss→no-default→`None`, `true`/`false`,
+  empty array → `None`, empty string → `None`.
+- **Live burst:** with `false`, the Meta frame omits `model`; with a dict, the
+  attempted fallback id maps to its display name (or `default`).
+- **Replay:** override is applied to DB rows (real id never leaks when hidden);
+  ghost replay omits `model`.
+- **Meta serialization:** `Some(..)` serializes `"model":"…"`; `None` omits the
+  key entirely. Update existing `meta_frame_*` constructor tests for the
+  `Option` type change.
+- **Committed example config:** `resolve("chat_companion", …).display_model(id)`
+  returns the real id (because the example sets `= true`); an untouched task
+  with no override → `None`.
+
+---
+
+## 4. Rollout
+
+- `examples/model_config.toml.example`: add
+  `model_name_display_override = true` to `[tasks.chat_companion]`, with a
+  doc-comment block covering all four forms (quote map keys; `default`
+  reserved).
+- `docs/model-config.md`: document the field and the SSE implication ("the
+  `meta.model` field may be omitted depending on this setting"); note it under
+  the stability commitments as an added optional field.
+- Update the SSE streaming spec note that `meta.model` is now optional.
+- Additive TOML schema; **default wire behavior changes** (model omitted when
+  unset) — the shipped example opts back into showing the real id so OSS users
+  see no behavior change out of the box.

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -26,6 +26,18 @@ max_tokens = 1600
 # object — set `{ exclude = true }` instead if you want it generated but hidden.
 # Inherited by every tier below.
 reasoning = { enabled = false }
+# Controls the `model` value sent to clients in chat `meta` frames. Affects ONLY
+# the client display — never the OpenRouter call or the persisted row. Omit this
+# line and the field defaults to `false` (the model name is NOT sent). Four forms:
+#   model_name_display_override = false               # omit model from meta
+#   model_name_display_override = true                # send the real model id (this line)
+#   model_name_display_override = "Aria"              # always show "Aria"
+#   model_name_display_override = ["Aria", "Nova"]    # random per bubble
+#   model_name_display_override = { "deepseek/deepseek-v4-flash" = "Aria", default = "Companion" }
+# Map keys must be quoted (ids contain "/" and "."); the bareword `default` key
+# is the fallback when the real id isn't listed (no default ⇒ omit). Task-level;
+# every tier inherits it.
+model_name_display_override = true
 # Optional prompt-trait allow-list (three-state). Commented out here means no
 # gating. See docs/prompt-traits.md.
 #allow_traits = ["nsfw_boost","politics_open"]


### PR DESCRIPTION
## Summary
- **Feature:** add `model_name_display_override` on `[tasks.chat_companion]` — controls the `model` value sent to clients in chat SSE `meta` frames (`bool | string | array | map`). It changes **only** the client display; the OpenRouter request, the persisted assistant row, and usage logging keep the **real** model id. Applied at both stream sites (live burst + replay; ghost frames omit it). Read via a side-effect-free `ModelConfig::display_override()` so replay never perturbs round-robin/weighted model selection.
- **Default flip:** when unset the field is `false` → `meta.model` is now **omitted** (`Meta.model` is `Option<String>`, `skip_serializing_if`). The shipped `examples/model_config.toml` sets `= true` so OSS behavior (real id shown) is unchanged out of the box.
- **Cleanup:** remove the dead, unrouted sync `pipeline::run` orchestrator + the `ActionHandler` trait and its four handler structs. Kept every helper shared with the streaming path (`build_reply_request`, `build_gift_request`, `assemble_chat_request`, `compute_signals_for_session`, `log_openrouter_usage`).
- **Incidental fix:** a prior commit renamed `examples/model_config.toml.example` → `examples/model_config.toml` but left stale references (broke `cargo test`, and the docker image build). Repointed `include_str!`, the `MODEL_CONFIG_PATH` defaults, the public `docker/Dockerfile` COPY, and `docs/model-config.{md,zh.md}`.

> Design spec: `docs/superpowers/specs/2026-05-25-model-name-display-override-design.md` lands on `main` separately (it was committed there, not on this branch).
> `README.{md,zh.md}` still carry the old `.toml.example` filename — left untouched here because they have uncommitted edits in the primary worktree.

## Test plan
- [x] `cargo clippy --workspace --all-targets` clean
- [x] `cargo test --workspace` green (core 45, llm 62, server 189, store 73; 0 failures)
- [ ] `codex exec review --base main`
- [ ] CI green