### PR TITLE
feat: tip-aware streaming reply (tips_amount_usd)

### DIFF
--- a/crates/eros-engine-core/src/pde.rs
+++ b/crates/eros-engine-core/src/pde.rs
@@ -32,6 +32,23 @@ const GHOST_DELTA_TENSION: f64 = 0.05;
 ///
 /// Phase 2: rules only. Phase 6 adds the LLM fallback path.
 pub fn decide(input: &DecisionInput) -> ActionPlan {
+    // 0. Tip on a user message — always reply, never ghost. Tone is driven by
+    //    tip_personality (injected into the prompt downstream); the ReplyStyle
+    //    here is only a baseline / fallback. Affinity deltas stay normal.
+    if let Event::UserMessage { tips_amount_usd: Some(_), .. } = &input.event {
+        let reply_style = match input.persona.genome.tip_personality.as_deref() {
+            Some(_) => ReplyStyle::Neutral,
+            None => ReplyStyle::Tsundere,
+        };
+        return ActionPlan {
+            action_type: ActionType::Reply,
+            reply_style,
+            affinity_deltas: predict_reply_deltas(input),
+            energy_cost: ENERGY_COST_REPLY,
+            context_hints: vec![],
+        };
+    }
+
     // 1. Gift event — deterministic
     if matches!(input.event, Event::Gift { .. }) {
         return ActionPlan {
@@ -211,6 +228,20 @@ mod tests {
             tier: None,
             memory_scope: Default::default(),
             affinity_scope: Default::default(),
+            tips_amount_usd: None,
+        }
+    }
+
+    fn tip_msg(amount: f64) -> Event {
+        Event::UserMessage {
+            content: String::new(),
+            message_id: Uuid::new_v4(),
+            prompt_traits: Vec::new(),
+            audit: None,
+            tier: None,
+            memory_scope: Default::default(),
+            affinity_scope: Default::default(),
+            tips_amount_usd: Some(amount),
         }
     }
 
@@ -234,6 +265,49 @@ mod tests {
         let plan = decide(&input);
         assert_eq!(plan.action_type, ActionType::GiftReaction);
         assert_eq!(plan.reply_style, ReplyStyle::Excited);
+    }
+
+    #[test]
+    fn test_tip_forces_reply_even_when_ghost_signals_present() {
+        // Same affinity that drives test_ghost_threshold_triggers_ghost_action.
+        let mut affinity = base_affinity();
+        affinity.intrigue = 0.05;
+        affinity.patience = 0.05;
+        affinity.tension = 0.5;
+        let input = DecisionInput {
+            event: tip_msg(20.0),
+            affinity,
+            persona: persona_with_tip(None),
+            signals: base_signals(),
+        };
+        let plan = decide(&input);
+        assert_eq!(plan.action_type, ActionType::Reply, "a tip must never be ghosted");
+    }
+
+    #[test]
+    fn test_tip_reply_style_neutral_when_personality_present() {
+        let input = DecisionInput {
+            event: tip_msg(20.0),
+            affinity: base_affinity(),
+            persona: persona_with_tip(Some("傲娇")),
+            signals: base_signals(),
+        };
+        let plan = decide(&input);
+        assert_eq!(plan.action_type, ActionType::Reply);
+        assert_eq!(plan.reply_style, ReplyStyle::Neutral);
+    }
+
+    #[test]
+    fn test_tip_reply_style_tsundere_when_personality_absent() {
+        let input = DecisionInput {
+            event: tip_msg(20.0),
+            affinity: base_affinity(),
+            persona: persona_with_tip(None),
+            signals: base_signals(),
+        };
+        let plan = decide(&input);
+        assert_eq!(plan.action_type, ActionType::Reply);
+        assert_eq!(plan.reply_style, ReplyStyle::Tsundere);
     }
 
     #[test]

--- a/crates/eros-engine-core/src/pde.rs
+++ b/crates/eros-engine-core/src/pde.rs
@@ -35,7 +35,11 @@ pub fn decide(input: &DecisionInput) -> ActionPlan {
     // 0. Tip on a user message — always reply, never ghost. Tone is driven by
     //    tip_personality (injected into the prompt downstream); the ReplyStyle
     //    here is only a baseline / fallback. Affinity deltas stay normal.
-    if let Event::UserMessage { tips_amount_usd: Some(_), .. } = &input.event {
+    if let Event::UserMessage {
+        tips_amount_usd: Some(_),
+        ..
+    } = &input.event
+    {
         let reply_style = match input.persona.genome.tip_personality.as_deref() {
             Some(_) => ReplyStyle::Neutral,
             None => ReplyStyle::Tsundere,
@@ -281,7 +285,11 @@ mod tests {
             signals: base_signals(),
         };
         let plan = decide(&input);
-        assert_eq!(plan.action_type, ActionType::Reply, "a tip must never be ghosted");
+        assert_eq!(
+            plan.action_type,
+            ActionType::Reply,
+            "a tip must never be ghosted"
+        );
     }
 
     #[test]

--- a/crates/eros-engine-core/src/types.rs
+++ b/crates/eros-engine-core/src/types.rs
@@ -230,6 +230,23 @@ mod tests {
     }
 
     #[test]
+    fn event_user_message_defaults_tips_amount_to_none() {
+        let raw = r#"{"UserMessage":{"content":"hi","message_id":"00000000-0000-0000-0000-000000000001"}}"#;
+        let ev: Event = serde_json::from_str(raw).expect("legacy body deserialises");
+        match ev {
+            Event::UserMessage {
+                tips_amount_usd, ..
+            } => {
+                assert!(
+                    tips_amount_usd.is_none(),
+                    "missing field must default to None"
+                );
+            }
+            _ => panic!("expected UserMessage"),
+        }
+    }
+
+    #[test]
     fn chat_response_defaults_audit_fields_to_none() {
         let r = ChatResponse {
             reply: "hi".into(),

--- a/crates/eros-engine-core/src/types.rs
+++ b/crates/eros-engine-core/src/types.rs
@@ -63,6 +63,11 @@ pub enum Event {
         /// Defaults to `bond` when absent.
         #[serde(default)]
         affinity_scope: AffinityScope,
+        /// Optional caller-supplied tip amount in USD. When `Some`, this turn
+        /// is a tip: the PDE forces a reply (never ghost) and the reply prompt
+        /// gets a tip fragment. `None` for normal messages.
+        #[serde(default)]
+        tips_amount_usd: Option<f64>,
     },
     Gift {
         gift_id: Uuid,

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -1749,6 +1749,13 @@
               "string",
               "null"
             ]
+          },
+          "tips_amount_usd": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double"
           }
         }
       },

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -493,7 +493,7 @@ pub(super) async fn build_reply_request(
         );
     }
 
-    let system_prompt = build_prompt(
+    let mut system_prompt = build_prompt(
         &input.persona,
         &profile_groups,
         &relationship_facts,
@@ -505,6 +505,15 @@ pub(super) async fn build_reply_request(
         &kept_traits,
         affinity_scope,
     );
+
+    if let Event::UserMessage {
+        tips_amount_usd: Some(amount),
+        ..
+    } = &input.event
+    {
+        let tp = input.persona.genome.tip_personality.as_deref();
+        system_prompt.push_str(&crate::prompt::tips_reaction_context(*amount, tp));
+    }
 
     let injected_tags: Vec<String> = kept_traits.iter().map(|t| t.tag.clone()).collect();
     Ok((

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -511,6 +511,8 @@ pub(super) async fn build_reply_request(
         ..
     } = &input.event
     {
+        // Raw Option (not the "normal"-defaulted local above): tips_reaction_context
+        // renders Some vs None as different prose, so the distinction must survive.
         let tp = input.persona.genome.tip_personality.as_deref();
         system_prompt.push_str(&crate::prompt::tips_reaction_context(*amount, tp));
     }

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -1231,6 +1231,7 @@ mod tests {
             tier: None,
             memory_scope: Default::default(),
             affinity_scope: Default::default(),
+            tips_amount_usd: None,
         };
         let extracted = audit_from_event(&ev);
         assert_eq!(extracted, Some(&audit));

--- a/crates/eros-engine-server/src/pipeline/post_process.rs
+++ b/crates/eros-engine-server/src/pipeline/post_process.rs
@@ -739,6 +739,7 @@ mod tests {
             tier: None,
             memory_scope: Default::default(),
             affinity_scope: Default::default(),
+            tips_amount_usd: None,
         };
         // Only `user` is taken; session_id/metadata are ignored by design.
         assert_eq!(client_id_from_event(&event).as_deref(), Some("u_abc"));
@@ -754,6 +755,7 @@ mod tests {
             tier: None,
             memory_scope: Default::default(),
             affinity_scope: Default::default(),
+            tips_amount_usd: None,
         };
         assert_eq!(client_id_from_event(&event), None);
     }

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -1807,6 +1807,89 @@ data: [DONE]\n\n";
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn run_stream_tip_injects_reward_block_in_prompt(pool: PgPool) {
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+        use futures_util::StreamExt;
+        use wiremock::matchers::path as wm_path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        let body = "\
+data: {\"choices\":[{\"delta\":{\"content\":\"谢谢\"}}],\"usage\":{\"prompt_tokens\":2,\"completion_tokens\":2,\"total_tokens\":4},\"id\":\"gen-r\",\"model\":\"primary\"}\n\n\
+data: [DONE]\n\n";
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+
+        let user_id = Uuid::new_v4();
+        let (_g, instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                eros_engine_llm::openrouter::AppAttribution::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+
+        let chat_repo = ChatRepo { pool: &pool };
+        let user_message_id = match chat_repo
+            .upsert_user_message_idempotent(session_id, "(打赏 $20)", "01J5555555555555555555555A")
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
+
+        let frames: Vec<ProtocolFrame> = run_stream(
+            std::sync::Arc::new(state),
+            PersistedUserMessage {
+                user_message_id,
+                session_id,
+                user_id,
+                instance_id,
+                content: "(打赏 $20)".into(),
+                prompt_traits: vec![],
+                audit: None,
+                tier: None,
+                memory_scope: Default::default(),
+                affinity_scope: Default::default(),
+                tips_amount_usd: Some(20.0),
+            },
+        )
+        .collect()
+        .await;
+
+        assert!(
+            !frames
+                .iter()
+                .any(|f| matches!(f, ProtocolFrame::Error { .. })),
+            "no error frame expected, got {frames:?}",
+        );
+        assert!(matches!(frames.last(), Some(ProtocolFrame::Final { .. })));
+
+        // A tip is never ghosted ⇒ exactly one LLM call, whose system prompt
+        // carries the tip block.
+        let reqs = mock.received_requests().await.unwrap();
+        assert!(
+            !reqs.is_empty(),
+            "tip must trigger an LLM call (never ghosted)"
+        );
+        let sent = String::from_utf8_lossy(&reqs[0].body);
+        assert!(
+            sent.contains("【刚收到的打赏】") && sent.contains("$20"),
+            "system prompt must contain the tip block, got: {sent}",
+        );
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
     async fn filtered_mode_models_miss_emits_original(pool: PgPool) {
         use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
         use futures_util::StreamExt;

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -474,6 +474,7 @@ pub struct PersistedUserMessage {
     pub tier: Option<String>,
     pub memory_scope: eros_engine_core::scope::MemoryScope,
     pub affinity_scope: eros_engine_core::scope::AffinityScope,
+    pub tips_amount_usd: Option<f64>,
 }
 
 /// Produce a stream of `ProtocolFrame` events for a single burst. The
@@ -542,7 +543,7 @@ pub fn run_stream(
                 tier: user_msg.tier.clone(),
                 memory_scope: user_msg.memory_scope,
                 affinity_scope: user_msg.affinity_scope,
-                tips_amount_usd: None,
+                tips_amount_usd: user_msg.tips_amount_usd,
             },
             affinity: affinity.clone(),
             persona,
@@ -694,7 +695,7 @@ pub fn run_stream(
                     tier: user_msg.tier.clone(),
                     memory_scope: user_msg.memory_scope,
                     affinity_scope: user_msg.affinity_scope,
-                    tips_amount_usd: None,
+                    tips_amount_usd: user_msg.tips_amount_usd,
                 };
                 let user_id_bg = user_msg.user_id;
                 let instance_id_bg = user_msg.instance_id;
@@ -1058,6 +1059,7 @@ mod tests {
                 tier: None,
                 memory_scope: Default::default(),
                 affinity_scope: Default::default(),
+                tips_amount_usd: None,
             },
         )
         .collect()
@@ -1182,6 +1184,7 @@ data: [DONE]\n\n";
                 tier: None,
                 memory_scope: Default::default(),
                 affinity_scope: Default::default(),
+                tips_amount_usd: None,
             },
         )
         .collect()
@@ -1258,6 +1261,7 @@ data: [DONE]\n\n";
                 tier: None,
                 memory_scope: Default::default(),
                 affinity_scope: Default::default(),
+                tips_amount_usd: None,
             },
         )
         .collect()
@@ -1350,6 +1354,7 @@ data: [DONE]\n\n";
                 tier: None,
                 memory_scope: Default::default(),
                 affinity_scope: Default::default(),
+                tips_amount_usd: None,
             },
         )
         .collect()
@@ -1538,6 +1543,7 @@ data: [DONE]\n\n";
                 tier: None,
                 memory_scope: Default::default(),
                 affinity_scope: Default::default(),
+                tips_amount_usd: None,
             },
         )
         .collect()
