### PR TITLE
feat: tip role (gift_user) + chat-reply filter audit columns + prompt_traits metadata

### DIFF
--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -258,7 +258,7 @@ impl OutputFilterTrigger {
                 TraitWhen::Present => tp
                     .any
                     .iter()
-                    .filter(|tag| trait_tags.iter().any(|t| *t == tag.as_str()))
+                    .filter(|tag| trait_tags.contains(&tag.as_str()))
                     .cloned()
                     .collect::<Vec<String>>(),
                 // Absent: the predicate fires because the tags are NOT present.
@@ -1537,22 +1537,37 @@ trigger = { traits = { any = ["a"] } }
     #[test]
     fn should_filter_predicate_combinations() {
         use super::*;
-        let none = OutputFilterTrigger { random: None, models: None, traits: None };
+        let none = OutputFilterTrigger {
+            random: None,
+            models: None,
+            traits: None,
+        };
         assert!(none.should_filter("any/model", &[], None).is_some());
         assert!(none.should_filter("any/model", &[], Some(0.999)).is_some());
 
-        let r = OutputFilterTrigger { random: Some(0.5), models: None, traits: None };
-        assert!(r.should_filter("m", &[], Some(0.0)).is_some());      // draw < 0.5
-        assert!(r.should_filter("m", &[], Some(0.999)).is_none());    // draw >= 0.5
+        let r = OutputFilterTrigger {
+            random: Some(0.5),
+            models: None,
+            traits: None,
+        };
+        assert!(r.should_filter("m", &[], Some(0.0)).is_some()); // draw < 0.5
+        assert!(r.should_filter("m", &[], Some(0.999)).is_none()); // draw >= 0.5
 
-        let m = OutputFilterTrigger { random: None, models: Some(vec!["x/y".into()]), traits: None };
+        let m = OutputFilterTrigger {
+            random: None,
+            models: Some(vec!["x/y".into()]),
+            traits: None,
+        };
         assert!(m.should_filter("x/y", &[], None).is_some());
         assert!(m.should_filter("a/b", &[], None).is_none());
 
         let tp = OutputFilterTrigger {
             random: None,
             models: None,
-            traits: Some(TraitPredicate { any: vec!["nsfw".into()], when: TraitWhen::Present }),
+            traits: Some(TraitPredicate {
+                any: vec!["nsfw".into()],
+                when: TraitWhen::Present,
+            }),
         };
         assert!(tp.should_filter("m", &["nsfw"], None).is_some());
         assert!(tp.should_filter("m", &["sfw"], None).is_none());
@@ -1560,7 +1575,10 @@ trigger = { traits = { any = ["a"] } }
         let ta = OutputFilterTrigger {
             random: None,
             models: None,
-            traits: Some(TraitPredicate { any: vec!["nsfw".into()], when: TraitWhen::Absent }),
+            traits: Some(TraitPredicate {
+                any: vec!["nsfw".into()],
+                when: TraitWhen::Absent,
+            }),
         };
         assert!(ta.should_filter("m", &["sfw"], None).is_some());
         assert!(ta.should_filter("m", &["nsfw"], None).is_none());
@@ -1568,11 +1586,14 @@ trigger = { traits = { any = ["a"] } }
         let all = OutputFilterTrigger {
             random: Some(0.5),
             models: Some(vec!["x/y".into()]),
-            traits: Some(TraitPredicate { any: vec!["nsfw".into()], when: TraitWhen::Present }),
+            traits: Some(TraitPredicate {
+                any: vec!["nsfw".into()],
+                when: TraitWhen::Present,
+            }),
         };
         assert!(all.should_filter("x/y", &["nsfw"], Some(0.0)).is_some());
         assert!(all.should_filter("x/y", &["nsfw"], Some(0.999)).is_none()); // random fails
-        assert!(all.should_filter("a/b", &["nsfw"], Some(0.0)).is_none());   // model fails
+        assert!(all.should_filter("a/b", &["nsfw"], Some(0.0)).is_none()); // model fails
 
         // turn_level_pass ignores models
         assert!(all.turn_level_pass(Some(0.0), &["nsfw"]));
@@ -1658,16 +1679,24 @@ trigger = { traits = { any = ["a"] } }
         // Defensive: if the caller wires random=Some(p) but forgets to thread
         // a per-turn random_draw, treat as "no fire" rather than silently
         // assume pass. Guards against a Task 7-era wiring mistake.
-        let r = OutputFilterTrigger { random: Some(0.5), models: None, traits: None };
+        let r = OutputFilterTrigger {
+            random: Some(0.5),
+            models: None,
+            traits: None,
+        };
         assert!(r.should_filter("m", &[], None).is_none());
-        assert!(r.turn_level_pass(None, &[]) == false);
+        assert!(!r.turn_level_pass(None, &[]));
     }
 
     #[test]
     fn trigger_hits_empty_serializes_to_empty_object() {
         // Spec §4.2: when an always-fire trigger (no configured predicates)
         // is recorded, filter_triggers JSONB must be `{}` — not `{"random":null, ...}`.
-        let hits = TriggerHits { random: None, models: None, traits: None };
+        let hits = TriggerHits {
+            random: None,
+            models: None,
+            traits: None,
+        };
         let v = serde_json::to_value(&hits).unwrap();
         assert_eq!(v, serde_json::json!({}));
     }

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -1654,6 +1654,25 @@ trigger = { traits = { any = ["a"] } }
     }
 
     #[test]
