### PR TITLE
docs(readme): GHCR images are amd64-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ eros-engine-llm   = "0.4"   # only if you want the OpenRouter + Voyage clients
 
 ## Run as a Docker image
 
-Multi-arch (`linux/amd64`, `linux/arm64`) images for `eros-engine-server` are published to GitHub Container Registry on every `v*` tag:
+`linux/amd64` images for `eros-engine-server` are published to GitHub Container Registry on every `v*` tag (need arm64? build it yourself from `docker/Dockerfile`):
 
 ```bash
 docker pull ghcr.io/etherfunlab/eros-engine:0.4.1


### PR DESCRIPTION
The "Run as a Docker image" section claimed multi-arch (`linux/amd64`, `linux/arm64`), but `release-docker.yml` builds `linux/amd64` only (arm64 + setup-qemu dropped as of v0.4.20). Corrected the line and pointed arm64 users at `docker/Dockerfile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)