### PR TITLE
chore(release): v0.4.20

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -33,8 +33,6 @@ jobs:
         with:
           ref: ${{ steps.ref.outputs.ref }}
 
-      - uses: docker/setup-qemu-action@v3
-
       - uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
@@ -49,7 +47,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: |
             ghcr.io/etherfunlab/eros-engine:${{ steps.ref.outputs.version }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,7 +405,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "eros-engine-core"
-version = "0.4.1"
+version = "0.4.20"
 dependencies = [
  "chrono",
  "serde",
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-llm"
-version = "0.4.1"
+version = "0.4.20"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -436,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-server"
-version = "0.4.1"
+version = "0.4.20"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -477,7 +477,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-store"
-version = "0.4.1"
+version = "0.4.20"
 dependencies = [
  "async-trait",
  "bs58",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.20"
 edition = "2021"
 license = "AGPL-3.0-only"
 repository = "https://github.com/etherfunlab/eros-engine"

--- a/crates/eros-engine-llm/Cargo.toml
+++ b/crates/eros-engine-llm/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "openrouter", "voyage", "embeddings", "llm"]
 categories = ["api-bindings"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "0.4.1" }
+eros-engine-core = { path = "../eros-engine-core", version = "0.4.20" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/eros-engine-server/Cargo.toml
+++ b/crates/eros-engine-server/Cargo.toml
@@ -10,9 +10,9 @@ name = "eros-engine"
 path = "src/main.rs"
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "0.4.1" }
-eros-engine-llm  = { path = "../eros-engine-llm", version = "0.4.1" }
-eros-engine-store = { path = "../eros-engine-store", version = "0.4.1" }
+eros-engine-core = { path = "../eros-engine-core", version = "0.4.20" }
+eros-engine-llm  = { path = "../eros-engine-llm", version = "0.4.20" }
+eros-engine-store = { path = "../eros-engine-store", version = "0.4.20" }
 axum = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0-only",
       "identifier": "AGPL-3.0-only"
     },
-    "version": "0.4.1"
+    "version": "0.4.20"
   },
   "servers": [
     {

--- a/crates/eros-engine-store/Cargo.toml
+++ b/crates/eros-engine-store/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "memory", "pgvector", "postgres", "sqlx"]
 categories = ["database"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "0.4.1" }
+eros-engine-core = { path = "../eros-engine-core", version = "0.4.20" }
 sqlx = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
## Summary
- Bump workspace + all crate path-dep pins `0.4.1` → `0.4.20`.
- GHCR release image dropped to **linux/amd64 only** (arm64 removed, `setup-qemu-action` no longer needed). Downstream needing arm64 can build from `docker/Dockerfile`.

## Included since v0.4.1
- feat: `model_name_display_override` (client-facing model-name hide/pin/remap) + remove dead sync pipeline (#42)
- chore: restore `model_config.toml` example, drop private fly config gitignore entries

## Test plan
- [x] `cargo check --workspace` green at 0.4.20
- [ ] tag push builds amd64-only image to GHCR