@@ -1654,6 +1660,7 @@ data: [DONE]\n\n";
                 tier: None,
                 memory_scope: Default::default(),
                 affinity_scope: Default::default(),
+                tips_amount_usd: None,
             },
         )
         .collect()
@@ -1767,6 +1774,7 @@ data: [DONE]\n\n";
                 tier: None,
                 memory_scope: Default::default(),
                 affinity_scope: Default::default(),
+                tips_amount_usd: None,
             },
         )
         .collect()
@@ -1873,6 +1881,7 @@ data: [DONE]\n\n";
                 tier: None,
                 memory_scope: Default::default(),
                 affinity_scope: Default::default(),
+                tips_amount_usd: None,
             },
         )
         .collect()

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -542,6 +542,7 @@ pub fn run_stream(
                 tier: user_msg.tier.clone(),
                 memory_scope: user_msg.memory_scope,
                 affinity_scope: user_msg.affinity_scope,
+                tips_amount_usd: None,
             },
             affinity: affinity.clone(),
             persona,
@@ -693,6 +694,7 @@ pub fn run_stream(
                     tier: user_msg.tier.clone(),
                     memory_scope: user_msg.memory_scope,
                     affinity_scope: user_msg.affinity_scope,
+                    tips_amount_usd: None,
                 };
                 let user_id_bg = user_msg.user_id;
                 let instance_id_bg = user_msg.instance_id;

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -1884,7 +1884,7 @@ data: [DONE]\n\n";
         );
         let sent = String::from_utf8_lossy(&reqs[0].body);
         assert!(
-            sent.contains("【刚收到的打赏】") && sent.contains("$20"),
+            sent.contains("【刚收到的打赏】") && sent.contains("$20 美元的红包"),
             "system prompt must contain the tip block, got: {sent}",
         );
     }