+    fn should_filter_returns_none_when_random_configured_but_no_draw() {
+        // Defensive: if the caller wires random=Some(p) but forgets to thread
+        // a per-turn random_draw, treat as "no fire" rather than silently
+        // assume pass. Guards against a Task 7-era wiring mistake.
+        let r = OutputFilterTrigger { random: Some(0.5), models: None, traits: None };
+        assert!(r.should_filter("m", &[], None).is_none());
+        assert!(r.turn_level_pass(None, &[]) == false);
+    }
+
+    #[test]
+    fn trigger_hits_empty_serializes_to_empty_object() {
+        // Spec §4.2: when an always-fire trigger (no configured predicates)
+        // is recorded, filter_triggers JSONB must be `{}` — not `{"random":null, ...}`.
+        let hits = TriggerHits { random: None, models: None, traits: None };
+        let v = serde_json::to_value(&hits).unwrap();
+        assert_eq!(v, serde_json::json!({}));
+    }
+
+    #[test]
     fn resolve_output_filter_gating() {
         use super::*;
         // #6: enabled but no [tasks.chat_output_filter] ⇒ None

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -195,16 +195,77 @@ pub struct OutputFilterTrigger {
     pub traits: Option<TraitPredicate>,
 }
 
+/// Detail of which predicates a turn matched. Each field present ⇒ that
+/// predicate was configured **and** passed. Serialises to JSONB for
+/// `chat_messages.filter_triggers`; absent fields skip serialization so the
+/// stored shape matches the spec (only fired predicates appear).
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+pub struct TriggerHits {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub random: Option<RandomHit>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub models: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub traits: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+pub struct RandomHit {
+    pub p: f64,
+    pub draw: f64,
+}
+
 impl OutputFilterTrigger {
     /// Turn-constant predicates (random + traits). When either is specified and
-    /// fails, no attempt can be filtered this turn.
-    pub fn turn_level_pass(&self, random_pass: bool, trait_tags: &[&str]) -> bool {
-        self.random.is_none_or(|_| random_pass) && self.traits_pass(trait_tags)
+    /// fails, no attempt can be filtered this turn. Used by the burst's
+    /// live-vs-buffer branch before any attempt runs.
+    pub fn turn_level_pass(&self, random_draw: Option<f64>, trait_tags: &[&str]) -> bool {
+        let random_ok = match (self.random, random_draw) {
+            (Some(p), Some(d)) => d < p,
+            (Some(_), None) => false, // misuse: a random predicate with no draw is a fail
+            (None, _) => true,
+        };
+        random_ok && self.traits_pass(trait_tags)
     }
 
-    /// Full per-attempt decision: turn-level predicates AND the model predicate.
-    pub fn should_filter(&self, model_id: &str, trait_tags: &[&str], random_pass: bool) -> bool {
-        self.turn_level_pass(random_pass, trait_tags) && self.models_pass(model_id)
+    /// Per-attempt decision. Returns `Some(hits)` when the trigger fires for
+    /// this attempt, with hit detail; `None` otherwise. Hits serialise to
+    /// `chat_messages.filter_triggers` JSONB on write.
+    pub fn should_filter(
+        &self,
+        model_id: &str,
+        trait_tags: &[&str],
+        random_draw: Option<f64>,
+    ) -> Option<TriggerHits> {
+        if !self.turn_level_pass(random_draw, trait_tags) {
+            return None;
+        }
+        if !self.models_pass(model_id) {
+            return None;
+        }
+        Some(TriggerHits {
+            random: match (self.random, random_draw) {
+                (Some(p), Some(d)) => Some(RandomHit { p, draw: d }),
+                _ => None,
+            },
+            models: self
+                .models
+                .as_ref()
+                .filter(|list| list.iter().any(|m| m == model_id))
+                .map(|_| model_id.to_string()),
+            traits: self.traits.as_ref().map(|tp| match tp.when {
+                // Present: record which tags from `tp.any` were actually seen.
+                TraitWhen::Present => tp
+                    .any
+                    .iter()
+                    .filter(|tag| trait_tags.iter().any(|t| *t == tag.as_str()))
+                    .cloned()
+                    .collect::<Vec<String>>(),
+                // Absent: the predicate fires because the tags are NOT present.
+                // Nothing to enumerate; record an empty vec.
+                TraitWhen::Absent => Vec::new(),
+            }),
+        })
     }
 
     fn models_pass(&self, model_id: &str) -> bool {
@@ -1476,45 +1537,97 @@ trigger = { traits = { any = ["a"] } }
     #[test]
     fn should_filter_predicate_combinations() {
         use super::*;
-        let none = OutputFilterTrigger {
-            random: None,
-            models: None,
-            traits: None,
-        };
-        // empty trigger ⇒ always filter
-        assert!(none.should_filter("any/model", &[], true));
-        assert!(none.should_filter("any/model", &[], false));
+        let none = OutputFilterTrigger { random: None, models: None, traits: None };
+        assert!(none.should_filter("any/model", &[], None).is_some());
+        assert!(none.should_filter("any/model", &[], Some(0.999)).is_some());
 
-        // random only
-        let r = OutputFilterTrigger {
-            random: Some(0.5),
-            models: None,
-            traits: None,
-        };
-        assert!(r.should_filter("m", &[], true));
-        assert!(!r.should_filter("m", &[], false));
+        let r = OutputFilterTrigger { random: Some(0.5), models: None, traits: None };
+        assert!(r.should_filter("m", &[], Some(0.0)).is_some());      // draw < 0.5
+        assert!(r.should_filter("m", &[], Some(0.999)).is_none());    // draw >= 0.5
 
-        // models only
-        let m = OutputFilterTrigger {
-            random: None,
-            models: Some(vec!["x/y".into()]),
-            traits: None,
-        };
-        assert!(m.should_filter("x/y", &[], true));
-        assert!(!m.should_filter("a/b", &[], true));
+        let m = OutputFilterTrigger { random: None, models: Some(vec!["x/y".into()]), traits: None };
+        assert!(m.should_filter("x/y", &[], None).is_some());
+        assert!(m.should_filter("a/b", &[], None).is_none());
 
-        // traits present / absent
         let tp = OutputFilterTrigger {
             random: None,
             models: None,
+            traits: Some(TraitPredicate { any: vec!["nsfw".into()], when: TraitWhen::Present }),
+        };
+        assert!(tp.should_filter("m", &["nsfw"], None).is_some());
+        assert!(tp.should_filter("m", &["sfw"], None).is_none());
+
+        let ta = OutputFilterTrigger {
+            random: None,
+            models: None,
+            traits: Some(TraitPredicate { any: vec!["nsfw".into()], when: TraitWhen::Absent }),
+        };
+        assert!(ta.should_filter("m", &["sfw"], None).is_some());
+        assert!(ta.should_filter("m", &["nsfw"], None).is_none());
+
+        let all = OutputFilterTrigger {
+            random: Some(0.5),
+            models: Some(vec!["x/y".into()]),
+            traits: Some(TraitPredicate { any: vec!["nsfw".into()], when: TraitWhen::Present }),
+        };
+        assert!(all.should_filter("x/y", &["nsfw"], Some(0.0)).is_some());
+        assert!(all.should_filter("x/y", &["nsfw"], Some(0.999)).is_none()); // random fails
+        assert!(all.should_filter("a/b", &["nsfw"], Some(0.0)).is_none());   // model fails
+
+        // turn_level_pass ignores models
+        assert!(all.turn_level_pass(Some(0.0), &["nsfw"]));
+        assert!(!all.turn_level_pass(Some(0.999), &["nsfw"]));
+        assert!(!all.turn_level_pass(Some(0.0), &["sfw"]));
+    }
+
+    #[test]
+    fn should_filter_returns_hits_on_match() {
+        let t = OutputFilterTrigger {
+            random: Some(0.3),
+            models: Some(vec!["x/y".into()]),
             traits: Some(TraitPredicate {
                 any: vec!["nsfw".into()],
                 when: TraitWhen::Present,
             }),
         };
-        assert!(tp.should_filter("m", &["nsfw"], true));
-        assert!(!tp.should_filter("m", &["sfw"], true));
-        let ta = OutputFilterTrigger {
+        let hits = t
+            .should_filter("x/y", &["nsfw"], Some(0.18))
+            .expect("should fire");
+        assert_eq!(hits.random.as_ref().unwrap().p, 0.3);
+        assert_eq!(hits.random.as_ref().unwrap().draw, 0.18);
+        assert_eq!(hits.models.as_deref(), Some("x/y"));
+        assert_eq!(hits.traits.as_deref(), Some(&["nsfw".to_string()][..]));
+    }
+
+    #[test]
+    fn should_filter_returns_none_when_any_predicate_fails() {
+        let t = OutputFilterTrigger {
+            random: Some(0.3),
+            models: Some(vec!["x/y".into()]),
+            traits: None,
+        };
+        // random draw above p → fail.
+        assert!(t.should_filter("x/y", &[], Some(0.9)).is_none());
+        // model not in list → fail.
+        assert!(t.should_filter("a/b", &[], Some(0.18)).is_none());
+    }
+
+    #[test]
+    fn should_filter_empty_trigger_returns_empty_hits() {
+        let t = OutputFilterTrigger {
+            random: None,
+            models: None,
+            traits: None,
+        };
+        let hits = t.should_filter("any/model", &[], None).expect("fires");
+        assert!(hits.random.is_none());
+        assert!(hits.models.is_none());
+        assert!(hits.traits.is_none());
+    }
+
+    #[test]
+    fn should_filter_traits_absent_predicate_returns_empty_traits_vec() {
+        let t = OutputFilterTrigger {
             random: None,
             models: None,
             traits: Some(TraitPredicate {
@@ -1522,26 +1635,22 @@ trigger = { traits = { any = ["a"] } }
                 when: TraitWhen::Absent,
             }),
         };
-        assert!(ta.should_filter("m", &["sfw"], true));
-        assert!(!ta.should_filter("m", &["nsfw"], true));
+        // "nsfw" not in tags → predicate passes; traits hit recorded as empty vec.
+        let hits = t.should_filter("m", &["sfw"], None).expect("fires");
+        assert_eq!(hits.traits.as_deref(), Some(&[][..]));
+    }
 
-        // AND of all three
-        let all = OutputFilterTrigger {
-            random: Some(0.9),
-            models: Some(vec!["x/y".into()]),
-            traits: Some(TraitPredicate {
-                any: vec!["nsfw".into()],
-                when: TraitWhen::Present,
-            }),
+    #[test]
+    fn trigger_hits_serializes_only_fired_fields() {
+        let hits = TriggerHits {
+            random: Some(RandomHit { p: 0.3, draw: 0.18 }),
+            models: None,
+            traits: Some(vec!["nsfw_boost".into()]),
         };
-        assert!(all.should_filter("x/y", &["nsfw"], true));
-        assert!(!all.should_filter("x/y", &["nsfw"], false)); // random fails
-        assert!(!all.should_filter("a/b", &["nsfw"], true)); // model fails
-
-        // turn_level_pass ignores models
-        assert!(all.turn_level_pass(true, &["nsfw"]));
-        assert!(!all.turn_level_pass(false, &["nsfw"]));
-        assert!(!all.turn_level_pass(true, &["sfw"]));
+        let v = serde_json::to_value(&hits).unwrap();
+        assert!(v.get("random").is_some());
+        assert!(v.get("models").is_none(), "absent fields skipped");
+        assert_eq!(v["traits"], serde_json::json!(["nsfw_boost"]));
     }
 
     #[test]

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -1165,6 +1165,14 @@
           "sent_at": {
             "type": "string",
             "format": "date-time"
+          },
+          "tips_amount_usd": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double",
+            "description": "Structured tip amount for `role='gift_user'` rows. Omitted from\nresponse when None (`skip_serializing_if`). Lets clients render tips\nat the right point in the timeline without parsing the `(打赏 $X)`\ncontent marker. Spec:\ndocs/superpowers/specs/2026-05-26-tip-role-and-filter-audit-design.md §3.4."
           }
         }
       },

--- a/crates/eros-engine-server/src/pipeline/mod.rs
+++ b/crates/eros-engine-server/src/pipeline/mod.rs
@@ -59,7 +59,8 @@ pub async fn compute_signals_for_session(
     affinity: &Affinity,
 ) -> Result<ConversationSignals, AppError> {
     let message_count: i64 = sqlx::query_scalar(
-        "SELECT COUNT(*) FROM engine.chat_messages WHERE session_id = $1 AND role = 'user'",
+        "SELECT COUNT(*) FROM engine.chat_messages \
+         WHERE session_id = $1 AND role IN ('user', 'gift_user')",
     )
     .bind(session_id)
     .fetch_one(pool)
@@ -67,7 +68,8 @@ pub async fn compute_signals_for_session(
     .unwrap_or(0);
 
     let last_time: Option<chrono::DateTime<chrono::Utc>> = sqlx::query_scalar(
-        "SELECT MAX(sent_at) FROM engine.chat_messages WHERE session_id = $1 AND role = 'user'",
+        "SELECT MAX(sent_at) FROM engine.chat_messages \
+         WHERE session_id = $1 AND role IN ('user', 'gift_user')",
     )
     .bind(session_id)
     .fetch_optional(pool)
@@ -89,4 +91,115 @@ pub async fn compute_signals_for_session(
         ghost_streak: affinity.ghost_streak,
         hours_since_last_ghost,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::PgPool;
+    use uuid::Uuid;
+
+    fn fixture_affinity(session_id: Uuid, user_id: Uuid, instance_id: Uuid) -> Affinity {
+        let now = chrono::Utc::now();
+        Affinity {
+            id: Uuid::new_v4(),
+            session_id,
+            user_id,
+            instance_id,
+            warmth: 0.3,
+            trust: 0.2,
+            intrigue: 0.5,
+            intimacy: 0.0,
+            patience: 0.5,
+            tension: 0.1,
+            ghost_streak: 0,
+            last_ghost_at: None,
+            total_ghosts: 0,
+            relationship_label: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    /// Seed a minimal persona_genome → persona_instance → chat_session chain so
+    /// the chat_messages FK is satisfied. Returns (genome_id, instance_id, session_id).
+    async fn seed_session(pool: &PgPool, user_id: Uuid) -> (Uuid, Uuid, Uuid) {
+        let genome_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata, is_active) \
+             VALUES ('SignalsTest', 'sp', '{}'::jsonb, true) RETURNING id",
+        )
+        .fetch_one(pool)
+        .await
+        .unwrap();
+        let instance_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_instances (genome_id, owner_uid) \
+             VALUES ($1, $2) RETURNING id",
+        )
+        .bind(genome_id)
+        .bind(user_id)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+        let session_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_sessions (user_id, instance_id) \
+             VALUES ($1, $2) RETURNING id",
+        )
+        .bind(user_id)
+        .bind(instance_id)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+        (genome_id, instance_id, session_id)
+    }
+
+    /// Tip turns persisted as `gift_user` must be counted by
+    /// `compute_signals_for_session` exactly like `user` turns.
+    /// Regression guard for the codex P2 finding on PR #52.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn signals_count_includes_gift_user_rows(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let (_genome_id, instance_id, session_id) = seed_session(&pool, user_id).await;
+
+        sqlx::query(
+            "INSERT INTO engine.chat_messages (session_id, role, content) \
+             VALUES ($1, 'user', 'hi'), ($1, 'gift_user', '(打赏 $20)')",
+        )
+        .bind(session_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let aff = fixture_affinity(session_id, user_id, instance_id);
+        let signals = compute_signals_for_session(&pool, session_id, &aff)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            signals.message_count, 2,
+            "gift_user tip rows must count toward message_count signals"
+        );
+    }
+
+    /// Pure `user` rows still count normally (baseline regression).
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn signals_count_user_only_rows(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let (_genome_id, _instance_id, session_id) = seed_session(&pool, user_id).await;
+
+        sqlx::query(
+            "INSERT INTO engine.chat_messages (session_id, role, content) \
+             VALUES ($1, 'user', 'hello'), ($1, 'user', 'world')",
+        )
+        .bind(session_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let aff = fixture_affinity(session_id, user_id, _instance_id);
+        let signals = compute_signals_for_session(&pool, session_id, &aff)
+            .await
+            .unwrap();
+
+        assert_eq!(signals.message_count, 2, "two user rows must yield count 2");
+    }
 }

--- a/crates/eros-engine-server/src/pipeline/mod.rs
+++ b/crates/eros-engine-server/src/pipeline/mod.rs
@@ -60,7 +60,10 @@ pub async fn compute_signals_for_session(
 ) -> Result<ConversationSignals, AppError> {
     let message_count: i64 = sqlx::query_scalar(
         "SELECT COUNT(*) FROM engine.chat_messages \
-         WHERE session_id = $1 AND role IN ('user', 'gift_user')",
+         WHERE session_id = $1 AND (\
+             role = 'user' \
+             OR (role = 'gift_user' AND metadata ? 'tips_amount_usd')\
+         )",
     )
     .bind(session_id)
     .fetch_one(pool)
@@ -69,7 +72,10 @@ pub async fn compute_signals_for_session(
 
     let last_time: Option<chrono::DateTime<chrono::Utc>> = sqlx::query_scalar(
         "SELECT MAX(sent_at) FROM engine.chat_messages \
-         WHERE session_id = $1 AND role IN ('user', 'gift_user')",
+         WHERE session_id = $1 AND (\
+             role = 'user' \
+             OR (role = 'gift_user' AND metadata ? 'tips_amount_usd')\
+         )",
     )
     .bind(session_id)
     .fetch_optional(pool)
@@ -152,17 +158,20 @@ mod tests {
         (genome_id, instance_id, session_id)
     }
 
-    /// Tip turns persisted as `gift_user` must be counted by
-    /// `compute_signals_for_session` exactly like `user` turns.
-    /// Regression guard for the codex P2 finding on PR #52.
+    /// Tip `gift_user` rows (with `tips_amount_usd` in metadata) must be
+    /// counted exactly like `user` turns; legacy in-app-gift `gift_user` rows
+    /// (no tip metadata, written by routes/companion.rs:827) must NOT count.
+    /// Regression guard for codex P2 v2 finding on PR #52.
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
-    async fn signals_count_includes_gift_user_rows(pool: PgPool) {
+    async fn signals_count_includes_tip_gift_user_but_excludes_legacy_gifts(pool: PgPool) {
         let user_id = Uuid::new_v4();
         let (_genome_id, instance_id, session_id) = seed_session(&pool, user_id).await;
 
         sqlx::query(
-            "INSERT INTO engine.chat_messages (session_id, role, content) \
-             VALUES ($1, 'user', 'hi'), ($1, 'gift_user', '(打赏 $20)')",
+            "INSERT INTO engine.chat_messages (session_id, role, content, metadata) VALUES \
+                 ($1, 'user', 'hi', NULL), \
+                 ($1, 'gift_user', '(打赏 $20)', '{\"tips_amount_usd\": 20.0}'::jsonb), \
+                 ($1, 'gift_user', 'in-app gift label', NULL)",
         )
         .bind(session_id)
         .execute(&pool)
@@ -176,7 +185,7 @@ mod tests {
 
         assert_eq!(
             signals.message_count, 2,
-            "gift_user tip rows must count toward message_count signals"
+            "user + tip gift_user count (2); legacy gift_user row does not"
         );
     }
 

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -140,7 +140,7 @@ fn drive_chat_burst(
     display_override: Option<eros_engine_llm::model_config::DisplayOverride>,
     filter: Option<eros_engine_llm::model_config::ResolvedOutputFilter>,
     trait_tags: Vec<String>, // requested prompt-trait tags (the turn's)
-    random_pass: bool,       // drawn once per turn by run_stream
+    random_draw: Option<f64>, // sampled once per turn by run_stream; None when trigger.random is unset
     outcome: std::sync::Arc<std::sync::Mutex<BurstOutcome>>,
 ) -> impl futures_util::Stream<Item = ProtocolFrame> + Send + 'static {
     async_stream::stream! {
@@ -163,7 +163,7 @@ fn drive_chat_burst(
         let tag_refs: Vec<&str> = trait_tags.iter().map(String::as_str).collect();
         let filtered_mode = filter
             .as_ref()
-            .map(|f| f.trigger.turn_level_pass(random_pass, &tag_refs))
+            .map(|f| f.trigger.turn_level_pass(random_draw, &tag_refs))
             .unwrap_or(false);
 
         if !filtered_mode {
@@ -328,7 +328,7 @@ fn drive_chat_burst(
             }
 
             outcome.lock().unwrap().retries_chat = idx as u32;
-            let do_filter = f.trigger.should_filter(model_id, &tag_refs, random_pass);
+            let hits = f.trigger.should_filter(model_id, &tag_refs, random_draw);
             yield ProtocolFrame::Meta {
                 message_id: ulid_string(msg_ulid),
                 action_type: frame_action,
@@ -336,18 +336,29 @@ fn drive_chat_burst(
                 continues_from: None,
             };
 
-            let visible: String = if do_filter {
-                match run_output_filter(&state, &f, &acc).await {
-                    Some((filtered_text, retries_filter)) => {
+            let (visible, filter_audit): (
+                String,
+                Option<eros_engine_store::chat::FilterAudit>,
+            ) = match hits {
+                Some(h) => match run_output_filter(&state, &f, &acc).await {
+                    Some(out) => {
                         let mut o = outcome.lock().unwrap();
                         o.filtered = true;
-                        o.retries_filter = retries_filter;
-                        filtered_text
+                        o.retries_filter = out.retries_filter;
+                        drop(o);
+                        let audit = eros_engine_store::chat::FilterAudit {
+                            pre_filter_content: acc.clone(),
+                            filter_model: out.filter_model,
+                            filter_triggers: serde_json::to_value(&h)
+                                .unwrap_or(serde_json::Value::Null),
+                            f_client_msg_id: out.f_client_msg_id,
+                            f_generation_id: out.f_generation_id,
+                        };
+                        (out.filtered_text, Some(audit))
                     }
-                    None => acc.clone(),
-                }
-            } else {
-                acc.clone()
+                    None => (acc.clone(), None), // fail-open
+                },
+                None => (acc.clone(), None), // models-miss or trigger off
             };
 
             if !visible.is_empty() {
@@ -366,7 +377,7 @@ fn drive_chat_burst(
                 model: Some(model_id.clone()),
                 usage: last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok()),
                 generation_id: last_gen_id.clone(),
-                filter_audit: None,
+                filter_audit,
             };
             if let Err(e) = chat_repo.insert_assistant_batch(session_id, user_message_id, &[row]).await {
                 tracing::warn!("stream(filtered): persist failed: {e}");
@@ -403,16 +414,30 @@ fn extract_text(
     }
 }
 
+/// Result of a filter LLM call. `f_client_msg_id` is the engine-generated
+/// idempotency / trace ULID for the call (prefix `f_`), reused across the
+/// filter's internal fallback retries. `filter_model` is the model actually
+/// served (from `ChatResponse.model`), falling back to the requested primary
+/// model if the response omits it. `f_generation_id` mirrors the optional
+/// nature of `ChatResponse.generation_id` so SQL NULL propagates cleanly.
+struct RunFilterOutcome {
+    filtered_text: String,
+    retries_filter: u32,
+    filter_model: String,
+    f_client_msg_id: String,
+    f_generation_id: Option<String>,
+}
+
 /// Run the output-filter LLM over `original`. `execute()` walks the (already
 /// depth-capped) chain; `ChatResponse.model` reports the model served. Returns
-/// `(filtered_text, retries_filter)` where retries_filter = served model's index
-/// in `[f.model] + f.fallback_model` (0 = primary). `None` on error/timeout/empty.
+/// `RunFilterOutcome` on success. `None` on error/timeout/empty.
 async fn run_output_filter(
     state: &AppState,
     f: &eros_engine_llm::model_config::ResolvedOutputFilter,
     original: &str,
-) -> Option<(String, u32)> {
+) -> Option<RunFilterOutcome> {
     use eros_engine_llm::openrouter::{ChatMessage, ChatRequest};
+    let f_client_msg_id = format!("f_{}", Ulid::new());
     let req = ChatRequest {
         model: f.model.clone(),
         fallback_model: f.fallback_model.clone(),
@@ -438,19 +463,29 @@ async fn run_output_filter(
             if out.is_empty() {
                 return None;
             }
+            let served = resp.model.clone();
             let chain = std::iter::once(f.model.as_str())
                 .chain(f.fallback_model.iter().map(String::as_str));
-            let retries_filter = resp
-                .model
+            let retries_filter = served
                 .as_deref()
-                .and_then(|served| {
+                .and_then(|s| {
                     chain
                         .enumerate()
-                        .find(|(_, m)| *m == served)
+                        .find(|(_, m)| *m == s)
                         .map(|(i, _)| i as u32)
                 })
                 .unwrap_or(0);
-            Some((out, retries_filter))
+            // Falling back to f.model when the response omits the served model is
+            // safe: that is the model we requested, and OpenRouter only omits it
+            // on error paths (which we have already excluded via .reply.is_empty()).
+            let filter_model = served.unwrap_or_else(|| f.model.clone());
+            Some(RunFilterOutcome {
+                filtered_text: out,
+                retries_filter,
+                filter_model,
+                f_client_msg_id,
+                f_generation_id: resp.generation_id,
+            })
         }
         Ok(Err(e)) => {
             tracing::warn!("output filter LLM failed: {e}");
@@ -622,11 +657,10 @@ pub fn run_stream(
                 // random gate ONCE (so live/filter share the same coin flip).
                 let tier = user_msg.tier.as_deref();
                 let filter = state.model_config.resolve_output_filter(tier);
-                let random_pass = filter
+                let random_draw: Option<f64> = filter
                     .as_ref()
                     .and_then(|f| f.trigger.random)
-                    .map(|p| rand::thread_rng().gen::<f64>() < p)
-                    .unwrap_or(true);
+                    .map(|_| rand::thread_rng().gen::<f64>());
 
                 let outcome = std::sync::Arc::new(std::sync::Mutex::new(
                     crate::pipeline::stream::BurstOutcome::default(),
@@ -642,7 +676,7 @@ pub fn run_stream(
                     display_override,
                     filter,
                     trait_tags,
-                    random_pass,
+                    random_draw,
                     outcome.clone(),
                 );
                 {

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -235,6 +235,7 @@ fn drive_chat_burst(
                     usage: last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok()),
                     generation_id: last_gen_id.clone(),
                     filter_audit: None,
+                    metadata: Some(serde_json::json!({ "prompt_traits": &trait_tags })),
                 };
                 if let Err(e) = chat_repo
                     .insert_assistant_batch(session_id, user_message_id, &[row])
@@ -378,6 +379,7 @@ fn drive_chat_burst(
                 usage: last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok()),
                 generation_id: last_gen_id.clone(),
                 filter_audit,
+                metadata: Some(serde_json::json!({ "prompt_traits": &trait_tags })),
             };
             if let Err(e) = chat_repo.insert_assistant_batch(session_id, user_message_id, &[row]).await {
                 tracing::warn!("stream(filtered): persist failed: {e}");

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -140,6 +140,7 @@ fn drive_chat_burst(
     display_override: Option<eros_engine_llm::model_config::DisplayOverride>,
     filter: Option<eros_engine_llm::model_config::ResolvedOutputFilter>,
     trait_tags: Vec<String>,  // requested prompt-trait tags (the turn's)
+    tier: Option<String>,     // user's tier at message time; None omitted from metadata
     random_draw: Option<f64>, // sampled once per turn by run_stream; None when trigger.random is unset
     outcome: std::sync::Arc<std::sync::Mutex<BurstOutcome>>,
 ) -> impl futures_util::Stream<Item = ProtocolFrame> + Send + 'static {
@@ -165,6 +166,17 @@ fn drive_chat_burst(
             .as_ref()
             .map(|f| f.trigger.turn_level_pass(random_draw, &tag_refs))
             .unwrap_or(false);
+
+        // Build the assistant row metadata bag: always includes prompt_traits;
+        // includes tier only when the request carried one (omit key entirely when None).
+        let build_metadata = || {
+            let mut m = serde_json::Map::new();
+            m.insert("prompt_traits".into(), serde_json::json!(&trait_tags));
+            if let Some(t) = tier.as_deref() {
+                m.insert("tier".into(), serde_json::json!(t));
+            }
+            Some(serde_json::Value::Object(m))
+        };
 
         if !filtered_mode {
             // ===== LIVE MODE (preserved verbatim from the pre-filter burst) =====
@@ -235,7 +247,7 @@ fn drive_chat_burst(
                     usage: last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok()),
                     generation_id: last_gen_id.clone(),
                     filter_audit: None,
-                    metadata: Some(serde_json::json!({ "prompt_traits": &trait_tags })),
+                    metadata: build_metadata(),
                 };
                 if let Err(e) = chat_repo
                     .insert_assistant_batch(session_id, user_message_id, &[row])
@@ -379,7 +391,7 @@ fn drive_chat_burst(
                 usage: last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok()),
                 generation_id: last_gen_id.clone(),
                 filter_audit,
-                metadata: Some(serde_json::json!({ "prompt_traits": &trait_tags })),
+                metadata: build_metadata(),
             };
             if let Err(e) = chat_repo.insert_assistant_batch(session_id, user_message_id, &[row]).await {
                 tracing::warn!("stream(filtered): persist failed: {e}");
@@ -678,6 +690,7 @@ pub fn run_stream(
                     display_override,
                     filter,
                     trait_tags,
+                    user_msg.tier.clone(),
                     random_draw,
                     outcome.clone(),
                 );

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -345,12 +345,12 @@ fn drive_chat_burst(
                         let mut o = outcome.lock().unwrap();
                         o.filtered = true;
                         o.retries_filter = out.retries_filter;
-                        drop(o);
+                        drop(o); // release MutexGuard before the yield below — must not cross suspension point
                         let audit = eros_engine_store::chat::FilterAudit {
                             pre_filter_content: acc.clone(),
                             filter_model: out.filter_model,
                             filter_triggers: serde_json::to_value(&h)
-                                .unwrap_or(serde_json::Value::Null),
+                                .expect("TriggerHits Serialize is infallible"),
                             f_client_msg_id: out.f_client_msg_id,
                             f_generation_id: out.f_generation_id,
                         };

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -234,6 +234,7 @@ fn drive_chat_burst(
                     model: Some(model_id.clone()),
                     usage: last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok()),
                     generation_id: last_gen_id.clone(),
+                    filter_audit: None,
                 };
                 if let Err(e) = chat_repo
                     .insert_assistant_batch(session_id, user_message_id, &[row])
@@ -365,6 +366,7 @@ fn drive_chat_burst(
                 model: Some(model_id.clone()),
                 usage: last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok()),
                 generation_id: last_gen_id.clone(),
+                filter_audit: None,
             };
             if let Err(e) = chat_repo.insert_assistant_batch(session_id, user_message_id, &[row]).await {
                 tracing::warn!("stream(filtered): persist failed: {e}");
@@ -1038,7 +1040,7 @@ mod tests {
         let state = std::sync::Arc::new(crate::routes::companion::test_state(pool.clone()));
         let chat_repo = ChatRepo { pool: &state.pool };
         let user_message_id = match chat_repo
-            .upsert_user_message_idempotent(session_id, "hi", "01J1111111111111111111111A")
+            .upsert_user_message_idempotent(session_id, "hi", "01J1111111111111111111111A", "user", None)
             .await
             .unwrap()
         {
@@ -1163,7 +1165,7 @@ data: [DONE]\n\n";
 
         let chat_repo = ChatRepo { pool: &pool };
         let user_message_id = match chat_repo
-            .upsert_user_message_idempotent(session_id, "hi", "01J2222222222222222222222A")
+            .upsert_user_message_idempotent(session_id, "hi", "01J2222222222222222222222A", "user", None)
             .await
             .unwrap()
         {
@@ -1240,7 +1242,7 @@ data: [DONE]\n\n";
 
         let chat_repo = ChatRepo { pool: &pool };
         let user_message_id = match chat_repo
-            .upsert_user_message_idempotent(session_id, "hi", "01J3333333333333333333333A")
+            .upsert_user_message_idempotent(session_id, "hi", "01J3333333333333333333333A", "user", None)
             .await
             .unwrap()
         {
@@ -1333,7 +1335,7 @@ data: [DONE]\n\n";
 
         let chat_repo = ChatRepo { pool: &pool };
         let user_message_id = match chat_repo
-            .upsert_user_message_idempotent(session_id, "hi", "01J4444444444444444444444A")
+            .upsert_user_message_idempotent(session_id, "hi", "01J4444444444444444444444A", "user", None)
             .await
             .unwrap()
         {
@@ -1522,6 +1524,8 @@ data: [DONE]\n\n";
                 session_id,
                 "hello there friend",
                 "01J9999999999999999999999A",
+                "user",
+                None,
             )
             .await
             .unwrap()
@@ -1639,6 +1643,8 @@ data: [DONE]\n\n";
                 session_id,
                 "hello there friend",
                 "01J9999999999999999999999B",
+                "user",
+                None,
             )
             .await
             .unwrap()
@@ -1753,6 +1759,8 @@ data: [DONE]\n\n";
                 session_id,
                 "hello there friend",
                 "01J9999999999999999999999C",
+                "user",
+                None,
             )
             .await
             .unwrap()
@@ -1840,7 +1848,7 @@ data: [DONE]\n\n";
 
         let chat_repo = ChatRepo { pool: &pool };
         let user_message_id = match chat_repo
-            .upsert_user_message_idempotent(session_id, "(打赏 $20)", "01J5555555555555555555555A")
+            .upsert_user_message_idempotent(session_id, "(打赏 $20)", "01J5555555555555555555555A", "gift_user", Some(&serde_json::json!({"tips_amount_usd": 20.0})))
             .await
             .unwrap()
         {
@@ -1943,6 +1951,8 @@ data: [DONE]\n\n";
                 session_id,
                 "hello there friend",
                 "01J9999999999999999999999D",
+                "user",
+                None,
             )
             .await
             .unwrap()

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -139,7 +139,7 @@ fn drive_chat_burst(
     req: eros_engine_llm::openrouter::ChatRequest,
     display_override: Option<eros_engine_llm::model_config::DisplayOverride>,
     filter: Option<eros_engine_llm::model_config::ResolvedOutputFilter>,
-    trait_tags: Vec<String>, // requested prompt-trait tags (the turn's)
+    trait_tags: Vec<String>,  // requested prompt-trait tags (the turn's)
     random_draw: Option<f64>, // sampled once per turn by run_stream; None when trigger.random is unset
     outcome: std::sync::Arc<std::sync::Mutex<BurstOutcome>>,
 ) -> impl futures_util::Stream<Item = ProtocolFrame> + Send + 'static {
@@ -1074,7 +1074,13 @@ mod tests {
         let state = std::sync::Arc::new(crate::routes::companion::test_state(pool.clone()));
         let chat_repo = ChatRepo { pool: &state.pool };
         let user_message_id = match chat_repo
-            .upsert_user_message_idempotent(session_id, "hi", "01J1111111111111111111111A", "user", None)
+            .upsert_user_message_idempotent(
+                session_id,
+                "hi",
+                "01J1111111111111111111111A",
+                "user",
+                None,
+            )
             .await
             .unwrap()
         {
@@ -1199,7 +1205,13 @@ data: [DONE]\n\n";
 
         let chat_repo = ChatRepo { pool: &pool };
         let user_message_id = match chat_repo
-            .upsert_user_message_idempotent(session_id, "hi", "01J2222222222222222222222A", "user", None)
+            .upsert_user_message_idempotent(
+                session_id,
+                "hi",
+                "01J2222222222222222222222A",
+                "user",
+                None,
+            )
             .await
             .unwrap()
         {
@@ -1276,7 +1288,13 @@ data: [DONE]\n\n";
 
         let chat_repo = ChatRepo { pool: &pool };
         let user_message_id = match chat_repo
-            .upsert_user_message_idempotent(session_id, "hi", "01J3333333333333333333333A", "user", None)
+            .upsert_user_message_idempotent(
+                session_id,
+                "hi",
+                "01J3333333333333333333333A",
+                "user",
+                None,
+            )
             .await
             .unwrap()
         {
@@ -1369,7 +1387,13 @@ data: [DONE]\n\n";
 
         let chat_repo = ChatRepo { pool: &pool };
         let user_message_id = match chat_repo
-            .upsert_user_message_idempotent(session_id, "hi", "01J4444444444444444444444A", "user", None)
+            .upsert_user_message_idempotent(
+                session_id,
+                "hi",
+                "01J4444444444444444444444A",
+                "user",
+                None,
+            )
             .await
             .unwrap()
         {
@@ -1882,7 +1906,13 @@ data: [DONE]\n\n";
 
         let chat_repo = ChatRepo { pool: &pool };
         let user_message_id = match chat_repo
-            .upsert_user_message_idempotent(session_id, "(打赏 $20)", "01J5555555555555555555555A", "gift_user", Some(&serde_json::json!({"tips_amount_usd": 20.0})))
+            .upsert_user_message_idempotent(
+                session_id,
+                "(打赏 $20)",
+                "01J5555555555555555555555A",
+                "gift_user",
+                Some(&serde_json::json!({"tips_amount_usd": 20.0})),
+            )
             .await
             .unwrap()
         {

--- a/crates/eros-engine-server/src/routes/bff/companion.rs
+++ b/crates/eros-engine-server/src/routes/bff/companion.rs
@@ -36,6 +36,13 @@ pub struct BffHistoryEntry {
     pub role: String,
     pub content: String,
     pub sent_at: DateTime<Utc>,
+    /// Structured tip amount for `role='gift_user'` rows. Omitted from
+    /// response when None (`skip_serializing_if`). Lets clients render tips
+    /// at the right point in the timeline without parsing the `(打赏 $X)`
+    /// content marker. Spec:
+    /// docs/superpowers/specs/2026-05-26-tip-role-and-filter-audit-design.md §3.4.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tips_amount_usd: Option<f64>,
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
@@ -126,6 +133,7 @@ async fn bff_get_history(
             role: r.role,
             content: r.content,
             sent_at: r.sent_at,
+            tips_amount_usd: r.tips_amount_usd,
         })
         .collect();
     let total = messages.len();
@@ -181,6 +189,7 @@ async fn bff_start_chat(
                 role: r.role,
                 content: r.content,
                 sent_at: r.sent_at,
+                tips_amount_usd: r.tips_amount_usd,
             })
             .collect()
     };
@@ -607,6 +616,52 @@ mod tests {
         )
         .await;
         assert_eq!(status, StatusCode::FORBIDDEN);
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn bff_history_exposes_tips_amount_usd_on_gift_user_rows(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+
+        sqlx::query(
+            "INSERT INTO engine.chat_messages \
+                 (session_id, role, content, metadata, sent_at) \
+             VALUES ($1, 'gift_user', '(打赏 $20)', '{\"tips_amount_usd\": 20.0}'::jsonb, \
+                     now() - interval '2 seconds'),
+                    ($1, 'user', 'hello', NULL, now() - interval '1 second')",
+        )
+        .bind(session_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let state = test_state(pool);
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        let (status, body) =
+            send_request(&mut app, bff_history_request(&token, session_id, "")).await;
+        assert_eq!(status, StatusCode::OK, "got body: {body}");
+
+        let messages = body["messages"].as_array().expect("messages array");
+        assert_eq!(messages.len(), 2);
+
+        let tip = messages
+            .iter()
+            .find(|m| m["role"] == "gift_user")
+            .expect("tip row");
+        assert_eq!(tip["tips_amount_usd"], json!(20.0));
+
+        let normal = messages
+            .iter()
+            .find(|m| m["role"] == "user")
+            .expect("user row");
+        assert!(
+            normal.get("tips_amount_usd").is_none(),
+            "non-tip user row must omit tips_amount_usd; got {normal}"
+        );
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/crates/eros-engine-server/src/routes/bff/companion.rs
+++ b/crates/eros-engine-server/src/routes/bff/companion.rs
@@ -628,9 +628,10 @@ mod tests {
         sqlx::query(
             "INSERT INTO engine.chat_messages \
                  (session_id, role, content, metadata, sent_at) \
-             VALUES ($1, 'gift_user', '(打赏 $20)', '{\"tips_amount_usd\": 20.0}'::jsonb, \
+             VALUES ($1, 'gift_user', '(打赏 $20)', \
+                     '{\"tips_amount_usd\": 20.0, \"tier\": \"gold\", \"prompt_traits\": [\"nsfw\"]}'::jsonb, \
                      now() - interval '2 seconds'),
-                    ($1, 'user', 'hello', NULL, now() - interval '1 second')",
+                    ($1, 'user', 'hello', '{\"tier\": \"silver\"}'::jsonb, now() - interval '1 second')",
         )
         .bind(session_id)
         .execute(&pool)
@@ -662,6 +663,23 @@ mod tests {
             normal.get("tips_amount_usd").is_none(),
             "non-tip user row must omit tips_amount_usd; got {normal}"
         );
+
+        // BFF MUST NOT leak any metadata key other than the typed tips_amount_usd
+        // extract. Spec §3.4: tier / prompt_traits are audit-only on the DB side.
+        for m in messages {
+            assert!(
+                m.get("metadata").is_none(),
+                "BFF must never expose raw metadata; got {m}"
+            );
+            assert!(
+                m.get("tier").is_none(),
+                "BFF must not surface tier from metadata; got {m}"
+            );
+            assert!(
+                m.get("prompt_traits").is_none(),
+                "BFF must not surface prompt_traits from metadata; got {m}"
+            );
+        }
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/crates/eros-engine-server/src/routes/companion_stream.rs
+++ b/crates/eros-engine-server/src/routes/companion_stream.rs
@@ -606,7 +606,13 @@ mod tests {
         // Pre-seed an original-request outcome.
         let chat_repo = ChatRepo { pool: &pool };
         let user_msg_id = match chat_repo
-            .upsert_user_message_idempotent(session_id, "hi", "01J3333333333333333333333A", "user", None)
+            .upsert_user_message_idempotent(
+                session_id,
+                "hi",
+                "01J3333333333333333333333A",
+                "user",
+                None,
+            )
             .await
             .unwrap()
         {

--- a/crates/eros-engine-server/src/routes/companion_stream.rs
+++ b/crates/eros-engine-server/src/routes/companion_stream.rs
@@ -271,18 +271,28 @@ pub async fn send_message_stream(
             })
         })?;
 
-    let (persisted_content, persisted_role, persisted_metadata) = match req.tips_amount_usd {
+    // Build metadata: conditionally include tips_amount_usd and tier.
+    // tier is omitted entirely (not written as null) when absent — keeps JSONB shape sparse.
+    let mut meta_map = serde_json::Map::new();
+    if let Some(amount) = req.tips_amount_usd {
+        meta_map.insert("tips_amount_usd".into(), serde_json::json!(amount));
+    }
+    if let Some(t) = req.tier.as_deref() {
+        meta_map.insert("tier".into(), serde_json::json!(t));
+    }
+    let persisted_metadata: Option<serde_json::Value> = if meta_map.is_empty() {
+        None
+    } else {
+        Some(serde_json::Value::Object(meta_map))
+    };
+
+    let (persisted_content, persisted_role) = match req.tips_amount_usd {
         Some(amount) if req.content.is_empty() => (
             format!("(打赏 ${})", crate::prompt::fmt_amount(amount)),
             "gift_user",
-            Some(serde_json::json!({ "tips_amount_usd": amount })),
         ),
-        Some(amount) => (
-            req.content.clone(),
-            "gift_user",
-            Some(serde_json::json!({ "tips_amount_usd": amount })),
-        ),
-        None => (req.content.clone(), "user", None),
+        Some(_) => (req.content.clone(), "gift_user"),
+        None => (req.content.clone(), "user"),
     };
     let outcome = chat_repo
         .upsert_user_message_idempotent(

--- a/crates/eros-engine-server/src/routes/companion_stream.rs
+++ b/crates/eros-engine-server/src/routes/companion_stream.rs
@@ -627,6 +627,7 @@ mod tests {
                     model: Some("primary".into()),
                     usage: Some(serde_json::json!({"prompt_tokens":1,"completion_tokens":2,"total_tokens":3})),
                     generation_id: Some("gen-1".into()),
+                    filter_audit: None,
                 }],
             )
             .await

--- a/crates/eros-engine-server/src/routes/companion_stream.rs
+++ b/crates/eros-engine-server/src/routes/companion_stream.rs
@@ -271,16 +271,27 @@ pub async fn send_message_stream(
             })
         })?;
 
-    let persisted_content = if req.content.is_empty() {
-        match req.tips_amount_usd {
-            Some(amount) => format!("(打赏 ${})", crate::prompt::fmt_amount(amount)),
-            None => req.content.clone(), // unreachable post-validation
-        }
-    } else {
-        req.content.clone()
+    let (persisted_content, persisted_role, persisted_metadata) = match req.tips_amount_usd {
+        Some(amount) if req.content.is_empty() => (
+            format!("(打赏 ${})", crate::prompt::fmt_amount(amount)),
+            "gift_user",
+            Some(serde_json::json!({ "tips_amount_usd": amount })),
+        ),
+        Some(amount) => (
+            req.content.clone(),
+            "gift_user",
+            Some(serde_json::json!({ "tips_amount_usd": amount })),
+        ),
+        None => (req.content.clone(), "user", None),
     };
     let outcome = chat_repo
-        .upsert_user_message_idempotent(session_id, &persisted_content, &req.client_msg_id)
+        .upsert_user_message_idempotent(
+            session_id,
+            &persisted_content,
+            &req.client_msg_id,
+            persisted_role,
+            persisted_metadata.as_ref(),
+        )
         .await?;
     // Resolve the proto stream. Replay returns early with a boxed stream;
     // Inserted continues to run_stream below. Boxing erases the concrete type
@@ -595,7 +606,7 @@ mod tests {
         // Pre-seed an original-request outcome.
         let chat_repo = ChatRepo { pool: &pool };
         let user_msg_id = match chat_repo
-            .upsert_user_message_idempotent(session_id, "hi", "01J3333333333333333333333A")
+            .upsert_user_message_idempotent(session_id, "hi", "01J3333333333333333333333A", "user", None)
             .await
             .unwrap()
         {

--- a/crates/eros-engine-server/src/routes/companion_stream.rs
+++ b/crates/eros-engine-server/src/routes/companion_stream.rs
@@ -634,6 +634,7 @@ mod tests {
                     usage: Some(serde_json::json!({"prompt_tokens":1,"completion_tokens":2,"total_tokens":3})),
                     generation_id: Some("gen-1".into()),
                     filter_audit: None,
+                    metadata: None,
                 }],
             )
             .await

--- a/crates/eros-engine-store/migrations/0019_chat_tip_marker_and_filter_audit.sql
+++ b/crates/eros-engine-store/migrations/0019_chat_tip_marker_and_filter_audit.sql
@@ -1,0 +1,31 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+--
+-- chat_messages gains:
+--   metadata           — open marker bag for user-side rows (today: tip amount)
+--   pre_filter_content, filter_model, filter_triggers, f_client_msg_id,
+--   f_generation_id   — assistant-side filter audit, written only when the
+--                       chat-reply output filter actually rewrote the reply.
+--
+-- All six columns are nullable and default-safe; existing inserts that do not
+-- mention them keep working. No backfill.
+--
+-- Spec: docs/superpowers/specs/2026-05-26-tip-role-and-filter-audit-design.md
+
+ALTER TABLE engine.chat_messages
+    ADD COLUMN metadata             JSONB NULL,
+    ADD COLUMN pre_filter_content   TEXT  NULL,
+    ADD COLUMN filter_model         TEXT  NULL,
+    ADD COLUMN filter_triggers      JSONB NULL,
+    ADD COLUMN f_client_msg_id      TEXT  NULL,
+    ADD COLUMN f_generation_id      TEXT  NULL;
+
+-- Audit index for tip-amount aggregation. Partial: only rows that carry a tip.
+CREATE INDEX chat_messages_tips_amount_idx
+    ON engine.chat_messages ((metadata->>'tips_amount_usd'))
+    WHERE metadata ? 'tips_amount_usd';
+
+-- f_client_msg_id is engine-generated per filter LLM call; enforce that a
+-- single logical filter call writes at most one row per session.
+CREATE UNIQUE INDEX chat_messages_f_client_msg_id_uidx
+    ON engine.chat_messages (session_id, f_client_msg_id)
+    WHERE f_client_msg_id IS NOT NULL;

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -264,7 +264,7 @@ pub struct FilterAudit {
     pub filter_model: String,
     pub filter_triggers: serde_json::Value,
     pub f_client_msg_id: String,
-    pub f_generation_id: String,
+    pub f_generation_id: Option<String>,
 }
 
 /// One assistant row to insert in a burst.
@@ -420,7 +420,7 @@ impl<'a> ChatRepo<'a> {
                         Some(a.filter_model.as_str()),
                         Some(&a.filter_triggers),
                         Some(a.f_client_msg_id.as_str()),
-                        Some(a.f_generation_id.as_str()),
+                        a.f_generation_id.as_deref(),
                     ),
                     None => (None, None, None, None, None),
                 };
@@ -907,7 +907,7 @@ mod tests {
                 filter_model: "anthropic/claude-haiku-4.5".into(),
                 filter_triggers: triggers.clone(),
                 f_client_msg_id: "f_01J0000000000000000000001Z".into(),
-                f_generation_id: "gen_filter_abc".into(),
+                f_generation_id: Some("gen_filter_abc".into()),
             }),
         };
         repo.insert_assistant_batch(s.id, user_msg_id, &[row])
@@ -1023,5 +1023,59 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(idx_count, 2, "both new indexes should exist");
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn assistant_batch_filter_audit_with_none_generation_id_writes_null(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let s = repo
+            .create_session(Uuid::new_v4(), Uuid::new_v4())
+            .await
+            .unwrap();
+        let user_msg_id = match repo
+            .upsert_user_message_idempotent(
+                s.id,
+                "hi",
+                "01J0000000000000000000003A",
+                "user",
+                None,
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            other => panic!("{other:?}"),
+        };
+        let row = AssistantInsert {
+            id: Uuid::new_v4(),
+            content: "filtered no gen".into(),
+            assistant_action_type: "reply".into(),
+            continues_from_message_id: None,
+            truncated: false,
+            model: Some("anthropic/claude-sonnet-4.6".into()),
+            usage: None,
+            generation_id: Some("gen_chat_xyz".into()),
+            filter_audit: Some(FilterAudit {
+                pre_filter_content: "raw".into(),
+                filter_model: "anthropic/claude-haiku-4.5".into(),
+                filter_triggers: serde_json::json!({}),
+                f_client_msg_id: "f_01J0000000000000000000003Z".into(),
+                f_generation_id: None,
+            }),
+        };
+        repo.insert_assistant_batch(s.id, user_msg_id, &[row])
+            .await
+            .unwrap();
+        let (pre_filter, f_gen): (Option<String>, Option<String>) = sqlx::query_as(
+            "SELECT pre_filter_content, f_generation_id \
+             FROM engine.chat_messages \
+             WHERE role='assistant' AND session_id=$1",
+        )
+        .bind(s.id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(pre_filter.as_deref(), Some("raw"));
+        assert!(f_gen.is_none(), "f_generation_id should be NULL when None inside Some(FilterAudit)");
     }
 }

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -69,6 +69,12 @@ pub struct ChatMessageSlim {
     /// Client-supplied message id forwarded during streaming (idempotency
     /// key). NULL for rows that never carried one (e.g. assistant turns).
     pub client_msg_id: Option<String>,
+    /// Structured tip amount extracted from `metadata->>'tips_amount_usd'`.
+    /// Present on `role='gift_user'` rows that carry tip metadata; NULL on
+    /// all other rows. Lets BFF / FE render tips as a structured field
+    /// instead of parsing the `(打赏 $X)` content marker.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tips_amount_usd: Option<f64>,
 }
 
 pub struct ChatRepo<'a> {
@@ -227,7 +233,9 @@ impl<'a> ChatRepo<'a> {
         offset: i64,
     ) -> Result<Vec<ChatMessageSlim>, sqlx::Error> {
         let mut rows = sqlx::query_as::<_, ChatMessageSlim>(
-            "SELECT id, role, content, sent_at, client_msg_id FROM engine.chat_messages \
+            "SELECT id, role, content, sent_at, client_msg_id, \
+                    (metadata->>'tips_amount_usd')::float8 AS tips_amount_usd \
+             FROM engine.chat_messages \
              WHERE session_id = $1 \
              ORDER BY sent_at DESC \
              LIMIT $2 OFFSET $3",

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -729,4 +729,35 @@ mod tests {
             "last_active_at must be bumped"
         );
     }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn migration_0019_adds_chat_messages_columns(pool: PgPool) {
+        // Probe the six new columns by name. Each query should succeed (NULL on
+        // legacy rows). If any column is missing, the SELECT errors out.
+        for col in [
+            "metadata",
+            "pre_filter_content",
+            "filter_model",
+            "filter_triggers",
+            "f_client_msg_id",
+            "f_generation_id",
+        ] {
+            let q = format!("SELECT {col} FROM engine.chat_messages LIMIT 0");
+            sqlx::query(&q).execute(&pool).await.unwrap_or_else(|e| {
+                panic!("expected column {col} on engine.chat_messages: {e}")
+            });
+        }
+        // Indexes exist.
+        let idx_count: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM pg_indexes \
+             WHERE schemaname = 'engine' \
+               AND tablename = 'chat_messages' \
+               AND indexname IN ('chat_messages_tips_amount_idx',
+                                 'chat_messages_f_client_msg_id_uidx')",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(idx_count, 2, "both new indexes should exist");
+    }
 }

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -598,7 +598,13 @@ mod tests {
         let s = repo.create_session(user_id, instance_id).await.unwrap();
 
         let outcome = repo
-            .upsert_user_message_idempotent(s.id, "hello", "01J0000000000000000000000A", "user", None)
+            .upsert_user_message_idempotent(
+                s.id,
+                "hello",
+                "01J0000000000000000000000A",
+                "user",
+                None,
+            )
             .await
             .unwrap();
         match outcome {
@@ -617,7 +623,13 @@ mod tests {
         let s = repo.create_session(user_id, instance_id).await.unwrap();
 
         let first = match repo
-            .upsert_user_message_idempotent(s.id, "hello", "01J0000000000000000000000A", "user", None)
+            .upsert_user_message_idempotent(
+                s.id,
+                "hello",
+                "01J0000000000000000000000A",
+                "user",
+                None,
+            )
             .await
             .unwrap()
         {
@@ -646,7 +658,13 @@ mod tests {
         .unwrap();
 
         let outcome = repo
-            .upsert_user_message_idempotent(s.id, "hello", "01J0000000000000000000000A", "user", None)
+            .upsert_user_message_idempotent(
+                s.id,
+                "hello",
+                "01J0000000000000000000000A",
+                "user",
+                None,
+            )
             .await
             .unwrap();
         match outcome {
@@ -672,7 +690,13 @@ mod tests {
         let s = repo.create_session(user_id, instance_id).await.unwrap();
 
         let first = match repo
-            .upsert_user_message_idempotent(s.id, "hello", "01J0000000000000000000000A", "user", None)
+            .upsert_user_message_idempotent(
+                s.id,
+                "hello",
+                "01J0000000000000000000000A",
+                "user",
+                None,
+            )
             .await
             .unwrap()
         {
@@ -681,7 +705,13 @@ mod tests {
         };
 
         match repo
-            .upsert_user_message_idempotent(s.id, "hello", "01J0000000000000000000000A", "user", None)
+            .upsert_user_message_idempotent(
+                s.id,
+                "hello",
+                "01J0000000000000000000000A",
+                "user",
+                None,
+            )
             .await
             .unwrap()
         {
@@ -700,7 +730,13 @@ mod tests {
         let s = repo.create_session(user_id, instance_id).await.unwrap();
 
         let first = match repo
-            .upsert_user_message_idempotent(s.id, "hello", "01J0000000000000000000000A", "user", None)
+            .upsert_user_message_idempotent(
+                s.id,
+                "hello",
+                "01J0000000000000000000000A",
+                "user",
+                None,
+            )
             .await
             .unwrap()
         {
@@ -710,7 +746,13 @@ mod tests {
         repo.mark_user_message_ghosted(first).await.unwrap();
 
         match repo
-            .upsert_user_message_idempotent(s.id, "hello", "01J0000000000000000000000A", "user", None)
+            .upsert_user_message_idempotent(
+                s.id,
+                "hello",
+                "01J0000000000000000000000A",
+                "user",
+                None,
+            )
             .await
             .unwrap()
         {
@@ -786,28 +828,24 @@ mod tests {
             .await
             .unwrap();
         let outcome = repo
-            .upsert_user_message_idempotent(
-                s.id,
-                "hi",
-                "01J0000000000000000000000A",
-                "user",
-                None,
-            )
+            .upsert_user_message_idempotent(s.id, "hi", "01J0000000000000000000000A", "user", None)
             .await
             .unwrap();
         match outcome {
             UpsertUserOutcome::Inserted { .. } => {}
-            other => panic!("expected Inserted, got {:?}", other),
+            other => panic!("expected Inserted, got {other:?}"),
         }
-        let (role, metadata): (String, Option<serde_json::Value>) = sqlx::query_as(
-            "SELECT role, metadata FROM engine.chat_messages WHERE session_id = $1",
-        )
-        .bind(s.id)
-        .fetch_one(&pool)
-        .await
-        .unwrap();
+        let (role, metadata): (String, Option<serde_json::Value>) =
+            sqlx::query_as("SELECT role, metadata FROM engine.chat_messages WHERE session_id = $1")
+                .bind(s.id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
         assert_eq!(role, "user");
-        assert!(metadata.is_none(), "metadata should be NULL on plain user rows");
+        assert!(
+            metadata.is_none(),
+            "metadata should be NULL on plain user rows"
+        );
     }
 
     #[sqlx::test(migrations = "./migrations")]
@@ -827,13 +865,12 @@ mod tests {
         )
         .await
         .unwrap();
-        let (role, metadata): (String, serde_json::Value) = sqlx::query_as(
-            "SELECT role, metadata FROM engine.chat_messages WHERE session_id = $1",
-        )
-        .bind(s.id)
-        .fetch_one(&pool)
-        .await
-        .unwrap();
+        let (role, metadata): (String, serde_json::Value) =
+            sqlx::query_as("SELECT role, metadata FROM engine.chat_messages WHERE session_id = $1")
+                .bind(s.id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
         assert_eq!(role, "gift_user");
         assert_eq!(metadata["tips_amount_usd"].as_f64(), Some(20.0));
     }
@@ -870,11 +907,12 @@ mod tests {
             .unwrap();
         match outcome {
             UpsertUserOutcome::DuplicateInProgress { .. } => {}
-            other => panic!("expected DuplicateInProgress, got {:?}", other),
+            other => panic!("expected DuplicateInProgress, got {other:?}"),
         }
     }
 
     #[sqlx::test(migrations = "./migrations")]
+    #[allow(clippy::type_complexity)] // sqlx tuple query — type alias would add noise
     async fn assistant_batch_round_trips_filter_audit(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
         let s = repo
@@ -882,13 +920,7 @@ mod tests {
             .await
             .unwrap();
         let user_msg_id = match repo
-            .upsert_user_message_idempotent(
-                s.id,
-                "hi",
-                "01J0000000000000000000001A",
-                "user",
-                None,
-            )
+            .upsert_user_message_idempotent(s.id, "hi", "01J0000000000000000000001A", "user", None)
             .await
             .unwrap()
         {
@@ -922,14 +954,7 @@ mod tests {
             .await
             .unwrap();
 
-        let (
-            content,
-            pre_filter,
-            filter_model,
-            filter_triggers,
-            f_client,
-            f_gen,
-        ): (
+        let (content, pre_filter, filter_model, filter_triggers, f_client, f_gen): (
             String,
             Option<String>,
             Option<String>,
@@ -961,13 +986,7 @@ mod tests {
             .await
             .unwrap();
         let user_msg_id = match repo
-            .upsert_user_message_idempotent(
-                s.id,
-                "hi",
-                "01J0000000000000000000002A",
-                "user",
-                None,
-            )
+            .upsert_user_message_idempotent(s.id, "hi", "01J0000000000000000000002A", "user", None)
             .await
             .unwrap()
         {
@@ -1015,9 +1034,10 @@ mod tests {
             "f_generation_id",
         ] {
             let q = format!("SELECT {col} FROM engine.chat_messages LIMIT 0");
-            sqlx::query(&q).execute(&pool).await.unwrap_or_else(|e| {
-                panic!("expected column {col} on engine.chat_messages: {e}")
-            });
+            sqlx::query(&q)
+                .execute(&pool)
+                .await
+                .unwrap_or_else(|e| panic!("expected column {col} on engine.chat_messages: {e}"));
         }
         // Indexes exist.
         let idx_count: i64 = sqlx::query_scalar(
@@ -1041,13 +1061,7 @@ mod tests {
             .await
             .unwrap();
         let user_msg_id = match repo
-            .upsert_user_message_idempotent(
-                s.id,
-                "hi",
-                "01J0000000000000000000003A",
-                "user",
-                None,
-            )
+            .upsert_user_message_idempotent(s.id, "hi", "01J0000000000000000000003A", "user", None)
             .await
             .unwrap()
         {
@@ -1084,6 +1098,9 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(pre_filter.as_deref(), Some("raw"));
-        assert!(f_gen.is_none(), "f_generation_id should be NULL when None inside Some(FilterAudit)");
+        assert!(
+            f_gen.is_none(),
+            "f_generation_id should be NULL when None inside Some(FilterAudit)"
+        );
     }
 }

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -254,6 +254,19 @@ impl<'a> ChatRepo<'a> {
     }
 }
 
+/// Audit metadata for a filtered-success assistant row. Threaded through
+/// `AssistantInsert::filter_audit` and bound into the five `chat_messages`
+/// audit columns. `None` ⇒ all five columns are NULL. See
+/// docs/superpowers/specs/2026-05-26-tip-role-and-filter-audit-design.md §4.
+#[derive(Debug, Clone)]
+pub struct FilterAudit {
+    pub pre_filter_content: String,
+    pub filter_model: String,
+    pub filter_triggers: serde_json::Value,
+    pub f_client_msg_id: String,
+    pub f_generation_id: String,
+}
+
 /// One assistant row to insert in a burst.
 #[derive(Debug, Clone)]
 pub struct AssistantInsert {
@@ -265,6 +278,7 @@ pub struct AssistantInsert {
     pub model: Option<String>,
     pub usage: Option<serde_json::Value>,
     pub generation_id: Option<String>,
+    pub filter_audit: Option<FilterAudit>,
 }
 
 /// Outcome of `upsert_user_message_idempotent`. The application uses this
@@ -399,12 +413,26 @@ impl<'a> ChatRepo<'a> {
         }
         let mut tx = self.pool.begin().await?;
         for row in rows {
+            let (pre_filter, filter_model, filter_triggers, f_client_msg_id, f_generation_id) =
+                match &row.filter_audit {
+                    Some(a) => (
+                        Some(a.pre_filter_content.as_str()),
+                        Some(a.filter_model.as_str()),
+                        Some(&a.filter_triggers),
+                        Some(a.f_client_msg_id.as_str()),
+                        Some(a.f_generation_id.as_str()),
+                    ),
+                    None => (None, None, None, None, None),
+                };
             sqlx::query(
                 "INSERT INTO engine.chat_messages \
                    (id, session_id, role, content, user_message_id, \
                     continues_from_message_id, truncated, model, usage, generation_id, \
-                    assistant_action_type) \
-                 VALUES ($1, $2, 'assistant', $3, $4, $5, $6, $7, $8, $9, $10)",
+                    assistant_action_type, \
+                    pre_filter_content, filter_model, filter_triggers, \
+                    f_client_msg_id, f_generation_id) \
+                 VALUES ($1, $2, 'assistant', $3, $4, $5, $6, $7, $8, $9, $10, \
+                         $11, $12, $13, $14, $15)",
             )
             .bind(row.id)
             .bind(session_id)
@@ -416,6 +444,11 @@ impl<'a> ChatRepo<'a> {
             .bind(&row.usage)
             .bind(&row.generation_id)
             .bind(&row.assistant_action_type)
+            .bind(pre_filter)
+            .bind(filter_model)
+            .bind(filter_triggers)
+            .bind(f_client_msg_id)
+            .bind(f_generation_id)
             .execute(&mut *tx)
             .await?;
         }
@@ -598,6 +631,7 @@ mod tests {
                     serde_json::json!({"prompt_tokens":3,"completion_tokens":2,"total_tokens":5}),
                 ),
                 generation_id: Some("gen-1".into()),
+                filter_audit: None,
             }],
         )
         .await
@@ -830,6 +864,134 @@ mod tests {
             UpsertUserOutcome::DuplicateInProgress { .. } => {}
             other => panic!("expected DuplicateInProgress, got {:?}", other),
         }
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn assistant_batch_round_trips_filter_audit(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let s = repo
+            .create_session(Uuid::new_v4(), Uuid::new_v4())
+            .await
+            .unwrap();
+        let user_msg_id = match repo
+            .upsert_user_message_idempotent(
+                s.id,
+                "hi",
+                "01J0000000000000000000001A",
+                "user",
+                None,
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            other => panic!("{other:?}"),
+        };
+
+        let triggers = serde_json::json!({
+            "random": { "p": 0.3, "draw": 0.18 },
+            "models": "deepseek/deepseek-v4-flash",
+            "traits": ["nsfw_boost"]
+        });
+        let row = AssistantInsert {
+            id: Uuid::new_v4(),
+            content: "filtered reply".into(),
+            assistant_action_type: "reply".into(),
+            continues_from_message_id: None,
+            truncated: false,
+            model: Some("anthropic/claude-sonnet-4.6".into()),
+            usage: None,
+            generation_id: Some("gen_chat_xyz".into()),
+            filter_audit: Some(FilterAudit {
+                pre_filter_content: "raw reply".into(),
+                filter_model: "anthropic/claude-haiku-4.5".into(),
+                filter_triggers: triggers.clone(),
+                f_client_msg_id: "f_01J0000000000000000000001Z".into(),
+                f_generation_id: "gen_filter_abc".into(),
+            }),
+        };
+        repo.insert_assistant_batch(s.id, user_msg_id, &[row])
+            .await
+            .unwrap();
+
+        let (
+            content,
+            pre_filter,
+            filter_model,
+            filter_triggers,
+            f_client,
+            f_gen,
+        ): (
+            String,
+            Option<String>,
+            Option<String>,
+            Option<serde_json::Value>,
+            Option<String>,
+            Option<String>,
+        ) = sqlx::query_as(
+            "SELECT content, pre_filter_content, filter_model, filter_triggers, \
+                    f_client_msg_id, f_generation_id \
+             FROM engine.chat_messages WHERE role = 'assistant' AND session_id = $1",
+        )
+        .bind(s.id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(content, "filtered reply");
+        assert_eq!(pre_filter.as_deref(), Some("raw reply"));
+        assert_eq!(filter_model.as_deref(), Some("anthropic/claude-haiku-4.5"));
+        assert_eq!(filter_triggers, Some(triggers));
+        assert_eq!(f_client.as_deref(), Some("f_01J0000000000000000000001Z"));
+        assert_eq!(f_gen.as_deref(), Some("gen_filter_abc"));
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn assistant_batch_filter_audit_columns_default_null(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let s = repo
+            .create_session(Uuid::new_v4(), Uuid::new_v4())
+            .await
+            .unwrap();
+        let user_msg_id = match repo
+            .upsert_user_message_idempotent(
+                s.id,
+                "hi",
+                "01J0000000000000000000002A",
+                "user",
+                None,
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            other => panic!("{other:?}"),
+        };
+        let row = AssistantInsert {
+            id: Uuid::new_v4(),
+            content: "plain reply".into(),
+            assistant_action_type: "reply".into(),
+            continues_from_message_id: None,
+            truncated: false,
+            model: Some("anthropic/claude-sonnet-4.6".into()),
+            usage: None,
+            generation_id: Some("gen_chat_xyz".into()),
+            filter_audit: None,
+        };
+        repo.insert_assistant_batch(s.id, user_msg_id, &[row])
+            .await
+            .unwrap();
+        let n: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM engine.chat_messages \
+             WHERE role='assistant' AND session_id=$1 \
+               AND pre_filter_content IS NULL AND filter_model IS NULL \
+               AND filter_triggers IS NULL AND f_client_msg_id IS NULL \
+               AND f_generation_id IS NULL",
+        )
+        .bind(s.id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(n, 1);
     }
 
     #[sqlx::test(migrations = "./migrations")]

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -863,7 +863,7 @@ mod tests {
             .create_session(Uuid::new_v4(), Uuid::new_v4())
             .await
             .unwrap();
-        let meta = serde_json::json!({ "tips_amount_usd": 20.0 });
+        let meta = serde_json::json!({ "tips_amount_usd": 20.0, "tier": "gold" });
         repo.upsert_user_message_idempotent(
             s.id,
             "(打赏 $20)",
@@ -881,6 +881,7 @@ mod tests {
                 .unwrap();
         assert_eq!(role, "gift_user");
         assert_eq!(metadata["tips_amount_usd"].as_f64(), Some(20.0));
+        assert_eq!(metadata["tier"], serde_json::json!("gold"));
     }
 
     #[sqlx::test(migrations = "./migrations")]
@@ -1196,5 +1197,50 @@ mod tests {
         .await
         .unwrap();
         assert!(m.is_none());
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn assistant_batch_persists_metadata_with_tier(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let s = repo
+            .create_session(Uuid::new_v4(), Uuid::new_v4())
+            .await
+            .unwrap();
+        let user_msg_id = match repo
+            .upsert_user_message_idempotent(s.id, "hi", "01J0000000000000000000006A", "user", None)
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            other => panic!("{other:?}"),
+        };
+        let metadata = serde_json::json!({
+            "prompt_traits": ["nsfw_boost"],
+            "tier": "gold"
+        });
+        let row = AssistantInsert {
+            id: Uuid::new_v4(),
+            content: "hi".into(),
+            assistant_action_type: "reply".into(),
+            continues_from_message_id: None,
+            truncated: false,
+            model: Some("anthropic/claude-sonnet-4.6".into()),
+            usage: None,
+            generation_id: Some("gen_chat_xyz".into()),
+            filter_audit: None,
+            metadata: Some(metadata.clone()),
+        };
+        repo.insert_assistant_batch(s.id, user_msg_id, &[row])
+            .await
+            .unwrap();
+        let m: Option<serde_json::Value> = sqlx::query_scalar(
+            "SELECT metadata FROM engine.chat_messages \
+             WHERE role='assistant' AND session_id=$1",
+        )
+        .bind(s.id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(m, Some(metadata));
     }
 }

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -299,14 +299,18 @@ impl<'a> ChatRepo<'a> {
         session_id: Uuid,
         content: &str,
         client_msg_id: &str,
+        role: &str,
+        metadata: Option<&serde_json::Value>,
     ) -> Result<UpsertUserOutcome, sqlx::Error> {
         let mut tx = self.pool.begin().await?;
 
-        // Look for an existing user row with the same (session_id, client_msg_id).
-        // The partial unique index guarantees at most one match if any.
+        // Widened role filter: tip path writes 'gift_user', and idempotency is
+        // keyed on (session_id, client_msg_id) regardless of which user-side
+        // role was originally persisted.
         let existing: Option<ChatMessage> = sqlx::query_as::<_, ChatMessage>(
             "SELECT * FROM engine.chat_messages \
-             WHERE session_id = $1 AND client_msg_id = $2 AND role = 'user' \
+             WHERE session_id = $1 AND client_msg_id = $2 \
+               AND role IN ('user', 'gift_user') \
              LIMIT 1",
         )
         .bind(session_id)
@@ -345,14 +349,16 @@ impl<'a> ChatRepo<'a> {
             });
         }
 
-        // First time: insert + bump last_active_at.
         let id: Uuid = sqlx::query_scalar(
-            "INSERT INTO engine.chat_messages (session_id, role, content, client_msg_id) \
-             VALUES ($1, 'user', $2, $3) RETURNING id",
+            "INSERT INTO engine.chat_messages \
+                 (session_id, role, content, client_msg_id, metadata) \
+             VALUES ($1, $2, $3, $4, $5) RETURNING id",
         )
         .bind(session_id)
+        .bind(role)
         .bind(content)
         .bind(client_msg_id)
+        .bind(metadata)
         .fetch_one(&mut *tx)
         .await?;
         sqlx::query("UPDATE engine.chat_sessions SET last_active_at = now() WHERE id = $1")
@@ -551,7 +557,7 @@ mod tests {
         let s = repo.create_session(user_id, instance_id).await.unwrap();
 
         let outcome = repo
-            .upsert_user_message_idempotent(s.id, "hello", "01J0000000000000000000000A")
+            .upsert_user_message_idempotent(s.id, "hello", "01J0000000000000000000000A", "user", None)
             .await
             .unwrap();
         match outcome {
@@ -570,7 +576,7 @@ mod tests {
         let s = repo.create_session(user_id, instance_id).await.unwrap();
 
         let first = match repo
-            .upsert_user_message_idempotent(s.id, "hello", "01J0000000000000000000000A")
+            .upsert_user_message_idempotent(s.id, "hello", "01J0000000000000000000000A", "user", None)
             .await
             .unwrap()
         {
@@ -598,7 +604,7 @@ mod tests {
         .unwrap();
 
         let outcome = repo
-            .upsert_user_message_idempotent(s.id, "hello", "01J0000000000000000000000A")
+            .upsert_user_message_idempotent(s.id, "hello", "01J0000000000000000000000A", "user", None)
             .await
             .unwrap();
         match outcome {
@@ -624,7 +630,7 @@ mod tests {
         let s = repo.create_session(user_id, instance_id).await.unwrap();
 
         let first = match repo
-            .upsert_user_message_idempotent(s.id, "hello", "01J0000000000000000000000A")
+            .upsert_user_message_idempotent(s.id, "hello", "01J0000000000000000000000A", "user", None)
             .await
             .unwrap()
         {
@@ -633,7 +639,7 @@ mod tests {
         };
 
         match repo
-            .upsert_user_message_idempotent(s.id, "hello", "01J0000000000000000000000A")
+            .upsert_user_message_idempotent(s.id, "hello", "01J0000000000000000000000A", "user", None)
             .await
             .unwrap()
         {
@@ -652,7 +658,7 @@ mod tests {
         let s = repo.create_session(user_id, instance_id).await.unwrap();
 
         let first = match repo
-            .upsert_user_message_idempotent(s.id, "hello", "01J0000000000000000000000A")
+            .upsert_user_message_idempotent(s.id, "hello", "01J0000000000000000000000A", "user", None)
             .await
             .unwrap()
         {
@@ -662,7 +668,7 @@ mod tests {
         repo.mark_user_message_ghosted(first).await.unwrap();
 
         match repo
-            .upsert_user_message_idempotent(s.id, "hello", "01J0000000000000000000000A")
+            .upsert_user_message_idempotent(s.id, "hello", "01J0000000000000000000000A", "user", None)
             .await
             .unwrap()
         {
@@ -728,6 +734,102 @@ mod tests {
             resumed.last_active_at >= before,
             "last_active_at must be bumped"
         );
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn upsert_user_message_writes_role_user_and_no_metadata(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let s = repo
+            .create_session(Uuid::new_v4(), Uuid::new_v4())
+            .await
+            .unwrap();
+        let outcome = repo
+            .upsert_user_message_idempotent(
+                s.id,
+                "hi",
+                "01J0000000000000000000000A",
+                "user",
+                None,
+            )
+            .await
+            .unwrap();
+        match outcome {
+            UpsertUserOutcome::Inserted { .. } => {}
+            other => panic!("expected Inserted, got {:?}", other),
+        }
+        let (role, metadata): (String, Option<serde_json::Value>) = sqlx::query_as(
+            "SELECT role, metadata FROM engine.chat_messages WHERE session_id = $1",
+        )
+        .bind(s.id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(role, "user");
+        assert!(metadata.is_none(), "metadata should be NULL on plain user rows");
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn upsert_user_message_writes_gift_user_role_and_tip_metadata(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let s = repo
+            .create_session(Uuid::new_v4(), Uuid::new_v4())
+            .await
+            .unwrap();
+        let meta = serde_json::json!({ "tips_amount_usd": 20.0 });
+        repo.upsert_user_message_idempotent(
+            s.id,
+            "(打赏 $20)",
+            "01J0000000000000000000000B",
+            "gift_user",
+            Some(&meta),
+        )
+        .await
+        .unwrap();
+        let (role, metadata): (String, serde_json::Value) = sqlx::query_as(
+            "SELECT role, metadata FROM engine.chat_messages WHERE session_id = $1",
+        )
+        .bind(s.id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(role, "gift_user");
+        assert_eq!(metadata["tips_amount_usd"].as_f64(), Some(20.0));
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn upsert_user_message_replay_finds_gift_user_row(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let s = repo
+            .create_session(Uuid::new_v4(), Uuid::new_v4())
+            .await
+            .unwrap();
+        let meta = serde_json::json!({ "tips_amount_usd": 5.0 });
+        repo.upsert_user_message_idempotent(
+            s.id,
+            "(打赏 $5)",
+            "01J0000000000000000000000C",
+            "gift_user",
+            Some(&meta),
+        )
+        .await
+        .unwrap();
+        // Second call with the same client_msg_id is a replay candidate even
+        // though the original wrote role='gift_user'. The widened role filter
+        // in the dedup lookup is what we're exercising.
+        let outcome = repo
+            .upsert_user_message_idempotent(
+                s.id,
+                "(打赏 $5)",
+                "01J0000000000000000000000C",
+                "gift_user",
+                Some(&meta),
+            )
+            .await
+            .unwrap();
+        match outcome {
+            UpsertUserOutcome::DuplicateInProgress { .. } => {}
+            other => panic!("expected DuplicateInProgress, got {:?}", other),
+        }
     }
 
     #[sqlx::test(migrations = "./migrations")]

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -287,6 +287,12 @@ pub struct AssistantInsert {
     pub usage: Option<serde_json::Value>,
     pub generation_id: Option<String>,
     pub filter_audit: Option<FilterAudit>,
+    /// Open marker bag for assistant rows. Today carries `{"prompt_traits": [...]}`
+    /// — the kept (post-tier-gated) prompt-trait tags injected this turn,
+    /// mirroring the final frame's `prompt_injected`. Always written when
+    /// trait info is known (potentially `{"prompt_traits": []}`). NULL on
+    /// legacy rows from before this column existed.
+    pub metadata: Option<serde_json::Value>,
 }
 
 /// Outcome of `upsert_user_message_idempotent`. The application uses this
@@ -438,9 +444,9 @@ impl<'a> ChatRepo<'a> {
                     continues_from_message_id, truncated, model, usage, generation_id, \
                     assistant_action_type, \
                     pre_filter_content, filter_model, filter_triggers, \
-                    f_client_msg_id, f_generation_id) \
+                    f_client_msg_id, f_generation_id, metadata) \
                  VALUES ($1, $2, 'assistant', $3, $4, $5, $6, $7, $8, $9, $10, \
-                         $11, $12, $13, $14, $15)",
+                         $11, $12, $13, $14, $15, $16)",
             )
             .bind(row.id)
             .bind(session_id)
@@ -457,6 +463,7 @@ impl<'a> ChatRepo<'a> {
             .bind(filter_triggers)
             .bind(f_client_msg_id)
             .bind(f_generation_id)
+            .bind(&row.metadata)
             .execute(&mut *tx)
             .await?;
         }
@@ -652,6 +659,7 @@ mod tests {
                 ),
                 generation_id: Some("gen-1".into()),
                 filter_audit: None,
+                metadata: None,
             }],
         )
         .await
@@ -949,6 +957,7 @@ mod tests {
                 f_client_msg_id: "f_01J0000000000000000000001Z".into(),
                 f_generation_id: Some("gen_filter_abc".into()),
             }),
+            metadata: None,
         };
         repo.insert_assistant_batch(s.id, user_msg_id, &[row])
             .await
@@ -1003,6 +1012,7 @@ mod tests {
             usage: None,
             generation_id: Some("gen_chat_xyz".into()),
             filter_audit: None,
+            metadata: None,
         };
         repo.insert_assistant_batch(s.id, user_msg_id, &[row])
             .await
@@ -1084,6 +1094,7 @@ mod tests {
                 f_client_msg_id: "f_01J0000000000000000000003Z".into(),
                 f_generation_id: None,
             }),
+            metadata: None,
         };
         repo.insert_assistant_batch(s.id, user_msg_id, &[row])
             .await
@@ -1102,5 +1113,88 @@ mod tests {
             f_gen.is_none(),
             "f_generation_id should be NULL when None inside Some(FilterAudit)"
         );
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn assistant_batch_persists_metadata_with_prompt_traits(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let s = repo
+            .create_session(Uuid::new_v4(), Uuid::new_v4())
+            .await
+            .unwrap();
+        let user_msg_id = match repo
+            .upsert_user_message_idempotent(s.id, "hi", "01J0000000000000000000004A", "user", None)
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            other => panic!("{other:?}"),
+        };
+        let metadata = serde_json::json!({ "prompt_traits": ["nsfw_boost", "tsundere"] });
+        let row = AssistantInsert {
+            id: Uuid::new_v4(),
+            content: "hi".into(),
+            assistant_action_type: "reply".into(),
+            continues_from_message_id: None,
+            truncated: false,
+            model: Some("anthropic/claude-sonnet-4.6".into()),
+            usage: None,
+            generation_id: Some("gen_chat_xyz".into()),
+            filter_audit: None,
+            metadata: Some(metadata.clone()),
+        };
+        repo.insert_assistant_batch(s.id, user_msg_id, &[row])
+            .await
+            .unwrap();
+        let m: Option<serde_json::Value> = sqlx::query_scalar(
+            "SELECT metadata FROM engine.chat_messages \
+             WHERE role='assistant' AND session_id=$1",
+        )
+        .bind(s.id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(m, Some(metadata));
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn assistant_batch_metadata_default_null(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let s = repo
+            .create_session(Uuid::new_v4(), Uuid::new_v4())
+            .await
+            .unwrap();
+        let user_msg_id = match repo
+            .upsert_user_message_idempotent(s.id, "hi", "01J0000000000000000000005A", "user", None)
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            other => panic!("{other:?}"),
+        };
+        let row = AssistantInsert {
+            id: Uuid::new_v4(),
+            content: "hi".into(),
+            assistant_action_type: "reply".into(),
+            continues_from_message_id: None,
+            truncated: false,
+            model: Some("anthropic/claude-sonnet-4.6".into()),
+            usage: None,
+            generation_id: Some("gen_chat_xyz".into()),
+            filter_audit: None,
+            metadata: None,
+        };
+        repo.insert_assistant_batch(s.id, user_msg_id, &[row])
+            .await
+            .unwrap();
+        let m: Option<serde_json::Value> = sqlx::query_scalar(
+            "SELECT metadata FROM engine.chat_messages \
+             WHERE role='assistant' AND session_id=$1",
+        )
+        .bind(s.id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert!(m.is_none());
     }
 }

--- a/docs/superpowers/specs/2026-05-25-chat-output-filter-design.md
+++ b/docs/superpowers/specs/2026-05-25-chat-output-filter-design.md
@@ -6,6 +6,11 @@
 
 ---
 
+> **Update (2026-05-26):** §2.6 "in-memory only / not recoverable" superseded
+> by `2026-05-26-tip-role-and-filter-audit-design.md` §4. The original
+> pre-filter text is now persisted on the assistant row as
+> `pre_filter_content` when the filter rewrites the reply.
+
 ## 0. Background
 
 The streaming chat path (`crates/eros-engine-server/src/pipeline/stream.rs`,

--- a/docs/superpowers/specs/2026-05-26-tip-role-and-filter-audit-design.md
+++ b/docs/superpowers/specs/2026-05-26-tip-role-and-filter-audit-design.md
@@ -202,6 +202,11 @@ field; omitted otherwise via `skip_serializing_if`.
 `"gift_user"` for tip rows where they previously saw `"user"`. This is the
 behaviour change clients act on.
 
+The BFF SELECT extracts ONLY `tips_amount_usd` from `metadata` —
+`(metadata->>'tips_amount_usd')::float8`. Other metadata keys (`tier`,
+`prompt_traits`, future additions) are intentionally NOT exposed; they remain
+audit-only on the DB side. Use a future admin endpoint if needed.
+
 ### 3.5 `prompt_traits` on assistant rows' `metadata`
 
 In addition to the user-side tip case, `engine.chat_messages.metadata` is also written
@@ -218,6 +223,16 @@ traits were injected (distinct from legacy rows with NULL metadata).
 
 **Not** exposed via BFF history — audit-only. A future admin/debug endpoint can read
 it if needed.
+
+Additionally, `metadata` records `{"tier": "<tier>"}` on every row where the
+user's tier-at-time is known — assistant rows (always, when the request
+carried a tier) and user-side rows (both tip and non-tip). Reason: the
+canonical tier table only stores the user's CURRENT tier; the row needs the
+tier-at-message-time for historical correctness. When `tier` is None on the
+request, the key is omitted entirely (not written as `null`) to keep the
+JSONB shape sparse.
+
+Example combined assistant metadata: `{"prompt_traits": ["nsfw_boost"], "tier": "gold"}`.
 
 ---
 

--- a/docs/superpowers/specs/2026-05-26-tip-role-and-filter-audit-design.md
+++ b/docs/superpowers/specs/2026-05-26-tip-role-and-filter-audit-design.md
@@ -202,6 +202,23 @@ field; omitted otherwise via `skip_serializing_if`.
 `"gift_user"` for tip rows where they previously saw `"user"`. This is the
 behaviour change clients act on.
 
+### 3.5 `prompt_traits` on assistant rows' `metadata`
+
+In addition to the user-side tip case, `engine.chat_messages.metadata` is also written
+on **every** assistant row persisted by `drive_chat_burst` — both live mode and
+filtered mode, regardless of whether the filter fired. Shape:
+
+```json
+{ "prompt_traits": ["nsfw_boost", "tsundere"] }
+```
+
+The array is the **kept** trait tags actually injected into the system prompt this
+turn — the same set as the final frame's `prompt_injected`. Empty array when no
+traits were injected (distinct from legacy rows with NULL metadata).
+
+**Not** exposed via BFF history — audit-only. A future admin/debug endpoint can read
+it if needed.
+
 ---
 
 ## 4. Gap B — filter audit columns

--- a/docs/superpowers/specs/2026-05-26-tip-role-and-filter-audit-design.md
+++ b/docs/superpowers/specs/2026-05-26-tip-role-and-filter-audit-design.md
@@ -1,0 +1,392 @@
+# eros-engine — Tip role (`gift_user`) + chat-reply filter audit columns (Spec)
+
+**Status**: design, pending implementation plan
+**Target release**: `0.4.x` dev track (`0.4.3-dev`); one additive `engine.chat_messages` migration
+**Audience**: anyone implementing issue #51 (distinct tip role + structured `tips_amount_usd` in BFF history) and persisting filter-layer audit fields previously declared in-memory-only by `2026-05-25-chat-output-filter-design.md` §2.6.
+
+---
+
+## 0. Background
+
+Two engine-side gaps land in the same migration because they both extend
+`engine.chat_messages` with optional metadata columns that are NULL on legacy
+rows and on rows that never touch the relevant path.
+
+**Gap A — issue #51 (tip user row).** The streaming chat path persists a
+user-side tip marker via `upsert_user_message_idempotent` (`crates/eros-engine-store/src/chat.rs` ~L297) with `role='user'` and `content="(打赏 $X)"`. In BFF
+history (`/bff/v1/comp/chat/{sid}/history`) the row is **indistinguishable from
+a normal user message**: role + content look like a regular turn, and parsing
+`(打赏 $X)` out of `content` is brittle and locale-dependent. The BFF DTO
+already documents `gift_user` as a role value, and the table's `role` `CHECK`
+constraint already accepts `gift_user` (`0001_chat.sql:18`), but the tip path
+never writes it. `2026-05-26-tips-stream-reply-design.md` §2.3 explicitly
+deferred the role flip ("Acceptable for v1; a distinct role is deferred to the
+later gift-route keep/remove decision"). This spec performs that flip.
+
+**Gap B — filter audit (supersedes 2026-05-25 §2.6).** The chat-reply output
+filter (`2026-05-25-chat-output-filter-design.md`) ships filtered text to the
+client and persists `content = filtered`. The original pre-filter text is
+intentionally **in-memory only** and **not recoverable** — fed to
+`post_process::run` when `timing = after_extract`, then dropped. Once the
+feature ran on production traffic, operators want to inspect what the filter
+rewrote, which model served the rewrite, and which trigger predicates fired.
+The original-as-in-memory-only choice was tagged as a user-approved tradeoff in
+that spec; this spec withdraws it.
+
+The two gaps are independent in semantics (one for `role='gift_user'` user
+rows, one for filtered `role='assistant'` rows), but additive on the same
+table with disjoint columns. Bundling avoids a second migration round-trip
+through release.
+
+---
+
+## 1. Goal / Non-goals
+
+**Goal — Gap A:**
+- Persist tip user rows with `role='gift_user'` (reusing the existing CHECK enum value, not introducing a new one).
+- Persist `tips_amount_usd` structurally on the row (no string parsing).
+- Expose `tips_amount_usd` in BFF history DTO so a client renders the tip as a system-style notice at the right point in the timeline.
+
+**Goal — Gap B:**
+- On filtered-success assistant rows, persist five audit columns: `pre_filter_content`, `filter_model`, `filter_triggers`, `f_client_msg_id`, `f_generation_id`.
+- Make the original recoverable for ad-hoc inspection (DB query) without exposing it through BFF history.
+
+**Non-goals:**
+- No new `role` value (`user_send_tips` is **rejected**; `gift_user` is reused — see §3.1).
+- No DTO surface for the filter audit columns (no BFF / no public API). A future admin/debug endpoint is **out of scope**; if it lands, it gets its own spec.
+- No retroactive backfill. Legacy rows stay NULL; downstream readers MUST tolerate NULL.
+- No change to filter timing semantics (`after_extract` / `before_extract`) or to `extracted_facts`.
+- No widening of the `assistant_action_type` CHECK; no change to its column type.
+- No change to chat-reply `content` semantics — the assistant row still stores the **filtered** text in `content` exactly as today.
+- No change to client `(打赏 $X)` marker content (kept for FE backward-compat fallback rendering).
+
+---
+
+## 2. Schema migration
+
+New file `crates/eros-engine-store/migrations/0019_chat_tip_marker_and_filter_audit.sql`:
+
+```sql
+-- SPDX-License-Identifier: AGPL-3.0-only
+--
+-- chat_messages gains:
+--   metadata           — open marker bag for user-side rows (today: tip amount)
+--   pre_filter_content, filter_model, filter_triggers, f_client_msg_id,
+--   f_generation_id   — assistant-side filter audit, written only when the
+--                       chat-reply output filter actually rewrote the reply.
+--
+-- All six columns are nullable and default-safe; existing inserts that do not
+-- mention them keep working. No backfill.
+
+ALTER TABLE engine.chat_messages
+    ADD COLUMN metadata             JSONB NULL,
+    ADD COLUMN pre_filter_content   TEXT  NULL,
+    ADD COLUMN filter_model         TEXT  NULL,
+    ADD COLUMN filter_triggers      JSONB NULL,
+    ADD COLUMN f_client_msg_id      TEXT  NULL,
+    ADD COLUMN f_generation_id      TEXT  NULL;
+
+-- Audit index for tip-amount aggregation. Partial: only rows that carry a tip.
+CREATE INDEX chat_messages_tips_amount_idx
+    ON engine.chat_messages ((metadata->>'tips_amount_usd'))
+    WHERE metadata ? 'tips_amount_usd';
+
+-- f_client_msg_id is engine-generated per filter LLM call (§4); enforce that
+-- a single logical filter call writes at most one row per session.
+CREATE UNIQUE INDEX chat_messages_f_client_msg_id_uidx
+    ON engine.chat_messages (session_id, f_client_msg_id)
+    WHERE f_client_msg_id IS NOT NULL;
+```
+
+The `role` `CHECK` is **not modified** — `gift_user` is already in the allowed
+set. `assistant_action_type` is **not modified** — its CHECK and TEXT type stay
+as-is.
+
+---
+
+## 3. Gap A — tip role + tips_amount_usd
+
+### 3.1 Why reuse `gift_user`, not introduce `user_send_tips`
+
+- The `role` `CHECK` constraint at `0001_chat.sql:18` already includes `gift_user`.
+- The BFF DTO comment at `crates/eros-engine-server/src/routes/bff/companion.rs:35` already documents `gift_user` as a returnable role.
+- Adding `user_send_tips` would require a second `CHECK` migration plus a DTO enum widening for no semantic gain over the existing slot.
+- Naming objection ("gift suggests an item, tips don't") is overridden by the cost of a parallel role-token taxonomy; downstream renders the role + the structured `tips_amount_usd`, and the visual presentation is FE-driven.
+
+### 3.2 `upsert_user_message_idempotent` signature change
+
+Current (`chat.rs:297`):
+
+```rust
+pub async fn upsert_user_message_idempotent(
+    &self,
+    session_id: Uuid,
+    content: &str,
+    client_msg_id: &str,
+) -> Result<UpsertUserOutcome, sqlx::Error>
+```
+
+New:
+
+```rust
+pub async fn upsert_user_message_idempotent(
+    &self,
+    session_id: Uuid,
+    content: &str,
+    client_msg_id: &str,
+    role: &str,                            // "user" (default) | "gift_user"
+    metadata: Option<&serde_json::Value>,  // tip path: Some({"tips_amount_usd": X})
+) -> Result<UpsertUserOutcome, sqlx::Error>
+```
+
+Insert statement updates to bind `role` and `metadata`:
+
+```sql
+INSERT INTO engine.chat_messages (session_id, role, content, client_msg_id, metadata)
+VALUES ($1, $4, $2, $3, $5)
+RETURNING id
+```
+
+The replay-lookup `SELECT` keeps the existing `role = 'user'` filter? **No**:
+widen to `role IN ('user','gift_user')`. The idempotency key is `(session_id,
+client_msg_id)` regardless of which role the row was inserted under, and the
+streaming protocol treats the row as the canonical user turn for the
+fallback/replay chain.
+
+All non-tip call sites pass `"user", None`. The single tip call site (in
+`crates/eros-engine-server/src/pipeline/stream.rs`, the
+`PersistedUserMessage`-with-`tips_amount_usd` branch) passes `"gift_user",
+Some(json!({"tips_amount_usd": amount}))`.
+
+### 3.3 Stream wiring
+
+The previously-shipped `2026-05-26-tips-stream-reply-design.md` already
+threads `tips_amount_usd: Option<f64>` through `PersistedUserMessage` and
+`Event::UserMessage`. This spec only changes the **persist call**:
+
+```rust
+let role = if user_msg.tips_amount_usd.is_some() { "gift_user" } else { "user" };
+let meta = user_msg
+    .tips_amount_usd
+    .map(|a| serde_json::json!({ "tips_amount_usd": a }));
+chat_repo
+    .upsert_user_message_idempotent(
+        session_id,
+        &content,                       // "(打赏 $X)" marker stays as-is for FE fallback
+        &client_msg_id,
+        role,
+        meta.as_ref(),
+    )
+    .await?;
+```
+
+`content` is **not** changed — keeping the `(打赏 $X)` marker preserves
+backward-compat for any client that has not yet read this spec and still
+renders by content-string parsing.
+
+### 3.4 BFF history DTO
+
+`crates/eros-engine-server/src/routes/bff/companion.rs` — `HistoryMessage`
+gains:
+
+```rust
+#[serde(skip_serializing_if = "Option::is_none")]
+pub tips_amount_usd: Option<f64>,
+```
+
+The SELECT for BFF history `(metadata->>'tips_amount_usd')::float8` extracts
+the value when present. Returned on rows with `role='gift_user'` that have the
+field; omitted otherwise via `skip_serializing_if`.
+
+`role` continues to serialise as the raw DB string, so frontends now see
+`"gift_user"` for tip rows where they previously saw `"user"`. This is the
+behaviour change clients act on.
+
+---
+
+## 4. Gap B — filter audit columns
+
+### 4.1 Where exactly the write happens
+
+In `crates/eros-engine-server/src/pipeline/stream.rs`, in `drive_chat_burst`'s
+**filtered-mode, per-attempt `models`-predicate passes, filter LLM call
+succeeds** branch (the success arm of §2.5 step 3 first sub-branch in
+`2026-05-25-chat-output-filter-design.md`). **Nowhere else.** Specifically:
+
+| Code path | Writes audit columns? |
+|---|---|
+| live mode (filter disabled or turn-level predicate failed) | No — NULL |
+| filtered mode, per-attempt `models` predicate failed | No — NULL |
+| filtered mode, filter LLM **failure / timeout** (fail-open) | No — NULL |
+| filtered mode, filter LLM **success**, this is what the client received | **Yes — all 5 columns set** |
+| filtered mode, chat-attempt truncated and discarded silently | No row persisted at all |
+
+The five columns travel together — they are either all set (filtered success)
+or all NULL. Code MUST enforce this as a single `Option<FilterAudit>` write,
+not five independent `Option`s.
+
+### 4.2 Column contents
+
+| Column | Source | Notes |
+|---|---|---|
+| `pre_filter_content` | `acc` (the accumulated original reply text before the filter rewrite) | The text previously dropped per `2026-05-25-chat-output-filter-design.md` §2.6. |
+| `filter_model` | `ChatResponse.model` from the filter LLM `execute()` call (the model **actually served**, accounting for the filter's depth-capped fallback) | Distinct from the assistant row's `model` column, which is the **chat** model. |
+| `filter_triggers` | JSONB capturing each predicate that fired, with the matched value | Format below. |
+| `f_client_msg_id` | Engine-generated ULID, prefix `f_`, created **once per logical filter call** before invoking `execute()`; reused across the filter's internal fallback retries | Used as an idempotency / trace key by ops; unique per `(session_id, f_client_msg_id)`. |
+| `f_generation_id` | `ChatResponse.generation_id` from the filter LLM call | OpenRouter generation id for the filter call. |
+
+`filter_triggers` JSON shape — **only fired predicates appear**:
+
+```json
+{
+  "random":  { "p": 0.30, "draw": 0.18 },
+  "models":  "deepseek/deepseek-v4-flash",
+  "traits":  ["nsfw_boost"]
+}
+```
+
+- `random` present iff `trigger.random` configured **and** drew under `p`. `p` echoes the configured probability; `draw` echoes the per-turn draw.
+- `models` present iff `trigger.models` configured **and** the chat model that produced the persisted reply is in the list; value = that model id.
+- `traits` present iff `trigger.traits` configured **and** the predicate passed; value = the **subset of `any` actually present in `kept_traits`** for `when = present`, or `[]` for a passing `when = absent` predicate.
+- The shape is deliberately additive — future predicates land as new top-level keys.
+
+A turn that is filtered with no `trigger` block configured at all (empty trigger ⇒ always-filter, per `2026-05-25 §2.4`) writes `filter_triggers = {}`.
+
+### 4.3 `should_filter` signature change
+
+`OutputFilterTrigger::should_filter` currently returns `bool`. Change to:
+
+```rust
+pub fn should_filter(
+    &self,
+    model_id: &str,
+    traits: &[PromptTrait],
+    random_draw: Option<f64>,           // None when trigger.random is absent
+) -> Option<TriggerHits>
+```
+
+Where:
+
+```rust
+pub struct TriggerHits {
+    pub random: Option<RandomHit>,
+    pub models: Option<String>,
+    pub traits: Option<Vec<String>>,
+}
+pub struct RandomHit { pub p: f64, pub draw: f64 }
+```
+
+`None` means the filter does not fire (per-attempt). `Some(hits)` means it
+fires; `hits` serialises to the `filter_triggers` JSONB above (drop fields that
+are `None`).
+
+Callers update from `if should_filter(...)` to `if let Some(hits) =
+should_filter(...)`. `random_draw` is the per-turn draw (`rng.gen::<f64>()`),
+sampled **once per turn** per `2026-05-25 §2.4`; the burst threads it into the
+per-attempt call so the random outcome is stable across attempts of one turn.
+
+### 4.4 Filter write site
+
+Inside the filtered-success branch:
+
+```rust
+let filter_audit = FilterAudit {
+    pre_filter_content: acc.clone(),         // original
+    filter_model:       filter_resp.model.clone(),
+    filter_triggers:    serde_json::to_value(&hits)?,
+    f_client_msg_id:    filter_call_id.clone(),
+    f_generation_id:    filter_resp.generation_id.clone(),
+};
+// passed into insert_assistant_batch / persist_assistant_row as an Option<FilterAudit>;
+// None at every other call site.
+```
+
+`AssistantInsert` (or the equivalent row struct in `eros-engine-store`) gains a
+single `filter_audit: Option<FilterAudit>` field that fans out into the five
+bound parameters in the `INSERT`. The store layer is responsible for binding
+NULL across all five when `None`.
+
+### 4.5 Implications for `2026-05-25-chat-output-filter-design.md`
+
+This spec **supersedes** the in-memory-only / not-recoverable wording in §2.6
+of that document. Specifically:
+
+- "The original on a filtered success is in-memory only" → original is now persisted on the same row as `pre_filter_content`.
+- "Not stored, not recoverable" → reverse.
+- `timing = after_extract` vs `before_extract` semantics for what `produced.full_text` feeds the extract pipeline are **unchanged** (still controlled by `timing`). Persisting the original to `pre_filter_content` is additive and orthogonal.
+
+Add a banner note at the top of `2026-05-25-chat-output-filter-design.md` (do
+not delete the existing wording; readers need the historical context):
+
+> **Update (2026-05-26):** §2.6 "in-memory only / not recoverable" superseded by
+> `2026-05-26-tip-role-and-filter-audit-design.md` §4. The original pre-filter
+> text is now persisted on the assistant row as `pre_filter_content` when the
+> filter rewrites the reply.
+
+---
+
+## 5. BFF history exposure
+
+- `tips_amount_usd`: **exposed** on `HistoryMessage`, via `metadata->>` extract, with `skip_serializing_if = "Option::is_none"`. Tip rows include it; other rows omit the field entirely from JSON.
+- `pre_filter_content`, `filter_model`, `filter_triggers`, `f_client_msg_id`, `f_generation_id`: **NOT exposed**. No DTO field is added. No SELECT pulls them. They are operator-side audit data, queryable via DB tooling. A future internal/admin endpoint can read them; that endpoint is out of scope for this spec.
+
+`role` continues to serialise raw; tip rows now report `"gift_user"`.
+
+---
+
+## 6. Persistence, replay & extract
+
+- `chat_messages.content` semantics unchanged. Assistant row holds filtered text exactly as today (or the chat reply on fail-open); user row holds `(打赏 $X)` marker on tip path.
+- Replay path is unchanged for assistant rows — it never read the new five audit columns. For user rows, the `role` filter widens to `IN ('user','gift_user')` at the dedup lookup (§3.2); replay decisions key on `client_msg_id` regardless of role.
+- `after_extract` / `before_extract` continue to control which text feeds `post_process::run`. The change is that the original is now also on disk; nothing in the extract pipeline reads `pre_filter_content`.
+
+---
+
+## 7. Testing
+
+**Migration:**
+- Apply on a DB with existing rows from 0001 + 0012: existing inserts still succeed (six columns NULL).
+- Insert one row with `metadata = '{"tips_amount_usd": 20.0}'`: round-trips; `(metadata->>'tips_amount_usd')::float8` returns `20.0`.
+- Insert two filtered rows with the same `(session_id, f_client_msg_id)`: second fails on unique index. Insert with `f_client_msg_id = NULL` on two rows: both succeed (partial index ignores NULL).
+
+**`upsert_user_message_idempotent`:**
+- `role="user", metadata=None` (existing behaviour) → row has `role='user'`, `metadata IS NULL`. All existing tests at `chat.rs:547+` keep passing with the updated call sites.
+- `role="gift_user", metadata=Some({"tips_amount_usd": 20.0})` → row has `role='gift_user'`, metadata round-trips.
+- Replay lookup: second call with same `(session_id, client_msg_id)` regardless of role → `Replay` outcome (the widened role filter sees both `user` and `gift_user` matches).
+
+**`should_filter` (pure):**
+- Empty trigger ⇒ returns `Some(TriggerHits { all None })` ⇒ serialises to `{}`.
+- Each predicate alone, hit case ⇒ corresponding field populated.
+- `traits` `when = absent` passing ⇒ `traits: Some(vec![])`.
+- AND-of-many: any specified predicate failing ⇒ returns `None`.
+- `random_draw = None` when `trigger.random` is absent ⇒ random gate is "no gate" (passes); when present, draw compared to `p`.
+
+**Stream (wiremock for chat + filter models):**
+- Filtered-success: client receives filtered delta; row persists `content = filtered`, all 5 audit columns set, `pre_filter_content == acc (original)`, `filter_model == ChatResponse.model`, `filter_triggers` matches the fired predicate set.
+- Filtered + fail-open: client receives original delta; row persists `content = acc`, all 5 audit columns NULL.
+- Live mode (filter disabled or turn-level predicate failed): all 5 audit columns NULL; byte-identical to today.
+- Filtered-mode `models`-miss: row persists `content = acc`, all 5 audit columns NULL.
+- Filter LLM's internal fallback served the second model: `filter_model` reflects the served model id; `f_generation_id` reflects that call's generation id; `f_client_msg_id` is the same id used across the chain.
+- Two consecutive filtered turns in the same session yield distinct `f_client_msg_id` values.
+
+**BFF history:**
+- Tip row (`role='gift_user'`, `metadata.tips_amount_usd = 20.0`): response includes `"role": "gift_user"`, `"tips_amount_usd": 20.0`.
+- Normal user row: response has `"role": "user"` and **no** `tips_amount_usd` field.
+- Filtered assistant row: response has no `pre_filter_content` / `filter_*` / `f_*` fields (DTO never declared them).
+
+---
+
+## 8. Rollout
+
+- Single PR into `dev`. The dev-track cut itself takes no version bump; the next release cut to `main` will bump the four `Cargo.toml`s + `openapi.json` + the README docker version as usual.
+- The migration runs automatically on the next deploy; no manual step required.
+- Frontend coordination: BFF response shape for tip rows changes (`role: "gift_user"` instead of `"user"`, new optional `tips_amount_usd`). Existing FE that filters on `role === "user"` will silently stop showing tip rows in the regular bubble lane — desired behaviour per issue #51 but flag it in the PR description so the FE team flips the rendering path in the same release window.
+- `2026-05-25-chat-output-filter-design.md` gets the §2.6 banner update committed in the same PR.
+- No OSS config file changes (no `model_config.toml` / `examples/` deltas).
+
+---
+
+## 9. Open questions / follow-ups
+
+- Admin/debug endpoint to surface filter audit columns (out of scope; track in a separate issue if/when ops asks).
+- Janitor for `metadata` JSONB shape evolution beyond `tips_amount_usd` (premature; revisit when the second user-marker type appears).


### PR DESCRIPTION
## Summary
- Implements issue #51: tip user rows now persist with `role='gift_user'` and structured `tips_amount_usd` in `chat_messages.metadata`; BFF history exposes the amount as a typed field.
- Persists chat-reply output filter audit metadata on filtered-success assistant rows: `pre_filter_content`, `filter_model`, `filter_triggers`, `f_client_msg_id`, `f_generation_id`. Supersedes `2026-05-25-chat-output-filter-design.md` §2.6 (in-memory-only original).
- Records `{"prompt_traits": [...]}` in `chat_messages.metadata` on every assistant row (live + filtered), same shape as the final frame's `prompt_injected`. Audit-only — not exposed via BFF.
- One migration (`0019`), six nullable columns, two indexes. No backfill. Zero OSS config changes.

## Spec / Plan
- Spec: `docs/superpowers/specs/2026-05-26-tip-role-and-filter-audit-design.md`
- Older spec banner: `2026-05-25-chat-output-filter-design.md` §2.6 now superseded
- 14 signed commits, TDD per task

## Test plan
- [x] `cargo test --workspace` green locally (407 tests across 4 crates)
- [x] `cargo fmt --check` + `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] OpenAPI regen diff = `BffHistoryEntry` gains `tips_amount_usd` only
- [x] Spec + plan reviewed
- [ ] FE team flagged: tip rows now serialise as \`role: "gift_user"\` (was \`"user"\`) — rendering path needs to switch in the same release window

🤖 Generated with [Claude Code](https://claude.com/claude-code)