### PR TITLE
feat: optional chat-reply output filter layer + final-frame status fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,6 +452,7 @@ dependencies = [
  "hex",
  "hmac",
  "jsonwebtoken",
+ "rand 0.8.6",
  "reqwest",
  "serde",
  "serde_json",

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -195,6 +195,38 @@ pub struct OutputFilterTrigger {
     pub traits: Option<TraitPredicate>,
 }
 
+impl OutputFilterTrigger {
+    /// Turn-constant predicates (random + traits). When either is specified and
+    /// fails, no attempt can be filtered this turn.
+    pub fn turn_level_pass(&self, random_pass: bool, trait_tags: &[&str]) -> bool {
+        self.random.is_none_or(|_| random_pass) && self.traits_pass(trait_tags)
+    }
+
+    /// Full per-attempt decision: turn-level predicates AND the model predicate.
+    pub fn should_filter(&self, model_id: &str, trait_tags: &[&str], random_pass: bool) -> bool {
+        self.turn_level_pass(random_pass, trait_tags) && self.models_pass(model_id)
+    }
+
+    fn models_pass(&self, model_id: &str) -> bool {
+        self.models
+            .as_ref()
+            .is_none_or(|list| list.iter().any(|m| m == model_id))
+    }
+
+    fn traits_pass(&self, tags: &[&str]) -> bool {
+        match &self.traits {
+            None => true,
+            Some(tp) => {
+                let any_present = tp.any.iter().any(|a| tags.iter().any(|t| t == a));
+                match tp.when {
+                    TraitWhen::Present => any_present,
+                    TraitWhen::Absent => !any_present,
+                }
+            }
+        }
+    }
+}
+
 /// Trait-match predicate: the predicate passes when at least one tag in `any`
 /// is present among the turn's prompt traits (`when = present`) or absent
 /// (`when = absent`).
@@ -1348,5 +1380,52 @@ trigger = { traits = { any = ["a"] } }
         let cfg = ModelConfig::from_toml_str(toml).unwrap();
         let tp = cfg.tasks["chat_output_filter"].trigger.clone().unwrap().traits.unwrap();
         assert_eq!(tp.when, TraitWhen::Present);
+    }
+
+    #[test]
+    fn should_filter_predicate_combinations() {
+        use super::*;
+        let none = OutputFilterTrigger { random: None, models: None, traits: None };
+        // empty trigger ⇒ always filter
+        assert!(none.should_filter("any/model", &[], true));
+        assert!(none.should_filter("any/model", &[], false));
+
+        // random only
+        let r = OutputFilterTrigger { random: Some(0.5), models: None, traits: None };
+        assert!(r.should_filter("m", &[], true));
+        assert!(!r.should_filter("m", &[], false));
+
+        // models only
+        let m = OutputFilterTrigger { random: None, models: Some(vec!["x/y".into()]), traits: None };
+        assert!(m.should_filter("x/y", &[], true));
+        assert!(!m.should_filter("a/b", &[], true));
+
+        // traits present / absent
+        let tp = OutputFilterTrigger {
+            random: None, models: None,
+            traits: Some(TraitPredicate { any: vec!["nsfw".into()], when: TraitWhen::Present }),
+        };
+        assert!(tp.should_filter("m", &["nsfw"], true));
+        assert!(!tp.should_filter("m", &["sfw"], true));
+        let ta = OutputFilterTrigger {
+            random: None, models: None,
+            traits: Some(TraitPredicate { any: vec!["nsfw".into()], when: TraitWhen::Absent }),
+        };
+        assert!(ta.should_filter("m", &["sfw"], true));
+        assert!(!ta.should_filter("m", &["nsfw"], true));
+
+        // AND of all three
+        let all = OutputFilterTrigger {
+            random: Some(0.9), models: Some(vec!["x/y".into()]),
+            traits: Some(TraitPredicate { any: vec!["nsfw".into()], when: TraitWhen::Present }),
+        };
+        assert!(all.should_filter("x/y", &["nsfw"], true));
+        assert!(!all.should_filter("x/y", &["nsfw"], false)); // random fails
+        assert!(!all.should_filter("a/b", &["nsfw"], true));  // model fails
+
+        // turn_level_pass ignores models
+        assert!(all.turn_level_pass(true, &["nsfw"]));
+        assert!(!all.turn_level_pass(false, &["nsfw"]));
+        assert!(!all.turn_level_pass(true, &["sfw"]));
     }
 }

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -381,7 +381,7 @@ pub struct ResolvedModel {
 #[derive(Debug, Clone)]
 pub struct ResolvedOutputFilter {
     pub model: String,
-    pub fallback_model: Vec<String>,   // already truncated to retry_depth
+    pub fallback_model: Vec<String>, // already truncated to retry_depth
     pub temperature: f64,
     pub max_tokens: u32,
     pub filter_prompt: String,
@@ -539,7 +539,11 @@ impl ModelConfig {
         let trigger = tier_cfg
             .and_then(|t| t.trigger.clone())
             .or_else(|| task_cfg.trigger.clone())
-            .unwrap_or(OutputFilterTrigger { random: None, models: None, traits: None });
+            .unwrap_or(OutputFilterTrigger {
+                random: None,
+                models: None,
+                traits: None,
+            });
         let timing = tier_cfg
             .and_then(|t| t.timing)
             .or(task_cfg.timing)
@@ -1445,7 +1449,10 @@ trigger = { random = 1.0 }
         assert_eq!(tp.when, TraitWhen::Present);
         // per-tier override parses; tier trigger replaces default wholesale
         assert_eq!(f.tiers["gold"].trigger.clone().unwrap().random, Some(1.0));
-        assert_eq!(f.tiers["gold"].filter_prompt.as_deref(), Some("tier prompt"));
+        assert_eq!(
+            f.tiers["gold"].filter_prompt.as_deref(),
+            Some("tier prompt")
+        );
     }
 
     #[test]
@@ -1457,50 +1464,79 @@ filter_prompt = "p"
 trigger = { traits = { any = ["a"] } }
 "#;
         let cfg = ModelConfig::from_toml_str(toml).unwrap();
-        let tp = cfg.tasks["chat_output_filter"].trigger.clone().unwrap().traits.unwrap();
+        let tp = cfg.tasks["chat_output_filter"]
+            .trigger
+            .clone()
+            .unwrap()
+            .traits
+            .unwrap();
         assert_eq!(tp.when, TraitWhen::Present);
     }
 
     #[test]
     fn should_filter_predicate_combinations() {
         use super::*;
-        let none = OutputFilterTrigger { random: None, models: None, traits: None };
+        let none = OutputFilterTrigger {
+            random: None,
+            models: None,
+            traits: None,
+        };
         // empty trigger ⇒ always filter
         assert!(none.should_filter("any/model", &[], true));
         assert!(none.should_filter("any/model", &[], false));
 
         // random only
-        let r = OutputFilterTrigger { random: Some(0.5), models: None, traits: None };
+        let r = OutputFilterTrigger {
+            random: Some(0.5),
+            models: None,
+            traits: None,
+        };
         assert!(r.should_filter("m", &[], true));
         assert!(!r.should_filter("m", &[], false));
 
         // models only
-        let m = OutputFilterTrigger { random: None, models: Some(vec!["x/y".into()]), traits: None };
+        let m = OutputFilterTrigger {
+            random: None,
+            models: Some(vec!["x/y".into()]),
+            traits: None,
+        };
         assert!(m.should_filter("x/y", &[], true));
         assert!(!m.should_filter("a/b", &[], true));
 
         // traits present / absent
         let tp = OutputFilterTrigger {
-            random: None, models: None,
-            traits: Some(TraitPredicate { any: vec!["nsfw".into()], when: TraitWhen::Present }),
+            random: None,
+            models: None,
+            traits: Some(TraitPredicate {
+                any: vec!["nsfw".into()],
+                when: TraitWhen::Present,
+            }),
         };
         assert!(tp.should_filter("m", &["nsfw"], true));
         assert!(!tp.should_filter("m", &["sfw"], true));
         let ta = OutputFilterTrigger {
-            random: None, models: None,
-            traits: Some(TraitPredicate { any: vec!["nsfw".into()], when: TraitWhen::Absent }),
+            random: None,
+            models: None,
+            traits: Some(TraitPredicate {
+                any: vec!["nsfw".into()],
+                when: TraitWhen::Absent,
+            }),
         };
         assert!(ta.should_filter("m", &["sfw"], true));
         assert!(!ta.should_filter("m", &["nsfw"], true));
 
         // AND of all three
         let all = OutputFilterTrigger {
-            random: Some(0.9), models: Some(vec!["x/y".into()]),
-            traits: Some(TraitPredicate { any: vec!["nsfw".into()], when: TraitWhen::Present }),
+            random: Some(0.9),
+            models: Some(vec!["x/y".into()]),
+            traits: Some(TraitPredicate {
+                any: vec!["nsfw".into()],
+                when: TraitWhen::Present,
+            }),
         };
         assert!(all.should_filter("x/y", &["nsfw"], true));
         assert!(!all.should_filter("x/y", &["nsfw"], false)); // random fails
-        assert!(!all.should_filter("a/b", &["nsfw"], true));  // model fails
+        assert!(!all.should_filter("a/b", &["nsfw"], true)); // model fails
 
         // turn_level_pass ignores models
         assert!(all.turn_level_pass(true, &["nsfw"]));
@@ -1512,9 +1548,9 @@ trigger = { traits = { any = ["a"] } }
     fn resolve_output_filter_gating() {
         use super::*;
         // #6: enabled but no [tasks.chat_output_filter] ⇒ None
-        let t = ModelConfig::from_toml_str(
-            "[tasks.chat_companion]\nmodel=\"m\"\noutput_filter=true\n",
-        ).unwrap();
+        let t =
+            ModelConfig::from_toml_str("[tasks.chat_companion]\nmodel=\"m\"\noutput_filter=true\n")
+                .unwrap();
         assert!(t.output_filter_enabled("chat_companion", None));
         assert!(t.resolve_output_filter(None).is_none());
 
@@ -1524,7 +1560,8 @@ trigger = { traits = { any = ["a"] } }
         assert!(off.resolve_output_filter(None).is_none());
 
         // enabled + table + prompt ⇒ Some, resolves fields
-        let on = ModelConfig::from_toml_str(r#"
+        let on = ModelConfig::from_toml_str(
+            r#"
 [tasks.chat_companion]
 model = "m"
 output_filter = true
@@ -1535,7 +1572,9 @@ filter_prompt = "P"
 temperature = 0.4
 max_tokens = 222
 timing = "before_extract"
-"#).unwrap();
+"#,
+        )
+        .unwrap();
         let r = on.resolve_output_filter(None).expect("some");
         assert_eq!(r.model, "fast/m");
         assert_eq!(r.filter_prompt, "P");
@@ -1546,7 +1585,8 @@ timing = "before_extract"
         assert_eq!(r.fallback_model, vec!["a".to_string()]);
 
         // explicit retry_depth = 0 ⇒ no fallback (primary only)
-        let d0 = ModelConfig::from_toml_str(r#"
+        let d0 = ModelConfig::from_toml_str(
+            r#"
 [tasks.chat_companion]
 model = "m"
 output_filter = true
@@ -1555,23 +1595,31 @@ model = "fast/m"
 fallback = ["a", "b"]
 filter_prompt = "P"
 retry_depth = 0
-"#).unwrap().resolve_output_filter(None).expect("some");
+"#,
+        )
+        .unwrap()
+        .resolve_output_filter(None)
+        .expect("some");
         assert_eq!(d0.retry_depth, 0);
         assert!(d0.fallback_model.is_empty());
 
         // blank filter_prompt ⇒ None even though enabled + table present
-        let blank = ModelConfig::from_toml_str(r#"
+        let blank = ModelConfig::from_toml_str(
+            r#"
 [tasks.chat_companion]
 model = "m"
 output_filter = true
 [tasks.chat_output_filter]
 model = "fast/m"
 filter_prompt = "   "
-"#).unwrap();
+"#,
+        )
+        .unwrap();
         assert!(blank.resolve_output_filter(None).is_none());
 
         // tier output_filter overrides task default (#3); tier filter_prompt falls back to default (#5)
-        let tiered = ModelConfig::from_toml_str(r#"
+        let tiered = ModelConfig::from_toml_str(
+            r#"
 [tasks.chat_companion]
 model = "m"
 output_filter = false
@@ -1582,12 +1630,14 @@ model = "fast/m"
 filter_prompt = "DEFAULT"
 [tasks.chat_output_filter.tiers.gold]
 model = "gold/m"
-"#).unwrap();
+"#,
+        )
+        .unwrap();
         assert!(!tiered.output_filter_enabled("chat_companion", Some("free")));
         assert!(tiered.output_filter_enabled("chat_companion", Some("gold")));
         let rg = tiered.resolve_output_filter(Some("gold")).expect("some");
-        assert_eq!(rg.model, "gold/m");           // tier model
-        assert_eq!(rg.filter_prompt, "DEFAULT");  // fell back to default block (#5)
+        assert_eq!(rg.model, "gold/m"); // tier model
+        assert_eq!(rg.filter_prompt, "DEFAULT"); // fell back to default block (#5)
         assert_eq!(rg.timing, FilterTiming::AfterExtract); // default timing
     }
 }

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -373,6 +373,23 @@ pub struct ResolvedModel {
     pub reasoning: Option<ReasoningConfig>,
 }
 
+/// Resolved output-filter parameters for a chat request.
+///
+/// `fallback_model` is already truncated to `retry_depth` entries —
+/// the runtime tries the primary, then each entry in order, and stops after
+/// `retry_depth` total attempts beyond the primary.
+#[derive(Debug, Clone)]
+pub struct ResolvedOutputFilter {
+    pub model: String,
+    pub fallback_model: Vec<String>,   // already truncated to retry_depth
+    pub temperature: f64,
+    pub max_tokens: u32,
+    pub filter_prompt: String,
+    pub trigger: OutputFilterTrigger,
+    pub timing: FilterTiming,
+    pub retry_depth: u32,
+}
+
 impl ModelConfig {
     pub fn from_toml_str(text: &str) -> Result<Self, LlmError> {
         Ok(toml::from_str(text)?)
@@ -485,6 +502,68 @@ impl ModelConfig {
         self.tasks
             .get(task)
             .and_then(|t| t.model_name_display_override.clone())
+    }
+
+    /// Resolve `output_filter` for `task`: tier override → task default → false.
+    pub fn output_filter_enabled(&self, task: &str, tier: Option<&str>) -> bool {
+        let task_cfg = self.tasks.get(task);
+        let tier_cfg = match (task_cfg, tier) {
+            (Some(t), Some(name)) => t.tiers.get(name),
+            _ => None,
+        };
+        tier_cfg
+            .and_then(|t| t.output_filter)
+            .or_else(|| task_cfg.and_then(|t| t.output_filter))
+            .unwrap_or(false)
+    }
+
+    /// Resolve the output filter for a chat request. `None` (filter disabled) when:
+    /// chat_companion `output_filter` is false (tier→task→false), OR the
+    /// `chat_output_filter` task is absent, OR its resolved `filter_prompt` is blank.
+    pub fn resolve_output_filter(&self, tier: Option<&str>) -> Option<ResolvedOutputFilter> {
+        const FILTER_TASK: &str = "chat_output_filter";
+        if !self.output_filter_enabled("chat_companion", tier) {
+            return None;
+        }
+        let task_cfg = self.tasks.get(FILTER_TASK)?; // #6: table absent ⇒ None
+        let tier_cfg = tier.and_then(|name| task_cfg.tiers.get(name));
+
+        // filter_prompt / trigger / timing: tier → default block.
+        let filter_prompt = tier_cfg
+            .and_then(|t| t.filter_prompt.clone())
+            .or_else(|| task_cfg.filter_prompt.clone())
+            .unwrap_or_default();
+        if filter_prompt.trim().is_empty() {
+            return None; // no usable instruction ⇒ inert
+        }
+        let trigger = tier_cfg
+            .and_then(|t| t.trigger.clone())
+            .or_else(|| task_cfg.trigger.clone())
+            .unwrap_or(OutputFilterTrigger { random: None, models: None, traits: None });
+        let timing = tier_cfg
+            .and_then(|t| t.timing)
+            .or(task_cfg.timing)
+            .unwrap_or_default();
+        let retry_depth = tier_cfg
+            .and_then(|t| t.retry_depth)
+            .or(task_cfg.retry_depth)
+            .unwrap_or(1); // default 1: primary + first fallback only
+
+        // model / fallback / temperature / max_tokens via the existing resolver
+        // (tier → default block → [defaults] → compiled-in).
+        let m = self.resolve(FILTER_TASK, tier);
+        let mut fallback_model = m.fallback_model;
+        fallback_model.truncate(retry_depth as usize); // cap to retry_depth entries
+        Some(ResolvedOutputFilter {
+            model: m.model,
+            fallback_model,
+            temperature: m.temperature,
+            max_tokens: m.max_tokens,
+            filter_prompt,
+            trigger,
+            timing,
+            retry_depth,
+        })
     }
 }
 
@@ -1427,5 +1506,88 @@ trigger = { traits = { any = ["a"] } }
         assert!(all.turn_level_pass(true, &["nsfw"]));
         assert!(!all.turn_level_pass(false, &["nsfw"]));
         assert!(!all.turn_level_pass(true, &["sfw"]));
+    }
+
+    #[test]
+    fn resolve_output_filter_gating() {
+        use super::*;
+        // #6: enabled but no [tasks.chat_output_filter] ⇒ None
+        let t = ModelConfig::from_toml_str(
+            "[tasks.chat_companion]\nmodel=\"m\"\noutput_filter=true\n",
+        ).unwrap();
+        assert!(t.output_filter_enabled("chat_companion", None));
+        assert!(t.resolve_output_filter(None).is_none());
+
+        // off by default (#7)
+        let off = ModelConfig::from_toml_str("[tasks.chat_companion]\nmodel=\"m\"\n").unwrap();
+        assert!(!off.output_filter_enabled("chat_companion", None));
+        assert!(off.resolve_output_filter(None).is_none());
+
+        // enabled + table + prompt ⇒ Some, resolves fields
+        let on = ModelConfig::from_toml_str(r#"
+[tasks.chat_companion]
+model = "m"
+output_filter = true
+[tasks.chat_output_filter]
+model = "fast/m"
+fallback = ["a", "b", "c"]
+filter_prompt = "P"
+temperature = 0.4
+max_tokens = 222
+timing = "before_extract"
+"#).unwrap();
+        let r = on.resolve_output_filter(None).expect("some");
+        assert_eq!(r.model, "fast/m");
+        assert_eq!(r.filter_prompt, "P");
+        assert_eq!(r.max_tokens, 222);
+        assert_eq!(r.timing, FilterTiming::BeforeExtract);
+        // retry_depth defaults to 1 ⇒ fallback truncated to the first entry
+        assert_eq!(r.retry_depth, 1);
+        assert_eq!(r.fallback_model, vec!["a".to_string()]);
+
+        // explicit retry_depth = 0 ⇒ no fallback (primary only)
+        let d0 = ModelConfig::from_toml_str(r#"
+[tasks.chat_companion]
+model = "m"
+output_filter = true
+[tasks.chat_output_filter]
+model = "fast/m"
+fallback = ["a", "b"]
+filter_prompt = "P"
+retry_depth = 0
+"#).unwrap().resolve_output_filter(None).expect("some");
+        assert_eq!(d0.retry_depth, 0);
+        assert!(d0.fallback_model.is_empty());
+
+        // blank filter_prompt ⇒ None even though enabled + table present
+        let blank = ModelConfig::from_toml_str(r#"
+[tasks.chat_companion]
+model = "m"
+output_filter = true
+[tasks.chat_output_filter]
+model = "fast/m"
+filter_prompt = "   "
+"#).unwrap();
+        assert!(blank.resolve_output_filter(None).is_none());
+
+        // tier output_filter overrides task default (#3); tier filter_prompt falls back to default (#5)
+        let tiered = ModelConfig::from_toml_str(r#"
+[tasks.chat_companion]
+model = "m"
+output_filter = false
+[tasks.chat_companion.tiers.gold]
+output_filter = true
+[tasks.chat_output_filter]
+model = "fast/m"
+filter_prompt = "DEFAULT"
+[tasks.chat_output_filter.tiers.gold]
+model = "gold/m"
+"#).unwrap();
+        assert!(!tiered.output_filter_enabled("chat_companion", Some("free")));
+        assert!(tiered.output_filter_enabled("chat_companion", Some("gold")));
+        let rg = tiered.resolve_output_filter(Some("gold")).expect("some");
+        assert_eq!(rg.model, "gold/m");           // tier model
+        assert_eq!(rg.filter_prompt, "DEFAULT");  // fell back to default block (#5)
+        assert_eq!(rg.timing, FilterTiming::AfterExtract); // default timing
     }
 }

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -183,7 +183,8 @@ pub struct ReasoningConfig {
 
 /// Per-turn filter trigger. Every field optional; the AND of all *specified*
 /// predicates decides whether a turn is filtered. None specified ⇒ filter every
-/// turn. `random` is the probability the turn passes the random gate.
+/// turn. `random` is the probability (0.0–1.0) that a turn passes the random
+/// gate (1.0 ≈ always, 0.0 = never); combined via AND with the other predicates.
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 pub struct OutputFilterTrigger {
     #[serde(default)]
@@ -194,7 +195,10 @@ pub struct OutputFilterTrigger {
     pub traits: Option<TraitPredicate>,
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+/// Trait-match predicate: the predicate passes when at least one tag in `any`
+/// is present among the turn's prompt traits (`when = present`) or absent
+/// (`when = absent`).
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub struct TraitPredicate {
     #[serde(default)]
     pub any: Vec<String>,
@@ -210,6 +214,10 @@ pub enum TraitWhen {
     Absent,
 }
 
+/// When the output filter runs relative to the post-process extraction pipeline
+/// (insight/memory/affinity). `AfterExtract` (default): extraction reads the
+/// original reply, only the client output is filtered. `BeforeExtract`:
+/// extraction reads the filtered text.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum FilterTiming {
@@ -287,12 +295,17 @@ pub struct TaskConfig {
     pub model_name_display_override: Option<DisplayOverride>,
     #[serde(default)]
     pub output_filter: Option<bool>,
+    /// System instruction sent to the filter LLM; the assistant reply to
+    /// rewrite is passed as a SEPARATE user message — this is NOT a template
+    /// with placeholder substitution.
     #[serde(default)]
     pub filter_prompt: Option<String>,
     #[serde(default)]
     pub trigger: Option<OutputFilterTrigger>,
     #[serde(default)]
     pub timing: Option<FilterTiming>,
+    /// Number of fallback models the filter may try on failure; the runtime
+    /// defaults this to 1 (primary + first fallback) when unset.
     #[serde(default)]
     pub retry_depth: Option<u32>,
     /// Per-tier overrides keyed by tier name. Empty for tasks that don't tier.

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -181,6 +181,43 @@ pub struct ReasoningConfig {
     pub exclude: Option<bool>,
 }
 
+/// Per-turn filter trigger. Every field optional; the AND of all *specified*
+/// predicates decides whether a turn is filtered. None specified ⇒ filter every
+/// turn. `random` is the probability the turn passes the random gate.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct OutputFilterTrigger {
+    #[serde(default)]
+    pub random: Option<f64>,
+    #[serde(default)]
+    pub models: Option<Vec<String>>,
+    #[serde(default)]
+    pub traits: Option<TraitPredicate>,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct TraitPredicate {
+    #[serde(default)]
+    pub any: Vec<String>,
+    #[serde(default)]
+    pub when: TraitWhen,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum TraitWhen {
+    #[default]
+    Present,
+    Absent,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum FilterTiming {
+    #[default]
+    AfterExtract,
+    BeforeExtract,
+}
+
 /// One tier's overrides for a task. Every field is optional; an absent
 /// field inherits from the enclosing task's default block in `resolve`.
 #[derive(Debug, Clone, Deserialize)]
@@ -194,6 +231,16 @@ pub struct TierConfig {
     /// (drop all); `["a","b"]` → keep only those tags.
     #[serde(default)]
     pub allow_traits: Option<Vec<String>>,
+    #[serde(default)]
+    pub output_filter: Option<bool>,
+    #[serde(default)]
+    pub filter_prompt: Option<String>,
+    #[serde(default)]
+    pub trigger: Option<OutputFilterTrigger>,
+    #[serde(default)]
+    pub timing: Option<FilterTiming>,
+    #[serde(default)]
+    pub retry_depth: Option<u32>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -238,6 +285,16 @@ pub struct TaskConfig {
     /// `model` field is omitted from chat `meta` frames). See `DisplayOverride`.
     #[serde(default)]
     pub model_name_display_override: Option<DisplayOverride>,
+    #[serde(default)]
+    pub output_filter: Option<bool>,
+    #[serde(default)]
+    pub filter_prompt: Option<String>,
+    #[serde(default)]
+    pub trigger: Option<OutputFilterTrigger>,
+    #[serde(default)]
+    pub timing: Option<FilterTiming>,
+    #[serde(default)]
+    pub retry_depth: Option<u32>,
     /// Per-tier overrides keyed by tier name. Empty for tasks that don't tier.
     #[serde(default)]
     pub tiers: HashMap<String, TierConfig>,
@@ -1223,5 +1280,60 @@ model = "m"
         );
         // A task without the field stays None (omit).
         assert_eq!(cfg.display_override("insight_extraction"), None);
+    }
+
+    #[test]
+    fn output_filter_config_parses() {
+        let toml = r#"
+[tasks.chat_companion]
+model = "m"
+output_filter = false
+[tasks.chat_companion.tiers.gold]
+model = "g"
+output_filter = true
+
+[tasks.chat_output_filter]
+model = "fast/model"
+filter_prompt = "Rewrite: {x}"
+temperature = 0.3
+max_tokens = 400
+retry_depth = 2
+trigger = { random = 0.3, models = ["x/y"], traits = { any = ["nsfw"], when = "present" } }
+timing = "after_extract"
+[tasks.chat_output_filter.tiers.gold]
+filter_prompt = "tier prompt"
+trigger = { random = 1.0 }
+"#;
+        let cfg = ModelConfig::from_toml_str(toml).unwrap();
+        let cc = &cfg.tasks["chat_companion"];
+        assert_eq!(cc.output_filter, Some(false));
+        assert_eq!(cc.tiers["gold"].output_filter, Some(true));
+
+        let f = &cfg.tasks["chat_output_filter"];
+        assert_eq!(f.filter_prompt.as_deref(), Some("Rewrite: {x}"));
+        assert_eq!(f.retry_depth, Some(2));
+        assert_eq!(f.timing, Some(FilterTiming::AfterExtract));
+        let trig = f.trigger.clone().unwrap();
+        assert_eq!(trig.random, Some(0.3));
+        assert_eq!(trig.models.as_deref(), Some(&["x/y".to_string()][..]));
+        let tp = trig.traits.unwrap();
+        assert_eq!(tp.any, vec!["nsfw".to_string()]);
+        assert_eq!(tp.when, TraitWhen::Present);
+        // per-tier override parses; tier trigger replaces default wholesale
+        assert_eq!(f.tiers["gold"].trigger.clone().unwrap().random, Some(1.0));
+        assert_eq!(f.tiers["gold"].filter_prompt.as_deref(), Some("tier prompt"));
+    }
+
+    #[test]
+    fn trait_when_defaults_to_present() {
+        let toml = r#"
+[tasks.chat_output_filter]
+model = "m"
+filter_prompt = "p"
+trigger = { traits = { any = ["a"] } }
+"#;
+        let cfg = ModelConfig::from_toml_str(toml).unwrap();
+        let tp = cfg.tasks["chat_output_filter"].trigger.clone().unwrap().traits.unwrap();
+        assert_eq!(tp.when, TraitWhen::Present);
     }
 }

--- a/crates/eros-engine-server/Cargo.toml
+++ b/crates/eros-engine-server/Cargo.toml
@@ -50,6 +50,7 @@ futures-util = { workspace = true }
 tokio-stream = { workspace = true }
 async-stream = { workspace = true }
 ulid         = { workspace = true }
+rand = "0.8"
 
 [dev-dependencies]
 wiremock = "0.6"

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -419,7 +419,7 @@ pub(super) async fn build_reply_request(
     session_id: Uuid,
     user_id: Uuid,
     instance_id: Uuid,
-) -> Result<ChatRequest, AppError> {
+) -> Result<(ChatRequest, Vec<String>), AppError> {
     let chat_repo = ChatRepo { pool: &state.pool };
     let history = chat_repo.history(session_id, HISTORY_WINDOW, 0).await?;
 
@@ -506,11 +506,15 @@ pub(super) async fn build_reply_request(
         affinity_scope,
     );
 
-    Ok(assemble_chat_request(
-        resolved,
-        system_prompt,
-        history,
-        audit_from_event(&input.event),
+    let injected_tags: Vec<String> = kept_traits.iter().map(|t| t.tag.clone()).collect();
+    Ok((
+        assemble_chat_request(
+            resolved,
+            system_prompt,
+            history,
+            audit_from_event(&input.event),
+        ),
+        injected_tags,
     ))
 }
 
@@ -524,7 +528,7 @@ pub(super) async fn build_gift_request(
     user_id: Uuid,
     instance_id: Uuid,
     pending: &[PendingGift],
-) -> Result<ChatRequest, AppError> {
+) -> Result<(ChatRequest, Vec<String>), AppError> {
     let chat_repo = ChatRepo { pool: &state.pool };
     let history = chat_repo.history(session_id, HISTORY_WINDOW, 0).await?;
 
@@ -565,11 +569,14 @@ pub(super) async fn build_gift_request(
         eros_engine_core::scope::AffinityScope::full(),
     );
 
-    Ok(assemble_chat_request(
-        resolved,
-        system_prompt,
-        history,
-        None,
+    Ok((
+        assemble_chat_request(
+            resolved,
+            system_prompt,
+            history,
+            None,
+        ),
+        Vec::new(),
     ))
 }
 

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -570,12 +570,7 @@ pub(super) async fn build_gift_request(
     );
 
     Ok((
-        assemble_chat_request(
-            resolved,
-            system_prompt,
-            history,
-            None,
-        ),
+        assemble_chat_request(resolved, system_prompt, history, None),
         Vec::new(),
     ))
 }

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -64,6 +64,13 @@ pub enum ProtocolFrame {
         lead_score: f64,
         should_show_cta: bool,
         agent_training_level: f64,
+        filtered: bool,
+        // null when no trait injected; always present (no skip_serializing_if).
+        prompt_injected: Option<Vec<String>>,
+        // echo of the request tier; null when none. always present.
+        tier: Option<String>,
+        retries_chat: u32,
+        retries_filter: u32,
     },
     Error {
         code: StreamErrorCode,
@@ -353,7 +360,7 @@ pub fn run_stream(
                     usage: None,
                     generation_id: None,
                 };
-                let final_frame = compute_final_frame(&state, user_msg.session_id, user_msg.user_id).await;
+                let final_frame = compute_final_frame(&state, user_msg.session_id, user_msg.user_id, false, None, user_msg.tier.clone(), 0, 0).await;
                 yield final_frame;
             }
             ActionType::Reply | ActionType::GiftReaction => {
@@ -430,7 +437,7 @@ pub fn run_stream(
                     tracing::warn!("stream: ghost streak reset failed: {e}");
                 }
 
-                let final_frame = compute_final_frame(&state, user_msg.session_id, user_msg.user_id).await;
+                let final_frame = compute_final_frame(&state, user_msg.session_id, user_msg.user_id, false, None, user_msg.tier.clone(), 0, 0).await;
                 yield final_frame;
 
                 // Spawn post-process; do not await.
@@ -463,7 +470,7 @@ pub fn run_stream(
             }
             _ => {
                 // Proactive and any future variants: Final-only.
-                let final_frame = compute_final_frame(&state, user_msg.session_id, user_msg.user_id).await;
+                let final_frame = compute_final_frame(&state, user_msg.session_id, user_msg.user_id, false, None, user_msg.tier.clone(), 0, 0).await;
                 yield final_frame;
             }
         }
@@ -471,7 +478,17 @@ pub fn run_stream(
 }
 
 /// Compute the spec's `final` frame from current session/user state.
-async fn compute_final_frame(state: &AppState, session_id: Uuid, user_id: Uuid) -> ProtocolFrame {
+#[allow(clippy::too_many_arguments)]
+async fn compute_final_frame(
+    state: &AppState,
+    session_id: Uuid,
+    user_id: Uuid,
+    filtered: bool,
+    prompt_injected: Option<Vec<String>>,
+    tier: Option<String>,
+    retries_chat: u32,
+    retries_filter: u32,
+) -> ProtocolFrame {
     let lead_score: f64 =
         sqlx::query_scalar("SELECT lead_score FROM engine.chat_sessions WHERE id = $1")
             .bind(session_id)
@@ -497,6 +514,11 @@ async fn compute_final_frame(state: &AppState, session_id: Uuid, user_id: Uuid) 
         lead_score: normalised_lead,
         should_show_cta,
         agent_training_level: training_level,
+        filtered,
+        prompt_injected,
+        tier,
+        retries_chat,
+        retries_filter,
     }
 }
 
@@ -575,7 +597,7 @@ pub fn replay_stream(
                 return;
             }
         }
-        let final_frame = compute_final_frame(&state, session_id, user_id).await;
+        let final_frame = compute_final_frame(&state, session_id, user_id, false, None, None, 0, 0).await;
         yield final_frame;
     }
 }
@@ -664,16 +686,34 @@ mod tests {
     }
 
     #[test]
-    fn final_frame_carries_three_floats() {
+    fn final_frame_carries_filter_and_status_fields() {
         let f = ProtocolFrame::Final {
             lead_score: 0.71,
             should_show_cta: false,
             agent_training_level: 0.42,
+            filtered: true,
+            prompt_injected: Some(vec!["nsfw_boost".into()]),
+            tier: Some("gold".into()),
+            retries_chat: 1,
+            retries_filter: 0,
         };
         let v: serde_json::Value = serde_json::to_value(&f).unwrap();
         assert_eq!(v["type"], "final");
-        assert!((v["lead_score"].as_f64().unwrap() - 0.71).abs() < 1e-9);
-        assert_eq!(v["should_show_cta"], false);
+        assert_eq!(v["filtered"], true);
+        assert_eq!(v["prompt_injected"][0], "nsfw_boost");
+        assert_eq!(v["tier"], "gold");
+        assert_eq!(v["retries_chat"], 1);
+        assert_eq!(v["retries_filter"], 0);
+
+        let f2 = ProtocolFrame::Final {
+            lead_score: 0.0, should_show_cta: false, agent_training_level: 0.0,
+            filtered: false, prompt_injected: None, tier: None,
+            retries_chat: 0, retries_filter: 0,
+        };
+        let v2: serde_json::Value = serde_json::to_value(&f2).unwrap();
+        assert!(v2["prompt_injected"].is_null());
+        assert!(v2["tier"].is_null());
+        assert_eq!(v2["filtered"], false);
     }
 
     #[test]

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -415,8 +415,14 @@ async fn run_output_filter(
         model: f.model.clone(),
         fallback_model: f.fallback_model.clone(),
         messages: vec![
-            ChatMessage { role: "system".into(), content: f.filter_prompt.clone() },
-            ChatMessage { role: "user".into(), content: original.to_string() },
+            ChatMessage {
+                role: "system".into(),
+                content: f.filter_prompt.clone(),
+            },
+            ChatMessage {
+                role: "user".into(),
+                content: original.to_string(),
+            },
         ],
         temperature: f.temperature as f32,
         max_tokens: f.max_tokens,
@@ -435,7 +441,12 @@ async fn run_output_filter(
             let retries_filter = resp
                 .model
                 .as_deref()
-                .and_then(|served| chain.enumerate().find(|(_, m)| *m == served).map(|(i, _)| i as u32))
+                .and_then(|served| {
+                    chain
+                        .enumerate()
+                        .find(|(_, m)| *m == served)
+                        .map(|(i, _)| i as u32)
+                })
                 .unwrap_or(0);
             Some((out, retries_filter))
         }
@@ -935,9 +946,14 @@ mod tests {
         assert_eq!(v["retries_filter"], 0);
 
         let f2 = ProtocolFrame::Final {
-            lead_score: 0.0, should_show_cta: false, agent_training_level: 0.0,
-            filtered: false, prompt_injected: None, tier: None,
-            retries_chat: 0, retries_filter: 0,
+            lead_score: 0.0,
+            should_show_cta: false,
+            agent_training_level: 0.0,
+            filtered: false,
+            prompt_injected: None,
+            tier: None,
+            retries_chat: 0,
+            retries_filter: 0,
         };
         let v2: serde_json::Value = serde_json::to_value(&f2).unwrap();
         assert!(v2["prompt_injected"].is_null());
@@ -1461,13 +1477,17 @@ data: [DONE]\n\n";
         Mock::given(wm_path("/api/v1/chat/completions"))
             .and(body_string_contains("fast/m"))
             .respond_with(ResponseTemplate::new(200).set_body_json(filt_body))
-            .mount(&mock).await;
+            .mount(&mock)
+            .await;
         Mock::given(wm_path("/api/v1/chat/completions"))
             .and(body_string_contains("deepseek/x"))
-            .respond_with(ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_body_raw(chat_body, "text/event-stream"))
-            .mount(&mock).await;
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(chat_body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
 
         let user_id = Uuid::new_v4();
         let (_g, instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
@@ -1476,32 +1496,80 @@ data: [DONE]\n\n";
             eros_engine_llm::model_config::ModelConfig::from_toml_str(
                 "[tasks.chat_companion]\nmodel=\"deepseek/x\"\noutput_filter=true\n\
                  [tasks.chat_output_filter]\nmodel=\"fast/m\"\nfilter_prompt=\"REWRITE\"\n",
-            ).unwrap());
+            )
+            .unwrap(),
+        );
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
-                "k".into(), Default::default(),
-                format!("{}/api/v1/chat/completions", mock.uri())));
+                "k".into(),
+                Default::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
 
         let chat_repo = ChatRepo { pool: &pool };
         let umid = match chat_repo
-            .upsert_user_message_idempotent(session_id, "hello there friend", "01J9999999999999999999999A")
-            .await.unwrap() { UpsertUserOutcome::Inserted { message_id } => message_id, _ => unreachable!() };
+            .upsert_user_message_idempotent(
+                session_id,
+                "hello there friend",
+                "01J9999999999999999999999A",
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
 
-        let frames: Vec<ProtocolFrame> = run_stream(std::sync::Arc::new(state), PersistedUserMessage {
-            user_message_id: umid, session_id, user_id, instance_id,
-            content: "hello there friend".into(), prompt_traits: vec![], audit: None, tier: None,
-            memory_scope: Default::default(), affinity_scope: Default::default(),
-        }).collect().await;
+        let frames: Vec<ProtocolFrame> = run_stream(
+            std::sync::Arc::new(state),
+            PersistedUserMessage {
+                user_message_id: umid,
+                session_id,
+                user_id,
+                instance_id,
+                content: "hello there friend".into(),
+                prompt_traits: vec![],
+                audit: None,
+                tier: None,
+                memory_scope: Default::default(),
+                affinity_scope: Default::default(),
+            },
+        )
+        .collect()
+        .await;
 
-        let deltas: String = frames.iter().filter_map(|f| match f {
-            ProtocolFrame::Delta { content, .. } => Some(content.clone()), _ => None,
-        }).collect();
-        if frames.iter().any(|f| matches!(f, ProtocolFrame::Delta { .. })) {
-            assert!(deltas.contains("FILT"), "client must see filtered text, got {deltas:?}");
-            assert!(!deltas.contains("ORIG"), "original must never reach client, got {deltas:?}");
-            let (filtered, rc, rf) = frames.iter().find_map(|f| match f {
-                ProtocolFrame::Final { filtered, retries_chat, retries_filter, .. }
-                    => Some((*filtered, *retries_chat, *retries_filter)), _ => None }).unwrap();
+        let deltas: String = frames
+            .iter()
+            .filter_map(|f| match f {
+                ProtocolFrame::Delta { content, .. } => Some(content.clone()),
+                _ => None,
+            })
+            .collect();
+        if frames
+            .iter()
+            .any(|f| matches!(f, ProtocolFrame::Delta { .. }))
+        {
+            assert!(
+                deltas.contains("FILT"),
+                "client must see filtered text, got {deltas:?}"
+            );
+            assert!(
+                !deltas.contains("ORIG"),
+                "original must never reach client, got {deltas:?}"
+            );
+            let (filtered, rc, rf) = frames
+                .iter()
+                .find_map(|f| match f {
+                    ProtocolFrame::Final {
+                        filtered,
+                        retries_chat,
+                        retries_filter,
+                        ..
+                    } => Some((*filtered, *retries_chat, *retries_filter)),
+                    _ => None,
+                })
+                .unwrap();
             assert!(filtered, "final.filtered must be true");
             assert_eq!(rc, 0, "primary chat model served");
             assert_eq!(rf, 0, "primary filter model served");
@@ -1525,13 +1593,17 @@ data: [DONE]\n\n";
         Mock::given(wm_path("/api/v1/chat/completions"))
             .and(body_string_contains("fast/m"))
             .respond_with(ResponseTemplate::new(500))
-            .mount(&mock).await;
+            .mount(&mock)
+            .await;
         Mock::given(wm_path("/api/v1/chat/completions"))
             .and(body_string_contains("deepseek/x"))
-            .respond_with(ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_body_raw(chat_body, "text/event-stream"))
-            .mount(&mock).await;
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(chat_body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
 
         let user_id = Uuid::new_v4();
         let (_g, instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
@@ -1540,31 +1612,75 @@ data: [DONE]\n\n";
             eros_engine_llm::model_config::ModelConfig::from_toml_str(
                 "[tasks.chat_companion]\nmodel=\"deepseek/x\"\noutput_filter=true\n\
                  [tasks.chat_output_filter]\nmodel=\"fast/m\"\nfilter_prompt=\"REWRITE\"\n",
-            ).unwrap());
+            )
+            .unwrap(),
+        );
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
-                "k".into(), Default::default(),
-                format!("{}/api/v1/chat/completions", mock.uri())));
+                "k".into(),
+                Default::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
 
         let chat_repo = ChatRepo { pool: &pool };
         let umid = match chat_repo
-            .upsert_user_message_idempotent(session_id, "hello there friend", "01J9999999999999999999999B")
-            .await.unwrap() { UpsertUserOutcome::Inserted { message_id } => message_id, _ => unreachable!() };
+            .upsert_user_message_idempotent(
+                session_id,
+                "hello there friend",
+                "01J9999999999999999999999B",
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
 
-        let frames: Vec<ProtocolFrame> = run_stream(std::sync::Arc::new(state), PersistedUserMessage {
-            user_message_id: umid, session_id, user_id, instance_id,
-            content: "hello there friend".into(), prompt_traits: vec![], audit: None, tier: None,
-            memory_scope: Default::default(), affinity_scope: Default::default(),
-        }).collect().await;
+        let frames: Vec<ProtocolFrame> = run_stream(
+            std::sync::Arc::new(state),
+            PersistedUserMessage {
+                user_message_id: umid,
+                session_id,
+                user_id,
+                instance_id,
+                content: "hello there friend".into(),
+                prompt_traits: vec![],
+                audit: None,
+                tier: None,
+                memory_scope: Default::default(),
+                affinity_scope: Default::default(),
+            },
+        )
+        .collect()
+        .await;
 
-        let deltas: String = frames.iter().filter_map(|f| match f {
-            ProtocolFrame::Delta { content, .. } => Some(content.clone()), _ => None,
-        }).collect();
-        if frames.iter().any(|f| matches!(f, ProtocolFrame::Delta { .. })) {
-            assert!(deltas.contains("ORIG"), "fail-open must emit original, got {deltas:?}");
-            assert!(!deltas.contains("FILT"), "no filtered text on fail-open, got {deltas:?}");
-            let filtered = frames.iter().find_map(|f| match f {
-                ProtocolFrame::Final { filtered, .. } => Some(*filtered), _ => None }).unwrap();
+        let deltas: String = frames
+            .iter()
+            .filter_map(|f| match f {
+                ProtocolFrame::Delta { content, .. } => Some(content.clone()),
+                _ => None,
+            })
+            .collect();
+        if frames
+            .iter()
+            .any(|f| matches!(f, ProtocolFrame::Delta { .. }))
+        {
+            assert!(
+                deltas.contains("ORIG"),
+                "fail-open must emit original, got {deltas:?}"
+            );
+            assert!(
+                !deltas.contains("FILT"),
+                "no filtered text on fail-open, got {deltas:?}"
+            );
+            let filtered = frames
+                .iter()
+                .find_map(|f| match f {
+                    ProtocolFrame::Final { filtered, .. } => Some(*filtered),
+                    _ => None,
+                })
+                .unwrap();
             assert!(!filtered, "final.filtered must be false on fail-open");
             let row = sqlx::query_scalar::<_, String>(
                 "SELECT content FROM engine.chat_messages WHERE session_id=$1 AND role='assistant' ORDER BY sent_at DESC LIMIT 1")
@@ -1586,17 +1702,23 @@ data: [DONE]\n\n";
         // must never be contacted.
         Mock::given(wm_path("/api/v1/chat/completions"))
             .and(body_string_contains("fast/m"))
-            .respond_with(ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_body_raw("data: [DONE]\n\n", "text/event-stream"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw("data: [DONE]\n\n", "text/event-stream"),
+            )
             .expect(0)
-            .mount(&mock).await;
+            .mount(&mock)
+            .await;
         Mock::given(wm_path("/api/v1/chat/completions"))
             .and(body_string_contains("deepseek/x"))
-            .respond_with(ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_body_raw(chat_body, "text/event-stream"))
-            .mount(&mock).await;
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(chat_body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
 
         let user_id = Uuid::new_v4();
         let (_g, instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
@@ -1608,27 +1730,66 @@ data: [DONE]\n\n";
             ).unwrap());
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
-                "k".into(), Default::default(),
-                format!("{}/api/v1/chat/completions", mock.uri())));
+                "k".into(),
+                Default::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
 
         let chat_repo = ChatRepo { pool: &pool };
         let umid = match chat_repo
-            .upsert_user_message_idempotent(session_id, "hello there friend", "01J9999999999999999999999C")
-            .await.unwrap() { UpsertUserOutcome::Inserted { message_id } => message_id, _ => unreachable!() };
+            .upsert_user_message_idempotent(
+                session_id,
+                "hello there friend",
+                "01J9999999999999999999999C",
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
 
-        let frames: Vec<ProtocolFrame> = run_stream(std::sync::Arc::new(state), PersistedUserMessage {
-            user_message_id: umid, session_id, user_id, instance_id,
-            content: "hello there friend".into(), prompt_traits: vec![], audit: None, tier: None,
-            memory_scope: Default::default(), affinity_scope: Default::default(),
-        }).collect().await;
+        let frames: Vec<ProtocolFrame> = run_stream(
+            std::sync::Arc::new(state),
+            PersistedUserMessage {
+                user_message_id: umid,
+                session_id,
+                user_id,
+                instance_id,
+                content: "hello there friend".into(),
+                prompt_traits: vec![],
+                audit: None,
+                tier: None,
+                memory_scope: Default::default(),
+                affinity_scope: Default::default(),
+            },
+        )
+        .collect()
+        .await;
 
-        let deltas: String = frames.iter().filter_map(|f| match f {
-            ProtocolFrame::Delta { content, .. } => Some(content.clone()), _ => None,
-        }).collect();
-        if frames.iter().any(|f| matches!(f, ProtocolFrame::Delta { .. })) {
-            assert!(deltas.contains("ORIG"), "live mode must emit original, got {deltas:?}");
-            let filtered = frames.iter().find_map(|f| match f {
-                ProtocolFrame::Final { filtered, .. } => Some(*filtered), _ => None }).unwrap();
+        let deltas: String = frames
+            .iter()
+            .filter_map(|f| match f {
+                ProtocolFrame::Delta { content, .. } => Some(content.clone()),
+                _ => None,
+            })
+            .collect();
+        if frames
+            .iter()
+            .any(|f| matches!(f, ProtocolFrame::Delta { .. }))
+        {
+            assert!(
+                deltas.contains("ORIG"),
+                "live mode must emit original, got {deltas:?}"
+            );
+            let filtered = frames
+                .iter()
+                .find_map(|f| match f {
+                    ProtocolFrame::Final { filtered, .. } => Some(*filtered),
+                    _ => None,
+                })
+                .unwrap();
             assert!(!filtered, "final.filtered must be false in live mode");
         }
     }
@@ -1647,17 +1808,23 @@ data: [DONE]\n\n";
         // not "other/model") ⇒ no filter call, emit the original.
         Mock::given(wm_path("/api/v1/chat/completions"))
             .and(body_string_contains("fast/m"))
-            .respond_with(ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_body_raw("data: [DONE]\n\n", "text/event-stream"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw("data: [DONE]\n\n", "text/event-stream"),
+            )
             .expect(0)
-            .mount(&mock).await;
+            .mount(&mock)
+            .await;
         Mock::given(wm_path("/api/v1/chat/completions"))
             .and(body_string_contains("deepseek/x"))
-            .respond_with(ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_body_raw(chat_body, "text/event-stream"))
-            .mount(&mock).await;
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(chat_body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
 
         let user_id = Uuid::new_v4();
         let (_g, instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
@@ -1669,30 +1836,78 @@ data: [DONE]\n\n";
             ).unwrap());
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
-                "k".into(), Default::default(),
-                format!("{}/api/v1/chat/completions", mock.uri())));
+                "k".into(),
+                Default::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
 
         let chat_repo = ChatRepo { pool: &pool };
         let umid = match chat_repo
-            .upsert_user_message_idempotent(session_id, "hello there friend", "01J9999999999999999999999D")
-            .await.unwrap() { UpsertUserOutcome::Inserted { message_id } => message_id, _ => unreachable!() };
+            .upsert_user_message_idempotent(
+                session_id,
+                "hello there friend",
+                "01J9999999999999999999999D",
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
 
-        let frames: Vec<ProtocolFrame> = run_stream(std::sync::Arc::new(state), PersistedUserMessage {
-            user_message_id: umid, session_id, user_id, instance_id,
-            content: "hello there friend".into(), prompt_traits: vec![], audit: None, tier: None,
-            memory_scope: Default::default(), affinity_scope: Default::default(),
-        }).collect().await;
+        let frames: Vec<ProtocolFrame> = run_stream(
+            std::sync::Arc::new(state),
+            PersistedUserMessage {
+                user_message_id: umid,
+                session_id,
+                user_id,
+                instance_id,
+                content: "hello there friend".into(),
+                prompt_traits: vec![],
+                audit: None,
+                tier: None,
+                memory_scope: Default::default(),
+                affinity_scope: Default::default(),
+            },
+        )
+        .collect()
+        .await;
 
-        let deltas: String = frames.iter().filter_map(|f| match f {
-            ProtocolFrame::Delta { content, .. } => Some(content.clone()), _ => None,
-        }).collect();
-        if frames.iter().any(|f| matches!(f, ProtocolFrame::Delta { .. })) {
-            assert_eq!(deltas, "ORIG", "models-miss must emit only the original, got {deltas:?}");
-            let filtered = frames.iter().find_map(|f| match f {
-                ProtocolFrame::Final { filtered, .. } => Some(*filtered), _ => None }).unwrap();
-            assert!(!filtered, "final.filtered must be false when models predicate misses");
-            let meta_count = frames.iter().filter(|f| matches!(f, ProtocolFrame::Meta { .. })).count();
-            let done_count = frames.iter().filter(|f| matches!(f, ProtocolFrame::Done { .. })).count();
+        let deltas: String = frames
+            .iter()
+            .filter_map(|f| match f {
+                ProtocolFrame::Delta { content, .. } => Some(content.clone()),
+                _ => None,
+            })
+            .collect();
+        if frames
+            .iter()
+            .any(|f| matches!(f, ProtocolFrame::Delta { .. }))
+        {
+            assert_eq!(
+                deltas, "ORIG",
+                "models-miss must emit only the original, got {deltas:?}"
+            );
+            let filtered = frames
+                .iter()
+                .find_map(|f| match f {
+                    ProtocolFrame::Final { filtered, .. } => Some(*filtered),
+                    _ => None,
+                })
+                .unwrap();
+            assert!(
+                !filtered,
+                "final.filtered must be false when models predicate misses"
+            );
+            let meta_count = frames
+                .iter()
+                .filter(|f| matches!(f, ProtocolFrame::Meta { .. }))
+                .count();
+            let done_count = frames
+                .iter()
+                .filter(|f| matches!(f, ProtocolFrame::Done { .. }))
+                .count();
             assert_eq!(meta_count, 1, "exactly one Meta frame");
             assert_eq!(done_count, 1, "exactly one Done frame");
         }

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -7,6 +7,7 @@
 //! Task 4 only ships the type layer; the `run_stream` generator lands in
 //! later tasks (T10/T11/T12).
 
+use rand::Rng;
 use serde::Serialize;
 use ulid::Ulid;
 
@@ -103,12 +104,30 @@ use eros_engine_store::persona::PersonaRepo;
 use crate::routes::companion::filter_usage_keys;
 use crate::state::AppState;
 
+/// Result of a single streaming burst, shared back to `run_stream` via a
+/// mutex. Replaces the old `produced_out: Vec<ProducedMessage>` channel so
+/// the caller can also learn whether the turn was filtered and which model
+/// attempt (chat / filter) actually served.
+#[derive(Default)]
+pub struct BurstOutcome {
+    pub produced: Vec<crate::pipeline::post_process::ProducedMessage>,
+    pub filtered: bool,
+    pub retries_chat: u32,   // successful chat-attempt index (0 = primary)
+    pub retries_filter: u32, // served filter-model index (0 when none/primary)
+}
+
 /// Per-burst driver: walks the model fallback chain, emits Meta/Delta/Done
 /// per attempt, persists each logical message before its Done, and yields
 /// a final Error{UpstreamUnavailable} if the chain exhausts. On a clean
-/// burst, returns the produced messages via `produced_out` for the caller
-/// to spawn post_process with. Does NOT yield Final — the caller emits it
-/// after the burst so it reflects post-burst state.
+/// burst, returns the produced messages (plus filter/attempt status) via
+/// `outcome` for the caller to spawn post_process with. Does NOT yield
+/// Final — the caller emits it after the burst so it reflects post-burst
+/// state.
+///
+/// Two modes: when the resolved output filter's turn-level predicates pass
+/// (live=false), the burst buffers each attempt, runs the filter LLM, and
+/// only emits the filtered text (never the original). Otherwise it streams
+/// live per-chunk exactly as before.
 #[allow(clippy::too_many_arguments)]
 fn drive_chat_burst(
     state: Arc<AppState>,
@@ -119,9 +138,10 @@ fn drive_chat_burst(
     plan_action: ActionType,
     req: eros_engine_llm::openrouter::ChatRequest,
     display_override: Option<eros_engine_llm::model_config::DisplayOverride>,
-    produced_out: std::sync::Arc<
-        std::sync::Mutex<Vec<crate::pipeline::post_process::ProducedMessage>>,
-    >,
+    filter: Option<eros_engine_llm::model_config::ResolvedOutputFilter>,
+    trait_tags: Vec<String>, // requested prompt-trait tags (the turn's)
+    random_pass: bool,       // drawn once per turn by run_stream
+    outcome: std::sync::Arc<std::sync::Mutex<BurstOutcome>>,
 ) -> impl futures_util::Stream<Item = ProtocolFrame> + Send + 'static {
     async_stream::stream! {
         let chat_repo = ChatRepo { pool: &state.pool };
@@ -139,7 +159,131 @@ fn drive_chat_burst(
             };
             return;
         }
-        let mut continues_from: Option<Ulid> = None;
+
+        let tag_refs: Vec<&str> = trait_tags.iter().map(String::as_str).collect();
+        let filtered_mode = filter
+            .as_ref()
+            .map(|f| f.trigger.turn_level_pass(random_pass, &tag_refs))
+            .unwrap_or(false);
+
+        if !filtered_mode {
+            // ===== LIVE MODE (preserved verbatim from the pre-filter burst) =====
+            let mut continues_from: Option<Ulid> = None;
+            for (idx, model_id) in chain.iter().enumerate() {
+                let msg_ulid = Ulid::new();
+                let msg_uuid: Uuid = msg_ulid.into();
+                let mut acc = String::new();
+                let mut last_usage: Option<eros_engine_llm::openrouter::UsageBlock> = None;
+                let mut last_gen_id: Option<String> = None;
+                let mut truncated = false;
+
+                yield ProtocolFrame::Meta {
+                    message_id: ulid_string(msg_ulid),
+                    action_type: frame_action,
+                    model: display_override.as_ref().and_then(|d| d.display(model_id)),
+                    continues_from: continues_from.map(ulid_string),
+                };
+
+                let mut per_model_req = req.clone();
+                per_model_req.model = model_id.clone();
+                per_model_req.fallback_model = Vec::new();
+
+                match state.openrouter.execute_stream(per_model_req).await {
+                    Ok(mut s) => {
+                        use futures_util::StreamExt as _;
+                        while let Some(item) = s.next().await {
+                            match item {
+                                Ok(c) => {
+                                    if let Some(content) = c.content {
+                                        acc.push_str(&content);
+                                        yield ProtocolFrame::Delta {
+                                            message_id: ulid_string(msg_ulid),
+                                            content,
+                                        };
+                                    }
+                                    if c.usage.is_some()         { last_usage = c.usage; }
+                                    if c.generation_id.is_some() { last_gen_id = c.generation_id; }
+                                    if matches!(c.finish_reason.as_deref(), Some("length")) {
+                                        truncated = true;
+                                    }
+                                }
+                                Err(e) => {
+                                    tracing::warn!("stream: upstream chunk err: {e}");
+                                    truncated = true;
+                                    break;
+                                }
+                            }
+                        }
+                        if !truncated && acc.is_empty() {
+                            truncated = true;
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!("stream: upstream open err: {e}");
+                        truncated = true;
+                    }
+                }
+
+                // Persist BEFORE yielding Done (spec §2.3 risk R7).
+                let row = eros_engine_store::chat::AssistantInsert {
+                    id: msg_uuid,
+                    content: acc.clone(),
+                    assistant_action_type: persist_action.into(),
+                    continues_from_message_id: continues_from.map(Into::into),
+                    truncated,
+                    model: Some(model_id.clone()),
+                    usage: last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok()),
+                    generation_id: last_gen_id.clone(),
+                };
+                if let Err(e) = chat_repo
+                    .insert_assistant_batch(session_id, user_message_id, &[row])
+                    .await
+                {
+                    tracing::warn!("stream: assistant persist failed: {e}");
+                }
+                outcome.lock().unwrap().produced.push(crate::pipeline::post_process::ProducedMessage {
+                    message_id: msg_uuid,
+                    full_text: acc.clone(),
+                    action: plan_action,
+                });
+
+                // Strip OPENROUTER_USAGE_HIDDEN_KEYS from the wire usage. The DB
+                // row above persists the full unfiltered usage; only the frame is
+                // filtered (mirrors the sync send_message path).
+                let mut wire_usage = last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok());
+                filter_usage_keys(&mut wire_usage, &state.config.openrouter_usage_hidden_keys);
+                yield ProtocolFrame::Done {
+                    message_id: ulid_string(msg_ulid),
+                    truncated,
+                    usage: wire_usage,
+                    generation_id: last_gen_id,
+                };
+
+                if !truncated {
+                    outcome.lock().unwrap().retries_chat = idx as u32;
+                    return;
+                }
+                if idx + 1 == chain.len() {
+                    yield ProtocolFrame::Error {
+                        code: StreamErrorCode::UpstreamUnavailable,
+                        retryable: true,
+                        message: "all fallback models truncated".into(),
+                        user_message: "AI 服务暂时不可用，稍后再试".into(),
+                    };
+                    return;
+                }
+                continues_from = Some(msg_ulid);
+            }
+            return;
+        }
+
+        // ===== FILTERED MODE =====
+        // The turn's trait/random predicates pass: buffer each attempt, run the
+        // filter LLM, and emit ONLY the filtered text (the original reply must
+        // never reach the client). Per-attempt the model predicate decides
+        // whether that specific served model is actually filtered; on filter
+        // error we fail open and emit the original.
+        let f = filter.expect("filtered_mode ⇒ filter present");
         for (idx, model_id) in chain.iter().enumerate() {
             let msg_ulid = Ulid::new();
             let msg_uuid: Uuid = msg_ulid.into();
@@ -148,103 +292,160 @@ fn drive_chat_burst(
             let mut last_gen_id: Option<String> = None;
             let mut truncated = false;
 
-            yield ProtocolFrame::Meta {
-                message_id: ulid_string(msg_ulid),
-                action_type: frame_action,
-                model: display_override.as_ref().and_then(|d| d.display(model_id)),
-                continues_from: continues_from.map(ulid_string),
-            };
-
             let mut per_model_req = req.clone();
             per_model_req.model = model_id.clone();
             per_model_req.fallback_model = Vec::new();
-
             match state.openrouter.execute_stream(per_model_req).await {
                 Ok(mut s) => {
                     use futures_util::StreamExt as _;
                     while let Some(item) = s.next().await {
                         match item {
                             Ok(c) => {
-                                if let Some(content) = c.content {
-                                    acc.push_str(&content);
-                                    yield ProtocolFrame::Delta {
-                                        message_id: ulid_string(msg_ulid),
-                                        content,
-                                    };
-                                }
-                                if c.usage.is_some()         { last_usage = c.usage; }
+                                if let Some(content) = c.content { acc.push_str(&content); }
+                                if c.usage.is_some() { last_usage = c.usage; }
                                 if c.generation_id.is_some() { last_gen_id = c.generation_id; }
-                                if matches!(c.finish_reason.as_deref(), Some("length")) {
-                                    truncated = true;
-                                }
+                                if matches!(c.finish_reason.as_deref(), Some("length")) { truncated = true; }
                             }
-                            Err(e) => {
-                                tracing::warn!("stream: upstream chunk err: {e}");
-                                truncated = true;
-                                break;
-                            }
+                            Err(e) => { tracing::warn!("stream(filtered): chunk err: {e}"); truncated = true; break; }
                         }
                     }
-                    if !truncated && acc.is_empty() {
-                        truncated = true;
-                    }
+                    if !truncated && acc.is_empty() { truncated = true; }
                 }
-                Err(e) => {
-                    tracing::warn!("stream: upstream open err: {e}");
-                    truncated = true;
-                }
+                Err(e) => { tracing::warn!("stream(filtered): open err: {e}"); truncated = true; }
             }
 
-            // Persist BEFORE yielding Done (spec §2.3 risk R7).
+            if truncated {
+                if idx + 1 == chain.len() {
+                    yield ProtocolFrame::Error {
+                        code: StreamErrorCode::UpstreamUnavailable,
+                        retryable: true,
+                        message: "all fallback models truncated".into(),
+                        user_message: "AI 服务暂时不可用，稍后再试".into(),
+                    };
+                }
+                continue;
+            }
+
+            outcome.lock().unwrap().retries_chat = idx as u32;
+            let do_filter = f.trigger.should_filter(model_id, &tag_refs, random_pass);
+            yield ProtocolFrame::Meta {
+                message_id: ulid_string(msg_ulid),
+                action_type: frame_action,
+                model: display_override.as_ref().and_then(|d| d.display(model_id)),
+                continues_from: None,
+            };
+
+            let visible: String = if do_filter {
+                match run_output_filter(&state, &f, &acc).await {
+                    Some((filtered_text, retries_filter)) => {
+                        let mut o = outcome.lock().unwrap();
+                        o.filtered = true;
+                        o.retries_filter = retries_filter;
+                        filtered_text
+                    }
+                    None => acc.clone(),
+                }
+            } else {
+                acc.clone()
+            };
+
+            if !visible.is_empty() {
+                yield ProtocolFrame::Delta {
+                    message_id: ulid_string(msg_ulid),
+                    content: visible.clone(),
+                };
+            }
+
             let row = eros_engine_store::chat::AssistantInsert {
                 id: msg_uuid,
-                content: acc.clone(),
+                content: visible.clone(),
                 assistant_action_type: persist_action.into(),
-                continues_from_message_id: continues_from.map(Into::into),
-                truncated,
+                continues_from_message_id: None,
+                truncated: false,
                 model: Some(model_id.clone()),
                 usage: last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok()),
                 generation_id: last_gen_id.clone(),
             };
-            if let Err(e) = chat_repo
-                .insert_assistant_batch(session_id, user_message_id, &[row])
-                .await
-            {
-                tracing::warn!("stream: assistant persist failed: {e}");
+            if let Err(e) = chat_repo.insert_assistant_batch(session_id, user_message_id, &[row]).await {
+                tracing::warn!("stream(filtered): persist failed: {e}");
             }
-            if let Ok(mut p) = produced_out.lock() {
-                p.push(crate::pipeline::post_process::ProducedMessage {
-                    message_id: msg_uuid,
-                    full_text: acc.clone(),
-                    action: plan_action,
-                });
-            }
+            let extracted = extract_text(f.timing, &acc, &visible);
+            outcome.lock().unwrap().produced.push(crate::pipeline::post_process::ProducedMessage {
+                message_id: msg_uuid,
+                full_text: extracted,
+                action: plan_action,
+            });
 
-            // Strip OPENROUTER_USAGE_HIDDEN_KEYS from the wire usage. The DB
-            // row above persists the full unfiltered usage; only the frame is
-            // filtered (mirrors the sync send_message path).
             let mut wire_usage = last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok());
             filter_usage_keys(&mut wire_usage, &state.config.openrouter_usage_hidden_keys);
             yield ProtocolFrame::Done {
                 message_id: ulid_string(msg_ulid),
-                truncated,
+                truncated: false,
                 usage: wire_usage,
                 generation_id: last_gen_id,
             };
+            return;
+        }
+    }
+}
 
-            if !truncated {
-                return;
+/// Pick the text post_process extracts from: original (after) vs visible (before).
+fn extract_text(
+    timing: eros_engine_llm::model_config::FilterTiming,
+    original: &str,
+    visible: &str,
+) -> String {
+    match timing {
+        eros_engine_llm::model_config::FilterTiming::AfterExtract => original.to_string(),
+        eros_engine_llm::model_config::FilterTiming::BeforeExtract => visible.to_string(),
+    }
+}
+
+/// Run the output-filter LLM over `original`. `execute()` walks the (already
+/// depth-capped) chain; `ChatResponse.model` reports the model served. Returns
+/// `(filtered_text, retries_filter)` where retries_filter = served model's index
+/// in `[f.model] + f.fallback_model` (0 = primary). `None` on error/timeout/empty.
+async fn run_output_filter(
+    state: &AppState,
+    f: &eros_engine_llm::model_config::ResolvedOutputFilter,
+    original: &str,
+) -> Option<(String, u32)> {
+    use eros_engine_llm::openrouter::{ChatMessage, ChatRequest};
+    let req = ChatRequest {
+        model: f.model.clone(),
+        fallback_model: f.fallback_model.clone(),
+        messages: vec![
+            ChatMessage { role: "system".into(), content: f.filter_prompt.clone() },
+            ChatMessage { role: "user".into(), content: original.to_string() },
+        ],
+        temperature: f.temperature as f32,
+        max_tokens: f.max_tokens,
+        ..Default::default()
+    };
+    const FILTER_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+    match tokio::time::timeout(FILTER_TIMEOUT, state.openrouter.execute(req)).await {
+        Ok(Ok(resp)) => {
+            super::log_openrouter_usage("chat_output_filter", None, &resp);
+            let out = resp.reply.trim().to_string();
+            if out.is_empty() {
+                return None;
             }
-            if idx + 1 == chain.len() {
-                yield ProtocolFrame::Error {
-                    code: StreamErrorCode::UpstreamUnavailable,
-                    retryable: true,
-                    message: "all fallback models truncated".into(),
-                    user_message: "AI 服务暂时不可用，稍后再试".into(),
-                };
-                return;
-            }
-            continues_from = Some(msg_ulid);
+            let chain = std::iter::once(f.model.as_str())
+                .chain(f.fallback_model.iter().map(String::as_str));
+            let retries_filter = resp
+                .model
+                .as_deref()
+                .and_then(|served| chain.enumerate().find(|(_, m)| *m == served).map(|(i, _)| i as u32))
+                .unwrap_or(0);
+            Some((out, retries_filter))
+        }
+        Ok(Err(e)) => {
+            tracing::warn!("output filter LLM failed: {e}");
+            None
+        }
+        Err(_) => {
+            tracing::warn!("output filter timed out");
+            None
         }
     }
 }
@@ -396,9 +597,23 @@ pub fn run_stream(
                     (FrameActionType::Reply, "reply", ActionType::Reply)
                 };
 
-                let produced_out: std::sync::Arc<std::sync::Mutex<Vec<crate::pipeline::post_process::ProducedMessage>>> =
-                    std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
                 let display_override = state.model_config.display_override("chat_companion");
+
+                // Resolve the output filter for this tier and draw the per-turn
+                // random gate ONCE (so live/filter share the same coin flip).
+                let tier = user_msg.tier.as_deref();
+                let filter = state.model_config.resolve_output_filter(tier);
+                let random_pass = filter
+                    .as_ref()
+                    .and_then(|f| f.trigger.random)
+                    .map(|p| rand::thread_rng().gen::<f64>() < p)
+                    .unwrap_or(true);
+                let trait_tags: Vec<String> =
+                    user_msg.prompt_traits.iter().map(|t| t.tag.clone()).collect();
+
+                let outcome = std::sync::Arc::new(std::sync::Mutex::new(
+                    crate::pipeline::stream::BurstOutcome::default(),
+                ));
                 let burst = drive_chat_burst(
                     state.clone(),
                     user_msg.session_id,
@@ -408,7 +623,10 @@ pub fn run_stream(
                     plan_action,
                     req,
                     display_override,
-                    produced_out.clone(),
+                    filter,
+                    trait_tags,
+                    random_pass,
+                    outcome.clone(),
                 );
                 {
                     use futures_util::StreamExt as _;
@@ -421,10 +639,10 @@ pub fn run_stream(
                         yield frame;
                     }
                 }
-                let produced: Vec<crate::pipeline::post_process::ProducedMessage> = produced_out
-                    .lock()
-                    .map(|g| g.clone())
-                    .unwrap_or_default();
+                let (produced, did_filter, retries_chat, retries_filter) = {
+                    let g = outcome.lock().unwrap();
+                    (g.produced.clone(), g.filtered, g.retries_chat, g.retries_filter)
+                };
 
                 // Reset ghost streak (mirrors sync pipeline policy).
                 if let Err(e) = sqlx::query(
@@ -438,7 +656,17 @@ pub fn run_stream(
                     tracing::warn!("stream: ghost streak reset failed: {e}");
                 }
 
-                let final_frame = compute_final_frame(&state, user_msg.session_id, user_msg.user_id, false, prompt_injected.clone(), user_msg.tier.clone(), 0, 0).await;
+                let final_frame = compute_final_frame(
+                    &state,
+                    user_msg.session_id,
+                    user_msg.user_id,
+                    did_filter,
+                    prompt_injected.clone(),
+                    user_msg.tier.clone(),
+                    retries_chat,
+                    retries_filter,
+                )
+                .await;
                 yield final_frame;
 
                 // Spawn post-process; do not await.
@@ -1201,5 +1429,272 @@ data: [DONE]\n\n";
         .collect()
         .await;
         assert_eq!(meta_model(&f3), Some("Nova".to_string()));
+    }
+
+    #[test]
+    fn extract_text_picks_by_timing() {
+        use eros_engine_llm::model_config::FilterTiming::*;
+        assert_eq!(extract_text(AfterExtract, "orig", "filt"), "orig");
+        assert_eq!(extract_text(BeforeExtract, "orig", "filt"), "filt");
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn filtered_turn_emits_filtered_and_persists_filtered(pool: PgPool) {
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+        use futures_util::StreamExt;
+        use wiremock::matchers::{body_string_contains, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        let chat_body = "data: {\"choices\":[{\"delta\":{\"content\":\"ORIG\"}}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1,\"total_tokens\":2},\"id\":\"g\",\"model\":\"primary\"}\n\ndata: [DONE]\n\n";
+        // The output filter uses the NON-streaming `execute()` path, so its mock
+        // must return a JSON completion object (choices[].message.content), not
+        // SSE. `model:"fast/m"` makes retries_filter resolve to the primary (0).
+        let filt_body = serde_json::json!({
+            "id": "gf", "model": "fast/m",
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            "choices": [{"message": {"content": "FILT"}}],
+        });
+        // Route the two calls by the MODEL ID present in the request body so the two
+        // mocks are MUTUALLY EXCLUSIVE (mount order / precedence cannot matter):
+        //   chat call body contains "deepseek/x"; filter call body contains "fast/m".
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("fast/m"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(filt_body))
+            .mount(&mock).await;
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("deepseek/x"))
+            .respond_with(ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_raw(chat_body, "text/event-stream"))
+            .mount(&mock).await;
+
+        let user_id = Uuid::new_v4();
+        let (_g, instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = std::sync::Arc::new(
+            eros_engine_llm::model_config::ModelConfig::from_toml_str(
+                "[tasks.chat_companion]\nmodel=\"deepseek/x\"\noutput_filter=true\n\
+                 [tasks.chat_output_filter]\nmodel=\"fast/m\"\nfilter_prompt=\"REWRITE\"\n",
+            ).unwrap());
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "k".into(), Default::default(),
+                format!("{}/api/v1/chat/completions", mock.uri())));
+
+        let chat_repo = ChatRepo { pool: &pool };
+        let umid = match chat_repo
+            .upsert_user_message_idempotent(session_id, "hello there friend", "01J9999999999999999999999A")
+            .await.unwrap() { UpsertUserOutcome::Inserted { message_id } => message_id, _ => unreachable!() };
+
+        let frames: Vec<ProtocolFrame> = run_stream(std::sync::Arc::new(state), PersistedUserMessage {
+            user_message_id: umid, session_id, user_id, instance_id,
+            content: "hello there friend".into(), prompt_traits: vec![], audit: None, tier: None,
+            memory_scope: Default::default(), affinity_scope: Default::default(),
+        }).collect().await;
+
+        let deltas: String = frames.iter().filter_map(|f| match f {
+            ProtocolFrame::Delta { content, .. } => Some(content.clone()), _ => None,
+        }).collect();
+        if frames.iter().any(|f| matches!(f, ProtocolFrame::Delta { .. })) {
+            assert!(deltas.contains("FILT"), "client must see filtered text, got {deltas:?}");
+            assert!(!deltas.contains("ORIG"), "original must never reach client, got {deltas:?}");
+            let (filtered, rc, rf) = frames.iter().find_map(|f| match f {
+                ProtocolFrame::Final { filtered, retries_chat, retries_filter, .. }
+                    => Some((*filtered, *retries_chat, *retries_filter)), _ => None }).unwrap();
+            assert!(filtered, "final.filtered must be true");
+            assert_eq!(rc, 0, "primary chat model served");
+            assert_eq!(rf, 0, "primary filter model served");
+            let row = sqlx::query_scalar::<_, String>(
+                "SELECT content FROM engine.chat_messages WHERE session_id=$1 AND role='assistant' ORDER BY sent_at DESC LIMIT 1")
+                .bind(session_id).fetch_one(&pool).await.unwrap();
+            assert_eq!(row, "FILT");
+        }
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn filtered_turn_fail_open_emits_original(pool: PgPool) {
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+        use futures_util::StreamExt;
+        use wiremock::matchers::{body_string_contains, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        let chat_body = "data: {\"choices\":[{\"delta\":{\"content\":\"ORIG\"}}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1,\"total_tokens\":2},\"id\":\"g\",\"model\":\"primary\"}\n\ndata: [DONE]\n\n";
+        // Filter model returns 500 → fail open to the original reply.
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("fast/m"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&mock).await;
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("deepseek/x"))
+            .respond_with(ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_raw(chat_body, "text/event-stream"))
+            .mount(&mock).await;
+
+        let user_id = Uuid::new_v4();
+        let (_g, instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = std::sync::Arc::new(
+            eros_engine_llm::model_config::ModelConfig::from_toml_str(
+                "[tasks.chat_companion]\nmodel=\"deepseek/x\"\noutput_filter=true\n\
+                 [tasks.chat_output_filter]\nmodel=\"fast/m\"\nfilter_prompt=\"REWRITE\"\n",
+            ).unwrap());
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "k".into(), Default::default(),
+                format!("{}/api/v1/chat/completions", mock.uri())));
+
+        let chat_repo = ChatRepo { pool: &pool };
+        let umid = match chat_repo
+            .upsert_user_message_idempotent(session_id, "hello there friend", "01J9999999999999999999999B")
+            .await.unwrap() { UpsertUserOutcome::Inserted { message_id } => message_id, _ => unreachable!() };
+
+        let frames: Vec<ProtocolFrame> = run_stream(std::sync::Arc::new(state), PersistedUserMessage {
+            user_message_id: umid, session_id, user_id, instance_id,
+            content: "hello there friend".into(), prompt_traits: vec![], audit: None, tier: None,
+            memory_scope: Default::default(), affinity_scope: Default::default(),
+        }).collect().await;
+
+        let deltas: String = frames.iter().filter_map(|f| match f {
+            ProtocolFrame::Delta { content, .. } => Some(content.clone()), _ => None,
+        }).collect();
+        if frames.iter().any(|f| matches!(f, ProtocolFrame::Delta { .. })) {
+            assert!(deltas.contains("ORIG"), "fail-open must emit original, got {deltas:?}");
+            assert!(!deltas.contains("FILT"), "no filtered text on fail-open, got {deltas:?}");
+            let filtered = frames.iter().find_map(|f| match f {
+                ProtocolFrame::Final { filtered, .. } => Some(*filtered), _ => None }).unwrap();
+            assert!(!filtered, "final.filtered must be false on fail-open");
+            let row = sqlx::query_scalar::<_, String>(
+                "SELECT content FROM engine.chat_messages WHERE session_id=$1 AND role='assistant' ORDER BY sent_at DESC LIMIT 1")
+                .bind(session_id).fetch_one(&pool).await.unwrap();
+            assert_eq!(row, "ORIG");
+        }
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn live_mode_when_random_zero(pool: PgPool) {
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+        use futures_util::StreamExt;
+        use wiremock::matchers::{body_string_contains, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        let chat_body = "data: {\"choices\":[{\"delta\":{\"content\":\"ORIG\"}}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1,\"total_tokens\":2},\"id\":\"g\",\"model\":\"primary\"}\n\ndata: [DONE]\n\n";
+        // random=0.0 ⇒ turn never passes the gate ⇒ LIVE mode; the filter model
+        // must never be contacted.
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("fast/m"))
+            .respond_with(ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_raw("data: [DONE]\n\n", "text/event-stream"))
+            .expect(0)
+            .mount(&mock).await;
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("deepseek/x"))
+            .respond_with(ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_raw(chat_body, "text/event-stream"))
+            .mount(&mock).await;
+
+        let user_id = Uuid::new_v4();
+        let (_g, instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = std::sync::Arc::new(
+            eros_engine_llm::model_config::ModelConfig::from_toml_str(
+                "[tasks.chat_companion]\nmodel=\"deepseek/x\"\noutput_filter=true\n\
+                 [tasks.chat_output_filter]\nmodel=\"fast/m\"\nfilter_prompt=\"REWRITE\"\ntrigger = { random = 0.0 }\n",
+            ).unwrap());
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "k".into(), Default::default(),
+                format!("{}/api/v1/chat/completions", mock.uri())));
+
+        let chat_repo = ChatRepo { pool: &pool };
+        let umid = match chat_repo
+            .upsert_user_message_idempotent(session_id, "hello there friend", "01J9999999999999999999999C")
+            .await.unwrap() { UpsertUserOutcome::Inserted { message_id } => message_id, _ => unreachable!() };
+
+        let frames: Vec<ProtocolFrame> = run_stream(std::sync::Arc::new(state), PersistedUserMessage {
+            user_message_id: umid, session_id, user_id, instance_id,
+            content: "hello there friend".into(), prompt_traits: vec![], audit: None, tier: None,
+            memory_scope: Default::default(), affinity_scope: Default::default(),
+        }).collect().await;
+
+        let deltas: String = frames.iter().filter_map(|f| match f {
+            ProtocolFrame::Delta { content, .. } => Some(content.clone()), _ => None,
+        }).collect();
+        if frames.iter().any(|f| matches!(f, ProtocolFrame::Delta { .. })) {
+            assert!(deltas.contains("ORIG"), "live mode must emit original, got {deltas:?}");
+            let filtered = frames.iter().find_map(|f| match f {
+                ProtocolFrame::Final { filtered, .. } => Some(*filtered), _ => None }).unwrap();
+            assert!(!filtered, "final.filtered must be false in live mode");
+        }
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn filtered_mode_models_miss_emits_original(pool: PgPool) {
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+        use futures_util::StreamExt;
+        use wiremock::matchers::{body_string_contains, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        let chat_body = "data: {\"choices\":[{\"delta\":{\"content\":\"ORIG\"}}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1,\"total_tokens\":2},\"id\":\"g\",\"model\":\"primary\"}\n\ndata: [DONE]\n\n";
+        // Turn-level predicates pass (no random/traits gate) ⇒ FILTERED mode, but
+        // the per-attempt models predicate fails (primary chat is "deepseek/x",
+        // not "other/model") ⇒ no filter call, emit the original.
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("fast/m"))
+            .respond_with(ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_raw("data: [DONE]\n\n", "text/event-stream"))
+            .expect(0)
+            .mount(&mock).await;
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("deepseek/x"))
+            .respond_with(ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_raw(chat_body, "text/event-stream"))
+            .mount(&mock).await;
+
+        let user_id = Uuid::new_v4();
+        let (_g, instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = std::sync::Arc::new(
+            eros_engine_llm::model_config::ModelConfig::from_toml_str(
+                "[tasks.chat_companion]\nmodel=\"deepseek/x\"\noutput_filter=true\n\
+                 [tasks.chat_output_filter]\nmodel=\"fast/m\"\nfilter_prompt=\"REWRITE\"\ntrigger = { models = [\"other/model\"] }\n",
+            ).unwrap());
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "k".into(), Default::default(),
+                format!("{}/api/v1/chat/completions", mock.uri())));
+
+        let chat_repo = ChatRepo { pool: &pool };
+        let umid = match chat_repo
+            .upsert_user_message_idempotent(session_id, "hello there friend", "01J9999999999999999999999D")
+            .await.unwrap() { UpsertUserOutcome::Inserted { message_id } => message_id, _ => unreachable!() };
+
+        let frames: Vec<ProtocolFrame> = run_stream(std::sync::Arc::new(state), PersistedUserMessage {
+            user_message_id: umid, session_id, user_id, instance_id,
+            content: "hello there friend".into(), prompt_traits: vec![], audit: None, tier: None,
+            memory_scope: Default::default(), affinity_scope: Default::default(),
+        }).collect().await;
+
+        let deltas: String = frames.iter().filter_map(|f| match f {
+            ProtocolFrame::Delta { content, .. } => Some(content.clone()), _ => None,
+        }).collect();
+        if frames.iter().any(|f| matches!(f, ProtocolFrame::Delta { .. })) {
+            assert_eq!(deltas, "ORIG", "models-miss must emit only the original, got {deltas:?}");
+            let filtered = frames.iter().find_map(|f| match f {
+                ProtocolFrame::Final { filtered, .. } => Some(*filtered), _ => None }).unwrap();
+            assert!(!filtered, "final.filtered must be false when models predicate misses");
+            let meta_count = frames.iter().filter(|f| matches!(f, ProtocolFrame::Meta { .. })).count();
+            let done_count = frames.iter().filter(|f| matches!(f, ProtocolFrame::Done { .. })).count();
+            assert_eq!(meta_count, 1, "exactly one Meta frame");
+            assert_eq!(done_count, 1, "exactly one Done frame");
+        }
     }
 }

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -601,6 +601,10 @@ pub fn run_stream(
                         return;
                     }
                 };
+                // The filter trigger's `traits` predicate AND `prompt_injected`
+                // both use the KEPT tags (post tier `allow_traits` gating), so a
+                // tier that drops a requested trait can't trigger filtering on it.
+                let trait_tags: Vec<String> = injected_tags.clone();
                 let prompt_injected = if injected_tags.is_empty() { None } else { Some(injected_tags) };
                 let (frame_action, persist_action, plan_action) = if is_gift {
                     (FrameActionType::GiftReaction, "gift_reaction", ActionType::GiftReaction)
@@ -619,8 +623,6 @@ pub fn run_stream(
                     .and_then(|f| f.trigger.random)
                     .map(|p| rand::thread_rng().gen::<f64>() < p)
                     .unwrap_or(true);
-                let trait_tags: Vec<String> =
-                    user_msg.prompt_traits.iter().map(|t| t.tag.clone()).collect();
 
                 let outcome = std::sync::Arc::new(std::sync::Mutex::new(
                     crate::pipeline::stream::BurstOutcome::default(),

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -377,7 +377,7 @@ pub fn run_stream(
                         user_msg.session_id, user_msg.user_id, user_msg.instance_id,
                     ).await
                 };
-                let req = match req_res {
+                let (req, injected_tags) = match req_res {
                     Ok(r) => r,
                     Err(e) => {
                         yield ProtocolFrame::Error {
@@ -389,6 +389,7 @@ pub fn run_stream(
                         return;
                     }
                 };
+                let prompt_injected = if injected_tags.is_empty() { None } else { Some(injected_tags) };
                 let (frame_action, persist_action, plan_action) = if is_gift {
                     (FrameActionType::GiftReaction, "gift_reaction", ActionType::GiftReaction)
                 } else {
@@ -437,7 +438,7 @@ pub fn run_stream(
                     tracing::warn!("stream: ghost streak reset failed: {e}");
                 }
 
-                let final_frame = compute_final_frame(&state, user_msg.session_id, user_msg.user_id, false, None, user_msg.tier.clone(), 0, 0).await;
+                let final_frame = compute_final_frame(&state, user_msg.session_id, user_msg.user_id, false, prompt_injected.clone(), user_msg.tier.clone(), 0, 0).await;
                 yield final_frame;
 
                 // Spawn post-process; do not await.

--- a/docs/model-config.md
+++ b/docs/model-config.md
@@ -131,14 +131,17 @@ filter_prompt = "..."            # any field is optional; falls back to the defa
 | `model` | `String` \| `Array` \| `Table` | — | Primary filter model. Accepts the same three shapes as `chat_companion.model`. |
 | `fallback` | `String` \| `Array<String>` | — | Fallback chain for the filter call. |
 | `retry_depth` | `u32` | `1` | Number of `fallback` entries the filter may try before giving up. `0` = primary only; `1` = primary + first fallback (default). |
-| `temperature` | `f64` | `defaults.fallback_temperature` | Sampling temperature for the filter model. |
-| `max_tokens` | `u32` | `defaults.fallback_max_tokens` | Token cap for the filter response. |
+| `temperature` | `f64` | `defaults.fallback_temperature` | Sampling temperature for the filter model. **Task-level only — no per-tier override** (same as every other task). |
+| `max_tokens` | `u32` | `defaults.fallback_max_tokens` | Token cap for the filter response. **Task-level only — no per-tier override.** |
 | `filter_prompt` | `String` | — | **Required for the filter to be active.** System/instruction prompt sent to the filter model. Blank or absent → filter is inert. |
 | `trigger` | inline table | absent (every turn) | AND-gate on when to apply the filter. Omit the whole key to filter every qualifying turn. |
 | `timing` | `"after_extract"` \| `"before_extract"` | `"after_extract"` | Controls whether extract (memory/insight/affinity) reads the original or the filtered text (see below). |
 
-Per-tier sub-tables (`[tasks.chat_output_filter.tiers.<tier>]`) may override any
-field. A tier that omits a field falls back to the default `[tasks.chat_output_filter]` block — the same precedence as every other task.
+Per-tier sub-tables (`[tasks.chat_output_filter.tiers.<tier>]`) may override
+`model`, `fallback`, `retry_depth`, `filter_prompt`, `trigger`, and `timing`; a
+tier that omits one falls back to the default `[tasks.chat_output_filter]` block.
+**`temperature` and `max_tokens` are task-level only** (per-tier sub-tables do not
+override them — the same rule as every other task).
 
 #### `trigger` predicates
 
@@ -148,7 +151,7 @@ field. A tier that omits a field falls back to the default `[tasks.chat_output_f
 |---|---|---|
 | `random` | `f64` in `(0.0, 1.0]` | Probability that this turn passes. `random = 0.3` → ~30 % of turns are filtered. |
 | `models` | `Array<String>` | Turn passes only if the producing model id is in the list. |
-| `traits` | `{ any = [...], when = "present" \| "absent" }` | Turn passes only if at least one tag in `any` is present (`when = "present"`) or absent (`when = "absent"`) in the active prompt-trait set. |
+| `traits` | `{ any = [...], when = "present" \| "absent" }` | Turn passes only if at least one tag in `any` is present (`when = "present"`) or absent (`when = "absent"`) among the tags **actually injected** into the prompt — i.e. after tier `allow_traits` gating, the same set reported in the `final` frame's `prompt_injected`. A trait the tier dropped does not count as present. |
 
 #### `timing` and extract behavior
 

--- a/docs/model-config.md
+++ b/docs/model-config.md
@@ -69,18 +69,127 @@ tier inherits it. Setting it on other tasks parses but has no effect.
 Because the display name is never persisted, the **array** form re-randomizes on
 history replay; `bool`/`string`/`map` are deterministic.
 
+### `output_filter` — second-pass reply rewrite (chat task only)
+
+Passes the completed chat reply through a second LLM before the client sees it. The
+filter is **off by default** and has no effect unless explicitly enabled.
+
+#### Turning the filter on
+
+`output_filter` is a boolean flag on `[tasks.chat_companion]`. It acts as a
+task-level default, which any tier sub-table may override:
+
+```toml
+[tasks.chat_companion]
+output_filter = true              # task-level default; applies when no matching tier block exists
+
+[tasks.chat_companion.tiers.gold]
+output_filter = true              # per-tier override; takes precedence over the task default
+```
+
+Resolution follows the same precedence as every other `chat_companion` field:
+
+```
+matched tier block > task default block
+```
+
+The compiled-in default when neither sets `output_filter` is `false`.
+
+#### Gating rules
+
+The filter runs for a given turn only when **all** of the following hold:
+
+1. `output_filter` resolves to `true` for the active tier (per the precedence above).
+2. `[tasks.chat_output_filter]` is present in the config.
+3. The resolved `filter_prompt` for the active tier is non-blank.
+4. Any `trigger` predicates that are present all pass (see below).
+
+If any condition is unmet the filter is **inert** — the original reply is delivered unchanged.
+
+#### `[tasks.chat_output_filter]` fields
+
+```toml
+[tasks.chat_output_filter]
+model        = "anthropic/claude-haiku-4.5"   # fast model recommended
+fallback     = ["deepseek/deepseek-v4-flash", "x/y"]
+retry_depth  = 1     # fallbacks to try on filter failure (default 1 = primary + first fallback)
+temperature  = 0.3
+max_tokens   = 400
+filter_prompt = """
+Rewrite the assistant reply below per <your policy>. Output only the rewrite.
+"""
+# trigger: AND of the predicates you specify; omit all ⇒ filter every turn.
+trigger      = { random = 0.3, models = ["x/y"], traits = { any = ["nsfw_boost"], when = "present" } }
+timing       = "after_extract"   # or "before_extract"
+
+[tasks.chat_output_filter.tiers.gold]
+filter_prompt = "..."            # any field is optional; falls back to the default block
+```
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `model` | `String` \| `Array` \| `Table` | — | Primary filter model. Accepts the same three shapes as `chat_companion.model`. |
+| `fallback` | `String` \| `Array<String>` | — | Fallback chain for the filter call. |
+| `retry_depth` | `u32` | `1` | Number of `fallback` entries the filter may try before giving up. `0` = primary only; `1` = primary + first fallback (default). |
+| `temperature` | `f64` | `defaults.fallback_temperature` | Sampling temperature for the filter model. |
+| `max_tokens` | `u32` | `defaults.fallback_max_tokens` | Token cap for the filter response. |
+| `filter_prompt` | `String` | — | **Required for the filter to be active.** System/instruction prompt sent to the filter model. Blank or absent → filter is inert. |
+| `trigger` | inline table | absent (every turn) | AND-gate on when to apply the filter. Omit the whole key to filter every qualifying turn. |
+| `timing` | `"after_extract"` \| `"before_extract"` | `"after_extract"` | Controls whether extract (memory/insight/affinity) reads the original or the filtered text (see below). |
+
+Per-tier sub-tables (`[tasks.chat_output_filter.tiers.<tier>]`) may override any
+field. A tier that omits a field falls back to the default `[tasks.chat_output_filter]` block — the same precedence as every other task.
+
+#### `trigger` predicates
+
+`trigger` is an optional inline table. Every predicate you include must pass; predicates you omit are treated as passing. Omit `trigger` entirely to filter every qualifying turn.
+
+| Predicate | Type | Semantics |
+|---|---|---|
+| `random` | `f64` in `(0.0, 1.0]` | Probability that this turn passes. `random = 0.3` → ~30 % of turns are filtered. |
+| `models` | `Array<String>` | Turn passes only if the producing model id is in the list. |
+| `traits` | `{ any = [...], when = "present" \| "absent" }` | Turn passes only if at least one tag in `any` is present (`when = "present"`) or absent (`when = "absent"`) in the active prompt-trait set. |
+
+#### `timing` and extract behavior
+
+| `timing` | Extract input | Notes |
+|---|---|---|
+| `"after_extract"` *(default)* | Original (pre-filter) text | Memory/insight/affinity see the unmodified reply; only the rewritten text is delivered to the client and persisted in `chat_messages`. |
+| `"before_extract"` | Filtered text | Extract also reads the rewritten text. Use this when the filter normalizes content that the extract pipeline should reflect. |
+
+**Fail-open:** if the filter LLM call times out or returns an error the engine delivers the **original** reply unchanged (the filter never blocks the chat response).
+
+#### What is stored / shown
+
+Only the **filtered** text is written to `chat_messages` and shown to the client. The original text is used internally for extract when `timing = "after_extract"` (default) and is then discarded. History replay therefore shows the filtered version.
+
+#### SSE `final`-frame fields
+
+The `final` event emitted at the end of a chat SSE stream includes several new
+fields. These are independent of whether the filter ran — all are always present
+when the frame is emitted.
+
+| Field | Type | Notes |
+|---|---|---|
+| `filtered` | `bool` | `true` if the output filter ran and rewrote the reply for this turn; `false` otherwise. |
+| `retries_chat` | `u32` | Number of fallback retries consumed by the chat model call (0 = primary succeeded). |
+| `retries_filter` | `u32` | Number of fallback retries consumed by the filter model call (0 = primary succeeded or filter did not run). |
+| `prompt_injected` | `Array<String>` \| `null` | Trait tags that were injected into the prompt this turn, or `null` if none. Independent of the filter. |
+| `tier` | `String` \| `null` | Echo of the `tier` field from the request, or `null` if none was sent. Independent of the filter. |
+
 ## Task names
 
 | Name | Consumed by | Status |
 |---|---|---|
 | `chat_companion` | `pipeline::handlers::ReplyHandler` and `GiftHandler` (chat completions) | live |
 | `insight_extraction` | `pipeline::post_process::extract_facts` and `extract_structured_insights` (fact mining + JSONB merge) | live |
+| `chat_output_filter` | `pipeline::handlers::ReplyHandler` (optional second-pass rewrite of the chat reply before delivery) | live |
 | `pde_decision` | reserved — current PDE is rule-based and does not call an LLM | reserved |
 | `embedding` | reserved — `VoyageClient` reads its own `VOYAGE_API_KEY` and hard-codes `voyage-3-lite` | reserved |
 
 A `[tasks.<name>]` entry is only meaningful if the engine actually calls `model_config.resolve("<name>", ...)` somewhere. The current call sites are:
 
-- `crates/eros-engine-server/src/pipeline/handlers.rs` → `chat_companion`
+- `crates/eros-engine-server/src/pipeline/handlers.rs` → `chat_companion`, `chat_output_filter`
 - `crates/eros-engine-server/src/pipeline/post_process.rs` → `insight_extraction`
 
 Anything else is either reserved for a future feature (`pde_decision`) or vestigial (`embedding` — Voyage doesn't go through this path).
@@ -162,6 +271,12 @@ What may still change without notice:
   0.x. When unset the chat `meta.model` field is **omitted** — a change from the
   earlier "always present" behavior. The shipped example sets `= true` to keep
   showing the real id.
+- `output_filter` (optional bool, `[tasks.chat_companion]` and per-tier): added in
+  0.x. Default `false`. Enables the second-pass reply rewrite via `[tasks.chat_output_filter]`.
+- `[tasks.chat_output_filter]` (new task): added in 0.x. Absent by default (filter
+  is inert). See "output_filter — second-pass reply rewrite" above.
+- SSE `final`-frame fields `filtered`, `retries_chat`, `retries_filter`,
+  `prompt_injected`, `tier`: added in 0.x.
 
 ## What this config does NOT control
 

--- a/docs/superpowers/specs/2026-05-25-chat-output-filter-design.md
+++ b/docs/superpowers/specs/2026-05-25-chat-output-filter-design.md
@@ -39,10 +39,13 @@ against the reply.
   (default block + per-tier overrides),
 - a combinable per-turn `trigger`,
 - two extract-timing modes (`after_extract` default, `before_extract`),
-- two new `final`-frame status fields: `filtered` (bool) and `prompt_injected`
-  (array of injected trait tags, `null` when none). **`prompt_injected` is
-  independent of the filter** — it surfaces the existing prompt-trait injection
-  feature (an oversight from its original design) and is bundled here for
+- a `retry_depth` on `[tasks.chat_output_filter]` capping the filter's fallback
+  chain, **default 1** (primary + first fallback only),
+- five new `final`-frame status fields: `filtered` (bool), `prompt_injected`
+  (array | null), `tier` (echo, string | null), `retries_chat` (u32),
+  `retries_filter` (u32). **`prompt_injected` and `tier` are independent of the
+  filter** — they surface the existing prompt-trait injection and the request
+  tier (both oversights from earlier designs) and are bundled here for
   convenience. (See §2.8.)
 
 **Non-goals / explicit boundaries:**
@@ -73,7 +76,8 @@ output_filter = true                  # per-tier override; beats the task defaul
 
 [tasks.chat_output_filter]            # whole table absent ⇒ filter never runs (#6)
 model        = "anthropic/claude-haiku-4.5"     # fast model recommended
-fallback     = ["deepseek/deepseek-v4-flash"]   # optional, like other tasks
+fallback     = ["deepseek/deepseek-v4-flash", "x/y"]  # optional, like other tasks
+retry_depth  = 1                       # fallbacks to try on filter failure; default 1
 temperature  = 0.3
 max_tokens   = 400
 filter_prompt = """
@@ -101,6 +105,8 @@ filter-specific fields:
   - `filter_prompt: Option<String>`
   - `trigger: Option<OutputFilterTrigger>`
   - `timing: Option<FilterTiming>`
+  - `retry_depth: Option<u32>` (chat_output_filter uses it; **default 1** when
+    unset — the filter tries the primary + at most the first `fallback` entry)
 
 ```rust
 #[derive(Debug, Clone, PartialEq, Deserialize)]
@@ -133,14 +139,21 @@ the existing `resolve()` machinery for model/fallback/temp/max_tokens):
 ```rust
 pub struct ResolvedOutputFilter {
     pub model: String,
-    pub fallback_model: Vec<String>,
+    pub fallback_model: Vec<String>,   // already truncated to retry_depth entries
     pub temperature: f64,
     pub max_tokens: u32,
     pub filter_prompt: String,
     pub trigger: OutputFilterTrigger,
     pub timing: FilterTiming,
+    pub retry_depth: u32,              // tier → default → 1
 }
 ```
+
+`retry_depth` resolves tier → default block → **1**. The filter's effective
+chain is `[model] + fallback_model[..retry_depth]` — so `retry_depth = 1`
+(default) ⇒ primary + first fallback only; `0` ⇒ primary only. The resolver
+truncates `fallback_model` to `retry_depth` entries so callers can pass the
+chain straight through.
 
 Decision procedure, per request + resolved `tier`:
 
@@ -221,14 +234,18 @@ logical bubble; every attempt is buffered (no live `Delta`s):
    predicate (`trigger.should_filter(model_id, traits, random_pass)`, with the
    turn-level parts already known true):
    - **Filter this attempt** (`should_filter` true) ⇒ call the filter LLM via
-     `execute_stream` on `ResolvedOutputFilter`'s model+fallback, messages
-     `[system: filter_prompt, user: acc]`, forwarding **its** deltas as the
-     bubble's `Delta`s, accumulating `filtered`. Log usage as task
-     `"chat_output_filter"`.
+     non-streaming `execute()` on `ResolvedOutputFilter`'s model + (depth-capped)
+     `fallback_model`, messages `[system: filter_prompt, user: acc]`. `execute()`
+     walks the chain itself; `ChatResponse.model` reports the model served, so
+     `retries_filter` = its index in the chain (`0` = primary). Emit the filtered
+     text as the bubble's `Delta` (one frame; replies are short — §0). Log usage
+     as task `"chat_output_filter"`.
      - **Success** ⇒ persist `content = filtered`; `produced.full_text =`
-       `after_extract ? acc (original) : filtered`.
-     - **Failure / timeout** ⇒ **fail-open**: emit `acc` as the bubble's
-       `Delta`s, persist `content = acc`, `produced.full_text = acc`.
+       `after_extract ? acc (original) : filtered`; set `filtered = true`,
+       `retries_filter`.
+     - **Failure / timeout** ⇒ **fail-open**: emit `acc` as the bubble's `Delta`,
+       persist `content = acc`, `produced.full_text = acc`; `filtered = false`,
+       `retries_filter = 0`.
    - **Don't filter this attempt** (only the `models` predicate failed for this
      fallback model) ⇒ emit `acc` (original) as the bubble's `Delta`s, persist
      `content = acc`, `produced.full_text = acc`.
@@ -238,6 +255,10 @@ logical bubble; every attempt is buffered (no live `Delta`s):
 
 `Meta`/`Done` framing is emitted once around the single bubble; `continues_from`
 is unused in filtered mode.
+
+In **both** modes the burst records `retries_chat` = the 0-based index of the
+successful (non-truncated) chat attempt onto the `BurstOutcome` (`0` = primary).
+`retries_filter` is set only on the filtered path (`0` otherwise).
 
 ### 2.6 Persistence, replay & extract (explicit consequences)
 
@@ -265,7 +286,7 @@ this path) are unaffected. The new fields live on the generic
 
 ### 2.8 `final`-frame status fields (`filtered`, `prompt_injected`)
 
-`ProtocolFrame::Final` gains two **always-present** fields:
+`ProtocolFrame::Final` gains five **always-present** fields:
 
 ```rust
 Final {
@@ -274,6 +295,9 @@ Final {
     agent_training_level: f64,
     filtered: bool,                        // client received filtered output this turn
     prompt_injected: Option<Vec<String>>,  // injected trait tags; null when none
+    tier: Option<String>,                  // echo of the request tier; null when none
+    retries_chat: u32,                     // fallback retries used for the chat reply
+    retries_filter: u32,                   // fallback retries used for the filter call
 }
 ```
 
@@ -286,20 +310,33 @@ Final {
 - **`filtered`** = `true` only when the client actually received filtered output
   (filtered mode + per-attempt `models` pass + filter LLM success). `false` for
   live mode, a `models`-miss, fail-open, ghost, and replay.
+- **`tier`** = the request's `tier` echoed back (`Option<String>`, `null` when
+  the request sent none). Independent of the filter — lets the frontend confirm
+  the backend actually received the tier it sent (it was never echoed before;
+  added here for convenience).
+- **`retries_chat`** = how many fallbacks the chat reply used: `0` = primary
+  succeeded, `1` = first fallback succeeded, etc. (= the successful attempt's
+  0-based index in the chain).
+- **`retries_filter`** = same for the filter call (`0` when primary filter model
+  served, `1` when its first fallback served, …). `0` whenever no filter ran.
 
 **Plumbing:**
 - `build_reply_request` / `build_gift_request` additionally return the injected
   tags (today they return only the `ChatRequest`), so `run_stream` can carry
   them into the Final frame.
-- `drive_chat_burst` reports whether it filtered via the shared burst result
-  (extend `produced_out` into a small `BurstOutcome { produced, filtered }`, or
-  add a parallel flag); `run_stream` reads it after the burst.
-- `compute_final_frame` takes `filtered` + `prompt_injected` params. The
-  Reply/GiftReaction branch passes the burst's `filtered` and the request's
-  injected tags; Ghost / Proactive / other branches pass `false` / `None`.
-- `replay_stream`: `filtered = false`, `prompt_injected = null` — neither is
-  persisted, so replay cannot reconstruct them (consistent with `lead_score` /
-  `agent_training_level` already being recomputed-from-current on replay).
+- `drive_chat_burst` reports `filtered`, `retries_chat`, `retries_filter` via the
+  shared burst result (`BurstOutcome { produced, filtered, retries_chat,
+  retries_filter }`). `retries_chat` = successful attempt index; `retries_filter`
+  = position of `ChatResponse.model` (model actually served) in the depth-capped
+  filter chain (§2.5).
+- `compute_final_frame` takes `filtered` / `prompt_injected` / `tier` /
+  `retries_chat` / `retries_filter`. The Reply/GiftReaction branch passes the
+  burst values + the request's injected tags + `user_msg.tier`; Ghost / Proactive
+  pass `false` / `None` / `user_msg.tier` / `0` / `0` (tier is still echoed).
+- `replay_stream`: `filtered=false`, `prompt_injected=null`, `tier=null`,
+  `retries_*=0` — none are persisted, so replay cannot reconstruct them
+  (consistent with `lead_score` / `agent_training_level` already being
+  recomputed-from-current on replay).
 
 Additive change to the `final` frame contract in
 `docs/superpowers/specs/2026-05-19-sse-streaming-chat-0.2-design.md` §1.5.
@@ -314,7 +351,9 @@ Additive change to the `final` frame contract in
 - **Resolve/gating:** `output_filter` precedence tier>task>false (#7/#3);
   `true` + no table ⇒ `None` (#6); `true` + table but blank `filter_prompt` ⇒
   `None`; tier missing in `chat_output_filter` ⇒ default block used (#5);
-  `timing` default `after_extract`.
+  `timing` default `after_extract`; `retry_depth` default `1` and
+  `fallback_model` truncated to it (e.g. `fallback=["a","b","c"]` + default ⇒
+  resolved chain `[model,"a"]`).
 - **`should_filter` (pure):** empty trigger ⇒ true; each predicate alone;
   AND combination; `traits` present/absent + empty `any`; `models` membership;
   `random_pass` true/false gates.
@@ -335,9 +374,13 @@ Additive change to the `final` frame contract in
 - **Final frame fields:** `filtered` true on filtered-success; false on
   fail-open / live mode / `models`-miss / ghost. `prompt_injected` = array of
   injected tags; reflects **kept** (post-gating) tags, not requested; `null`
-  when none or all dropped by tier gating. Replay Final ⇒ `filtered=false`,
-  `prompt_injected=null`. `null` serializes as `null` (field always present).
-  Update existing `final_frame_*` constructor tests for the new fields.
+  when none or all dropped by tier gating. `tier` echoes the request tier
+  (string | null), present on Reply/Ghost/Gift/Proactive, `null` on replay.
+  `retries_chat` = successful chat-attempt index (0 = primary); `retries_filter`
+  = served-filter-model index (0 when no filter / primary served). Replay Final
+  ⇒ `filtered=false`, `prompt_injected=null`, `tier=null`, `retries_*=0`. `null`
+  fields serialize as `null` (always present). Update existing `final_frame_*`
+  constructor tests for the new fields.
 
 ---
 
@@ -352,8 +395,9 @@ Additive change to the `final` frame contract in
   consequence (only filtered text is stored; after- vs before-extract).
 - Additive TOML schema; default behavior unchanged (off unless configured).
 - Update `docs/superpowers/specs/2026-05-19-sse-streaming-chat-0.2-design.md`
-  §1.5: the `final` frame now carries `filtered` (bool) and `prompt_injected`
-  (array | null). Note `prompt_injected` reflects the pre-existing trait
-  injection and is unrelated to the filter.
+  §1.5: the `final` frame now carries `filtered` (bool), `prompt_injected`
+  (array | null), `tier` (string | null), `retries_chat` (u32), `retries_filter`
+  (u32). Note `prompt_injected` + `tier` reflect pre-existing features
+  (trait injection / request tier) and are unrelated to the filter.
 - Dev-track feature: lands on `feat/chat-output-filter` → PR into `dev` →
   ships in a `0.4.21-dev` cut before promotion to stable `0.4.21`.

--- a/docs/superpowers/specs/2026-05-25-chat-output-filter-design.md
+++ b/docs/superpowers/specs/2026-05-25-chat-output-filter-design.md
@@ -1,0 +1,303 @@
+# eros-engine — Optional chat-reply output filter layer (Spec)
+
+**Status**: design, pending implementation plan
+**Target release**: `0.4.x` dev track (`0.4.21-dev`); additive TOML schema, no store migration
+**Audience**: anyone implementing the engine-side `output_filter` + `[tasks.chat_output_filter]` knobs
+
+---
+
+## 0. Background
+
+The streaming chat path (`crates/eros-engine-server/src/pipeline/stream.rs`,
+`drive_chat_burst`) generates an assistant reply token-by-token: it forwards
+each OpenRouter chunk to the client as a `Delta` frame, accumulates the full
+text in `acc`, persists one `chat_messages` row (`content = acc`), emits
+`Done`, and pushes a `ProducedMessage { full_text: acc }` to `produced_out`.
+After the burst, `post_process::run` consumes `produced[].full_text` for the
+three "extract" jobs: insight extraction, two-layer memory write, and the
+six-axis affinity eval.
+
+Downstream operators want an **optional** layer that rewrites the assistant's
+reply through a second LLM before the client sees it — purpose defined entirely
+by downstream (de-AI-ify tone, style-normalize, strip/soften content, watermark,
+etc.). It must be opt-in: if `model_config.toml` declares nothing, behavior is
+exactly as today.
+
+The transformation is purpose-agnostic to the engine: downstream supplies the
+**filter prompt** and the **model**; the engine just runs `filter_prompt`
+against the reply.
+
+---
+
+## 1. Goal / Non-goals
+
+**Goal:** a TOML-driven output filter for `chat_companion` replies with:
+- an `output_filter` on/off switch on `[tasks.chat_companion]` (global default +
+  per-tier override),
+- a `[tasks.chat_output_filter]` task holding the filter's `model` / `fallback` /
+  `temperature` / `max_tokens` / `filter_prompt` / `trigger` / `timing`
+  (default block + per-tier overrides),
+- a combinable per-turn `trigger`,
+- two extract-timing modes (`after_extract` default, `before_extract`).
+
+**Non-goals / explicit boundaries:**
+- **Not enabled by default.** Absent config ⇒ no filtering, byte-identical to
+  today's stream.
+- **No store migration.** Only the **filtered** text is persisted (`content`);
+  the original is in-memory only (fed to after-extract, then dropped). The
+  original is intentionally **not** recoverable. (See §2.6.)
+- **No new failure knob.** Filter LLM error/timeout ⇒ **fail-open**: emit the
+  original reply. (See §2.5.)
+- Scope is the chat reply path only (`Reply` + `GiftReaction`, both via
+  `drive_chat_burst`). `Ghost` has no content; `Proactive` is not on this path.
+- Not applied to non-chat tasks (insight/affinity/memory/dreaming).
+
+---
+
+## 2. Design
+
+### 2.1 Config schema (`model_config.toml`)
+
+```toml
+[tasks.chat_companion]
+# ...existing fields...
+output_filter = false                 # global on/off, default false when omitted (#7)
+
+[tasks.chat_companion.tiers.gold]
+output_filter = true                  # per-tier override; beats the task default (#3)
+
+[tasks.chat_output_filter]            # whole table absent ⇒ filter never runs (#6)
+model        = "anthropic/claude-haiku-4.5"     # fast model recommended
+fallback     = ["deepseek/deepseek-v4-flash"]   # optional, like other tasks
+temperature  = 0.3
+max_tokens   = 400
+filter_prompt = """
+Rewrite the assistant reply below. <downstream-authored instruction>.
+Output only the rewritten reply, no preamble.
+"""
+trigger      = { random = 0.3, models = ["x/y"], traits = { any = ["nsfw_boost"], when = "present" } }
+timing       = "after_extract"        # or "before_extract"; default after_extract (#2)
+
+[tasks.chat_output_filter.tiers.gold]
+model         = "..."                 # each of model/fallback/temperature/max_tokens/
+filter_prompt = "..."                 #   filter_prompt/trigger/timing is optional and
+trigger       = { random = 1.0 }      #   falls back to the default block when omitted (#5)
+```
+
+### 2.2 Config types (`model_config.rs`)
+
+Follows the existing "generic field on `TaskConfig`, inert on other tasks"
+pattern (same as `model_name_display_override`). Reuse the existing
+`model` / `fallback` / `temperature` / `max_tokens` / `tiers` plumbing; add the
+filter-specific fields:
+
+- On `TaskConfig` **and** `TierConfig`:
+  - `output_filter: Option<bool>` (chat_companion uses it; inert elsewhere)
+  - `filter_prompt: Option<String>`
+  - `trigger: Option<OutputFilterTrigger>`
+  - `timing: Option<FilterTiming>`
+
+```rust
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct OutputFilterTrigger {        // all fields optional; AND of those present
+    #[serde(default)] pub random: Option<f64>,        // probability 0.0..=1.0
+    #[serde(default)] pub models: Option<Vec<String>>,// producing model ∈ list
+    #[serde(default)] pub traits: Option<TraitPredicate>,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct TraitPredicate {
+    #[serde(default)] pub any: Vec<String>,           // tags to look for
+    #[serde(default)] pub when: TraitWhen,            // Present (default) | Absent
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum TraitWhen { #[default] Present, Absent }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum FilterTiming { #[default] AfterExtract, BeforeExtract }
+```
+
+### 2.3 Resolution & gating (`resolve_output_filter`)
+
+A request resolves to `Option<ResolvedOutputFilter>` (the `chat` handler reuses
+the existing `resolve()` machinery for model/fallback/temp/max_tokens):
+
+```rust
+pub struct ResolvedOutputFilter {
+    pub model: String,
+    pub fallback_model: Vec<String>,
+    pub temperature: f64,
+    pub max_tokens: u32,
+    pub filter_prompt: String,
+    pub trigger: OutputFilterTrigger,
+    pub timing: FilterTiming,
+}
+```
+
+Decision procedure, per request + resolved `tier`:
+
+1. **Enabled?** `output_filter` = `chat_companion` tier override → task default →
+   `false` (#7, #3). If `false` ⇒ return `None` (no filtering).
+2. **Table present?** If `[tasks.chat_output_filter]` is absent
+   (`!tasks.contains_key("chat_output_filter")`) ⇒ return `None` (#6) — regardless
+   of the `output_filter` value.
+3. **Usable prompt?** Resolve `filter_prompt` (tier → default). If it resolves
+   empty/blank ⇒ return `None` (a filter with no instruction is a no-op; treated
+   like §2.3.2).
+4. Otherwise resolve `model` / `fallback` / `temperature` / `max_tokens`
+   (tier → default block → `[defaults]` → compiled-in, via the existing
+   `resolve("chat_output_filter", tier)`), and `trigger` / `timing`
+   (tier → default; `timing` default `after_extract`; a missing `trigger` ⇒
+   empty trigger = "filter every turn"). Return `Some(ResolvedOutputFilter)`.
+
+`output_filter = true` with no `[tasks.chat_output_filter]` (or no
+`filter_prompt`) is therefore **inert**, exactly per requirement #6.
+
+### 2.4 Trigger evaluation (`should_filter`)
+
+Pure, unit-testable (scope.rs-style). All **specified** predicates must pass
+(AND); unspecified predicates impose no constraint; an entirely empty trigger
+⇒ always `true`.
+
+```rust
+impl OutputFilterTrigger {
+    pub fn should_filter(&self, model_id: &str, traits: &[PromptTrait],
+                         random_pass: bool) -> bool { ... }
+}
+```
+
+- `random`: drawn **once per turn** (before the fallback loop) into
+  `random_pass = rng.gen::<f64>() < p`; stable across all attempts of that turn.
+  Absent ⇒ no random gate.
+- `models`: `model_id` ∈ `models` — checked **per attempt** (the model about to
+  be called is known before any token is requested).
+- `traits`: `Present` ⇒ at least one of `any` is in the turn's `prompt_traits`;
+  `Absent` ⇒ none of `any` present. Empty `any` ⇒ predicate passes.
+
+Split the predicates by when they're knowable:
+- **Turn-level** (`random`, `traits`): constant for the whole turn, known before
+  any generation. If either is *specified and fails*, **no attempt can ever be
+  filtered** this turn.
+- **Per-attempt** (`models`): depends on the model about to be called.
+
+This split drives the live-vs-buffer decision in §2.5 and guarantees no original
+token reaches the client on an attempt that will be filtered.
+
+### 2.5 Runtime flow (`drive_chat_burst`)
+
+`run_stream` resolves `Option<ResolvedOutputFilter>` once (mirroring how it
+already fetches `display_override`) and threads it + the turn's `prompt_traits`
+into `drive_chat_burst`. Draw `random_pass` once.
+
+The burst picks **one of two modes** up front:
+
+**Live mode** — today's behavior, byte-identical: stream `Delta`s live per
+attempt, persist `content = acc` (original) per bubble, multi-bubble fallback
+chaining, `produced.full_text = acc`. Entered when **any** of:
+- `resolved_filter` is `None`; or
+- a turn-level predicate is specified and fails (`random_pass == false`, or the
+  `traits` predicate fails) ⇒ no attempt can be filtered this turn.
+
+**Filtered mode** — entered when `resolved_filter` is `Some` and the turn-level
+predicates pass (so at least one attempt *could* be filtered). Produces **one**
+logical bubble; every attempt is buffered (no live `Delta`s):
+
+1. Walk the fallback chain. For each attempt, generate the original with the
+   existing streaming call **but suppress client `Delta` frames** (accumulate
+   `acc` only). Truncation/usage bookkeeping is unchanged.
+2. If an attempt truncates ⇒ discard it silently (no client frames, **not
+   persisted** — a partial unfiltered reply must never be stored/shown) and
+   continue. If the whole chain truncates ⇒ emit the existing
+   `Error{UpstreamUnavailable}`.
+3. On the first non-truncated `acc`, branch on the **per-attempt** `models`
+   predicate (`trigger.should_filter(model_id, traits, random_pass)`, with the
+   turn-level parts already known true):
+   - **Filter this attempt** (`should_filter` true) ⇒ call the filter LLM via
+     `execute_stream` on `ResolvedOutputFilter`'s model+fallback, messages
+     `[system: filter_prompt, user: acc]`, forwarding **its** deltas as the
+     bubble's `Delta`s, accumulating `filtered`. Log usage as task
+     `"chat_output_filter"`.
+     - **Success** ⇒ persist `content = filtered`; `produced.full_text =`
+       `after_extract ? acc (original) : filtered`.
+     - **Failure / timeout** ⇒ **fail-open**: emit `acc` as the bubble's
+       `Delta`s, persist `content = acc`, `produced.full_text = acc`.
+   - **Don't filter this attempt** (only the `models` predicate failed for this
+     fallback model) ⇒ emit `acc` (original) as the bubble's `Delta`s, persist
+     `content = acc`, `produced.full_text = acc`.
+   - Either way persist `model = original model_id`, `usage =` the **original**
+     chat-gen usage (the filter's usage is logged, not stored on the row). Emit
+     `Done`, `return`.
+
+`Meta`/`Done` framing is emitted once around the single bubble; `continues_from`
+is unused in filtered mode.
+
+### 2.6 Persistence, replay & extract (explicit consequences)
+
+- `chat_messages.content` = what the client saw (filtered on success, original
+  on fail-open). **Replay needs no change** — it already replays stored
+  `content`.
+- The original on a filtered success is **in-memory only**: handed to
+  `post_process` via `produced.full_text` when `timing = after_extract`, then
+  dropped. Not stored, not recoverable. (User-approved tradeoff: no migration.)
+- `after_extract` (default): insight/memory/affinity run on the **original** raw
+  text; the client/history shows filtered.
+- `before_extract`: those jobs run on the **filtered** text.
+- Multi-bubble fallback chaining is **collapsed to one bubble** on filtered
+  turns (intermediate truncated attempts are invisible) — a deliberate deviation
+  from the unfiltered multi-attempt behavior, required to avoid leaking
+  unfiltered partials.
+
+### 2.7 Scope
+
+Honored for `chat_companion` replies streamed through `drive_chat_burst`:
+both `Reply` and `GiftReaction`. `Ghost` (no content) and `Proactive` (not on
+this path) are unaffected. The new fields live on the generic
+`TaskConfig`/`TierConfig`; setting them on other task blocks parses but is inert
+(consistent with the rest of the config — no `deny_unknown_fields`).
+
+---
+
+## 3. Testing
+
+- **Parse:** `output_filter` bool on task + tier; full `[tasks.chat_output_filter]`
+  incl. inline-table `trigger` (all sub-forms), `timing` enum, `filter_prompt`
+  multiline; per-tier partial overrides parse.
+- **Resolve/gating:** `output_filter` precedence tier>task>false (#7/#3);
+  `true` + no table ⇒ `None` (#6); `true` + table but blank `filter_prompt` ⇒
+  `None`; tier missing in `chat_output_filter` ⇒ default block used (#5);
+  `timing` default `after_extract`.
+- **`should_filter` (pure):** empty trigger ⇒ true; each predicate alone;
+  AND combination; `traits` present/absent + empty `any`; `models` membership;
+  `random_pass` true/false gates.
+- **Stream (wiremock for chat model + filter model):**
+  - filtered success ⇒ client receives filtered deltas, row persists filtered,
+    original never emitted;
+  - `after_extract` ⇒ `produced.full_text` = original; `before_extract` ⇒
+    filtered;
+  - filter LLM error ⇒ fail-open emits + persists original;
+  - **live mode** when a turn-level predicate fails (`random_pass` false or
+    `traits` fail) ⇒ byte-identical to today (live deltas, multi-bubble);
+  - **filtered mode, per-attempt `models` miss** ⇒ single bubble emits the
+    original (no filter call), persists original;
+  - whole chain truncates ⇒ existing error frame; truncated intermediate
+    attempt in filtered mode is not persisted/emitted.
+- **Committed example config:** parses; with `output_filter` unset, resolve ⇒
+  `None` (off by default).
+
+---
+
+## 4. Rollout
+
+- `examples/model_config.toml`: ship `[tasks.chat_output_filter]` **commented
+  out** (off by default) with a doc-comment covering `output_filter` (task +
+  per-tier), `filter_prompt`, the combinable `trigger` (random/models/traits +
+  `when`), and `timing`. Leave `chat_companion.output_filter` absent (⇒ false).
+- `docs/model-config.md`: document the two knobs, the gating rules (#5/#6/#7),
+  the trigger semantics, the fail-open behavior, and the persistence/replay
+  consequence (only filtered text is stored; after- vs before-extract).
+- Additive TOML schema; default behavior unchanged (off unless configured).
+- Dev-track feature: lands on `feat/chat-output-filter` → PR into `dev` →
+  ships in a `0.4.21-dev` cut before promotion to stable `0.4.21`.

--- a/docs/superpowers/specs/2026-05-25-chat-output-filter-design.md
+++ b/docs/superpowers/specs/2026-05-25-chat-output-filter-design.md
@@ -88,9 +88,10 @@ trigger      = { random = 0.3, models = ["x/y"], traits = { any = ["nsfw_boost"]
 timing       = "after_extract"        # or "before_extract"; default after_extract (#2)
 
 [tasks.chat_output_filter.tiers.gold]
-model         = "..."                 # each of model/fallback/temperature/max_tokens/
-filter_prompt = "..."                 #   filter_prompt/trigger/timing is optional and
-trigger       = { random = 1.0 }      #   falls back to the default block when omitted (#5)
+model         = "..."                 # per-tier overridable: model/fallback/retry_depth/
+filter_prompt = "..."                 #   filter_prompt/trigger/timing (fall back to default
+trigger       = { random = 1.0 }      #   block when omitted, #5). temperature/max_tokens are
+                                      #   task-level only (no per-tier override).
 ```
 
 ### 2.2 Config types (`model_config.rs`)
@@ -192,8 +193,10 @@ impl OutputFilterTrigger {
   Absent ⇒ no random gate.
 - `models`: `model_id` ∈ `models` — checked **per attempt** (the model about to
   be called is known before any token is requested).
-- `traits`: `Present` ⇒ at least one of `any` is in the turn's `prompt_traits`;
-  `Absent` ⇒ none of `any` present. Empty `any` ⇒ predicate passes.
+- `traits`: `Present` ⇒ at least one of `any` is in the turn's **injected** trait
+  tags (the `kept_traits` after tier `allow_traits` gating — the same set as
+  `prompt_injected`, NOT the raw requested tags, so a trait the tier dropped does
+  not count); `Absent` ⇒ none present. Empty `any` ⇒ predicate passes.
 
 Split the predicates by when they're knowable:
 - **Turn-level** (`random`, `traits`): constant for the whole turn, known before
@@ -207,8 +210,9 @@ token reaches the client on an attempt that will be filtered.
 ### 2.5 Runtime flow (`drive_chat_burst`)
 
 `run_stream` resolves `Option<ResolvedOutputFilter>` once (mirroring how it
-already fetches `display_override`) and threads it + the turn's `prompt_traits`
-into `drive_chat_burst`. Draw `random_pass` once.
+already fetches `display_override`) and threads it + the turn's **injected** trait
+tags (the `kept_traits` from `build_*_request`, post `allow_traits` gating) into
+`drive_chat_burst`. Draw `random_pass` once.
 
 The burst picks **one of two modes** up front:
 

--- a/docs/superpowers/specs/2026-05-25-chat-output-filter-design.md
+++ b/docs/superpowers/specs/2026-05-25-chat-output-filter-design.md
@@ -38,7 +38,12 @@ against the reply.
   `temperature` / `max_tokens` / `filter_prompt` / `trigger` / `timing`
   (default block + per-tier overrides),
 - a combinable per-turn `trigger`,
-- two extract-timing modes (`after_extract` default, `before_extract`).
+- two extract-timing modes (`after_extract` default, `before_extract`),
+- two new `final`-frame status fields: `filtered` (bool) and `prompt_injected`
+  (array of injected trait tags, `null` when none). **`prompt_injected` is
+  independent of the filter** — it surfaces the existing prompt-trait injection
+  feature (an oversight from its original design) and is bundled here for
+  convenience. (See §2.8.)
 
 **Non-goals / explicit boundaries:**
 - **Not enabled by default.** Absent config ⇒ no filtering, byte-identical to
@@ -258,6 +263,47 @@ this path) are unaffected. The new fields live on the generic
 `TaskConfig`/`TierConfig`; setting them on other task blocks parses but is inert
 (consistent with the rest of the config — no `deny_unknown_fields`).
 
+### 2.8 `final`-frame status fields (`filtered`, `prompt_injected`)
+
+`ProtocolFrame::Final` gains two **always-present** fields:
+
+```rust
+Final {
+    lead_score: f64,
+    should_show_cta: bool,
+    agent_training_level: f64,
+    filtered: bool,                        // client received filtered output this turn
+    prompt_injected: Option<Vec<String>>,  // injected trait tags; null when none
+}
+```
+
+- **`prompt_injected`** = JSON array of the trait tags **actually injected** into
+  the system prompt — i.e. `kept_traits` *after* tier `allow_traits` gating in
+  `build_reply_request` / `build_gift_request`, mapped to their `tag`. `null`
+  when nothing was injected. **No `skip_serializing_if`** → always present
+  (array or `null`). Independent of the filter feature; reflects only trait
+  injection. (Example: `"prompt_injected": ["nsfw_boost"]`.)
+- **`filtered`** = `true` only when the client actually received filtered output
+  (filtered mode + per-attempt `models` pass + filter LLM success). `false` for
+  live mode, a `models`-miss, fail-open, ghost, and replay.
+
+**Plumbing:**
+- `build_reply_request` / `build_gift_request` additionally return the injected
+  tags (today they return only the `ChatRequest`), so `run_stream` can carry
+  them into the Final frame.
+- `drive_chat_burst` reports whether it filtered via the shared burst result
+  (extend `produced_out` into a small `BurstOutcome { produced, filtered }`, or
+  add a parallel flag); `run_stream` reads it after the burst.
+- `compute_final_frame` takes `filtered` + `prompt_injected` params. The
+  Reply/GiftReaction branch passes the burst's `filtered` and the request's
+  injected tags; Ghost / Proactive / other branches pass `false` / `None`.
+- `replay_stream`: `filtered = false`, `prompt_injected = null` — neither is
+  persisted, so replay cannot reconstruct them (consistent with `lead_score` /
+  `agent_training_level` already being recomputed-from-current on replay).
+
+Additive change to the `final` frame contract in
+`docs/superpowers/specs/2026-05-19-sse-streaming-chat-0.2-design.md` §1.5.
+
 ---
 
 ## 3. Testing
@@ -286,6 +332,12 @@ this path) are unaffected. The new fields live on the generic
     attempt in filtered mode is not persisted/emitted.
 - **Committed example config:** parses; with `output_filter` unset, resolve ⇒
   `None` (off by default).
+- **Final frame fields:** `filtered` true on filtered-success; false on
+  fail-open / live mode / `models`-miss / ghost. `prompt_injected` = array of
+  injected tags; reflects **kept** (post-gating) tags, not requested; `null`
+  when none or all dropped by tier gating. Replay Final ⇒ `filtered=false`,
+  `prompt_injected=null`. `null` serializes as `null` (field always present).
+  Update existing `final_frame_*` constructor tests for the new fields.
 
 ---
 
@@ -299,5 +351,9 @@ this path) are unaffected. The new fields live on the generic
   the trigger semantics, the fail-open behavior, and the persistence/replay
   consequence (only filtered text is stored; after- vs before-extract).
 - Additive TOML schema; default behavior unchanged (off unless configured).
+- Update `docs/superpowers/specs/2026-05-19-sse-streaming-chat-0.2-design.md`
+  §1.5: the `final` frame now carries `filtered` (bool) and `prompt_injected`
+  (array | null). Note `prompt_injected` reflects the pre-existing trait
+  injection and is unrelated to the filter.
 - Dev-track feature: lands on `feat/chat-output-filter` → PR into `dev` →
   ships in a `0.4.21-dev` cut before promotion to stable `0.4.21`.

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -58,6 +58,32 @@ model_name_display_override = true
 #fallback     = ["thedrummer/cydonia-24b-v4.1", "x-ai/grok-4.3"]
 #allow_traits = ["nsfw_boost", "politics_open"]
 
+# ── Optional output filter (OFF by default) ──────────────────────────────
+# Rewrites the chat reply through a second LLM before the client sees it.
+# Enable per-tier (or globally) with `output_filter` on [tasks.chat_companion]:
+#   [tasks.chat_companion]
+#   output_filter = true                 # global default (default: false)
+#   [tasks.chat_companion.tiers.gold]
+#   output_filter = true                 # per-tier; overrides the global default
+#
+# The filter only runs if BOTH output_filter is true AND this table exists with
+# a non-blank filter_prompt; otherwise it is inert. Only the FILTERED text is
+# shown/stored; extract (memory/insight/affinity) reads the original by default.
+#[tasks.chat_output_filter]
+#model        = "anthropic/claude-haiku-4.5"   # fast model recommended
+#fallback     = ["deepseek/deepseek-v4-flash", "x/y"]
+#retry_depth  = 1     # fallbacks to try on filter failure; default 1 (primary + first fallback)
+#temperature  = 0.3
+#max_tokens   = 400
+#filter_prompt = """
+#Rewrite the assistant reply below per <your policy>. Output only the rewrite.
+#"""
+# trigger: AND of the predicates you specify; omit all ⇒ filter every turn.
+#trigger      = { random = 0.3, models = ["x/y"], traits = { any = ["nsfw_boost"], when = "present" } }
+#timing       = "after_extract"   # or "before_extract"
+#[tasks.chat_output_filter.tiers.gold]
+#filter_prompt = "..."            # any field optional; falls back to the default block
+
 [tasks.insight_extraction]
 model = "anthropic/claude-haiku-4.5"
 fallback = ["deepseek/deepseek-v4-flash","google/gemini-3.1-flash-lite"]

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -79,10 +79,14 @@ model_name_display_override = true
 #Rewrite the assistant reply below per <your policy>. Output only the rewrite.
 #"""
 # trigger: AND of the predicates you specify; omit all ⇒ filter every turn.
+# `traits` matches the tags ACTUALLY injected (after tier allow_traits gating),
+# i.e. the same set reported in the final frame's prompt_injected.
 #trigger      = { random = 0.3, models = ["x/y"], traits = { any = ["nsfw_boost"], when = "present" } }
 #timing       = "after_extract"   # or "before_extract"
 #[tasks.chat_output_filter.tiers.gold]
-#filter_prompt = "..."            # any field optional; falls back to the default block
+# per-tier may override model/fallback/retry_depth/filter_prompt/trigger/timing
+# (NOT temperature/max_tokens — those are task-level only, like every other task)
+#filter_prompt = "..."
 
 [tasks.insight_extraction]
 model = "anthropic/claude-haiku-4.5"


### PR DESCRIPTION
## Summary
- Adds an **opt-in chat-reply output filter**: `output_filter` switch on `[tasks.chat_companion]` (task default + per-tier) plus a `[tasks.chat_output_filter]` task (`model`/`fallback`/`retry_depth`/`temperature`/`max_tokens`/`filter_prompt`/`trigger`/`timing`). When active, the streamed reply is rewritten by a second LLM before the client sees it.
- **Gating** (per spec): inert unless `output_filter` is true AND `[tasks.chat_output_filter]` exists AND `filter_prompt` is non-blank; tier fields fall back to the default block; default OFF.
- **Trigger**: AND of optional predicates — `random` (probability), `models` (producing model in list), `traits` (`{any, when: present|absent}`); omit all ⇒ every turn.
- **Behavior**: filtered mode buffers the original (never streamed), runs the filter, emits one bubble; only the filtered text is shown/persisted; `timing=after_extract` (default) extracts on the original, `before_extract` on the filtered; **fail-open** to the original on filter error/timeout; `retry_depth` default 1 caps the filter fallback chain.
- New SSE `final`-frame fields: `filtered`, `prompt_injected` (injected trait tags | null), `tier` (echo | null), `retries_chat`, `retries_filter`. `prompt_injected` + `tier` surface pre-existing features (trait injection / request tier).
- Spec: `docs/superpowers/specs/2026-05-25-chat-output-filter-design.md`; docs in `docs/model-config.md`; example in `examples/model_config.toml` (off by default).

## Test plan
- [x] `cargo test --workspace` green (incl. new sqlx+wiremock tests: filtered-success, fail-open, live-when-random-0, models-miss, extract_text)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] OpenAPI snapshot no drift
- [ ] Verify a live dev cut once merged (manual smoke of a filtered turn)

🤖 Generated with [Claude Code](https://claude.com/claude-code)