--- a/crates/eros-engine-server/src/prompt.rs
+++ b/crates/eros-engine-server/src/prompt.rs
@@ -267,6 +267,49 @@ pub fn gift_reaction_context(gifts: &[PendingGift], tip_personality: &str) -> St
     )
 }
 
+/// Format a USD amount for display: whole numbers drop decimals (`$20`),
+/// fractional amounts keep two (`$5.50`). Used by the tip prompt fragment and
+/// the persisted tip marker content.
+pub(crate) fn fmt_amount(amount_usd: f64) -> String {
+    if amount_usd.fract() == 0.0 {
+        format!("{}", amount_usd as i64)
+    } else {
+        format!("{:.2}", (amount_usd * 100.0).round() / 100.0)
+    }
+}
+
+/// Coarse magnitude adjective for a tip, log10-bucketed. Covers any positive
+/// amount; the frontend's 5 preset buttons each land squarely in one bucket.
+fn tip_tier_adjective(amount_usd: f64) -> &'static str {
+    if amount_usd < 10.0 {
+        "一般"
+    } else if amount_usd < 100.0 {
+        "有点多"
+    } else if amount_usd < 1000.0 {
+        "超级多"
+    } else if amount_usd < 10000.0 {
+        "非常夸张"
+    } else {
+        "近乎不可思议"
+    }
+}
+
+/// Prompt fragment appended to a tip turn's system prompt. Carries the literal
+/// dollar amount, the tier adjective, and — when set — the persona's free-form
+/// `tip_personality` passed through verbatim for the LLM to interpret.
+pub fn tips_reaction_context(amount_usd: f64, tip_personality: Option<&str>) -> String {
+    let how = match tip_personality {
+        Some(p) => format!("请代入你「{p}」的打赏反应人设，自然地回应这份心意"),
+        None => "请自然地回应这份心意".to_string(),
+    };
+    format!(
+        "\n\n【刚收到的打赏】\n用户刚刚给你发了一个 ${} 美元的红包，对你来说算「{}」的一笔。\n{}，不要照搬本指令原文。",
+        fmt_amount(amount_usd),
+        tip_tier_adjective(amount_usd),
+        how,
+    )
+}
+
 /// Pluck a string field out of `art_metadata`.
 fn meta_str<'a>(persona: &'a CompanionPersona, key: &str) -> Option<&'a str> {
     persona
