### PR TITLE
chore(dev): open dev track at 0.4.3-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,7 +405,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "eros-engine-core"
-version = "0.4.21-dev"
+version = "0.4.3-dev"
 dependencies = [
  "chrono",
  "serde",
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-llm"
-version = "0.4.21-dev"
+version = "0.4.3-dev"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -436,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-server"
-version = "0.4.21-dev"
+version = "0.4.3-dev"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-store"
-version = "0.4.21-dev"
+version = "0.4.3-dev"
 dependencies = [
  "async-trait",
  "bs58",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.4.21-dev"
+version = "0.4.3-dev"
 edition = "2021"
 license = "AGPL-3.0-only"
 repository = "https://github.com/etherfunlab/eros-engine"

--- a/crates/eros-engine-llm/Cargo.toml
+++ b/crates/eros-engine-llm/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "openrouter", "voyage", "embeddings", "llm"]
 categories = ["api-bindings"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "0.4.21-dev" }
+eros-engine-core = { path = "../eros-engine-core", version = "0.4.3-dev" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/eros-engine-server/Cargo.toml
+++ b/crates/eros-engine-server/Cargo.toml
@@ -10,9 +10,9 @@ name = "eros-engine"
 path = "src/main.rs"
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "0.4.21-dev" }
-eros-engine-llm  = { path = "../eros-engine-llm", version = "0.4.21-dev" }
-eros-engine-store = { path = "../eros-engine-store", version = "0.4.21-dev" }
+eros-engine-core = { path = "../eros-engine-core", version = "0.4.3-dev" }
+eros-engine-llm  = { path = "../eros-engine-llm", version = "0.4.3-dev" }
+eros-engine-store = { path = "../eros-engine-store", version = "0.4.3-dev" }
 axum = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0-only",
       "identifier": "AGPL-3.0-only"
     },
-    "version": "0.4.21-dev"
+    "version": "0.4.3-dev"
   },
   "servers": [
     {

--- a/crates/eros-engine-store/Cargo.toml
+++ b/crates/eros-engine-store/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "memory", "pgvector", "postgres", "sqlx"]
 categories = ["database"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "0.4.21-dev" }
+eros-engine-core = { path = "../eros-engine-core", version = "0.4.3-dev" }
 sqlx = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
Open the next dev track after the v0.4.21 stable release.

Bumps `0.4.21-dev` → `0.4.3-dev` (workspace version + 3 inter-crate dep pins + `Cargo.lock` + `openapi.json`).

Stylized version scheme: `0.4.20`/`0.4.21` read as `0.4.2` / `0.4.2-1`, so the next minor after the `0.4.2x` line is `0.4.3` — not `0.4.22`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)