### PR TITLE
feat(v0.5.0): chat_output_filter output validity gate

### DIFF
--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -61,6 +61,11 @@ pub struct ChatResponse {
     /// OpenRouter `usage` block — tokens / cost. Opaque to engine;
     /// caller deserialises as needed.
     pub usage: Option<serde_json::Value>,
+    /// `finish_reason` from the first choice in the wire response.
+    /// `None` when the upstream omits it (most normal completions).
+    /// Present as `"content_filter"` when Gemini/OpenAI mid-response
+    /// safety truncation fires; callers can gate on this value.
+    pub finish_reason: Option<String>,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -94,6 +99,8 @@ struct WireMessage {
 #[derive(Debug, Deserialize)]
 struct WireChoice {
     message: WireMessage,
+    #[serde(default)]
+    finish_reason: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -360,16 +367,18 @@ impl OpenRouterClient {
         }
 
         let parsed: WireResponse = resp.json().await?;
-        let raw = parsed
-            .choices
-            .first()
+        let first_choice = parsed.choices.into_iter().next();
+        let raw = first_choice
+            .as_ref()
             .and_then(|c| c.message.content.clone())
             .unwrap_or_default();
+        let finish_reason = first_choice.and_then(|c| c.finish_reason);
         Ok(ChatResponse {
             reply: clean_response(raw.trim()),
             generation_id: parsed.id,
             model: parsed.model,
             usage: parsed.usage,
+            finish_reason,
         })
     }
 

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -519,6 +519,11 @@ struct RunFilterOutcome {
 /// Refusal phrases checked in the leading [`REFUSAL_HEAD_SCAN_CHARS`] chars
 /// of the filter output.  When any prefix matches, the call is treated as a
 /// model refusal regardless of HTTP status.
+///
+/// **Matching is ASCII-case-insensitive** — the input head is lowercased before
+/// `contains` runs, so models that emit `"as an ai ..."` or `"I'M SORRY"` are
+/// caught.  All English patterns are stored lowercase; Chinese patterns are
+/// unaffected by lowercasing (CJK code points have no case).
 const REFUSAL_PATTERNS_HEAD: &[&str] = &[
     // Chinese refusals — observed in production from gpt-4.1-nano
     "抱歉，我无法",
@@ -529,27 +534,30 @@ const REFUSAL_PATTERNS_HEAD: &[&str] = &[
     "对不起，无法",
     "很抱歉，我无法",
     "很抱歉，我不能",
-    // English refusals — standard OpenAI/Anthropic apology shapes
-    "I'm sorry, but I can't",
-    "I'm sorry, but I cannot",
-    "I cannot rewrite",
-    "I can't rewrite",
-    "I cannot help",
-    "I can't help",
-    "I won't be able to",
-    "I'm not able to",
-    "I am not able to",
-    "As an AI",
-    "I apologize, but",
-    "Sorry, I can't",
-    "Sorry, I cannot",
-    "Unfortunately, I can't",
-    "Unfortunately, I cannot",
+    // English refusals — standard OpenAI/Anthropic apology shapes (lowercase)
+    "i'm sorry, but i can't",
+    "i'm sorry, but i cannot",
+    "i cannot rewrite",
+    "i can't rewrite",
+    "i cannot help",
+    "i can't help",
+    "i won't be able to",
+    "i'm not able to",
+    "i am not able to",
+    "as an ai",
+    "i apologize, but",
+    "sorry, i can't",
+    "sorry, i cannot",
+    "unfortunately, i can't",
+    "unfortunately, i cannot",
 ];
 
 /// Refusal verbs used in the short-response branch: if the total response is
 /// shorter than [`MIN_FILTERED_OUTPUT_CHARS`] and contains any of these
 /// anywhere in the text, it is treated as a refusal rather than just too-short.
+///
+/// English entries are stored lowercase; the input is lowercased before
+/// matching (see [`filter_output_invalidity`]).
 const REFUSAL_SHORT_VERBS: &[&str] = &[
     "无法", "不能", "拒绝", "won't", "cannot", "can't", "unable", "refuse",
 ];
@@ -580,15 +588,24 @@ fn filter_output_invalidity(text: &str, finish_reason: Option<&str>) -> Option<&
         return Some("content_filter");
     }
     let total_chars = text.chars().count();
-    let head: String = text.chars().take(REFUSAL_HEAD_SCAN_CHARS).collect();
+    // ASCII-case-insensitive matching: lowercase the head (and the short-text
+    // body below) once so models that emit `"as an ai ..."` or `"I'M SORRY"`
+    // are caught.  `to_lowercase` is Unicode-aware; CJK code points are
+    // unchanged, so the Chinese patterns still match exactly.
+    let head_lower: String = text
+        .chars()
+        .take(REFUSAL_HEAD_SCAN_CHARS)
+        .flat_map(char::to_lowercase)
+        .collect();
     for pat in REFUSAL_PATTERNS_HEAD {
-        if head.contains(pat) {
+        if head_lower.contains(pat) {
             return Some("refusal_pattern");
         }
     }
     if total_chars < MIN_FILTERED_OUTPUT_CHARS {
+        let text_lower = text.to_lowercase();
         for verb in REFUSAL_SHORT_VERBS {
-            if text.contains(verb) {
+            if text_lower.contains(verb) {
                 return Some("refusal_pattern");
             }
         }
@@ -1872,6 +1889,31 @@ data: [DONE]\n\n";
             filter_output_invalidity(text, Some("stop")),
             None,
             "long clean rewrite with stop finish_reason must pass the gate"
+        );
+    }
+
+    #[test]
+    fn filter_output_invalidity_detects_lowercase_english_refusal() {
+        // Codex regression guard: a model that emits the apology shape with
+        // lowercase `i` / `ai` (or all-caps `I'M SORRY`) must still be caught,
+        // because the gate runs case-insensitively after lowercasing the head.
+        let lower = "i'm sorry, but i can't help with rewriting that content. it's outside what i can produce safely.";
+        assert_eq!(
+            filter_output_invalidity(lower, None),
+            Some("refusal_pattern"),
+            "lowercase apology must hit the head pattern via case-insensitive match"
+        );
+        let mixed = "As an ai language model, I am not able to rewrite the text in the way you have requested.";
+        assert_eq!(
+            filter_output_invalidity(mixed, None),
+            Some("refusal_pattern"),
+            "mixed-case 'As an ai' must still match the lowercase pattern"
+        );
+        let upper = "I'M SORRY, BUT I CAN'T REWRITE THIS PASSAGE IN THE FORM YOU'VE REQUESTED — IT VIOLATES POLICY.";
+        assert_eq!(
+            filter_output_invalidity(upper, None),
+            Some("refusal_pattern"),
+            "uppercase apology must match via lowercased head"
         );
     }
 

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -514,9 +514,99 @@ struct RunFilterOutcome {
     f_generation_id: Option<String>,
 }
 
-/// Run the output-filter LLM over `original`. `execute()` walks the (already
-/// depth-capped) chain; `ChatResponse.model` reports the model served. Returns
-/// `RunFilterOutcome` on success. `None` on error/timeout/empty.
+// ── Output validity gate ─────────────────────────────────────────────────────
+
+/// Refusal phrases checked in the leading [`REFUSAL_HEAD_SCAN_CHARS`] chars
+/// of the filter output.  When any prefix matches, the call is treated as a
+/// model refusal regardless of HTTP status.
+const REFUSAL_PATTERNS_HEAD: &[&str] = &[
+    // Chinese refusals — observed in production from gpt-4.1-nano
+    "抱歉，我无法",
+    "抱歉，我不能",
+    "对不起，我无法",
+    "对不起，我不能",
+    "抱歉，无法",
+    "对不起，无法",
+    "很抱歉，我无法",
+    "很抱歉，我不能",
+    // English refusals — standard OpenAI/Anthropic apology shapes
+    "I'm sorry, but I can't",
+    "I'm sorry, but I cannot",
+    "I cannot rewrite",
+    "I can't rewrite",
+    "I cannot help",
+    "I can't help",
+    "I won't be able to",
+    "I'm not able to",
+    "I am not able to",
+    "As an AI",
+    "I apologize, but",
+    "Sorry, I can't",
+    "Sorry, I cannot",
+    "Unfortunately, I can't",
+    "Unfortunately, I cannot",
+];
+
+/// Refusal verbs used in the short-response branch: if the total response is
+/// shorter than [`MIN_FILTERED_OUTPUT_CHARS`] and contains any of these
+/// anywhere in the text, it is treated as a refusal rather than just too-short.
+const REFUSAL_SHORT_VERBS: &[&str] = &[
+    "无法", "不能", "拒绝", "won't", "cannot", "can't", "unable", "refuse",
+];
+
+/// How many Unicode characters to scan from the start of the response when
+/// checking [`REFUSAL_PATTERNS_HEAD`].
+const REFUSAL_HEAD_SCAN_CHARS: usize = 120;
+
+/// Minimum character count for a valid filter output.  A real rewrite is at
+/// least this long.  Responses shorter than this threshold are either flagged
+/// as `"refusal_pattern"` (if a refusal verb appears) or `"too_short"`.
+const MIN_FILTERED_OUTPUT_CHARS: usize = 80;
+
+/// Check whether a filter LLM response should be rejected by the validity gate.
+///
+/// Returns `Some(reason_label)` when the output is invalid, `None` when valid.
+/// The label is a stable lowercase ASCII string used for log fields:
+/// - `"content_filter"` — `finish_reason == "content_filter"` (Gemini/OpenAI safety block)
+/// - `"refusal_pattern"` — refusal phrase found in the head, or short text with a refusal verb
+/// - `"too_short"` — text is shorter than [`MIN_FILTERED_OUTPUT_CHARS`] with no refusal verb
+///
+/// Checks are ordered cheapest-first:
+/// 1. `finish_reason`
+/// 2. Refusal pattern in head (first `REFUSAL_HEAD_SCAN_CHARS` chars)
+/// 3. Short-text checks (refusal-verb-or-too-short)
+fn filter_output_invalidity(text: &str, finish_reason: Option<&str>) -> Option<&'static str> {
+    if finish_reason == Some("content_filter") {
+        return Some("content_filter");
+    }
+    let total_chars = text.chars().count();
+    let head: String = text.chars().take(REFUSAL_HEAD_SCAN_CHARS).collect();
+    for pat in REFUSAL_PATTERNS_HEAD {
+        if head.contains(pat) {
+            return Some("refusal_pattern");
+        }
+    }
+    if total_chars < MIN_FILTERED_OUTPUT_CHARS {
+        for verb in REFUSAL_SHORT_VERBS {
+            if text.contains(verb) {
+                return Some("refusal_pattern");
+            }
+        }
+        return Some("too_short");
+    }
+    None
+}
+
+// ── run_output_filter ────────────────────────────────────────────────────────
+
+/// Per-model timeout for a single filter LLM call.
+const FILTER_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+
+/// Run the output-filter LLM over `original`, walking the (already
+/// depth-capped) fallback chain one model at a time.  After each successful
+/// HTTP 200 response, `filter_output_invalidity` is applied; on failure the
+/// next model is tried.  Returns `None` when the whole chain exhausts (callers
+/// fall open and emit the original reply).
 async fn run_output_filter(
     state: &AppState,
     f: &eros_engine_llm::model_config::ResolvedOutputFilter,
@@ -524,65 +614,62 @@ async fn run_output_filter(
 ) -> Option<RunFilterOutcome> {
     use eros_engine_llm::openrouter::{ChatMessage, ChatRequest};
     let f_client_msg_id = format!("f_{}", Ulid::new());
-    let req = ChatRequest {
-        model: f.model.clone(),
-        fallback_model: f.fallback_model.clone(),
-        messages: vec![
-            ChatMessage {
-                role: "system".into(),
-                content: f.filter_prompt.clone(),
-            },
-            ChatMessage {
-                role: "user".into(),
-                content: original.to_string(),
-            },
-        ],
-        temperature: f.temperature as f32,
-        max_tokens: f.max_tokens,
-        reasoning: f.reasoning.clone(),
-        ..Default::default()
-    };
-    const FILTER_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
-    match tokio::time::timeout(FILTER_TIMEOUT, state.openrouter.execute(req)).await {
-        Ok(Ok(resp)) => {
-            super::log_openrouter_usage("chat_output_filter", None, &resp);
-            let out = resp.reply.trim().to_string();
-            if out.is_empty() {
-                return None;
+    let chain: Vec<String> = std::iter::once(f.model.clone())
+        .chain(f.fallback_model.iter().cloned())
+        .collect();
+    for (idx, model_id) in chain.iter().enumerate() {
+        let req = ChatRequest {
+            model: model_id.clone(),
+            fallback_model: vec![],
+            messages: vec![
+                ChatMessage {
+                    role: "system".into(),
+                    content: f.filter_prompt.clone(),
+                },
+                ChatMessage {
+                    role: "user".into(),
+                    content: original.to_string(),
+                },
+            ],
+            temperature: f.temperature as f32,
+            max_tokens: f.max_tokens,
+            reasoning: f.reasoning.clone(),
+            ..Default::default()
+        };
+        let resp = match tokio::time::timeout(FILTER_TIMEOUT, state.openrouter.execute(req)).await {
+            Ok(Ok(r)) => r,
+            Ok(Err(e)) => {
+                tracing::warn!(model = %model_id, error = %e, "filter: model error; walking to next");
+                continue;
             }
-            let served = resp.model.clone();
-            let chain = std::iter::once(f.model.as_str())
-                .chain(f.fallback_model.iter().map(String::as_str));
-            let retries_filter = served
-                .as_deref()
-                .and_then(|s| {
-                    chain
-                        .enumerate()
-                        .find(|(_, m)| *m == s)
-                        .map(|(i, _)| i as u32)
-                })
-                .unwrap_or(0);
-            // Falling back to f.model when the response omits the served model is
-            // safe: that is the model we requested, and OpenRouter only omits it
-            // on error paths (which we have already excluded via .reply.is_empty()).
-            let filter_model = served.unwrap_or_else(|| f.model.clone());
-            Some(RunFilterOutcome {
-                filtered_text: out,
-                retries_filter,
-                filter_model,
-                f_client_msg_id,
-                f_generation_id: resp.generation_id,
-            })
+            Err(_) => {
+                tracing::warn!(model = %model_id, "filter: model timeout; walking to next");
+                continue;
+            }
+        };
+        super::log_openrouter_usage("chat_output_filter", None, &resp);
+        let text = resp.reply.trim().to_string();
+        if let Some(reason) = filter_output_invalidity(&text, resp.finish_reason.as_deref()) {
+            tracing::warn!(
+                model = %model_id,
+                invalidity = %reason,
+                "filter: output failed validity gate; walking to next model"
+            );
+            continue;
         }
-        Ok(Err(e)) => {
-            tracing::warn!("output filter LLM failed: {e}");
-            None
-        }
-        Err(_) => {
-            tracing::warn!("output filter timed out");
-            None
-        }
+        // Falling back to model_id when the response omits the served model is
+        // safe: that is the model we requested, and OpenRouter only omits it
+        // on error paths (which we have already excluded via the validity gate).
+        let filter_model = resp.model.unwrap_or_else(|| model_id.clone());
+        return Some(RunFilterOutcome {
+            filtered_text: text,
+            retries_filter: idx as u32,
+            filter_model,
+            f_client_msg_id,
+            f_generation_id: resp.generation_id,
+        });
     }
+    None
 }
 
 /// Try to emit a pseudo-ghost on chain exhaustion.
@@ -1723,6 +1810,99 @@ data: [DONE]\n\n";
         assert_eq!(extract_text(BeforeExtract, "orig", "filt"), "filt");
     }
 
+    // ── filter_output_invalidity unit tests ──────────────────────────────────
+
+    #[test]
+    fn filter_output_invalidity_detects_chinese_refusal_in_head() {
+        let text = "抱歉，我无法协助完成您的请求。";
+        assert_eq!(
+            filter_output_invalidity(text, None),
+            Some("refusal_pattern"),
+            "Chinese refusal in head must be detected"
+        );
+    }
+
+    #[test]
+    fn filter_output_invalidity_detects_english_refusal_in_head() {
+        let text = "I'm sorry, but I can't rewrite this content.";
+        assert_eq!(
+            filter_output_invalidity(text, None),
+            Some("refusal_pattern"),
+            "English refusal in head must be detected"
+        );
+    }
+
+    #[test]
+    fn filter_output_invalidity_detects_content_filter_finish_reason() {
+        // Long text that would otherwise pass — finish_reason overrides.
+        let text = "她轻轻地望向窗外，思绪飘向了远方。阳光洒在她的脸上，温柔而明亮。她记得那个夏天，记得他说过的每一句话，记得那些再也回不去的日子。";
+        assert_eq!(
+            filter_output_invalidity(text, Some("content_filter")),
+            Some("content_filter"),
+            "content_filter finish_reason must be detected regardless of text length"
+        );
+    }
+
+    #[test]
+    fn filter_output_invalidity_short_response_with_refusal_verb() {
+        let text = "我无法。";
+        assert_eq!(
+            filter_output_invalidity(text, None),
+            Some("refusal_pattern"),
+            "short text containing refusal verb must be flagged as refusal_pattern"
+        );
+    }
+
+    #[test]
+    fn filter_output_invalidity_short_response_without_refusal_verb() {
+        // A genuinely short clean rewrite — still fails the length gate.
+        let text = "她笑了。";
+        assert_eq!(
+            filter_output_invalidity(text, None),
+            Some("too_short"),
+            "short text with no refusal verb must be flagged as too_short"
+        );
+    }
+
+    #[test]
+    fn filter_output_invalidity_passes_long_clean_rewrite() {
+        // 200+ chars, finish_reason = "stop", no refusal pattern.
+        let text = "她轻轻地望向窗外，思绪飘向了远方。阳光洒在她的脸上，温柔而明亮。她记得那个夏天，记得他说过的每一句话，记得那些再也回不去的日子。风轻轻吹过，带走了她的叹息，也带走了那些沉甸甸的思念。";
+        assert_eq!(
+            filter_output_invalidity(text, Some("stop")),
+            None,
+            "long clean rewrite with stop finish_reason must pass the gate"
+        );
+    }
+
+    #[test]
+    fn filter_output_invalidity_passes_when_refusal_word_appears_late() {
+        // Regression guard: a clean rewrite that incidentally contains "won't"
+        // well past character 120 must NOT be flagged.  The prefix must be
+        // >= REFUSAL_HEAD_SCAN_CHARS (120) chars so "won't" lands outside the
+        // scan window.  The full text must also be >= MIN_FILTERED_OUTPUT_CHARS
+        // (80) so it does not hit the too_short branch.
+        let prefix = "她轻轻地望向窗外，思绪飘向了远方。阳光洒在她的脸上，温柔而明亮。她记得那个夏天，记得他说过的每一句话，那些记忆再也不会消逝。她告诉自己要坚强，岁月会带走一切，但那段回忆会永远珍藏在心底，无论时光如何流逝，她都不会忘记那些岁月里的每一天每一刻。";
+        // suffix contains "won't" deep in the text — past the 120-char head window.
+        let text = format!("{prefix}但她won't忘记那段岁月，那是她最珍贵的时光，永远珍藏心底。");
+        // Verify the premise: prefix is beyond the scan window.
+        let prefix_chars = prefix.chars().count();
+        assert!(
+            prefix_chars >= REFUSAL_HEAD_SCAN_CHARS,
+            "prefix must be >= {REFUSAL_HEAD_SCAN_CHARS} chars so won't is outside the head window; got {prefix_chars}"
+        );
+        assert!(
+            text.chars().count() >= MIN_FILTERED_OUTPUT_CHARS,
+            "full text must be >= {MIN_FILTERED_OUTPUT_CHARS} chars to bypass too_short; got {}",
+            text.chars().count()
+        );
+        assert_eq!(
+            filter_output_invalidity(&text, Some("stop")),
+            None,
+            "refusal word past char 120 must not trigger refusal_pattern"
+        );
+    }
+
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
     async fn filtered_turn_emits_filtered_and_persists_filtered(pool: PgPool) {
         use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
@@ -1735,10 +1915,13 @@ data: [DONE]\n\n";
         // The output filter uses the NON-streaming `execute()` path, so its mock
         // must return a JSON completion object (choices[].message.content), not
         // SSE. `model:"fast/m"` makes retries_filter resolve to the primary (0).
+        // The filtered content must be >= MIN_FILTERED_OUTPUT_CHARS (80) chars to
+        // pass the validity gate (a real rewrite is always that long).
+        let filt_text = "FILT_START 她轻轻地望向窗外，思绪飘向了远方。阳光洒在她的脸上，温柔而明亮。她记得那个夏天的每一天，岁月如流水般逝去，带走了所有的悲欢离合。 FILT_END";
         let filt_body = serde_json::json!({
             "id": "gf", "model": "fast/m",
             "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
-            "choices": [{"message": {"content": "FILT"}}],
+            "choices": [{"message": {"content": filt_text}}],
         });
         // Route the two calls by the MODEL ID present in the request body so the two
         // mocks are MUTUALLY EXCLUSIVE (mount order / precedence cannot matter):
@@ -1823,7 +2006,7 @@ data: [DONE]\n\n";
             .any(|f| matches!(f, ProtocolFrame::Delta { .. }))
         {
             assert!(
-                deltas.contains("FILT"),
+                deltas.contains("FILT_START"),
                 "client must see filtered text, got {deltas:?}"
             );
             assert!(
@@ -1848,7 +2031,10 @@ data: [DONE]\n\n";
             let row = sqlx::query_scalar::<_, String>(
                 "SELECT content FROM engine.chat_messages WHERE session_id=$1 AND role='assistant' ORDER BY sent_at DESC LIMIT 1")
                 .bind(session_id).fetch_one(&pool).await.unwrap();
-            assert_eq!(row, "FILT");
+            assert!(
+                row.contains("FILT_START"),
+                "persisted content must be the filtered text, got {row:?}"
+            );
         }
     }
 

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -164,12 +164,19 @@ fn drive_chat_burst(
             .unwrap_or(false);
 
         // Build the assistant row metadata bag: always includes prompt_traits;
-        // includes tier only when the request carried one (omit key entirely when None).
-        let build_metadata = || {
+        // includes tier only when the request carried one (omit key entirely
+        // when None). When the filter chain failed entirely (fail-open), also
+        // writes the per-attempt audit log so ops can identify these rows.
+        let build_metadata = |filter_failure: Option<&FilterFailOpen>| -> Option<serde_json::Value> {
             let mut m = serde_json::Map::new();
             m.insert("prompt_traits".into(), serde_json::json!(&trait_tags));
             if let Some(t) = tier.as_deref() {
                 m.insert("tier".into(), serde_json::json!(t));
+            }
+            if let Some(fail) = filter_failure {
+                m.insert("filter_outcome".into(), serde_json::json!("fail_open"));
+                m.insert("f_client_msg_id".into(), serde_json::json!(&fail.f_client_msg_id));
+                m.insert("filter_attempts".into(), serde_json::json!(&fail.attempts));
             }
             Some(serde_json::Value::Object(m))
         };
@@ -243,7 +250,7 @@ fn drive_chat_burst(
                     usage: last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok()),
                     generation_id: last_gen_id.clone(),
                     filter_audit: None,
-                    metadata: build_metadata(),
+                    metadata: build_metadata(None),
                 };
                 if let Err(e) = chat_repo
                     .insert_assistant_batch(session_id, user_message_id, &[row])
@@ -421,12 +428,16 @@ fn drive_chat_burst(
                 continues_from: None,
             };
 
-            let (visible, filter_audit): (
+            // `filter_failure` carries the per-attempt audit when filter fails.
+            // Threaded into AssistantInsert via build_metadata — distinct from
+            // the prompt_traits/tier metadata to keep concerns separate.
+            let (visible, filter_audit, filter_failure): (
                 String,
                 Option<eros_engine_store::chat::FilterAudit>,
+                Option<FilterFailOpen>,
             ) = match hits {
                 Some(h) => match run_output_filter(&state, &f, &acc).await {
-                    Some(out) => {
+                    Ok(out) => {
                         let mut o = outcome.lock().unwrap();
                         o.filtered = true;
                         o.retries_filter = out.retries_filter;
@@ -439,11 +450,18 @@ fn drive_chat_burst(
                             f_client_msg_id: out.f_client_msg_id,
                             f_generation_id: out.f_generation_id,
                         };
-                        (out.filtered_text, Some(audit))
+                        (out.filtered_text, Some(audit), None)
                     }
-                    None => (acc.clone(), None), // fail-open
+                    Err(fail) => {
+                        tracing::warn!(
+                            f_client_msg_id = %fail.f_client_msg_id,
+                            attempts = ?fail.attempts,
+                            "filter: all models in chain failed validity; falling open"
+                        );
+                        (acc.clone(), None, Some(fail))
+                    }
                 },
-                None => (acc.clone(), None), // models-miss or trigger off
+                None => (acc.clone(), None, None), // models-miss or trigger off — not a failure
             };
 
             if !visible.is_empty() {
@@ -463,7 +481,7 @@ fn drive_chat_burst(
                 usage: last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok()),
                 generation_id: last_gen_id.clone(),
                 filter_audit,
-                metadata: build_metadata(),
+                metadata: build_metadata(filter_failure.as_ref()),
             };
             if let Err(e) = chat_repo.insert_assistant_batch(session_id, user_message_id, &[row]).await {
                 tracing::warn!("stream(filtered): persist failed: {e}");
@@ -512,6 +530,27 @@ struct RunFilterOutcome {
     filter_model: String,
     f_client_msg_id: String,
     f_generation_id: Option<String>,
+}
+
+/// One filter-chain attempt that did NOT produce a valid filtered reply.
+/// Recorded into `chat_messages.metadata.filter_attempts[]` when fail-open
+/// kicks in so ops can see WHY filter didn't apply on this row.
+#[derive(Debug, Clone, serde::Serialize)]
+struct FilterAttemptFailure {
+    /// OpenRouter model id of the attempted filter model.
+    model: String,
+    /// Stable lowercase ASCII label. Same vocabulary as
+    /// `filter_output_invalidity` plus `"error"`, `"timeout"`, `"empty"`.
+    reason: &'static str,
+}
+
+/// Returned by `run_output_filter` when the whole chain failed validity /
+/// errored / timed out. Caller writes these into `chat_messages.metadata`
+/// before emitting the original reply (fail-open).
+#[derive(Debug, Clone)]
+struct FilterFailOpen {
+    f_client_msg_id: String,
+    attempts: Vec<FilterAttemptFailure>,
 }
 
 // ── Output validity gate ─────────────────────────────────────────────────────
@@ -622,18 +661,20 @@ const FILTER_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
 /// Run the output-filter LLM over `original`, walking the (already
 /// depth-capped) fallback chain one model at a time.  After each successful
 /// HTTP 200 response, `filter_output_invalidity` is applied; on failure the
-/// next model is tried.  Returns `None` when the whole chain exhausts (callers
-/// fall open and emit the original reply).
+/// next model is tried.  Returns `Err(FilterFailOpen)` when the whole chain
+/// exhausts (callers fall open and emit the original reply, and write the
+/// per-attempt audit log into `chat_messages.metadata`).
 async fn run_output_filter(
     state: &AppState,
     f: &eros_engine_llm::model_config::ResolvedOutputFilter,
     original: &str,
-) -> Option<RunFilterOutcome> {
+) -> Result<RunFilterOutcome, FilterFailOpen> {
     use eros_engine_llm::openrouter::{ChatMessage, ChatRequest};
     let f_client_msg_id = format!("f_{}", Ulid::new());
     let chain: Vec<String> = std::iter::once(f.model.clone())
         .chain(f.fallback_model.iter().cloned())
         .collect();
+    let mut attempts: Vec<FilterAttemptFailure> = Vec::with_capacity(chain.len());
     for (idx, model_id) in chain.iter().enumerate() {
         let req = ChatRequest {
             model: model_id.clone(),
@@ -657,28 +698,51 @@ async fn run_output_filter(
             Ok(Ok(r)) => r,
             Ok(Err(e)) => {
                 tracing::warn!(model = %model_id, error = %e, "filter: model error; walking to next");
+                attempts.push(FilterAttemptFailure {
+                    model: model_id.clone(),
+                    reason: "error",
+                });
                 continue;
             }
             Err(_) => {
                 tracing::warn!(model = %model_id, "filter: model timeout; walking to next");
+                attempts.push(FilterAttemptFailure {
+                    model: model_id.clone(),
+                    reason: "timeout",
+                });
                 continue;
             }
         };
         super::log_openrouter_usage("chat_output_filter", None, &resp);
         let text = resp.reply.trim().to_string();
+        // Empty reply check before the validity gate: "model returned literally
+        // nothing" is distinguished from "model returned a short non-empty
+        // response" so ops can see the difference in filter_attempts.
+        if text.is_empty() {
+            tracing::warn!(model = %model_id, "filter: empty reply; walking to next");
+            attempts.push(FilterAttemptFailure {
+                model: model_id.clone(),
+                reason: "empty",
+            });
+            continue;
+        }
         if let Some(reason) = filter_output_invalidity(&text, resp.finish_reason.as_deref()) {
             tracing::warn!(
                 model = %model_id,
                 invalidity = %reason,
                 "filter: output failed validity gate; walking to next model"
             );
+            attempts.push(FilterAttemptFailure {
+                model: model_id.clone(),
+                reason,
+            });
             continue;
         }
         // Falling back to model_id when the response omits the served model is
         // safe: that is the model we requested, and OpenRouter only omits it
         // on error paths (which we have already excluded via the validity gate).
         let filter_model = resp.model.unwrap_or_else(|| model_id.clone());
-        return Some(RunFilterOutcome {
+        return Ok(RunFilterOutcome {
             filtered_text: text,
             retries_filter: idx as u32,
             filter_model,
@@ -686,7 +750,10 @@ async fn run_output_filter(
             f_generation_id: resp.generation_id,
         });
     }
-    None
+    Err(FilterFailOpen {
+        f_client_msg_id,
+        attempts,
+    })
 }
 
 /// Try to emit a pseudo-ghost on chain exhaustion.
@@ -2189,6 +2256,287 @@ data: [DONE]\n\n";
                 "SELECT content FROM engine.chat_messages WHERE session_id=$1 AND role='assistant' ORDER BY sent_at DESC LIMIT 1")
                 .bind(session_id).fetch_one(&pool).await.unwrap();
             assert_eq!(row, "ORIG");
+        }
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn filter_fail_open_writes_attempt_audit_to_metadata(pool: PgPool) {
+        // Filter chain = primary + 1 fallback. Both return refusal text (200 OK
+        // with a Chinese refusal phrase) → validity gate rejects both → engine
+        // fails open, emits the ORIGINAL reply, and the persisted row's metadata
+        // carries filter_outcome=fail_open + filter_attempts (2 entries).
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+        use futures_util::StreamExt;
+        use wiremock::matchers::{body_string_contains, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        let chat_body = "data: {\"choices\":[{\"delta\":{\"content\":\"ORIG\"}}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1,\"total_tokens\":2},\"id\":\"g\",\"model\":\"primary\"}\n\ndata: [DONE]\n\n";
+
+        // Both filter models return a refusal — Chinese phrase caught by the
+        // head-pattern gate.
+        let refusal_body_1 = serde_json::json!({
+            "id": "gf1", "model": "filter-1",
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            "choices": [{"message": {"content": "抱歉，我无法协助完成您的请求。"}}],
+        });
+        let refusal_body_2 = serde_json::json!({
+            "id": "gf2", "model": "filter-2",
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            "choices": [{"message": {"content": "抱歉，我无法协助完成您的请求。"}}],
+        });
+
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("filter-1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(refusal_body_1))
+            .mount(&mock)
+            .await;
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("filter-2"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(refusal_body_2))
+            .mount(&mock)
+            .await;
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("deepseek/x"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(chat_body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+
+        let user_id = Uuid::new_v4();
+        let (_g, instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = std::sync::Arc::new(
+            eros_engine_llm::model_config::ModelConfig::from_toml_str(
+                "[tasks.chat_companion]\nmodel=\"deepseek/x\"\noutput_filter=true\n\
+                 [tasks.chat_output_filter]\nmodel=\"filter-1\"\nfallback=[\"filter-2\"]\n\
+                 retry_depth=1\nfilter_prompt=\"REWRITE\"\ntrigger = { random = 1.0 }\n",
+            )
+            .unwrap(),
+        );
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "k".into(),
+                Default::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+
+        let chat_repo = ChatRepo { pool: &pool };
+        let umid = match chat_repo
+            .upsert_user_message_idempotent(
+                session_id,
+                "hello",
+                "01JFAILOPEN111111111111111",
+                "user",
+                None,
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
+
+        let frames: Vec<ProtocolFrame> = run_stream(
+            std::sync::Arc::new(state),
+            PersistedUserMessage {
+                user_message_id: umid,
+                session_id,
+                user_id,
+                instance_id,
+                content: "hello".into(),
+                prompt_traits: vec![],
+                audit: None,
+                tier: None,
+                memory_scope: Default::default(),
+                affinity_scope: Default::default(),
+                tips_amount_usd: None,
+            },
+        )
+        .collect()
+        .await;
+
+        // Only run assertions when PDE chose Reply (not Ghost).
+        if frames
+            .iter()
+            .any(|f| matches!(f, ProtocolFrame::Delta { .. }))
+        {
+            // Client must see the original, not the refusals.
+            let deltas: String = frames
+                .iter()
+                .filter_map(|f| match f {
+                    ProtocolFrame::Delta { content, .. } => Some(content.clone()),
+                    _ => None,
+                })
+                .collect();
+            assert!(
+                deltas.contains("ORIG"),
+                "fail-open must emit original, got {deltas:?}"
+            );
+
+            // final.filtered must be false (we failed open).
+            let filtered = frames
+                .iter()
+                .find_map(|f| match f {
+                    ProtocolFrame::Final { filtered, .. } => Some(*filtered),
+                    _ => None,
+                })
+                .unwrap();
+            assert!(!filtered, "final.filtered must be false on fail-open");
+
+            // The persisted row must carry the fail-open audit in metadata.
+            let metadata: serde_json::Value = sqlx::query_scalar(
+                "SELECT metadata FROM engine.chat_messages \
+                 WHERE session_id=$1 AND role='assistant' ORDER BY sent_at DESC LIMIT 1",
+            )
+            .bind(session_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+            assert_eq!(
+                metadata["filter_outcome"], "fail_open",
+                "metadata.filter_outcome must be 'fail_open', got {metadata}"
+            );
+            let attempts = metadata["filter_attempts"].as_array().unwrap();
+            assert_eq!(
+                attempts.len(),
+                2,
+                "both filter models must be recorded in filter_attempts, got {attempts:?}"
+            );
+            // Both should have reason=refusal_pattern.
+            for attempt in attempts {
+                assert_eq!(
+                    attempt["reason"], "refusal_pattern",
+                    "expected refusal_pattern reason, got {attempt}"
+                );
+            }
+            // f_client_msg_id must be present and start with "f_".
+            let fid = metadata["f_client_msg_id"].as_str().unwrap();
+            assert!(
+                fid.starts_with("f_"),
+                "f_client_msg_id must start with 'f_', got {fid}"
+            );
+        }
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn filter_success_does_not_write_fail_open_metadata(pool: PgPool) {
+        // Sanity: when filter succeeds the metadata does NOT contain
+        // filter_outcome / filter_attempts keys (no false-positive audit).
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+        use futures_util::StreamExt;
+        use wiremock::matchers::{body_string_contains, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        let chat_body = "data: {\"choices\":[{\"delta\":{\"content\":\"ORIG\"}}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1,\"total_tokens\":2},\"id\":\"g\",\"model\":\"primary\"}\n\ndata: [DONE]\n\n";
+        let filt_text = "FILT_OK 她轻轻地望向窗外，思绪飘向了远方。阳光洒在她的脸上，温柔而明亮。她记得那个夏天的每一天，岁月如流水般逝去，带走了所有的悲欢离合。 FILT_OK_END";
+        let filt_body = serde_json::json!({
+            "id": "gf", "model": "fast/m",
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            "choices": [{"message": {"content": filt_text}}],
+        });
+
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("fast/m"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(filt_body))
+            .mount(&mock)
+            .await;
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("deepseek/x"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(chat_body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+
+        let user_id = Uuid::new_v4();
+        let (_g, instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = std::sync::Arc::new(
+            eros_engine_llm::model_config::ModelConfig::from_toml_str(
+                "[tasks.chat_companion]\nmodel=\"deepseek/x\"\noutput_filter=true\n\
+                 [tasks.chat_output_filter]\nmodel=\"fast/m\"\nfilter_prompt=\"REWRITE\"\n",
+            )
+            .unwrap(),
+        );
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "k".into(),
+                Default::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+
+        let chat_repo = ChatRepo { pool: &pool };
+        let umid = match chat_repo
+            .upsert_user_message_idempotent(
+                session_id,
+                "hello",
+                "01JFILTSUCCESS1111111111A",
+                "user",
+                None,
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
+
+        let frames: Vec<ProtocolFrame> = run_stream(
+            std::sync::Arc::new(state),
+            PersistedUserMessage {
+                user_message_id: umid,
+                session_id,
+                user_id,
+                instance_id,
+                content: "hello".into(),
+                prompt_traits: vec![],
+                audit: None,
+                tier: None,
+                memory_scope: Default::default(),
+                affinity_scope: Default::default(),
+                tips_amount_usd: None,
+            },
+        )
+        .collect()
+        .await;
+
+        if frames
+            .iter()
+            .any(|f| matches!(f, ProtocolFrame::Delta { .. }))
+        {
+            // Filter succeeded — no fail-open audit keys must appear.
+            let metadata: serde_json::Value = sqlx::query_scalar(
+                "SELECT metadata FROM engine.chat_messages \
+                 WHERE session_id=$1 AND role='assistant' ORDER BY sent_at DESC LIMIT 1",
+            )
+            .bind(session_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+            assert!(
+                metadata.get("filter_outcome").is_none(),
+                "successful filter must not write filter_outcome, got {metadata}"
+            );
+            assert!(
+                metadata.get("filter_attempts").is_none(),
+                "successful filter must not write filter_attempts, got {metadata}"
+            );
+            // prompt_traits must still be present.
+            assert!(
+                metadata.get("prompt_traits").is_some(),
+                "prompt_traits must still be present, got {metadata}"
+            );
         }
     }
 

--- a/docs/superpowers/specs/2026-05-26-filter-validity-gate-design.md
+++ b/docs/superpowers/specs/2026-05-26-filter-validity-gate-design.md
@@ -1,0 +1,139 @@
+# chat_output_filter — Output Validity Gate Design
+
+**Date:** 2026-05-26
+**Status:** Implemented (feat/v0.5.0-filter-validity-gate)
+
+---
+
+## §0 Background
+
+`run_output_filter` calls the filter LLM and, on any HTTP 200 response, persists
+the reply text into `chat_messages.content`.  A filter model can return an HTTP
+200 with a refusal text ("抱歉，我无法协助完成您的请求。") — the engine has no way
+to distinguish that from a valid rewrite.  This has been observed in production.
+
+A single-model swap is insufficient as a fix: any model's safety alignment policy
+can shift at any time and begin producing refusals.  The fix must be structural.
+
+---
+
+## §1 Goal / Non-goals
+
+**Goal:** After each per-model filter response, run a lightweight validity check.
+On failure, walk to the next model in the chain exactly as the chat burst already
+does.  The check is cheap (no extra LLM call) and covers the three known failure
+modes.
+
+**Non-goals:**
+
+- The fail-open semantic is unchanged: when the whole chain exhausts (every model
+  fails the gate, errors, or times out), `run_output_filter` returns `None` and
+  the caller emits and persists the original reply.
+- No schema changes; no config-file changes; no new environment variables.
+- No change to how the streaming chat burst walks its own chain.
+
+---
+
+## §2 Validity Gate Spec
+
+`filter_output_invalidity(text, finish_reason) -> Option<&'static str>`
+
+Returns `Some(label)` when invalid, `None` when valid.  Checks run in order
+(cheapest first):
+
+### 2.1 `finish_reason == "content_filter"` → label `"content_filter"`
+
+Gemini and OpenAI both use this string when mid-response safety truncation fires.
+Checked before any text scan so it is O(1).
+
+### 2.2 Refusal pattern in head → label `"refusal_pattern"`
+
+Scan the first `REFUSAL_HEAD_SCAN_CHARS = 120` Unicode characters of the text.
+If any pattern in `REFUSAL_PATTERNS_HEAD` appears, the response is a refusal.
+
+Curated list covers Chinese shapes observed in production and the standard
+OpenAI/Anthropic English apology forms.  Anchored to the head to avoid false
+positives: a clean rewrite that incidentally contains "won't" or "sorry" past
+character 120 is NOT flagged.
+
+### 2.3 Short-text checks
+
+`total_chars = text.chars().count()` (Unicode code points — correct for CJK).
+
+If `total_chars < MIN_FILTERED_OUTPUT_CHARS (= 80)`:
+
+- Contains a verb in `REFUSAL_SHORT_VERBS` anywhere in the text →
+  label `"refusal_pattern"`.
+- Otherwise → label `"too_short"`.
+
+A valid filter rewrite is at least 80 characters.  Clean rewrites shorter than
+that are flagged as `"too_short"` and cause the next model to be tried.  This
+is an acceptable trade-off: the filter task is full-text rewriting, not
+summarisation.
+
+---
+
+## §3 Chain Walking
+
+`run_output_filter` previously delegated chain walking to
+`OpenRouterClient::execute()`, which walks internally and returns the first
+non-error HTTP 200.  The validity gate requires seeing each model's response
+individually before deciding to continue.
+
+The function now builds its own chain:
+
+```text
+chain = [f.model] ++ f.fallback_model
+```
+
+For each model, it builds a `ChatRequest` with `fallback_model = vec![]` and
+calls `execute()` (single-model, no internal walking).  On a validity gate
+failure it logs the reason and advances to the next model.  If the chain
+exhausts, it returns `None` (fail-open).
+
+`f_client_msg_id` (the `f_` ULID) is generated once before the loop and reused
+across all model attempts within a single logical filter call.  `retries_filter`
+reflects the index of the model that passed the validity gate — 0 for the
+primary, 1 for the first fallback, etc.
+
+---
+
+## §4 `finish_reason` Plumbing
+
+The non-streaming `execute()` path did not previously surface `finish_reason`.
+This change threads it from the wire:
+
+- `WireChoice` gains `#[serde(default)] finish_reason: Option<String>`.
+- `ChatResponse` gains `pub finish_reason: Option<String>`.
+- `call_once` copies `choices[0].finish_reason` into the returned `ChatResponse`.
+
+The streaming path (`DeltaChunk`) already carries `finish_reason` — that field
+is not touched.
+
+---
+
+## §5 Testing
+
+Seven unit tests on the pure `filter_output_invalidity` function cover:
+
+| Test | Input | Expected |
+|------|-------|----------|
+| Chinese refusal in head | `"抱歉，我无法…"` | `Some("refusal_pattern")` |
+| English refusal in head | `"I'm sorry, but I can't…"` | `Some("refusal_pattern")` |
+| `content_filter` finish_reason | long clean text + `"content_filter"` | `Some("content_filter")` |
+| Short + refusal verb | `"我无法。"` | `Some("refusal_pattern")` |
+| Short + no refusal verb | `"她笑了。"` | `Some("too_short")` |
+| Long clean rewrite | 200+ char text + `"stop"` | `None` |
+| Refusal word past char 120 | clean rewrite with `"won't"` at position >120 | `None` (regression guard) |
+
+---
+
+## §6 Rollout
+
+- Additive change only: new field on `ChatResponse` (default `None`), new
+  constants, new helper function, refactored loop in `run_output_filter`.
+- No OpenAPI schema changes (the filter is internal stream logic; `ChatResponse`
+  does not surface in any DTO).
+- No database schema changes.
+- No operator config changes required — the gate is always-on.
+- Deployed by building and releasing a new image as usual; no migration needed.

--- a/docs/superpowers/specs/2026-05-26-filter-validity-gate-design.md
+++ b/docs/superpowers/specs/2026-05-26-filter-validity-gate-design.md
@@ -96,6 +96,51 @@ across all model attempts within a single logical filter call.  `retries_filter`
 reflects the index of the model that passed the validity gate — 0 for the
 primary, 1 for the first fallback, etc.
 
+### §3.5 Fail-open audit (`chat_messages.metadata`)
+
+When the whole filter chain fails validity (or every model errors / times out),
+the engine still fails open — emits + persists the original reply — but now also
+writes a fail-open audit into `chat_messages.metadata` so ops can identify these
+rows without ambiguity:
+
+```json
+{
+  "prompt_traits": ["..."],
+  "tier": "...",
+  "filter_outcome": "fail_open",
+  "f_client_msg_id": "f_01J...",
+  "filter_attempts": [
+    {"model": "openai/gpt-5.4-nano", "reason": "refusal_pattern"},
+    {"model": "google/gemini-3.1-flash-lite", "reason": "content_filter"}
+  ]
+}
+```
+
+Reason vocabulary:
+- `"refusal_pattern"`, `"too_short"`, `"content_filter"` — from
+  `filter_output_invalidity`
+- `"empty"` — model returned an empty `reply` field (checked before the
+  validity gate; distinguishes "model returned literally nothing" from
+  "model returned a short but non-empty response")
+- `"error"` — HTTP error / non-2xx response from the OpenRouter call
+- `"timeout"` — exceeded the 15s per-model filter timeout
+
+`run_output_filter` now returns `Result<RunFilterOutcome, FilterFailOpen>`
+instead of `Option<RunFilterOutcome>`. The `FilterFailOpen` value carries the
+`f_client_msg_id` (generated once before the loop) and the `Vec<FilterAttemptFailure>`
+audit log. The caller writes these into metadata only when `Err(fail)` is
+received — i.e., when filter was triggered AND every model in the chain failed.
+
+Rows where the filter trigger NEVER fired (trigger predicate returned `None`,
+or no filter is configured) are unchanged: `filter_outcome` / `filter_attempts`
+are absent. The audit is specifically for "we tried to filter and failed,"
+not "we chose not to filter." Ops query:
+
+```sql
+SELECT * FROM engine.chat_messages
+WHERE metadata->>'filter_outcome' = 'fail_open';
+```
+
 ---
 
 ## §4 `finish_reason` Plumbing


### PR DESCRIPTION
## Summary

Adds a defensive output validity gate to `chat_output_filter` so that a refusal text / suspiciously-short output / `finish_reason = content_filter` is treated as a filter failure and the engine walks to the next model in the chain — instead of trusting any HTTP 200 from the filter LLM.

### Why

Today `run_output_filter` calls `state.openrouter.execute(req)` with the full ChatRequest, which walks the fallback chain internally and returns the first non-error response. A filter model that returns HTTP 200 with body `"抱歉，我无法协助完成您的请求。"` (observed in production with the previous primary filter model) is treated as a valid filtered rewrite and persisted as `chat_messages.content`.

Single-point model swaps are not enough — any model's safety alignment can shift and produce refusals at any time. The engine needs a defensive output validity gate.

### What

Three checks, run after each successful HTTP 200 from a filter model:

1. **`finish_reason == "content_filter"`** — Gemini-style mid-response safety truncation (OpenAI also uses this string). Threaded through `ChatResponse` from the OpenRouter wire.
2. **Refusal pattern match** — curated zh + en patterns checked against the **lowercased** leading 120 chars (catches `"i'm sorry, but i can't ..."`, `"As an ai ..."`, `"I'M SORRY"` regardless of case).
3. **Length too short** — response under 80 Unicode chars (`text.chars().count()`). A real rewrite is always longer.

On any of these, log the rejection with a stable label (`"content_filter"` / `"refusal_pattern"` / `"too_short"`) and walk to the next model in the chain. If the whole chain exhausts, return `None` — caller falls open and emits the original reply (spec'd behavior, unchanged).

`run_output_filter` is restructured to walk the chain itself with single-model `execute()` calls; `retries_filter` now reflects the model that passed validity, not just one that responded 200.

## Spec

`docs/superpowers/specs/2026-05-26-filter-validity-gate-design.md`

## Test plan

- [x] 8 unit tests on `filter_output_invalidity` (zh refusal, en refusal, lowercase/upper/mixed-case en, content_filter finish_reason, short+verb, short-no-verb, long clean pass, late-refusal-word regression guard)
- [x] Existing `filtered_turn_emits_filtered_and_persists_filtered` updated to use an 84-char Chinese rewrite that passes the new gate; mock now routes by model id in request body for mount-order independence
- [x] `cargo test --workspace` green (428 tests across 4 crates)
- [x] `cargo fmt --check` + `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] OpenAPI snapshot unchanged (internal stream logic + an additive `ChatResponse.finish_reason` field that doesn't surface to DTOs)
- [x] 2 codex review passes — case-sensitive matching finding fixed; second pass clean
- [ ] Optional follow-up: integration test for chain-walking when the first model returns a refusal and the second model passes the gate (the unit tests + happy-path integration test cover the structural correctness; production audit can drive this if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)