@@ -1049,6 +1092,51 @@ mod tests {
     #[test]
     fn test_gift_reaction_empty_when_no_gifts() {
         assert!(gift_reaction_context(&[], "normal").is_empty());
+    }
+
+    #[test]
+    fn fmt_amount_integer_has_no_decimals() {
+        assert_eq!(fmt_amount(20.0), "20");
+        assert_eq!(fmt_amount(2.0), "2");
+        assert_eq!(fmt_amount(20000.0), "20000");
+    }
+
+    #[test]
+    fn fmt_amount_fractional_has_two_decimals() {
+        assert_eq!(fmt_amount(5.5), "5.50");
+        assert_eq!(fmt_amount(5.555), "5.56");
+    }
+
+    #[test]
+    fn tip_tier_adjective_buckets_by_magnitude() {
+        assert_eq!(tip_tier_adjective(2.0), "一般");
+        assert_eq!(tip_tier_adjective(9.99), "一般");
+        assert_eq!(tip_tier_adjective(10.0), "有点多");
+        assert_eq!(tip_tier_adjective(99.0), "有点多");
+        assert_eq!(tip_tier_adjective(100.0), "超级多");
+        assert_eq!(tip_tier_adjective(999.0), "超级多");
+        assert_eq!(tip_tier_adjective(1000.0), "非常夸张");
+        assert_eq!(tip_tier_adjective(9999.0), "非常夸张");
+        assert_eq!(tip_tier_adjective(10000.0), "近乎不可思议");
+        assert_eq!(tip_tier_adjective(20000.0), "近乎不可思议");
+    }
+
+    #[test]
+    fn tips_reaction_context_with_personality_includes_name_amount_adjective() {
+        let s = tips_reaction_context(20.0, Some("傲娇"));
+        assert!(s.contains("【刚收到的打赏】"));
+        assert!(s.contains("$20"));
+        assert!(s.contains("有点多"));
+        assert!(s.contains("傲娇"));
+    }
+
+    #[test]
+    fn tips_reaction_context_without_personality_omits_persona_clause() {
+        let s = tips_reaction_context(20.0, None);
+        assert!(s.contains("【刚收到的打赏】"));
+        assert!(s.contains("$20"));
+        assert!(s.contains("有点多"));
+        assert!(!s.contains("人设"));
     }
 
     fn fixture_affinity() -> Affinity {

--- a/crates/eros-engine-server/src/routes/companion_stream.rs
+++ b/crates/eros-engine-server/src/routes/companion_stream.rs
@@ -29,6 +29,7 @@ use crate::state::AppState;
 
 const MAX_CONTENT_CHARS: usize = 4096;
 const MAX_TIER_LEN: usize = 32;
+const MAX_TIP_USD: f64 = 1_000_000.0;
 const MIN_CLIENT_MSG_ID_LEN: usize = 26;
 const MAX_CLIENT_MSG_ID_LEN: usize = 36;
 const CONCURRENT_STREAMS_PER_USER: u32 = 3;
@@ -82,6 +83,8 @@ pub struct StreamSendRequest {
     pub memory_scope: Option<MemoryScope>,
     #[serde(default)]
     pub affinity_scope: Option<AffinityScopeDto>,
+    #[serde(default)]
+    pub tips_amount_usd: Option<f64>,
 }
 
 /// Pre-stream error body per spec §1.3. Schema-only struct for utoipa;
@@ -96,7 +99,8 @@ pub struct StreamPreErrorBody {
 }
 
 fn validate_payload(req: &StreamSendRequest) -> Result<(), AppError> {
-    if req.content.is_empty() {
+    // Content may be empty only when a tip is attached (a tip is a button tap).
+    if req.content.is_empty() && req.tips_amount_usd.is_none() {
         return Err(AppError::StreamPre(StreamPreError {
             status: StatusCode::UNPROCESSABLE_ENTITY,
             code: "unprocessable",
@@ -104,6 +108,17 @@ fn validate_payload(req: &StreamSendRequest) -> Result<(), AppError> {
             user_message: "请输入一条消息".into(),
             original_user_message_id: None,
         }));
+    }
+    if let Some(amount) = req.tips_amount_usd {
+        if !amount.is_finite() || amount <= 0.0 || amount > MAX_TIP_USD {
+            return Err(AppError::StreamPre(StreamPreError {
+                status: StatusCode::UNPROCESSABLE_ENTITY,
+                code: "unprocessable",
+                message: format!("tips_amount_usd must be a finite value in (0, {MAX_TIP_USD}]"),
+                user_message: "打赏金额无效".into(),
+                original_user_message_id: None,
+            }));
+        }
     }
     if req.content.chars().count() > MAX_CONTENT_CHARS {
         return Err(AppError::StreamPre(StreamPreError {
@@ -256,8 +271,16 @@ pub async fn send_message_stream(
             })
         })?;
 
+    let persisted_content = if req.content.is_empty() {
+        match req.tips_amount_usd {
+            Some(amount) => format!("(打赏 ${})", crate::prompt::fmt_amount(amount)),
+            None => req.content.clone(), // unreachable post-validation
+        }
+    } else {
+        req.content.clone()
+    };
     let outcome = chat_repo
-        .upsert_user_message_idempotent(session_id, &req.content, &req.client_msg_id)
+        .upsert_user_message_idempotent(session_id, &persisted_content, &req.client_msg_id)
         .await?;
     // Resolve the proto stream. Replay returns early with a boxed stream;
     // Inserted continues to run_stream below. Boxing erases the concrete type
@@ -277,12 +300,13 @@ pub async fn send_message_stream(
                     session_id,
                     user_id,
                     instance_id,
-                    content: req.content.clone(),
+                    content: persisted_content.clone(),
                     prompt_traits: prompt_traits.clone(),
                     audit: audit.clone(),
                     tier: req.tier.clone(),
                     memory_scope,
                     affinity_scope,
+                    tips_amount_usd: req.tips_amount_usd,
                 };
                 Box::pin(run_stream(state_arc, user_msg))
             }
@@ -360,7 +384,47 @@ mod tests {
             tier: tier.map(String::from),
             memory_scope: None,
             affinity_scope: None,
+            tips_amount_usd: None,
         }
+    }
+
+    fn req_tip(amount: Option<f64>, content: &str) -> StreamSendRequest {
+        StreamSendRequest {
+            content: content.into(),
+            client_msg_id: "01J5555555555555555555555A".into(),
+            prompt_traits: None,
+            audit: None,
+            tier: None,
+            memory_scope: None,
+            affinity_scope: None,
+            tips_amount_usd: amount,
+        }
+    }
+
+    #[test]
+    fn validate_payload_tip_allows_empty_content() {
+        assert!(validate_payload(&req_tip(Some(20.0), "")).is_ok());
+    }
+
+    #[test]
+    fn validate_payload_rejects_empty_content_without_tip() {
+        assert!(validate_payload(&req_tip(None, "")).is_err());
+    }
+
+    #[test]
+    fn validate_payload_rejects_bad_tip_amounts() {
+        assert!(validate_payload(&req_tip(Some(0.0), "")).is_err());
+        assert!(validate_payload(&req_tip(Some(-5.0), "")).is_err());
+        assert!(validate_payload(&req_tip(Some(2_000_000.0), "")).is_err());
+        assert!(validate_payload(&req_tip(Some(f64::NAN), "")).is_err());
+        assert!(validate_payload(&req_tip(Some(f64::INFINITY), "")).is_err());
+    }
+
+    #[test]
+    fn validate_payload_accepts_wellformed_tip() {
+        assert!(validate_payload(&req_tip(Some(2.0), "")).is_ok());
+        assert!(validate_payload(&req_tip(Some(20000.0), "")).is_ok());
+        assert!(validate_payload(&req_tip(Some(1_000_000.0), "")).is_ok());
     }
 
     #[test]

--- a/docs/superpowers/specs/2026-05-26-tips-stream-reply-design.md
+++ b/docs/superpowers/specs/2026-05-26-tips-stream-reply-design.md
@@ -1,0 +1,228 @@
+# eros-engine — Tip-aware streaming reply (Spec)
+
+**Status**: design, pending implementation plan
+**Target release**: `0.4.x` dev track; additive request field, no store migration
+**Audience**: anyone implementing the `tips_amount_usd` field on the streaming chat path
+
+---
+
+## 0. Background
+
+The frontend is building a tipping ("打赏") feature. After a user tips the
+companion, we want the companion to react to the tip in its reply, with the
+intensity of the reaction scaled to the dollar amount.
+
+The engine already has a separate, deliberately LLM-free gift path
+(`POST /comp/chat/{session_id}/event/gift`, `routes/companion.rs:812`) that
+records a `gift_user` row + applies caller-supplied affinity deltas and returns
+`reply: None`. It also has a dormant synchronous `GiftReaction` action
+(`Event::Gift` → `pde.rs:36` → `build_gift_request`) that is **unreachable in
+production** because `run_stream` only ever builds `Event::UserMessage`
+(`stream.rs:537`). That `Event::Gift` line is "gift value → reaction" machinery
+(amount + item kind + `tip_personality`) and is **out of scope here** — we are
+not touching it. Its fate (keep / remove) is a separate later decision.
+
+This spec adds a much smaller capability to the **existing streaming chat
+endpoint**: it can carry a tip amount, the engine appends a short
+amount-aware fragment to the system prompt, and the rest flows as a normal
+chat reply.
+
+---
+
+## 1. Goal / Non-goals
+
+**Goal:** `POST /comp/chat/{session_id}/message/stream` accepts an optional
+`tips_amount_usd`. When present:
+- the turn is allowed to carry no user text (a tip is a button tap),
+- the engine appends a `【刚收到的打赏】` fragment to the reply's system prompt,
+  containing both the literal dollar amount and a tier adjective,
+- the turn is guaranteed a reply (never ghosted),
+- everything else (affinity, persistence mechanics, streaming) behaves exactly
+  like a normal chat turn.
+
+**Non-goals / explicit boundaries:**
+- **No affinity special-casing.** The normal `predict_reply_deltas`
+  (`pde.rs:97`) micro-tweak still runs. We do **not** apply gift-specific
+  deltas and do **not** write a `gift` row to `companion_affinity_events`.
+- **No `Event::Gift` / `GiftReaction` / `PendingGift` / `tip_personality`.**
+  The dormant gift-value reaction line is untouched.
+- **No new endpoint.** The change rides on the existing stream endpoint.
+- **No new chat role / no store migration.** The tip turn persists as a normal
+  `role='user'` row so the existing replay/idempotency machinery is unchanged.
+- **No engine-side tier menu.** The frontend's 5 preset buttons
+  ($2/$20/$200/$2000/$20000) are a UI detail; the engine accepts an arbitrary
+  positive amount and buckets it by order of magnitude.
+- Old clients that never send the field are byte-for-byte unaffected.
+
+---
+
+## 2. Design
+
+### 2.1 Request schema
+
+`StreamSendRequest` (`routes/companion_stream.rs:70`) gains:
+
+```rust
+#[serde(default)]
+pub tips_amount_usd: Option<f64>,
+```
+
+The number **is** USD (e.g. `20.0` = $20). We pass dollars because every LLM
+understands USD magnitude semantics, so the model itself judges how big the tip
+feels — the engine just supplies the number and a coarse adjective.
+
+### 2.2 Validation (`validate_payload`, `companion_stream.rs:98`)
+
+- When `tips_amount_usd` is `Some(a)`:
+  - **content may be empty** (skip the non-empty check); all other content
+    rules (≤ `MAX_CONTENT_CHARS`) still apply if content is non-empty.
+  - require `a.is_finite() && a > 0.0 && a <= 1_000_000.0`. Reject otherwise
+    with a `422 unprocessable` pre-stream error (bounds the value and prevents
+    a garbage/huge number from polluting the prompt).
+- When `tips_amount_usd` is `None`: current rules unchanged (content required).
+- If **both** content is empty **and** `tips_amount_usd` is `None`: the existing
+  `422 "请输入一条消息"` still fires.
+
+### 2.3 Persistence (reuse `role='user'`)
+
+A standalone tip has no user text, but the stream's idempotency + replay logic
+keys on a `role='user'` row (`chat.rs:309`). Rather than add a new role (which
+would force changes to `upsert_user_message_idempotent` and the replay path), we
+**synthesize a marker content** and persist via the existing idempotent upsert:
+
+```
+content = "(打赏 $20)"      // fmt_amount(amount), see §2.6
+```
+
+- Replay / idempotency / `user_message_id` wiring is unchanged.
+- The marker is human-readable; the frontend may special-render this bubble.
+- Trade-off: in history the tip is a `user` message, not a distinct
+  `gift_user` row. Acceptable for v1; a distinct role is deferred to the later
+  "gift route keep/remove" decision.
+
+If `content` is non-empty (tip riding on a typed message — allowed but not the
+primary FE flow), persist the user's actual content unchanged.
+
+### 2.4 Field threading
+
+Add `tips_amount_usd: Option<f64>` to:
+- `PersistedUserMessage` (`pipeline/stream.rs`) — set from the request at
+  `companion_stream.rs:275`.
+- `Event::UserMessage` (`eros_engine_core/src/types.rs:39`) with
+  `#[serde(default)]`.
+
+`run_stream` (`stream.rs:537`) sets the field on the foreground
+`Event::UserMessage` from `user_msg.tips_amount_usd`. The background
+`event_bg` construction (`stream.rs:688`) passes `None`. Existing `match` arms
+that use `..` need no change; the few **construction** sites in tests
+(`handlers.rs:1226`, `post_process.rs:730`/`:749`) get `tips_amount_usd: None`.
+
+### 2.5 PDE guard — tip always replies, never ghosts
+
+`pde::decide` checks ghost at step 2 (`pde.rs:46`), before the reply default at
+step 5 (`pde.rs:85`). A tip routed as a normal `UserMessage` could therefore be
+ghosted — taking money and going silent. Add a deterministic rule at the **top**
+of `decide`:
+
+```rust
+// 0. Tip on a user message — always reply, never ghost. reply_style and
+//    affinity deltas are identical to a normal reply; the only effect is
+//    bypassing the ghost branch below.
+if let Event::UserMessage { tips_amount_usd: Some(_), .. } = &input.event {
+    return ActionPlan {
+        action_type: ActionType::Reply,
+        reply_style: ReplyStyle::Neutral,
+        affinity_deltas: predict_reply_deltas(input),
+        energy_cost: ENERGY_COST_REPLY,
+        context_hints: vec![],
+    };
+}
+```
+
+This keeps "treat like a normal chat" (same style, same predictive deltas)
+while guaranteeing a reply.
+
+### 2.6 Prompt fragment + bucketing
+
+New helper in `prompt.rs`, sibling to (but independent of)
+`gift_reaction_context`:
+
+```rust
+fn tip_tier_adjective(amount_usd: f64) -> &'static str {
+    match amount_usd {
+        a if a < 10.0    => "一般",
+        a if a < 100.0   => "有点多",
+        a if a < 1000.0  => "超级多",
+        a if a < 10000.0 => "非常夸张",
+        _                => "近乎不可思议",
+    }
+}
+
+pub fn tips_reaction_context(amount_usd: f64) -> String {
+    format!(
+        "\n\n【刚收到的打赏】\n用户刚刚给你发了一个 ${} 美元的红包，对你来说算「{}」的一笔。\n请在回复中自然地回应这份心意，不要照搬本指令原文。",
+        fmt_amount(amount_usd),
+        tip_tier_adjective(amount_usd),
+    )
+}
+```
+
+`fmt_amount`: whole numbers render without decimals (`$20`, not `$20.0`);
+fractional amounts render with two decimals (`$5.50`). Same helper used for the
+§2.3 marker content.
+
+Bucketing (log10 order-of-magnitude, covers any positive amount; each FE preset
+lands squarely in its bucket):
+
+| Tier | Range (USD) | Preset | Adjective |
+|---|---|---|---|
+| 1 | `< 10` | $2 | 一般 |
+| 2 | `10 – 99` | $20 | 有点多 |
+| 3 | `100 – 999` | $200 | 超级多 |
+| 4 | `1000 – 9999` | $2000 | 非常夸张 |
+| 5 | `≥ 10000` | $20000 | 近乎不可思议 |
+
+Wiring: in `build_reply_request` (`handlers.rs:415`), read `tips_amount_usd`
+from `input.event`; after `build_prompt(...)` returns `system_prompt`
+(`handlers.rs:496`), if `Some(amount)`, append `tips_reaction_context(amount)`.
+`build_prompt`'s signature is **not** changed — the tip logic stays isolated to
+the reply builder.
+
+### 2.7 Data flow
+
+```
+FE taps tip ($20)
+  → POST /comp/chat/{sid}/message/stream { tips_amount_usd: 20, client_msg_id }
+  → validate_payload (content may be empty; 0 < amount ≤ 1_000_000)
+  → upsert_user_message_idempotent(role='user', content="(打赏 $20)")
+  → run_stream → Event::UserMessage { tips_amount_usd: Some(20.0), .. }
+  → pde::decide → rule 0 → Reply (normal deltas, ghost bypassed)
+  → build_reply_request → system_prompt += tips_reaction_context(20)
+  → SSE stream (same channel as a normal reply) → Done
+```
+
+---
+
+## 3. Testing
+
+- **pde**: `UserMessage` with `tips_amount_usd: Some(_)` → `Reply`; forced even
+  when ghost signals would otherwise fire; deltas equal `predict_reply_deltas`.
+- **prompt**: bucket boundaries (`$9.99`→一般, `$10`→有点多, `$99`→有点多,
+  `$100`→超级多, `$999`→超级多, `$1000`→非常夸张, `$10000`→近乎不可思议);
+  `fmt_amount` integer vs fractional (`$20`, `$5.50`); fragment contains both the
+  amount and the adjective.
+- **validate_payload**: tip present allows empty content; `amount ≤ 0`,
+  non-finite, `> 1_000_000` each rejected; content + tip both absent → 422.
+- **stream integration** (mock OpenRouter): a tip request streams to `Done`, and
+  the assembled system prompt contains the `【刚收到的打赏】` block.
+
+---
+
+## 4. Open items / deferred
+
+- Distinct `gift_user` role for tip turns (needs idempotent-upsert + replay
+  changes) — deferred to the gift-route keep/remove decision.
+- Affinity movement / `companion_affinity_events` recording for tips — out of
+  scope; if wanted later, the existing `event/gift` route or a new rule can own
+  it.
+- `Event::Gift` / `GiftReaction` / `tip_personality` reaction line — untouched.

--- a/docs/superpowers/specs/2026-05-26-tips-stream-reply-design.md
+++ b/docs/superpowers/specs/2026-05-26-tips-stream-reply-design.md
@@ -37,8 +37,8 @@ chat reply.
 - the engine appends a `【刚收到的打赏】` fragment to the reply's system prompt,
   containing both the literal dollar amount and a tier adjective,
 - the reply's tone is driven by the persona's free-form `tip_personality`
-  (passed through verbatim for the LLM to interpret), falling back to an
-  enthusiastic default when the field is absent,
+  (passed through verbatim for the LLM to interpret), falling back to a
+  `Tsundere` style when the field is absent,
 - the turn is guaranteed a reply (never ghosted),
 - affinity, persistence mechanics, and streaming behave like a normal chat turn.
 
@@ -135,8 +135,8 @@ of `decide`:
 //    identical to a normal reply.
 if let Event::UserMessage { tips_amount_usd: Some(_), .. } = &input.event {
     let reply_style = match input.persona.genome.tip_personality.as_deref() {
-        Some(_) => ReplyStyle::Neutral,  // neutral baseline; the §2.6 personality line drives the vibe
-        None    => ReplyStyle::Excited,  // no personality set → enthusiastic default for good UX
+        Some(_) => ReplyStyle::Neutral,   // neutral baseline; the §2.6 personality line drives the vibe
+        None    => ReplyStyle::Tsundere,  // no personality set → tsundere default ("带点傲娇、欲拒还迎")
     };
     return ActionPlan {
         action_type: ActionType::Reply,
@@ -179,7 +179,7 @@ fn tip_tier_adjective(amount_usd: f64) -> &'static str {
 pub fn tips_reaction_context(amount_usd: f64, tip_personality: Option<&str>) -> String {
     let how = match tip_personality {
         Some(p) => format!("请代入你「{p}」的打赏反应人设，自然地回应这份心意"),
-        None    => "请自然地回应这份心意".to_string(),  // tone leans on the Excited fallback style
+        None    => "请自然地回应这份心意".to_string(),  // tone leans on the Tsundere fallback style
     };
     format!(
         "\n\n【刚收到的打赏】\n用户刚刚给你发了一个 ${} 美元的红包，对你来说算「{}」的一笔。\n{}，不要照搬本指令原文。",
@@ -221,7 +221,7 @@ FE taps tip ($20)
   → validate_payload (content may be empty; 0 < amount ≤ 1_000_000)
   → upsert_user_message_idempotent(role='user', content="(打赏 $20)")
   → run_stream → Event::UserMessage { tips_amount_usd: Some(20.0), .. }
-  → pde::decide → rule 0 → Reply (style from tip_personality / Excited fallback;
+  → pde::decide → rule 0 → Reply (style from tip_personality / Tsundere fallback;
                                   normal deltas; ghost bypassed)
   → build_reply_request → system_prompt += tips_reaction_context(20, tip_personality)
   → SSE stream (same channel as a normal reply) → Done
@@ -233,7 +233,7 @@ FE taps tip ($20)
 
 - **pde**: `UserMessage` with `tips_amount_usd: Some(_)` → `Reply`; forced even
   when ghost signals would otherwise fire; deltas equal `predict_reply_deltas`;
-  `reply_style` = `Excited` when `tip_personality` is `None`, `Neutral` when
+  `reply_style` = `Tsundere` when `tip_personality` is `None`, `Neutral` when
   `Some(_)`.
 - **prompt**: bucket boundaries (`$9.99`→一般, `$10`→有点多, `$99`→有点多,
   `$100`→超级多, `$999`→超级多, `$1000`→非常夸张, `$10000`→近乎不可思议);

--- a/docs/superpowers/specs/2026-05-26-tips-stream-reply-design.md
+++ b/docs/superpowers/specs/2026-05-26-tips-stream-reply-design.md
@@ -36,16 +36,20 @@ chat reply.
 - the turn is allowed to carry no user text (a tip is a button tap),
 - the engine appends a `【刚收到的打赏】` fragment to the reply's system prompt,
   containing both the literal dollar amount and a tier adjective,
+- the reply's tone is driven by the persona's free-form `tip_personality`
+  (passed through verbatim for the LLM to interpret), falling back to an
+  enthusiastic default when the field is absent,
 - the turn is guaranteed a reply (never ghosted),
-- everything else (affinity, persistence mechanics, streaming) behaves exactly
-  like a normal chat turn.
+- affinity, persistence mechanics, and streaming behave like a normal chat turn.
 
 **Non-goals / explicit boundaries:**
 - **No affinity special-casing.** The normal `predict_reply_deltas`
   (`pde.rs:97`) micro-tweak still runs. We do **not** apply gift-specific
   deltas and do **not** write a `gift` row to `companion_affinity_events`.
-- **No `Event::Gift` / `GiftReaction` / `PendingGift` / `tip_personality`.**
-  The dormant gift-value reaction line is untouched.
+- **No `Event::Gift` / `GiftReaction` / `PendingGift` / `gift_reaction_context`
+  / `pick_gift_style`.** The dormant gift-value reaction line is untouched. We
+  *do* read `tip_personality` (§2.5/§2.6), but inject it as a free-form string
+  rather than through that enum-mapping machinery.
 - **No new endpoint.** The change rides on the existing stream endpoint.
 - **No new chat role / no store migration.** The tip turn persists as a normal
   `role='user'` row so the existing replay/idempotency machinery is unchanged.
@@ -117,7 +121,7 @@ Add `tips_amount_usd: Option<f64>` to:
 that use `..` need no change; the few **construction** sites in tests
 (`handlers.rs:1226`, `post_process.rs:730`/`:749`) get `tips_amount_usd: None`.
 
-### 2.5 PDE guard — tip always replies, never ghosts
+### 2.5 PDE guard — tip always replies, never ghosts; tone from `tip_personality`
 
 `pde::decide` checks ghost at step 2 (`pde.rs:46`), before the reply default at
 step 5 (`pde.rs:85`). A tip routed as a normal `UserMessage` could therefore be
@@ -125,13 +129,18 @@ ghosted — taking money and going silent. Add a deterministic rule at the **top
 of `decide`:
 
 ```rust
-// 0. Tip on a user message — always reply, never ghost. reply_style and
-//    affinity deltas are identical to a normal reply; the only effect is
-//    bypassing the ghost branch below.
+// 0. Tip on a user message — always reply, never ghost. Tone is driven by the
+//    persona's free-form tip_personality (injected as text in §2.6); the
+//    ReplyStyle enum is only a baseline / fallback. Affinity deltas stay
+//    identical to a normal reply.
 if let Event::UserMessage { tips_amount_usd: Some(_), .. } = &input.event {
+    let reply_style = match input.persona.genome.tip_personality.as_deref() {
+        Some(_) => ReplyStyle::Neutral,  // neutral baseline; the §2.6 personality line drives the vibe
+        None    => ReplyStyle::Excited,  // no personality set → enthusiastic default for good UX
+    };
     return ActionPlan {
         action_type: ActionType::Reply,
-        reply_style: ReplyStyle::Neutral,
+        reply_style,
         affinity_deltas: predict_reply_deltas(input),
         energy_cost: ENERGY_COST_REPLY,
         context_hints: vec![],
@@ -139,13 +148,22 @@ if let Event::UserMessage { tips_amount_usd: Some(_), .. } = &input.event {
 }
 ```
 
-This keeps "treat like a normal chat" (same style, same predictive deltas)
-while guaranteeing a reply.
+This guarantees a reply, keeps the normal predictive affinity deltas, and routes
+tone through `tip_personality`. We deliberately bypass the gift line's
+`pick_gift_style` enum mapping — `tip_personality` reaches the LLM verbatim, so
+arbitrary values (`"傲娇"`, `"gold_digger"`, anything) are interpreted by the
+model rather than coerced into one of the five fixed styles.
 
-### 2.6 Prompt fragment + bucketing
+### 2.6 Prompt fragment + bucketing + tip_personality
 
-New helper in `prompt.rs`, sibling to (but independent of)
-`gift_reaction_context`:
+`tip_personality` is a free-form `Option<String>` on the **genome** — a
+dedicated column `engine.persona_genomes.tip_personality`, *separate* from the
+`art_metadata` JSONB blob (`core/persona.rs:11`). Already unrestricted at the
+type level; only the dormant `pick_gift_style` treats it as an enum, which we
+bypass here.
+
+New helpers in `prompt.rs`, sibling to (but independent of)
+`gift_reaction_context` / `pick_gift_style`:
 
 ```rust
 fn tip_tier_adjective(amount_usd: f64) -> &'static str {
@@ -158,11 +176,16 @@ fn tip_tier_adjective(amount_usd: f64) -> &'static str {
     }
 }
 
-pub fn tips_reaction_context(amount_usd: f64) -> String {
+pub fn tips_reaction_context(amount_usd: f64, tip_personality: Option<&str>) -> String {
+    let how = match tip_personality {
+        Some(p) => format!("请代入你「{p}」的打赏反应人设，自然地回应这份心意"),
+        None    => "请自然地回应这份心意".to_string(),  // tone leans on the Excited fallback style
+    };
     format!(
-        "\n\n【刚收到的打赏】\n用户刚刚给你发了一个 ${} 美元的红包，对你来说算「{}」的一笔。\n请在回复中自然地回应这份心意，不要照搬本指令原文。",
+        "\n\n【刚收到的打赏】\n用户刚刚给你发了一个 ${} 美元的红包，对你来说算「{}」的一笔。\n{}，不要照搬本指令原文。",
         fmt_amount(amount_usd),
         tip_tier_adjective(amount_usd),
+        how,
     )
 }
 ```
@@ -183,8 +206,10 @@ lands squarely in its bucket):
 | 5 | `≥ 10000` | $20000 | 近乎不可思议 |
 
 Wiring: in `build_reply_request` (`handlers.rs:415`), read `tips_amount_usd`
-from `input.event`; after `build_prompt(...)` returns `system_prompt`
-(`handlers.rs:496`), if `Some(amount)`, append `tips_reaction_context(amount)`.
+from `input.event` and `tip_personality` from
+`input.persona.genome.tip_personality` (already read at `handlers.rs:466`);
+after `build_prompt(...)` returns `system_prompt` (`handlers.rs:496`), if
+`Some(amount)`, append `tips_reaction_context(amount, tip_personality)`.
 `build_prompt`'s signature is **not** changed — the tip logic stays isolated to
 the reply builder.
 
@@ -196,8 +221,9 @@ FE taps tip ($20)
   → validate_payload (content may be empty; 0 < amount ≤ 1_000_000)
   → upsert_user_message_idempotent(role='user', content="(打赏 $20)")
   → run_stream → Event::UserMessage { tips_amount_usd: Some(20.0), .. }
-  → pde::decide → rule 0 → Reply (normal deltas, ghost bypassed)
-  → build_reply_request → system_prompt += tips_reaction_context(20)
+  → pde::decide → rule 0 → Reply (style from tip_personality / Excited fallback;
+                                  normal deltas; ghost bypassed)
+  → build_reply_request → system_prompt += tips_reaction_context(20, tip_personality)
   → SSE stream (same channel as a normal reply) → Done
 ```
 
@@ -206,11 +232,14 @@ FE taps tip ($20)
 ## 3. Testing
 
 - **pde**: `UserMessage` with `tips_amount_usd: Some(_)` → `Reply`; forced even
-  when ghost signals would otherwise fire; deltas equal `predict_reply_deltas`.
+  when ghost signals would otherwise fire; deltas equal `predict_reply_deltas`;
+  `reply_style` = `Excited` when `tip_personality` is `None`, `Neutral` when
+  `Some(_)`.
 - **prompt**: bucket boundaries (`$9.99`→一般, `$10`→有点多, `$99`→有点多,
   `$100`→超级多, `$999`→超级多, `$1000`→非常夸张, `$10000`→近乎不可思议);
   `fmt_amount` integer vs fractional (`$20`, `$5.50`); fragment contains both the
-  amount and the adjective.
+  amount and the adjective; `tip_personality: Some("傲娇")` puts the literal
+  `傲娇` in the fragment, `None` omits the persona clause.
 - **validate_payload**: tip present allows empty content; `amount ≤ 0`,
   non-finite, `> 1_000_000` each rejected; content + tip both absent → 422.
 - **stream integration** (mock OpenRouter): a tip request streams to `Done`, and
@@ -225,4 +254,9 @@ FE taps tip ($20)
 - Affinity movement / `companion_affinity_events` recording for tips — out of
   scope; if wanted later, the existing `event/gift` route or a new rule can own
   it.
-- `Event::Gift` / `GiftReaction` / `tip_personality` reaction line — untouched.
+- `Event::Gift` / `GiftReaction` / `gift_reaction_context` / `pick_gift_style`
+  reaction line — untouched. (This spec uses `tip_personality` via its own
+  free-form injection, not that machinery.)
+- This is an intentional first live test of `tip_personality` — reversing the
+  earlier "don't use tip_personality" stance. If the free-form approach proves
+  out, the dormant gift line's enum mapping becomes a candidate for removal.


### PR DESCRIPTION
## Summary
- `POST /comp/chat/{session_id}/message/stream` accepts an optional `tips_amount_usd` (USD). When present, the companion **always replies** (never ghosted) with an amount-aware, `tip_personality`-flavored prompt fragment.
- A standalone tip needs no user text: empty `content` is allowed when a tip is attached, and the turn persists as a normal `role='user'` row with a synthesized `"(打赏 $N)"` marker (replay/idempotency unchanged).
- PDE rule-0 guard forces `Reply` and picks a baseline style: `Neutral` when the persona has a `tip_personality`, `Tsundere` when absent. The free-form `tip_personality` is injected verbatim (bypassing the dormant `pick_gift_style` enum mapping) so the LLM interprets it.
- Amount is bucketed by order of magnitude into 5 adjectives (一般 / 有点多 / 超级多 / 非常夸张 / 近乎不可思议) and rendered alongside the literal `$N` in the fragment.
- No affinity special-casing, no new endpoint, no store migration. The dormant `Event::Gift` / `GiftReaction` line is untouched.

Spec: `docs/superpowers/specs/2026-05-26-tips-stream-reply-design.md`

## Scope of changes
- `eros-engine-core`: `Event::UserMessage.tips_amount_usd` field + PDE tip guard
- `eros-engine-server`: `tips_reaction_context` / `fmt_amount` / tier bucketing (prompt.rs); request field + validation + marker (companion_stream.rs); `PersistedUserMessage` threading (stream.rs); fragment append in `build_reply_request` (handlers.rs)
- `openapi.json` snapshot regenerated (single additive property)

## Security
`tip_personality` is admin-controlled (written only by the `seed-personas` CLI), not user-settable. `tips_amount_usd` is validated finite and in `(0, 1_000_000]` before any stringification.

## Test plan
- [x] `pde`: tip forces Reply even under ghost-triggering signals; style Neutral(personality) / Tsundere(none)
- [x] `prompt`: bucket boundaries, `fmt_amount` integer vs fractional, fragment with/without personality
- [x] `validate_payload`: empty content allowed only with a tip; amount bounds (0/neg/NaN/Inf/oversized) rejected
- [x] e2e (mock OpenRouter): tip stream completes; system prompt contains `【刚收到的打赏】` + `$20 美元的红包`
- [x] full workspace suite green (392 tests); `cargo fmt --check` + `clippy -D warnings` clean; OpenAPI snapshot in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)