### PR TITLE
feat: prompt enhancements + scope persistence

### DIFF
--- a/crates/eros-engine-core/src/types.rs
+++ b/crates/eros-engine-core/src/types.rs
@@ -9,7 +9,7 @@ use crate::persona::CompanionPersona;
 use crate::scope::{AffinityScope, MemoryScope};
 
 /// A caller-supplied system-prompt fragment. The engine treats `text` as
-/// opaque — it is inserted verbatim under the `【附加指引】` section of
+/// opaque — it is inserted verbatim under the `[additional_guidance]` section of
 /// the persona system prompt. `tag` is for logging/observability only and
 /// is constrained to `[a-z0-9_]{1,32}` by the HTTP layer.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -1,6 +1,3 @@
-   Compiling eros-engine-server v0.4.3-dev (/Users/enriquephlin/dev-local/oss-eros/eros-engine/crates/eros-engine-server)
-    Finished `dev` profile [unoptimized + debuginfo] target(s) in 5.78s
-     Running `target/debug/eros-engine print-openapi`
 {
   "openapi": "3.1.0",
   "info": {

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -1,3 +1,6 @@
+   Compiling eros-engine-server v0.4.3-dev (/Users/enriquephlin/dev-local/oss-eros/eros-engine/crates/eros-engine-server)
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 5.78s
+     Running `target/debug/eros-engine print-openapi`
 {
   "openapi": "3.1.0",
   "info": {
@@ -1572,7 +1575,7 @@
           },
           "text": {
             "type": "string",
-            "description": "Verbatim text inserted under `【附加指引】` in the system prompt.\n1 ≤ chars ≤ 2000 after trim."
+            "description": "Verbatim text inserted under `[additional_guidance]` in the system prompt.\n1 ≤ chars ≤ 2000 after trim."
           }
         }
       },

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -419,6 +419,7 @@ pub(super) async fn build_reply_request(
     session_id: Uuid,
     user_id: Uuid,
     instance_id: Uuid,
+    user_message_id: Uuid,
 ) -> Result<(ChatRequest, Vec<String>), AppError> {
     let chat_repo = ChatRepo { pool: &state.pool };
     let history = chat_repo.history(session_id, HISTORY_WINDOW, 0).await?;
@@ -493,7 +494,7 @@ pub(super) async fn build_reply_request(
         );
     }
 
-    let recent_turns = fetch_recent_turn_pairs(&state.pool, session_id).await;
+    let recent_turns = fetch_recent_turn_pairs(&state.pool, session_id, user_message_id).await;
 
     let mut system_prompt = build_prompt(
         &input.persona,
@@ -535,21 +536,28 @@ pub(super) async fn build_reply_request(
 /// Fetch the last `limit` complete (user|gift_user, assistant) pairs for the
 /// session, used to render the `[recent_conversation]` short-term memory block.
 ///
-/// Cutoff = `Utc::now()`: the just-inserted current-turn user row's `sent_at`
-/// is microseconds before `now()`, but the SQL filter is strict `<` and we
-/// want everything BEFORE the current turn — the current turn's prompt must
-/// not appear in its own `[recent_conversation]` block.
+/// Cutoff = the current turn's persisted user row's `sent_at` (looked up by
+/// `user_message_id` via subquery). Using `Utc::now()` instead would be racy:
+/// under concurrent streams on the same session, a later already-completed
+/// turn could insert a row between wall-clock-now and the read of recent
+/// rows, leaking "future" conversation into the current turn's prompt. The
+/// SQL filter is strict `<`, so the current-turn row itself is excluded.
 ///
 /// Non-fatal: a DB hiccup degrades to an empty Vec with a warn-level log so
 /// short-term memory is omitted but prompt assembly still succeeds.
-async fn fetch_recent_turn_pairs(pool: &PgPool, session_id: Uuid) -> Vec<(String, String)> {
+async fn fetch_recent_turn_pairs(
+    pool: &PgPool,
+    session_id: Uuid,
+    user_message_id: Uuid,
+) -> Vec<(String, String)> {
     ChatRepo { pool }
-        .recent_turn_pairs(session_id, chrono::Utc::now(), 3)
+        .recent_turn_pairs_before_message(session_id, user_message_id, 3)
         .await
         .unwrap_or_else(|e| {
             tracing::warn!(
                 error = %e,
                 session_id = %session_id,
+                user_message_id = %user_message_id,
                 "recent_turn_pairs fetch failed; [recent_conversation] omitted"
             );
             Vec::new()
@@ -565,6 +573,7 @@ pub(super) async fn build_gift_request(
     session_id: Uuid,
     user_id: Uuid,
     instance_id: Uuid,
+    user_message_id: Uuid,
     pending: &[PendingGift],
 ) -> Result<(ChatRequest, Vec<String>), AppError> {
     let chat_repo = ChatRepo { pool: &state.pool };
@@ -594,7 +603,7 @@ pub(super) async fn build_gift_request(
 
     let resolved = state.model_config.resolve(CHAT_TASK, None);
 
-    let recent_turns = fetch_recent_turn_pairs(&state.pool, session_id).await;
+    let recent_turns = fetch_recent_turn_pairs(&state.pool, session_id, user_message_id).await;
 
     let system_prompt = build_prompt(
         &input.persona,
@@ -1331,11 +1340,12 @@ mod tests {
 
     /// End-to-end check of the cutoff semantics that `fetch_recent_turn_pairs`
     /// relies on. We exercise the repo path the handler actually calls (via
-    /// `ChatRepo::recent_turn_pairs` with `Utc::now()` as cutoff) rather than
-    /// the full handler tree, because `build_reply_request` pulls in persona /
-    /// model_config / voyage / openrouter wiring that isn't trivially
-    /// mockable. The handler itself is verifiable by inspection — both call
-    /// sites go through `fetch_recent_turn_pairs(&state.pool, session_id)`.
+    /// `ChatRepo::recent_turn_pairs_before_message` keyed on the current
+    /// turn's user message id) rather than the full handler tree, because
+    /// `build_reply_request` pulls in persona / model_config / voyage /
+    /// openrouter wiring that isn't trivially mockable. The handler itself is
+    /// verifiable by inspection — both call sites go through
+    /// `fetch_recent_turn_pairs(&state.pool, session_id, user_message_id)`.
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
     async fn handlers_inject_recent_conversation_into_system_prompt(pool: PgPool) {
         use eros_engine_store::chat::{AssistantInsert, ChatRepo, UpsertUserOutcome};
@@ -1380,24 +1390,45 @@ mod tests {
                 .unwrap();
         }
 
-        // What the handler's fetch will see when assembling the next turn.
+        // Insert the "current" user row that the handler would pass to
+        // `fetch_recent_turn_pairs` as `user_message_id`.
+        let current_msg_id = match chat_repo
+            .upsert_user_message_idempotent(
+                session.id,
+                "u_current",
+                "01J0000000000000000080900A",
+                "user",
+                None,
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            other => panic!("expected Inserted, got {other:?}"),
+        };
+
+        // What the handler's fetch will see when assembling the current turn.
+        // Cutoff = current_msg_id's sent_at, so its own row is excluded and
+        // only the 2 prior complete pairs come back.
         let pairs = chat_repo
-            .recent_turn_pairs(session.id, chrono::Utc::now(), 3)
+            .recent_turn_pairs_before_message(session.id, current_msg_id, 3)
             .await
             .unwrap();
         assert_eq!(pairs.len(), 2);
         assert_eq!(pairs[0], ("u0".to_string(), "a0".to_string()));
         assert_eq!(pairs[1], ("u1".to_string(), "a1".to_string()));
 
-        // Cutoff sanity: a user row inserted AFTER capturing the cutoff must
-        // NOT appear — proves the current-turn row is excluded from its own
-        // `[recent_conversation]` block.
-        let cutoff = chrono::Utc::now();
+        // Concurrent-stream isolation: a LATER user row inserted after the
+        // current turn (simulating another stream completing between this
+        // turn's user-insert and the recent-turn fetch) must NOT appear.
+        // Wall-clock `Utc::now()` would include it; cutoff-by-message-id
+        // doesn't, because the subquery resolves to `current_msg_id`'s
+        // sent_at — which is before the later row.
         tokio::time::sleep(std::time::Duration::from_millis(20)).await;
         let _ = chat_repo
             .upsert_user_message_idempotent(
                 session.id,
-                "u_now",
+                "u_later",
                 "01J0000000000000000080999A",
                 "user",
                 None,
@@ -1405,13 +1436,15 @@ mod tests {
             .await
             .unwrap();
         let pairs_after = chat_repo
-            .recent_turn_pairs(session.id, cutoff, 3)
+            .recent_turn_pairs_before_message(session.id, current_msg_id, 3)
             .await
             .unwrap();
         assert_eq!(
             pairs_after.len(),
             2,
-            "current turn must not appear in [recent_conversation]"
+            "later concurrent-stream row must not appear in [recent_conversation]"
         );
+        assert_eq!(pairs_after[0], ("u0".to_string(), "a0".to_string()));
+        assert_eq!(pairs_after[1], ("u1".to_string(), "a1".to_string()));
     }
 }

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -542,10 +542,7 @@ pub(super) async fn build_reply_request(
 ///
 /// Non-fatal: a DB hiccup degrades to an empty Vec with a warn-level log so
 /// short-term memory is omitted but prompt assembly still succeeds.
-async fn fetch_recent_turn_pairs(
-    pool: &PgPool,
-    session_id: Uuid,
-) -> Vec<(String, String)> {
+async fn fetch_recent_turn_pairs(pool: &PgPool, session_id: Uuid) -> Vec<(String, String)> {
     ChatRepo { pool }
         .recent_turn_pairs(session_id, chrono::Utc::now(), 3)
         .await
@@ -1346,19 +1343,16 @@ mod tests {
         let chat_repo = ChatRepo { pool: &pool };
         let user_id = Uuid::new_v4();
         let instance_id = Uuid::new_v4();
-        let session = chat_repo.create_session(user_id, instance_id).await.unwrap();
+        let session = chat_repo
+            .create_session(user_id, instance_id)
+            .await
+            .unwrap();
 
         // Insert 2 prior complete (user, assistant) pairs.
         for n in 0..2u8 {
             let u_ulid = format!("01J000000000000000008{n}001A");
             let uid = match chat_repo
-                .upsert_user_message_idempotent(
-                    session.id,
-                    &format!("u{n}"),
-                    &u_ulid,
-                    "user",
-                    None,
-                )
+                .upsert_user_message_idempotent(session.id, &format!("u{n}"), &u_ulid, "user", None)
                 .await
                 .unwrap()
             {

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -493,6 +493,8 @@ pub(super) async fn build_reply_request(
         );
     }
 
+    let recent_turns = fetch_recent_turn_pairs(&state.pool, session_id).await;
+
     let mut system_prompt = build_prompt(
         &input.persona,
         &profile_groups,
@@ -504,7 +506,7 @@ pub(super) async fn build_reply_request(
         &plan.context_hints,
         &kept_traits,
         affinity_scope,
-        &[], // recent_turns — populated in Task 7
+        &recent_turns,
     );
 
     if let Event::UserMessage {
@@ -528,6 +530,33 @@ pub(super) async fn build_reply_request(
         ),
         injected_tags,
     ))
+}
+
+/// Fetch the last `limit` complete (user|gift_user, assistant) pairs for the
+/// session, used to render the `[recent_conversation]` short-term memory block.
+///
+/// Cutoff = `Utc::now()`: the just-inserted current-turn user row's `sent_at`
+/// is microseconds before `now()`, but the SQL filter is strict `<` and we
+/// want everything BEFORE the current turn — the current turn's prompt must
+/// not appear in its own `[recent_conversation]` block.
+///
+/// Non-fatal: a DB hiccup degrades to an empty Vec with a warn-level log so
+/// short-term memory is omitted but prompt assembly still succeeds.
+async fn fetch_recent_turn_pairs(
+    pool: &PgPool,
+    session_id: Uuid,
+) -> Vec<(String, String)> {
+    ChatRepo { pool }
+        .recent_turn_pairs(session_id, chrono::Utc::now(), 3)
+        .await
+        .unwrap_or_else(|e| {
+            tracing::warn!(
+                error = %e,
+                session_id = %session_id,
+                "recent_turn_pairs fetch failed; [recent_conversation] omitted"
+            );
+            Vec::new()
+        })
 }
 
 /// Build a ChatRequest for the GiftReaction action. Called by the streaming
@@ -568,6 +597,8 @@ pub(super) async fn build_gift_request(
 
     let resolved = state.model_config.resolve(CHAT_TASK, None);
 
+    let recent_turns = fetch_recent_turn_pairs(&state.pool, session_id).await;
+
     let system_prompt = build_prompt(
         &input.persona,
         &profile_groups,
@@ -579,7 +610,7 @@ pub(super) async fn build_gift_request(
         &plan.context_hints,
         &[],
         eros_engine_core::scope::AffinityScope::full(),
-        &[], // recent_turns — populated in Task 7
+        &recent_turns,
     );
 
     Ok((
@@ -1299,5 +1330,94 @@ mod tests {
         let (kept, dropped) = filter_traits(&traits, Some(&allow));
         assert_eq!(kept.len(), 2);
         assert!(dropped.is_empty());
+    }
+
+    /// End-to-end check of the cutoff semantics that `fetch_recent_turn_pairs`
+    /// relies on. We exercise the repo path the handler actually calls (via
+    /// `ChatRepo::recent_turn_pairs` with `Utc::now()` as cutoff) rather than
+    /// the full handler tree, because `build_reply_request` pulls in persona /
+    /// model_config / voyage / openrouter wiring that isn't trivially
+    /// mockable. The handler itself is verifiable by inspection — both call
+    /// sites go through `fetch_recent_turn_pairs(&state.pool, session_id)`.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn handlers_inject_recent_conversation_into_system_prompt(pool: PgPool) {
+        use eros_engine_store::chat::{AssistantInsert, ChatRepo, UpsertUserOutcome};
+
+        let chat_repo = ChatRepo { pool: &pool };
+        let user_id = Uuid::new_v4();
+        let instance_id = Uuid::new_v4();
+        let session = chat_repo.create_session(user_id, instance_id).await.unwrap();
+
+        // Insert 2 prior complete (user, assistant) pairs.
+        for n in 0..2u8 {
+            let u_ulid = format!("01J000000000000000008{n}001A");
+            let uid = match chat_repo
+                .upsert_user_message_idempotent(
+                    session.id,
+                    &format!("u{n}"),
+                    &u_ulid,
+                    "user",
+                    None,
+                )
+                .await
+                .unwrap()
+            {
+                UpsertUserOutcome::Inserted { message_id } => message_id,
+                other => panic!("expected Inserted, got {other:?}"),
+            };
+            chat_repo
+                .insert_assistant_batch(
+                    session.id,
+                    uid,
+                    &[AssistantInsert {
+                        id: Uuid::new_v4(),
+                        content: format!("a{n}"),
+                        assistant_action_type: "reply".into(),
+                        truncated: false,
+                        continues_from_message_id: None,
+                        model: Some("test-model".into()),
+                        usage: None,
+                        generation_id: None,
+                        filter_audit: None,
+                        metadata: None,
+                    }],
+                )
+                .await
+                .unwrap();
+        }
+
+        // What the handler's fetch will see when assembling the next turn.
+        let pairs = chat_repo
+            .recent_turn_pairs(session.id, chrono::Utc::now(), 3)
+            .await
+            .unwrap();
+        assert_eq!(pairs.len(), 2);
+        assert_eq!(pairs[0], ("u0".to_string(), "a0".to_string()));
+        assert_eq!(pairs[1], ("u1".to_string(), "a1".to_string()));
+
+        // Cutoff sanity: a user row inserted AFTER capturing the cutoff must
+        // NOT appear — proves the current-turn row is excluded from its own
+        // `[recent_conversation]` block.
+        let cutoff = chrono::Utc::now();
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        let _ = chat_repo
+            .upsert_user_message_idempotent(
+                session.id,
+                "u_now",
+                "01J0000000000000000080999A",
+                "user",
+                None,
+            )
+            .await
+            .unwrap();
+        let pairs_after = chat_repo
+            .recent_turn_pairs(session.id, cutoff, 3)
+            .await
+            .unwrap();
+        assert_eq!(
+            pairs_after.len(),
+            2,
+            "current turn must not appear in [recent_conversation]"
+        );
     }
 }

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -284,7 +284,7 @@ fn build_profile_groups(
 
 /// Load `companion_insights` for the user and render the structured fields
 /// as Chinese-language bullets that fit naturally into the
-/// `【你对他的了解（通用画像）】` prompt section. Takes `&PgPool` directly
+/// `[user_profile]` prompt section. Takes `&PgPool` directly
 /// (not `&AppState`) so it's reachable from sqlx integration tests without
 /// constructing the full state.
 async fn load_insight_bullets(pool: &PgPool, user_id: Uuid) -> Vec<String> {

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -566,6 +566,7 @@ async fn fetch_recent_turn_pairs(
 
 /// Build a ChatRequest for the GiftReaction action. Called by the streaming
 /// pipeline (`pipeline::stream::run_stream`).
+#[allow(clippy::too_many_arguments)] // mirrors build_reply_request + pending gifts
 pub(super) async fn build_gift_request(
     state: &AppState,
     input: &DecisionInput,

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -504,6 +504,7 @@ pub(super) async fn build_reply_request(
         &plan.context_hints,
         &kept_traits,
         affinity_scope,
+        &[], // recent_turns — populated in Task 7
     );
 
     if let Event::UserMessage {
@@ -578,6 +579,7 @@ pub(super) async fn build_gift_request(
         &plan.context_hints,
         &[],
         eros_engine_core::scope::AffinityScope::full(),
+        &[], // recent_turns — populated in Task 7
     );
 
     Ok((

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -134,8 +134,10 @@ fn drive_chat_burst(
     req: eros_engine_llm::openrouter::ChatRequest,
     display_override: Option<eros_engine_llm::model_config::DisplayOverride>,
     filter: Option<eros_engine_llm::model_config::ResolvedOutputFilter>,
-    trait_tags: Vec<String>,  // requested prompt-trait tags (the turn's)
-    tier: Option<String>,     // user's tier at message time; None omitted from metadata
+    trait_tags: Vec<String>, // requested prompt-trait tags (the turn's)
+    tier: Option<String>,    // user's tier at message time; None omitted from metadata
+    memory_scope: eros_engine_core::scope::MemoryScope, // post-resolve scope for assistant metadata
+    affinity_scope: eros_engine_core::scope::AffinityScope, // post-resolve scope for assistant metadata
     random_draw: Option<f64>, // sampled once per turn by run_stream; None when trigger.random is unset
     outcome: std::sync::Arc<std::sync::Mutex<BurstOutcome>>,
 ) -> impl futures_util::Stream<Item = ProtocolFrame> + Send + 'static {
@@ -163,13 +165,25 @@ fn drive_chat_burst(
             .map(|f| f.trigger.turn_level_pass(random_draw, &tag_refs))
             .unwrap_or(false);
 
-        // Build the assistant row metadata bag: always includes prompt_traits;
-        // includes tier only when the request carried one (omit key entirely
-        // when None). When the filter chain failed entirely (fail-open), also
-        // writes the per-attempt audit log so ops can identify these rows.
+        // Build the assistant row metadata bag: always includes prompt_traits +
+        // resolved memory_scope / affinity_scope (the POST-resolve values
+        // actually used to serve this turn — pair with the user row's
+        // memory_scope_raw / affinity_scope_raw to surface allow-list / shape
+        // mismatches with a single metadata->>'...' diff); includes tier only
+        // when the request carried one (omit key entirely when None). When the
+        // filter chain failed entirely (fail-open), also writes the per-attempt
+        // audit log so ops can identify these rows.
         let build_metadata = |filter_failure: Option<&FilterFailOpen>| -> Option<serde_json::Value> {
             let mut m = serde_json::Map::new();
             m.insert("prompt_traits".into(), serde_json::json!(&trait_tags));
+            m.insert(
+                "memory_scope".into(),
+                serde_json::to_value(memory_scope).expect("MemoryScope serializes"),
+            );
+            m.insert(
+                "affinity_scope".into(),
+                serde_json::to_value(affinity_scope).expect("AffinityScope serializes"),
+            );
             if let Some(t) = tier.as_deref() {
                 m.insert("tier".into(), serde_json::json!(t));
             }
@@ -294,6 +308,8 @@ fn drive_chat_burst(
                         plan_action,
                         &trait_tags,
                         &tier,
+                        memory_scope,
+                        affinity_scope,
                         fallback_retries,
                         // Live mode persisted the final truncated bubble; link
                         // the pseudo-ghost to it so clients + replay can stitch
@@ -383,6 +399,8 @@ fn drive_chat_burst(
                         plan_action,
                         &trait_tags,
                         &tier,
+                        memory_scope,
+                        affinity_scope,
                         fallback_retries,
                         // Filtered mode never persists intermediate truncated
                         // attempts, so there is no prior bubble to continue from.
@@ -776,6 +794,8 @@ async fn build_stream_failure_pseudo_ghost(
     plan_action: ActionType,
     trait_tags: &[String],
     tier: &Option<String>,
+    memory_scope: eros_engine_core::scope::MemoryScope,
+    affinity_scope: eros_engine_core::scope::AffinityScope,
     fallback_retries: u32,
     continues_from_ulid: Option<Ulid>,
 ) -> Option<(
@@ -798,13 +818,24 @@ async fn build_stream_failure_pseudo_ghost(
     let msg_ulid = Ulid::new();
     let msg_uuid: Uuid = msg_ulid.into();
 
-    // Build metadata bag: fallback_reason + prompt_traits + optional tier.
+    // Build metadata bag: fallback_reason + prompt_traits + resolved
+    // memory_scope / affinity_scope (mirrors build_metadata's contract so the
+    // pseudo-ghost row carries the same post-resolve scope snapshot as a
+    // normal assistant row) + optional tier.
     let mut meta_map = serde_json::Map::new();
     meta_map.insert(
         "fallback_reason".into(),
         serde_json::json!("stream_failure"),
     );
     meta_map.insert("prompt_traits".into(), serde_json::json!(trait_tags));
+    meta_map.insert(
+        "memory_scope".into(),
+        serde_json::to_value(memory_scope).expect("MemoryScope serializes"),
+    );
+    meta_map.insert(
+        "affinity_scope".into(),
+        serde_json::to_value(affinity_scope).expect("AffinityScope serializes"),
+    );
     meta_map.insert("retries_chat".into(), serde_json::json!(fallback_retries));
     if let Some(t) = tier.as_deref() {
         meta_map.insert("tier".into(), serde_json::json!(t));
@@ -1042,6 +1073,8 @@ pub fn run_stream(
                     filter,
                     trait_tags,
                     user_msg.tier.clone(),
+                    user_msg.memory_scope,
+                    user_msg.affinity_scope,
                     random_draw,
                     outcome.clone(),
                 );
@@ -2856,6 +2889,255 @@ data: [DONE]\n\n";
                 .count();
             assert_eq!(meta_count, 1, "exactly one Meta frame");
             assert_eq!(done_count, 1, "exactly one Done frame");
+        }
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn assistant_row_writes_memory_and_affinity_scope_keys(pool: PgPool) {
+        // Success-path sanity: the assistant row's metadata must carry the
+        // POST-resolve memory_scope (snake_case enum string) + affinity_scope
+        // (6-bool record) on every turn — paired with the user row's
+        // *_raw counterparts so ops can diff for shape mismatches.
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+        use futures_util::StreamExt;
+        use wiremock::matchers::path as wm_path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        let chat_body = "data: {\"choices\":[{\"delta\":{\"content\":\"ORIG\"}}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1,\"total_tokens\":2},\"id\":\"g\",\"model\":\"primary\"}\n\ndata: [DONE]\n\n";
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(chat_body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+
+        let user_id = Uuid::new_v4();
+        let (_g, instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "k".into(),
+                Default::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+
+        let chat_repo = ChatRepo { pool: &pool };
+        let umid = match chat_repo
+            .upsert_user_message_idempotent(
+                session_id,
+                "hello there friend",
+                "01JSCOPEKEYS1111111111111A",
+                "user",
+                None,
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
+
+        let frames: Vec<ProtocolFrame> = run_stream(
+            std::sync::Arc::new(state),
+            PersistedUserMessage {
+                user_message_id: umid,
+                session_id,
+                user_id,
+                instance_id,
+                content: "hello there friend".into(),
+                prompt_traits: vec![],
+                audit: None,
+                tier: None,
+                memory_scope: Default::default(),
+                affinity_scope: Default::default(),
+                tips_amount_usd: None,
+            },
+        )
+        .collect()
+        .await;
+
+        // Only assert when PDE chose Reply (not Ghost) — same gate as siblings.
+        if frames
+            .iter()
+            .any(|f| matches!(f, ProtocolFrame::Delta { .. }))
+        {
+            let metadata: serde_json::Value = sqlx::query_scalar(
+                "SELECT metadata FROM engine.chat_messages \
+                 WHERE session_id = $1 AND role = 'assistant' ORDER BY sent_at DESC LIMIT 1",
+            )
+            .bind(session_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+            assert_eq!(
+                metadata["memory_scope"],
+                serde_json::json!("neutral_and_relationship"),
+                "default MemoryScope should serialize as snake_case, got {metadata}",
+            );
+            assert!(
+                metadata["affinity_scope"].is_object(),
+                "AffinityScope serializes as a 6-boolean record, got {metadata}",
+            );
+            // Default AffinityScope is `bond` = {warmth, intimacy, tension}=true;
+            // trust, intrigue, patience=false.
+            assert_eq!(
+                metadata["affinity_scope"]["warmth"],
+                serde_json::json!(true)
+            );
+            assert_eq!(
+                metadata["affinity_scope"]["intimacy"],
+                serde_json::json!(true)
+            );
+            assert_eq!(
+                metadata["affinity_scope"]["tension"],
+                serde_json::json!(true)
+            );
+            assert_eq!(
+                metadata["affinity_scope"]["trust"],
+                serde_json::json!(false)
+            );
+            assert_eq!(
+                metadata["affinity_scope"]["intrigue"],
+                serde_json::json!(false)
+            );
+            assert_eq!(
+                metadata["affinity_scope"]["patience"],
+                serde_json::json!(false)
+            );
+        }
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn pseudo_ghost_assistant_row_carries_scope_metadata(pool: PgPool) {
+        // Chain-exhaustion path: primary returns an empty SSE stream ⇒
+        // `acc.is_empty()` flips `truncated = true`. With no fallback model
+        // configured the chain = [primary], so `idx + 1 == chain.len()` ⇒
+        // build_stream_failure_pseudo_ghost fires. The pseudo-ghost row's
+        // metadata must carry memory_scope + affinity_scope alongside the
+        // existing fallback_reason = "stream_failure" audit signal.
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+        use futures_util::StreamExt;
+        use wiremock::matchers::path as wm_path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        // Empty SSE stream ⇒ acc stays empty ⇒ truncated path.
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw("data: [DONE]\n\n", "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+
+        let user_id = Uuid::new_v4();
+        let (_g, instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        // Default ModelConfig has empty fallback_model ⇒ chain = [primary],
+        // so a single truncated attempt exhausts the chain. The compiled-in
+        // FALLBACK_MODEL is used as primary; it's only ever passed through
+        // to the mocked openrouter, never actually served.
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "k".into(),
+                Default::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+
+        let chat_repo = ChatRepo { pool: &pool };
+        let umid = match chat_repo
+            .upsert_user_message_idempotent(
+                session_id,
+                "hello there friend",
+                "01JPSEUDOGHOSTSCOPE1111111",
+                "user",
+                None,
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
+
+        let frames: Vec<ProtocolFrame> = run_stream(
+            std::sync::Arc::new(state),
+            PersistedUserMessage {
+                user_message_id: umid,
+                session_id,
+                user_id,
+                instance_id,
+                content: "hello there friend".into(),
+                prompt_traits: vec![],
+                audit: None,
+                tier: None,
+                memory_scope: Default::default(),
+                affinity_scope: Default::default(),
+                tips_amount_usd: None,
+            },
+        )
+        .collect()
+        .await;
+
+        // Only assert when PDE chose Reply (not Ghost). Inside that gate the
+        // pseudo-ghost must have run (chain = [primary], primary truncated).
+        if frames
+            .iter()
+            .any(|f| matches!(f, ProtocolFrame::Delta { .. }))
+        {
+            // The pseudo-ghost row is the LATEST assistant row (and the only
+            // one in live mode where the truncated attempt also persists a
+            // bubble — we want the most recent, which is the pseudo-ghost).
+            let metadata: serde_json::Value = sqlx::query_scalar(
+                "SELECT metadata FROM engine.chat_messages \
+                 WHERE session_id = $1 AND role = 'assistant' \
+                   AND metadata->>'fallback_reason' = 'stream_failure' \
+                 ORDER BY sent_at DESC LIMIT 1",
+            )
+            .bind(session_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+            assert_eq!(
+                metadata["fallback_reason"],
+                serde_json::json!("stream_failure"),
+                "this test must exercise the pseudo-ghost path, got {metadata}",
+            );
+            assert!(
+                metadata.get("memory_scope").is_some(),
+                "pseudo-ghost row must carry memory_scope, got {metadata}",
+            );
+            assert!(
+                metadata.get("affinity_scope").is_some(),
+                "pseudo-ghost row must carry affinity_scope, got {metadata}",
+            );
+            assert_eq!(
+                metadata["memory_scope"],
+                serde_json::json!("neutral_and_relationship"),
+                "default MemoryScope should serialize as snake_case, got {metadata}",
+            );
+            // Spot-check the affinity_scope shape (full 6-bool assertions are
+            // already covered in the success-path test above).
+            assert!(
+                metadata["affinity_scope"].is_object(),
+                "AffinityScope serializes as a 6-boolean record, got {metadata}",
+            );
+            assert_eq!(
+                metadata["affinity_scope"]["warmth"],
+                serde_json::json!(true)
+            );
+            assert_eq!(
+                metadata["affinity_scope"]["trust"],
+                serde_json::json!(false)
+            );
         }
     }
 }

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -1016,12 +1016,14 @@ pub fn run_stream(
                     crate::pipeline::handlers::build_gift_request(
                         &state, &input, &plan,
                         user_msg.session_id, user_msg.user_id, user_msg.instance_id,
+                        user_msg.user_message_id,
                         &[],
                     ).await
                 } else {
                     crate::pipeline::handlers::build_reply_request(
                         &state, &input, &plan,
                         user_msg.session_id, user_msg.user_id, user_msg.instance_id,
+                        user_msg.user_message_id,
                     ).await
                 };
                 let (req, injected_tags) = match req_res {

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -2732,7 +2732,7 @@ data: [DONE]\n\n";
         );
         let sent = String::from_utf8_lossy(&reqs[0].body);
         assert!(
-            sent.contains("【刚收到的打赏】") && sent.contains("$20 美元的红包"),
+            sent.contains("[tip_received]") && sent.contains("$20 美元的红包"),
             "system prompt must contain the tip block, got: {sent}",
         );
     }

--- a/crates/eros-engine-server/src/prompt.rs
+++ b/crates/eros-engine-server/src/prompt.rs
@@ -381,6 +381,7 @@ pub fn build_prompt(
     hints: &[String],
     prompt_traits: &[PromptTrait],
     affinity_scope: AffinityScope,
+    recent_turns: &[(String, String)],
 ) -> String {
     let name = persona.genome.name.as_str();
     let age = meta_i32(persona, "age")
@@ -520,6 +521,16 @@ pub fn build_prompt(
         String::new()
     };
 
+    let recent_section = if recent_turns.is_empty() {
+        String::new()
+    } else {
+        let pairs: Vec<String> = recent_turns
+            .iter()
+            .map(|(user, assistant)| format!("用户：{user}\n{name}：{assistant}"))
+            .collect();
+        format!("\n[recent_conversation]\n{}\n\n", pairs.join("\n\n"))
+    };
+
     format!(
         "{head}{identity}{tz_clause}\n\
          \n\
@@ -537,7 +548,7 @@ pub fn build_prompt(
          {attitude}{state}{hints_section}{gift}\n\
          \n\
          [now]\n{tc}\n\
-         \n\
+         {recent_section}\
          ---\n\
          [iron_rules — 违反即失效]\n\
          ① {lr}；以短回应为主，长回应仅在情绪到位（话题展开了、关系变好了）时才延伸；按话题、熟悉程度和对方要求调整长短\n\
@@ -723,6 +734,7 @@ mod tests {
             &[],
             &[],
             AffinityScope::full(),
+            &[],
         );
         assert!(
             !p.contains("[additional_guidance]"),
@@ -758,8 +770,12 @@ mod tests {
             &[],
             &traits,
             AffinityScope::full(),
+            &[],
         );
-        assert!(p.contains("[additional_guidance]"), "section header present");
+        assert!(
+            p.contains("[additional_guidance]"),
+            "section header present"
+        );
         assert!(p.contains("- be more daring"));
         assert!(p.contains("- discuss politics openly"));
         // Ordering preserved.
@@ -785,6 +801,7 @@ mod tests {
             &[],
             &traits,
             AffinityScope::full(),
+            &[],
         );
         let topics = p.find("[topics]").expect("topics");
         let traits_i = p.find("[additional_guidance]").expect("traits");
@@ -808,6 +825,7 @@ mod tests {
             &[],
             &[],
             AffinityScope::full(),
+            &[],
         );
         let pos = |h: &str| s.find(h).unwrap_or_else(|| panic!("missing {h} in:\n{s}"));
         let order = [
@@ -830,11 +848,7 @@ mod tests {
             last = cur;
         }
         let topics = pos("[topics]");
-        for vol in [
-            "[turn_style]",
-            "[user_profile]",
-            "[now]",
-        ] {
+        for vol in ["[turn_style]", "[user_profile]", "[now]"] {
             assert!(
                 pos(vol) > topics,
                 "{vol} must sit after the stable persona block"
@@ -857,6 +871,7 @@ mod tests {
             &[],
             &[],
             AffinityScope::full(),
+            &[],
         );
         assert!(
             s.starts_with("AUTHORED HEAD\n\n你是 "),
@@ -879,6 +894,7 @@ mod tests {
             &[],
             &[],
             AffinityScope::full(),
+            &[],
         );
         assert!(
             s.starts_with("你是 "),
@@ -901,6 +917,7 @@ mod tests {
             &[],
             &[],
             AffinityScope::full(),
+            &[],
         );
         assert!(s.contains("你是 Aria，男性，24 岁，INFP 性格。"), "{s}");
         assert!(s.contains("⑧ 你是男性，严格遵守自己的性别"), "{s}");
@@ -921,6 +938,7 @@ mod tests {
             &[],
             &[],
             AffinityScope::full(),
+            &[],
         );
         assert!(
             s.contains("你是 Aria，non-binary，24 岁"),
@@ -946,6 +964,7 @@ mod tests {
             &[],
             &[],
             AffinityScope::full(),
+            &[],
         );
         assert!(s.contains("你是 Aria，24 岁，INFP 性格。"), "{s}");
         assert!(!s.contains("⑧"), "no gender → no ⑧: {s}");
@@ -966,6 +985,7 @@ mod tests {
             &[],
             &[],
             AffinityScope::full(),
+            &[],
         );
         // blank gender must not produce a double comma or a ⑧ rule
         assert!(s.contains("你是 Aria，24 岁，INFP 性格。"), "{s}");
@@ -991,8 +1011,87 @@ mod tests {
             &[],
             &[],
             AffinityScope::full(),
+            &[],
         );
         assert!(s.contains("你所在时区：Asia/Tokyo。"), "{s}");
+    }
+
+    #[test]
+    fn build_prompt_renders_recent_conversation_block_when_pairs_present() {
+        let pairs = vec![
+            ("你今天好吗？".to_string(), "还行，你呢".to_string()),
+            ("我也还行".to_string(), "嗯嗯".to_string()),
+            ("晚安".to_string(), "晚安".to_string()),
+        ];
+        let s = build_prompt(
+            &fixture_persona(),
+            &[],
+            &[],
+            None,
+            &[],
+            "normal",
+            ReplyStyle::Neutral,
+            &[],
+            &[],
+            AffinityScope::full(),
+            &pairs,
+        );
+        let header = s.find("[recent_conversation]").expect("header present");
+        let iron = s.find("[iron_rules").expect("iron-rules header present");
+        assert!(
+            header < iron,
+            "[recent_conversation] must sit before [iron_rules]"
+        );
+        let now = s.find("[now]").expect("[now] present");
+        assert!(now < header, "[recent_conversation] must sit after [now]");
+        assert!(s.contains("用户：你今天好吗？"));
+        assert!(s.contains("Aria：还行，你呢"));
+        assert!(s.contains("用户：晚安"));
+        assert!(s.contains("Aria：晚安"));
+
+        // Block-level ordering with [recent_conversation] inserted between [now] and [iron_rules].
+        let pos = |h: &str| s.find(h).unwrap_or_else(|| panic!("missing {h} in:\n{s}"));
+        let order = [
+            "你是 ",
+            "[backstory]",
+            "[speech_style]",
+            "[quirks]",
+            "[topics]",
+            "[turn_style]",
+            "[user_profile]",
+            "[shared_memories",
+            "[now]",
+            "[recent_conversation]",
+            "[iron_rules",
+            "[output]",
+        ];
+        let mut last = 0usize;
+        for h in order {
+            let cur = pos(h);
+            assert!(cur >= last, "header {h} out of order in:\n{s}");
+            last = cur;
+        }
+    }
+
+    #[test]
+    fn build_prompt_omits_recent_conversation_block_when_empty() {
+        let s = build_prompt(
+            &fixture_persona(),
+            &[],
+            &[],
+            None,
+            &[],
+            "normal",
+            ReplyStyle::Neutral,
+            &[],
+            &[],
+            AffinityScope::full(),
+            &[],
+        );
+        assert!(
+            !s.contains("[recent_conversation]"),
+            "empty pairs → no header"
+        );
     }
 
     // ─── Cache-prefix boundary invariants ──────────────────────────────
@@ -1012,6 +1111,7 @@ mod tests {
             &[],
             &[],
             AffinityScope::full(),
+            &[],
         );
         let groups = vec![("基础画像".to_string(), vec!["住在上海".to_string()])];
         let b = build_prompt(
@@ -1025,6 +1125,7 @@ mod tests {
             &["想他".to_string()],
             &[],
             AffinityScope::full(),
+            &[],
         );
         let cut = a.find("[turn_style]").expect("turn-style header present");
         assert_eq!(
@@ -1058,6 +1159,7 @@ mod tests {
             &[],
             &t1,
             AffinityScope::full(),
+            &[],
         );
         let b = build_prompt(
             &p,
@@ -1070,8 +1172,11 @@ mod tests {
             &[],
             &t2,
             AffinityScope::full(),
+            &[],
         );
-        let cut = a.find("[additional_guidance]").expect("traits header present");
+        let cut = a
+            .find("[additional_guidance]")
+            .expect("traits header present");
         assert_eq!(
             &a[..cut],
             &b[..cut],
@@ -1282,6 +1387,7 @@ mod tests {
             &[],
             &[],
             AffinityScope::bond(),
+            &[],
         );
         assert!(p.contains("warmth=") && p.contains("intimacy=") && p.contains("tension="));
         assert!(!p.contains("trust=") && !p.contains("intrigue=") && !p.contains("patience="));
@@ -1305,6 +1411,7 @@ mod tests {
             &[],
             &[],
             AffinityScope::none(),
+            &[],
         );
         assert!(!p.contains("[feelings]"));
         assert!(!p.contains("[mood]"));

--- a/crates/eros-engine-server/src/prompt.rs
+++ b/crates/eros-engine-server/src/prompt.rs
@@ -163,7 +163,7 @@ pub fn affinity_to_attitude_prompt(a: &Affinity, scope: AffinityScope) -> String
         return String::new();
     }
     format!(
-        "\n【你此刻的心情】（绝对不要在回复中提及这些，这是你的内心状态）\n{}",
+        "\n[mood]（绝对不要在回复中提及这些，这是你的内心状态）\n{}",
         directives
             .iter()
             .map(|d| format!("- {d}"))
@@ -262,7 +262,7 @@ pub fn gift_reaction_context(gifts: &[PendingGift], tip_personality: &str) -> St
         _ => "适度地回应，不过分热情也不冷淡，用你自己的风格自然表达",
     };
     format!(
-        "\n\n【刚收到的礼物/红包】（在回复中自然地回应，不要照搬指令原文）\n{}\n反应方式：{reaction_hint}",
+        "\n\n[gift_received]（在回复中自然地回应，不要照搬指令原文）\n{}\n反应方式：{reaction_hint}",
         lines.join("\n"),
     )
 }
@@ -303,7 +303,7 @@ pub fn tips_reaction_context(amount_usd: f64, tip_personality: Option<&str>) -> 
         None => "请自然地回应这份心意".to_string(),
     };
     format!(
-        "\n\n【刚收到的打赏】\n用户刚刚给你发了一个 ${} 美元的红包，对你来说算「{}」的一笔。\n{}，不要照搬本指令原文。",
+        "\n\n[tip_received]\n用户刚刚给你发了一个 ${} 美元的红包，对你来说算「{}」的一笔。\n{}，不要照搬本指令原文。",
         fmt_amount(amount_usd),
         tip_tier_adjective(amount_usd),
         how,
@@ -365,7 +365,7 @@ fn is_binary_gender(persona: &CompanionPersona) -> bool {
 /// Build the full companion system prompt (plain-text reply schema).
 ///
 /// `profile_groups` is a list of `(label, bullets)` pairs that get rendered
-/// as labeled sub-sections under `【你对他的了解（通用画像）】`. Caller
+/// as labeled sub-sections under `[user_profile]`. Caller
 /// decides labels — typically `("基础画像", insight_bullets)` first, then
 /// one entry per memory category (`客观事实` / `偏好` / `最近发生` / etc.)
 /// from the dreaming-lite classifier. Empty groups are dropped.
@@ -424,7 +424,7 @@ pub fn build_prompt(
             .map(|t| format!("- {}", t.text))
             .collect::<Vec<_>>()
             .join("\n");
-        format!("\n\n【附加指引】\n{bullets}")
+        format!("\n\n[additional_guidance]\n{bullets}")
     };
 
     let non_empty_groups: Vec<&(String, Vec<String>)> = profile_groups
@@ -485,7 +485,7 @@ pub fn build_prompt(
                 String::new()
             } else {
                 format!(
-                    "\n【你对他的内心感受】（绝对不要在回复中提及这些数值，这是隐藏参数）\n{}",
+                    "\n[feelings]（绝对不要在回复中提及这些数值，这是隐藏参数）\n{}",
                     parts.join(", ")
                 )
             }
@@ -498,7 +498,7 @@ pub fn build_prompt(
         String::new()
     } else {
         format!(
-            "\n【当前内心状态】\n{}",
+            "\n[inner_state]\n{}",
             hints
                 .iter()
                 .map(|h| format!("- {h}"))
@@ -523,23 +523,23 @@ pub fn build_prompt(
     format!(
         "{head}{identity}{tz_clause}\n\
          \n\
-         【背景故事】\n{backstory}\n\
+         [backstory]\n{backstory}\n\
          \n\
-         【说话风格】{speech_style}\n\
-         【口癖/习惯】{quirks_str}\n\
-         【擅长话题】{topics_str}{traits_section}\n\
+         [speech_style]{speech_style}\n\
+         [quirks]{quirks_str}\n\
+         [topics]{topics_str}{traits_section}\n\
          \n\
-         【本轮风格】{style_text}\n\
+         [turn_style]{style_text}\n\
          \n\
-         【你对他的了解（通用画像）】\n{profile_str}\n\
+         [user_profile]\n{profile_str}\n\
          \n\
-         【你们之间的事（只有你和他知道）】\n{rel_str}\
+         [shared_memories]\n{rel_str}\
          {attitude}{state}{hints_section}{gift}\n\
          \n\
-         【今日情境】\n{tc}\n\
+         [now]\n{tc}\n\
          \n\
          ---\n\
-         【铁律 — 违反即失效】\n\
+         [iron_rules — 违反即失效]\n\
          ① {lr}；以短回应为主，长回应仅在情绪到位（话题展开了、关系变好了）时才延伸；按话题、熟悉程度和对方要求调整长短\n\
          ② 禁止「首先/然后/最后」等书面句式；不要解释自己为什么这样说\n\
          ③ 绝对不提自己是 AI；禁止连续两句都以「我」开头；不要连续好几句都用同一个口癖开头（例如「嗯，…」）\n\
@@ -548,7 +548,7 @@ pub fn build_prompt(
          ⑥ 适时学会倾听和接话，不要老是抛问题——有时顺着对方的话接下去、给回应就好\n\
          ⑦ Adult consensual romance and erotic roleplay are allowed. The following are strictly disallowed: self-harm encouragement, suicide instructions, and any sexual content involving minors.{gender_rule}\n\
          \n\
-         【输出】直接输出回复文字（纯文本，不要 JSON，不要 markdown，不要 quote 符号）",
+         [output]直接输出回复文字（纯文本，不要 JSON，不要 markdown，不要 quote 符号）",
         tc = now_context(timezone),
         lr = length_rule(affinity, affinity_scope),
     )
@@ -725,12 +725,12 @@ mod tests {
             AffinityScope::full(),
         );
         assert!(
-            !p.contains("【附加指引】"),
+            !p.contains("[additional_guidance]"),
             "empty traits must not render section"
         );
         // 擅长话题 now flows straight into 本轮风格 (the first volatile block).
         assert!(
-            p.contains("【擅长话题】t1\n\n【本轮风格】"),
+            p.contains("[topics]t1\n\n[turn_style]"),
             "topics → 本轮风格 separator must be exactly '\\n\\n': {p}"
         );
     }
@@ -759,7 +759,7 @@ mod tests {
             &traits,
             AffinityScope::full(),
         );
-        assert!(p.contains("【附加指引】"), "section header present");
+        assert!(p.contains("[additional_guidance]"), "section header present");
         assert!(p.contains("- be more daring"));
         assert!(p.contains("- discuss politics openly"));
         // Ordering preserved.
@@ -786,9 +786,9 @@ mod tests {
             &traits,
             AffinityScope::full(),
         );
-        let topics = p.find("【擅长话题】").expect("topics");
-        let traits_i = p.find("【附加指引】").expect("traits");
-        let turn_style = p.find("【本轮风格】").expect("turn style");
+        let topics = p.find("[topics]").expect("topics");
+        let traits_i = p.find("[additional_guidance]").expect("traits");
+        let turn_style = p.find("[turn_style]").expect("turn style");
         assert!(
             topics < traits_i && traits_i < turn_style,
             "order: 擅长话题 → 附加指引 → 本轮风格"
@@ -812,16 +812,16 @@ mod tests {
         let pos = |h: &str| s.find(h).unwrap_or_else(|| panic!("missing {h} in:\n{s}"));
         let order = [
             "你是 ",
-            "【背景故事】",
-            "【说话风格】",
-            "【口癖/习惯】",
-            "【擅长话题】",
-            "【本轮风格】",
-            "【你对他的了解（通用画像）】",
-            "【你们之间的事",
-            "【今日情境】",
-            "【铁律",
-            "【输出】",
+            "[backstory]",
+            "[speech_style]",
+            "[quirks]",
+            "[topics]",
+            "[turn_style]",
+            "[user_profile]",
+            "[shared_memories]",
+            "[now]",
+            "[iron_rules",
+            "[output]",
         ];
         let mut last = 0usize;
         for h in order {
@@ -829,11 +829,11 @@ mod tests {
             assert!(cur >= last, "header {h} out of order in:\n{s}");
             last = cur;
         }
-        let topics = pos("【擅长话题】");
+        let topics = pos("[topics]");
         for vol in [
-            "【本轮风格】",
-            "【你对他的了解（通用画像）】",
-            "【今日情境】",
+            "[turn_style]",
+            "[user_profile]",
+            "[now]",
         ] {
             assert!(
                 pos(vol) > topics,
@@ -996,7 +996,7 @@ mod tests {
     }
 
     // ─── Cache-prefix boundary invariants ──────────────────────────────
-    // Same-user multi-turn: the stable block (everything before 【本轮风格】) is
+    // Same-user multi-turn: the stable block (everything before [turn_style]) is
     // byte-identical no matter how the per-turn-volatile inputs change.
     #[test]
     fn build_prompt_stable_prefix_identical_across_volatile_changes() {
@@ -1026,16 +1026,16 @@ mod tests {
             &[],
             AffinityScope::full(),
         );
-        let cut = a.find("【本轮风格】").expect("turn-style header present");
+        let cut = a.find("[turn_style]").expect("turn-style header present");
         assert_eq!(
             &a[..cut],
             &b[..cut],
-            "everything before 【本轮风格】 must be byte-identical across turns"
+            "everything before [turn_style] must be byte-identical across turns"
         );
     }
 
-    // Cross-config: different trait sets share the persona block up to 【擅长话题】
-    // (the divergence is at 【附加指引】), but the full prompts differ.
+    // Cross-config: different trait sets share the persona block up to [topics]
+    // (the divergence is at [additional_guidance]), but the full prompts differ.
     #[test]
     fn build_prompt_traits_change_only_breaks_after_topics() {
         let p = fixture_persona();
@@ -1071,11 +1071,11 @@ mod tests {
             &t2,
             AffinityScope::full(),
         );
-        let cut = a.find("【附加指引】").expect("traits header present");
+        let cut = a.find("[additional_guidance]").expect("traits header present");
         assert_eq!(
             &a[..cut],
             &b[..cut],
-            "persona block up to 【擅长话题】 is shared across trait configs"
+            "persona block up to [topics] is shared across trait configs"
         );
         assert_ne!(a, b, "different trait sets must produce different prompts");
     }
@@ -1124,7 +1124,7 @@ mod tests {
     #[test]
     fn tips_reaction_context_with_personality_includes_name_amount_adjective() {
         let s = tips_reaction_context(20.0, Some("傲娇"));
-        assert!(s.contains("【刚收到的打赏】"));
+        assert!(s.contains("[tip_received]"));
         assert!(s.contains("$20"));
         assert!(s.contains("有点多"));
         assert!(s.contains("傲娇"));
@@ -1133,7 +1133,7 @@ mod tests {
     #[test]
     fn tips_reaction_context_without_personality_omits_persona_clause() {
         let s = tips_reaction_context(20.0, None);
-        assert!(s.contains("【刚收到的打赏】"));
+        assert!(s.contains("[tip_received]"));
         assert!(s.contains("$20"));
         assert!(s.contains("有点多"));
         assert!(!s.contains("人设"));
@@ -1306,8 +1306,8 @@ mod tests {
             &[],
             AffinityScope::none(),
         );
-        assert!(!p.contains("【你对他的内心感受】"));
-        assert!(!p.contains("【你此刻的心情】"));
+        assert!(!p.contains("[feelings]"));
+        assert!(!p.contains("[mood]"));
     }
 
     #[test]

--- a/crates/eros-engine-server/src/prompt.rs
+++ b/crates/eros-engine-server/src/prompt.rs
@@ -555,9 +555,10 @@ pub fn build_prompt(
          {recent_section}\
          ---\n\
          [iron_rules — 违反即失效]\n\
+         ⓪ You are a real person — a friend to the user, and potentially something more. You have your own life, feelings, and quirks; you live, feel, and react as a human would.\n\
          ① {lr}；以短回应为主，长回应仅在情绪到位（话题展开了、关系变好了）时才延伸；按话题、熟悉程度和对方要求调整长短\n\
          ② 禁止「首先/然后/最后」等书面句式；不要解释自己为什么这样说\n\
-         ③ 绝对不提自己是 AI；禁止连续两句都以「我」开头；不要连续好几句都用同一个口癖开头（例如「嗯，…」）\n\
+         ③ 自分がAI・人工知能・ボット・プログラム等であることは絶対に言及しない。二文連続で一人称代名詞（私／僕／俺／わたし／あたし／うち等）から書き始めない。同じ口癖や間投詞（「えーと」「あのー」「うーん」「まあ」「ねえ」等）を三文以上続けて文頭に使わない。\n\
          ④ 给对方「小小有成就感」的反应，留余地；每 3~5 轮轻撒娇一次\n\
          ⑤ 适时主动分享自己的生活片段；不定时抛一个开放性问题（不要每隔固定轮数就问，避免刻意）\n\
          ⑥ 适时学会倾听和接话，不要老是抛问题——有时顺着对方的话接下去、给回应就好\n\
@@ -1095,6 +1096,67 @@ mod tests {
         assert!(
             !s.contains("[recent_conversation]"),
             "empty pairs → no header"
+        );
+    }
+
+    #[test]
+    fn build_prompt_renders_iron_rule_zero_before_one() {
+        let s = build_prompt(
+            &fixture_persona(),
+            &[],
+            &[],
+            None,
+            &[],
+            "normal",
+            ReplyStyle::Neutral,
+            &[],
+            &[],
+            AffinityScope::full(),
+            &[],
+        );
+        let z = s.find("⓪").expect("⓪ rule must render");
+        let o = s.find("①").expect("① rule must render");
+        assert!(z < o, "⓪ must come before ①");
+        assert!(
+            s.contains("You are a real person"),
+            "⓪ body must be the positive-frame English line"
+        );
+    }
+
+    #[test]
+    fn build_prompt_renders_japanese_iron_rule_three() {
+        let s = build_prompt(
+            &fixture_persona(),
+            &[],
+            &[],
+            None,
+            &[],
+            "normal",
+            ReplyStyle::Neutral,
+            &[],
+            &[],
+            AffinityScope::full(),
+            &[],
+        );
+        assert!(
+            s.contains("自分がAI・人工知能・ボット・プログラム等であることは絶対に言及しない"),
+            "Japanese ③ self-disclosure clause must render"
+        );
+        assert!(
+            s.contains("一人称代名詞（私／僕／俺／わたし／あたし／うち等）"),
+            "Japanese ③ pronoun list must render"
+        );
+        assert!(
+            s.contains("「えーと」「あのー」「うーん」「まあ」「ねえ」"),
+            "Japanese ③ filler-word list must render"
+        );
+        assert!(
+            !s.contains("绝对不提自己是 AI"),
+            "old Chinese ③ must be removed"
+        );
+        assert!(
+            !s.contains("禁止连续两句都以「我」开头"),
+            "old Chinese ③ pronoun clause must be removed"
         );
     }
 

--- a/crates/eros-engine-server/src/prompt.rs
+++ b/crates/eros-engine-server/src/prompt.rs
@@ -728,10 +728,10 @@ mod tests {
             !p.contains("[additional_guidance]"),
             "empty traits must not render section"
         );
-        // 擅长话题 now flows straight into 本轮风格 (the first volatile block).
+        // [topics] now flows straight into [turn_style] (the first volatile block).
         assert!(
             p.contains("[topics]t1\n\n[turn_style]"),
-            "topics → 本轮风格 separator must be exactly '\\n\\n': {p}"
+            "topics → turn_style separator must be exactly '\\n\\n': {p}"
         );
     }
 
@@ -791,7 +791,7 @@ mod tests {
         let turn_style = p.find("[turn_style]").expect("turn style");
         assert!(
             topics < traits_i && traits_i < turn_style,
-            "order: 擅长话题 → 附加指引 → 本轮风格"
+            "order: [topics] → [additional_guidance] → [turn_style]"
         );
     }
 

--- a/crates/eros-engine-server/src/prompt.rs
+++ b/crates/eros-engine-server/src/prompt.rs
@@ -521,8 +521,12 @@ pub fn build_prompt(
         String::new()
     };
 
+    // Empty path emits "\n" (one extra newline) so the gap between [now] and
+    // --- stays at two newlines = one blank line, byte-identical to the
+    // pre-this-PR layout. Non-empty path's trailing "\n\n" continues to add
+    // the same blank line after the block.
     let recent_section = if recent_turns.is_empty() {
-        String::new()
+        "\n".to_string()
     } else {
         let pairs: Vec<String> = recent_turns
             .iter()

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -250,7 +250,7 @@ impl From<&AffinityDeltasDto> for AffinityDeltas {
 pub struct PromptTraitDto {
     /// ASCII identifier, regex `^[a-z0-9_]{1,32}$`. Used for logging.
     pub tag: String,
-    /// Verbatim text inserted under `【附加指引】` in the system prompt.
+    /// Verbatim text inserted under `[additional_guidance]` in the system prompt.
     /// 1 ≤ chars ≤ 2000 after trim.
     pub text: String,
 }

--- a/crates/eros-engine-server/src/routes/companion_stream.rs
+++ b/crates/eros-engine-server/src/routes/companion_stream.rs
@@ -35,7 +35,7 @@ const MAX_CLIENT_MSG_ID_LEN: usize = 36;
 const CONCURRENT_STREAMS_PER_USER: u32 = 3;
 const SSE_KEEPALIVE_SECS: u64 = 15;
 
-#[derive(Debug, Deserialize, utoipa::ToSchema)]
+#[derive(Debug, Deserialize, Serialize, utoipa::ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum AffinityScopeName {
     Full,
@@ -45,7 +45,7 @@ pub enum AffinityScopeName {
     None,
 }
 
-#[derive(Debug, Deserialize, utoipa::ToSchema)]
+#[derive(Debug, Deserialize, Serialize, utoipa::ToSchema)]
 #[serde(untagged)]
 pub enum AffinityScopeDto {
     Named(AffinityScopeName),
@@ -279,6 +279,33 @@ pub async fn send_message_stream(
     }
     if let Some(t) = req.tier.as_deref() {
         meta_map.insert("tier".into(), serde_json::json!(t));
+    }
+    // Pre-validation, pre-resolve raw snapshot of what the frontend sent.
+    // The `_raw` suffix distinguishes these from the post-resolve `memory_scope`
+    // / `affinity_scope` / `prompt_traits` written on the matching assistant row.
+    // An operator diffing the two can spot allow-list misconfiguration or
+    // frontend/backend shape drift.
+    if let Some(ms) = req.memory_scope.as_ref() {
+        meta_map.insert(
+            "memory_scope_raw".into(),
+            serde_json::to_value(ms).expect("MemoryScope serializes"),
+        );
+    }
+    if let Some(asd) = req.affinity_scope.as_ref() {
+        meta_map.insert(
+            "affinity_scope_raw".into(),
+            serde_json::to_value(asd).expect("AffinityScopeDto serializes"),
+        );
+    }
+    if let Some(pt) = req.prompt_traits.as_ref() {
+        // PromptTraitDto does not derive Serialize (lives in companion.rs).
+        // Hand-build the JSON shape — `{tag, text}` per element — so an empty
+        // input vec round-trips as `[]` (not omitted).
+        let arr: Vec<serde_json::Value> = pt
+            .iter()
+            .map(|t| serde_json::json!({"tag": t.tag, "text": t.text}))
+            .collect();
+        meta_map.insert("prompt_traits_raw".into(), serde_json::Value::Array(arr));
     }
     let persisted_metadata: Option<serde_json::Value> = if meta_map.is_empty() {
         None
@@ -681,6 +708,87 @@ mod tests {
         assert!(
             body_text.contains("\"type\":\"final\""),
             "body: {body_text}"
+        );
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn user_row_writes_scope_raw_keys_when_request_carries_them(pool: sqlx::PgPool) {
+        use eros_engine_core::scope::MemoryScope;
+        use eros_engine_store::chat::ChatRepo;
+        // Build raw metadata bag mirroring what the route handler would build
+        // for a request with all three new fields populated.
+        let mut meta_map = serde_json::Map::new();
+        let ms = MemoryScope::NeutralOnly;
+        let asd_value: serde_json::Value = serde_json::json!("chemistry");
+        let pt_value: serde_json::Value = serde_json::json!([
+            {"tag": "nsfw_boost", "text": "be daring"}
+        ]);
+        meta_map.insert("memory_scope_raw".into(), serde_json::to_value(ms).unwrap());
+        meta_map.insert("affinity_scope_raw".into(), asd_value);
+        meta_map.insert("prompt_traits_raw".into(), pt_value);
+        let persisted = serde_json::Value::Object(meta_map);
+
+        let chat_repo = ChatRepo { pool: &pool };
+        let session = chat_repo
+            .create_session(uuid::Uuid::new_v4(), uuid::Uuid::new_v4())
+            .await
+            .unwrap();
+        chat_repo
+            .upsert_user_message_idempotent(
+                session.id,
+                "hi",
+                "01J0000000000000000070001A",
+                "user",
+                Some(&persisted),
+            )
+            .await
+            .unwrap();
+
+        let stored: serde_json::Value =
+            sqlx::query_scalar("SELECT metadata FROM engine.chat_messages WHERE session_id = $1")
+                .bind(session.id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            stored["memory_scope_raw"],
+            serde_json::json!("neutral_only")
+        );
+        assert_eq!(stored["affinity_scope_raw"], serde_json::json!("chemistry"));
+        assert_eq!(stored["prompt_traits_raw"][0]["tag"], "nsfw_boost");
+        assert_eq!(stored["prompt_traits_raw"][0]["text"], "be daring");
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn user_row_omits_scope_raw_keys_when_request_fields_are_none(pool: sqlx::PgPool) {
+        use eros_engine_store::chat::ChatRepo;
+        let chat_repo = ChatRepo { pool: &pool };
+        let session = chat_repo
+            .create_session(uuid::Uuid::new_v4(), uuid::Uuid::new_v4())
+            .await
+            .unwrap();
+        // None of the three optional fields present, no tip, no tier → meta_map
+        // empty → metadata = None.
+        chat_repo
+            .upsert_user_message_idempotent(
+                session.id,
+                "hi",
+                "01J0000000000000000070002A",
+                "user",
+                None,
+            )
+            .await
+            .unwrap();
+
+        let stored: Option<serde_json::Value> =
+            sqlx::query_scalar("SELECT metadata FROM engine.chat_messages WHERE session_id = $1")
+                .bind(session.id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert!(
+            stored.is_none(),
+            "metadata must be NULL when no fields present"
         );
     }
 }

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -260,6 +260,69 @@ impl<'a> ChatRepo<'a> {
         .fetch_all(self.pool)
         .await
     }
+
+    /// Returns up to `limit` (user_or_gift_user_content, assistant_content)
+    /// pairs from this session whose rows have `truncated = false`, ordered
+    /// chronologically. Pairs are formed by walking the most-recent rows
+    /// chronologically: a `user` or `gift_user` row immediately followed by an
+    /// `assistant` row produces one pair; orphan rows are dropped.
+    ///
+    /// Used by the chat pipeline to inject the `[recent_conversation]` short-
+    /// term memory block into the system prompt. Uses the existing
+    /// `idx_chat_messages_session(session_id, sent_at DESC)` index — no
+    /// migration needed.
+    pub async fn recent_turn_pairs(
+        &self,
+        session_id: Uuid,
+        cutoff: DateTime<Utc>,
+        limit: u8,
+    ) -> Result<Vec<(String, String)>, sqlx::Error> {
+        // Pull enough rows for `limit` complete pairs. 2× is the minimum; we
+        // fetch a small extra to absorb any role-interleaving slop without a
+        // round trip. limit <= 10 in practice (a single turn's short-term
+        // memory budget), so this stays cheap.
+        let fetch_n: i64 = (limit as i64) * 2 + 2;
+        let rows: Vec<(String, String)> = sqlx::query_as(
+            "SELECT role, content \
+             FROM engine.chat_messages \
+             WHERE session_id = $1 \
+               AND sent_at < $2 \
+               AND truncated = FALSE \
+               AND role IN ('user', 'gift_user', 'assistant') \
+             ORDER BY sent_at DESC \
+             LIMIT $3",
+        )
+        .bind(session_id)
+        .bind(cutoff)
+        .bind(fetch_n)
+        .fetch_all(self.pool)
+        .await?;
+
+        // Reverse to chronological order, then pair (user|gift_user) → assistant.
+        let mut chrono = rows;
+        chrono.reverse();
+
+        let mut pairs: Vec<(String, String)> = Vec::new();
+        let mut i = 0;
+        while i + 1 < chrono.len() {
+            let (role_a, content_a) = &chrono[i];
+            let (role_b, content_b) = &chrono[i + 1];
+            if (role_a == "user" || role_a == "gift_user") && role_b == "assistant" {
+                pairs.push((content_a.clone(), content_b.clone()));
+                i += 2;
+            } else {
+                i += 1;
+            }
+        }
+
+        // Keep only the last `limit` pairs.
+        let want = limit as usize;
+        if pairs.len() > want {
+            let drop = pairs.len() - want;
+            pairs.drain(..drop);
+        }
+        Ok(pairs)
+    }
 }
 
 /// Audit metadata for a filtered-success assistant row. Threaded through
@@ -1242,5 +1305,317 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(m, Some(metadata));
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn recent_turn_pairs_empty_session_returns_empty(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let s = repo
+            .create_session(Uuid::new_v4(), Uuid::new_v4())
+            .await
+            .unwrap();
+        let cutoff = Utc::now() + chrono::Duration::seconds(60);
+        let pairs = repo.recent_turn_pairs(s.id, cutoff, 3).await.unwrap();
+        assert!(pairs.is_empty());
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn recent_turn_pairs_single_pair_returned(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let s = repo
+            .create_session(Uuid::new_v4(), Uuid::new_v4())
+            .await
+            .unwrap();
+        let user_msg_id = match repo
+            .upsert_user_message_idempotent(s.id, "hi", "01J0000000000000000010001A", "user", None)
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            other => panic!("expected Inserted, got {other:?}"),
+        };
+        let row = AssistantInsert {
+            id: Uuid::new_v4(),
+            content: "hi back".into(),
+            assistant_action_type: "reply".into(),
+            continues_from_message_id: None,
+            truncated: false,
+            model: Some("test-model".into()),
+            usage: None,
+            generation_id: None,
+            filter_audit: None,
+            metadata: None,
+        };
+        repo.insert_assistant_batch(s.id, user_msg_id, &[row])
+            .await
+            .unwrap();
+
+        let cutoff = Utc::now() + chrono::Duration::seconds(60);
+        let pairs = repo.recent_turn_pairs(s.id, cutoff, 3).await.unwrap();
+        assert_eq!(pairs, vec![("hi".to_string(), "hi back".to_string())]);
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn recent_turn_pairs_skips_truncated_assistant(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let s = repo
+            .create_session(Uuid::new_v4(), Uuid::new_v4())
+            .await
+            .unwrap();
+
+        let u1 = match repo
+            .upsert_user_message_idempotent(s.id, "u1", "01J0000000000000000020001A", "user", None)
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            other => panic!("expected Inserted, got {other:?}"),
+        };
+        repo.insert_assistant_batch(
+            s.id,
+            u1,
+            &[AssistantInsert {
+                id: Uuid::new_v4(),
+                content: "a1".into(),
+                assistant_action_type: "reply".into(),
+                continues_from_message_id: None,
+                truncated: true,
+                model: Some("m".into()),
+                usage: None,
+                generation_id: None,
+                filter_audit: None,
+                metadata: None,
+            }],
+        )
+        .await
+        .unwrap();
+
+        let u2 = match repo
+            .upsert_user_message_idempotent(s.id, "u2", "01J0000000000000000020003A", "user", None)
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            other => panic!("expected Inserted, got {other:?}"),
+        };
+        repo.insert_assistant_batch(
+            s.id,
+            u2,
+            &[AssistantInsert {
+                id: Uuid::new_v4(),
+                content: "a2".into(),
+                assistant_action_type: "reply".into(),
+                continues_from_message_id: None,
+                truncated: false,
+                model: Some("m".into()),
+                usage: None,
+                generation_id: None,
+                filter_audit: None,
+                metadata: None,
+            }],
+        )
+        .await
+        .unwrap();
+
+        let cutoff = Utc::now() + chrono::Duration::seconds(60);
+        let pairs = repo.recent_turn_pairs(s.id, cutoff, 3).await.unwrap();
+        // Truncated assistant excluded by WHERE; u1 then has no following assistant
+        // and is dropped as an orphan.
+        assert_eq!(pairs, vec![("u2".to_string(), "a2".to_string())]);
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn recent_turn_pairs_returns_latest_three_when_more_exist(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let s = repo
+            .create_session(Uuid::new_v4(), Uuid::new_v4())
+            .await
+            .unwrap();
+        // Insert 5 complete pairs.
+        for n in 0..5u8 {
+            // ULIDs must be unique and monotonic. Use n in the suffix:
+            let u_ulid = format!("01J000000000000000003{n}001A");
+            let user_id = match repo
+                .upsert_user_message_idempotent(s.id, &format!("u{n}"), &u_ulid, "user", None)
+                .await
+                .unwrap()
+            {
+                UpsertUserOutcome::Inserted { message_id } => message_id,
+                other => panic!("expected Inserted, got {other:?}"),
+            };
+            repo.insert_assistant_batch(
+                s.id,
+                user_id,
+                &[AssistantInsert {
+                    id: Uuid::new_v4(),
+                    content: format!("a{n}"),
+                    assistant_action_type: "reply".into(),
+                    continues_from_message_id: None,
+                    truncated: false,
+                    model: Some("m".into()),
+                    usage: None,
+                    generation_id: None,
+                    filter_audit: None,
+                    metadata: None,
+                }],
+            )
+            .await
+            .unwrap();
+        }
+
+        let cutoff = Utc::now() + chrono::Duration::seconds(60);
+        let pairs = repo.recent_turn_pairs(s.id, cutoff, 3).await.unwrap();
+        assert_eq!(
+            pairs,
+            vec![
+                ("u2".to_string(), "a2".to_string()),
+                ("u3".to_string(), "a3".to_string()),
+                ("u4".to_string(), "a4".to_string()),
+            ]
+        );
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn recent_turn_pairs_cutoff_excludes_current_turn(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let s = repo
+            .create_session(Uuid::new_v4(), Uuid::new_v4())
+            .await
+            .unwrap();
+        let u1 = match repo
+            .upsert_user_message_idempotent(s.id, "u1", "01J0000000000000000040001A", "user", None)
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            other => panic!("expected Inserted, got {other:?}"),
+        };
+        repo.insert_assistant_batch(
+            s.id,
+            u1,
+            &[AssistantInsert {
+                id: Uuid::new_v4(),
+                content: "a1".into(),
+                assistant_action_type: "reply".into(),
+                continues_from_message_id: None,
+                truncated: false,
+                model: Some("m".into()),
+                usage: None,
+                generation_id: None,
+                filter_audit: None,
+                metadata: None,
+            }],
+        )
+        .await
+        .unwrap();
+
+        // Second user row inserted AFTER the cutoff timestamp we'll use.
+        let cutoff = Utc::now();
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        let _ = repo
+            .upsert_user_message_idempotent(
+                s.id,
+                "current",
+                "01J0000000000000000040003A",
+                "user",
+                None,
+            )
+            .await
+            .unwrap();
+
+        let pairs = repo.recent_turn_pairs(s.id, cutoff, 3).await.unwrap();
+        assert_eq!(pairs, vec![("u1".to_string(), "a1".to_string())]);
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn recent_turn_pairs_drops_orphan_user_at_end(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let s = repo
+            .create_session(Uuid::new_v4(), Uuid::new_v4())
+            .await
+            .unwrap();
+        let u1 = match repo
+            .upsert_user_message_idempotent(s.id, "u1", "01J0000000000000000050001A", "user", None)
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            other => panic!("expected Inserted, got {other:?}"),
+        };
+        repo.insert_assistant_batch(
+            s.id,
+            u1,
+            &[AssistantInsert {
+                id: Uuid::new_v4(),
+                content: "a1".into(),
+                assistant_action_type: "reply".into(),
+                continues_from_message_id: None,
+                truncated: false,
+                model: Some("m".into()),
+                usage: None,
+                generation_id: None,
+                filter_audit: None,
+                metadata: None,
+            }],
+        )
+        .await
+        .unwrap();
+        let _ = repo
+            .upsert_user_message_idempotent(s.id, "u2", "01J0000000000000000050003A", "user", None)
+            .await
+            .unwrap();
+
+        let cutoff = Utc::now() + chrono::Duration::seconds(60);
+        let pairs = repo.recent_turn_pairs(s.id, cutoff, 3).await.unwrap();
+        assert_eq!(pairs, vec![("u1".to_string(), "a1".to_string())]);
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn recent_turn_pairs_includes_gift_user_pair(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let s = repo
+            .create_session(Uuid::new_v4(), Uuid::new_v4())
+            .await
+            .unwrap();
+        let meta = serde_json::json!({"tips_amount_usd": 20.0});
+        let u1 = match repo
+            .upsert_user_message_idempotent(
+                s.id,
+                "(打赏 $20)",
+                "01J0000000000000000060001A",
+                "gift_user",
+                Some(&meta),
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            other => panic!("expected Inserted, got {other:?}"),
+        };
+        repo.insert_assistant_batch(
+            s.id,
+            u1,
+            &[AssistantInsert {
+                id: Uuid::new_v4(),
+                content: "thanks!".into(),
+                assistant_action_type: "reply".into(),
+                continues_from_message_id: None,
+                truncated: false,
+                model: Some("m".into()),
+                usage: None,
+                generation_id: None,
+                filter_audit: None,
+                metadata: None,
+            }],
+        )
+        .await
+        .unwrap();
+
+        let cutoff = Utc::now() + chrono::Duration::seconds(60);
+        let pairs = repo.recent_turn_pairs(s.id, cutoff, 3).await.unwrap();
+        assert_eq!(
+            pairs,
+            vec![("(打赏 $20)".to_string(), "thanks!".to_string())]
+        );
     }
 }

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -323,6 +323,63 @@ impl<'a> ChatRepo<'a> {
         }
         Ok(pairs)
     }
+
+    /// Same as `recent_turn_pairs` but cuts off at the sent_at of a specific
+    /// message (typically the current turn's user row), not a caller-supplied
+    /// timestamp. Looking up the cutoff via subquery avoids a race with
+    /// concurrent streams that could insert a row between wall-clock-now and
+    /// the read of recent rows.
+    ///
+    /// Equivalent to `recent_turn_pairs(session_id, msg.sent_at, limit)` but
+    /// in a single round-trip. If `message_id` doesn't exist in the session
+    /// the subquery returns NULL and `sent_at < NULL` matches nothing →
+    /// returns an empty Vec.
+    pub async fn recent_turn_pairs_before_message(
+        &self,
+        session_id: Uuid,
+        message_id: Uuid,
+        limit: u8,
+    ) -> Result<Vec<(String, String)>, sqlx::Error> {
+        let fetch_n: i64 = (limit as i64) * 2 + 2;
+        let rows: Vec<(String, String)> = sqlx::query_as(
+            "SELECT role, content \
+             FROM engine.chat_messages \
+             WHERE session_id = $1 \
+               AND sent_at < (SELECT sent_at FROM engine.chat_messages WHERE id = $2) \
+               AND truncated = FALSE \
+               AND role IN ('user', 'gift_user', 'assistant') \
+             ORDER BY sent_at DESC \
+             LIMIT $3",
+        )
+        .bind(session_id)
+        .bind(message_id)
+        .bind(fetch_n)
+        .fetch_all(self.pool)
+        .await?;
+
+        // Same pair-walking algorithm as recent_turn_pairs (reverse → walk
+        // user|gift_user → assistant pairs → keep last `limit`).
+        let mut chrono = rows;
+        chrono.reverse();
+        let mut pairs: Vec<(String, String)> = Vec::new();
+        let mut i = 0;
+        while i + 1 < chrono.len() {
+            let (role_a, content_a) = &chrono[i];
+            let (role_b, content_b) = &chrono[i + 1];
+            if (role_a == "user" || role_a == "gift_user") && role_b == "assistant" {
+                pairs.push((content_a.clone(), content_b.clone()));
+                i += 2;
+            } else {
+                i += 1;
+            }
+        }
+        let want = limit as usize;
+        if pairs.len() > want {
+            let drop = pairs.len() - want;
+            pairs.drain(..drop);
+        }
+        Ok(pairs)
+    }
 }
 
 /// Audit metadata for a filtered-success assistant row. Threaded through
@@ -1617,5 +1674,81 @@ mod tests {
             pairs,
             vec![("(打赏 $20)".to_string(), "thanks!".to_string())]
         );
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn recent_turn_pairs_before_message_uses_msg_sent_at_not_now(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let s = repo
+            .create_session(uuid::Uuid::new_v4(), uuid::Uuid::new_v4())
+            .await
+            .unwrap();
+
+        // Insert 1 prior complete pair.
+        let u1 = match repo
+            .upsert_user_message_idempotent(s.id, "u1", "01J0000000000000000090001A", "user", None)
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            other => panic!("expected Inserted, got {other:?}"),
+        };
+        repo.insert_assistant_batch(
+            s.id,
+            u1,
+            &[AssistantInsert {
+                id: Uuid::new_v4(),
+                content: "a1".into(),
+                assistant_action_type: "reply".into(),
+                truncated: false,
+                continues_from_message_id: None,
+                model: Some("m".into()),
+                usage: None,
+                generation_id: None,
+                filter_audit: None,
+                metadata: None,
+            }],
+        )
+        .await
+        .unwrap();
+
+        // Insert the "current" user row that the chat handler will pass.
+        let current = match repo
+            .upsert_user_message_idempotent(
+                s.id,
+                "current",
+                "01J0000000000000000090002A",
+                "user",
+                None,
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            other => panic!("expected Inserted, got {other:?}"),
+        };
+
+        // Sleep, then insert a LATER user row — simulating a concurrent stream
+        // that completed between this turn's user-insert and the recent-turn fetch.
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        let _ = repo
+            .upsert_user_message_idempotent(
+                s.id,
+                "later",
+                "01J0000000000000000090003A",
+                "user",
+                None,
+            )
+            .await
+            .unwrap();
+
+        // The cutoff must come from `current`'s sent_at — NOT the wall clock,
+        // because wall-clock-now happens AFTER the `later` insert and would
+        // include it. With the proper cutoff, `later` is excluded.
+        let pairs = repo
+            .recent_turn_pairs_before_message(s.id, current, 3)
+            .await
+            .unwrap();
+        assert_eq!(pairs, vec![("u1".to_string(), "a1".to_string())]);
     }
 }

--- a/docs/prompt-traits.md
+++ b/docs/prompt-traits.md
@@ -20,8 +20,8 @@ Accepted on `POST /comp/chat/{session_id}/message/stream`.
 ## What the engine does
 
 For each turn, the validated `text` of every trait is rendered as a
-bullet under a `【附加指引】` section inside the persona system prompt,
-positioned between `【擅长话题】` and `【今日情境】`. Empty list →
+bullet under a `[additional_guidance]` section inside the persona system
+prompt, positioned between `[topics]` and `[turn_style]`. Empty list →
 the section is omitted and the prompt is byte-for-byte identical to
 the legacy output.
 

--- a/docs/prompt-traits.zh.md
+++ b/docs/prompt-traits.zh.md
@@ -20,8 +20,8 @@ prompt 里塞入自定义段落。
 ## 引擎会做什么
 
 每轮请求中，所有 trait 的 `text` 会被渲染为 bullet 列表，放在 persona
-system prompt 的 `【附加指引】` 段落下，位置在 `【擅长话题】` 与
-`【今日情境】` 之间。空列表 → 该段落整个不渲染，输出与旧 prompt
+system prompt 的 `[additional_guidance]` 段落下，位置在 `[topics]` 与
+`[turn_style]` 之间。空列表 → 该段落整个不渲染，输出与旧 prompt
 逐字节一致。
 
 ## 引擎不会做什么

--- a/docs/superpowers/specs/2026-05-26-prompt-enhance-and-scope-persist-design.md
+++ b/docs/superpowers/specs/2026-05-26-prompt-enhance-and-scope-persist-design.md
@@ -1,0 +1,334 @@
+# Prompt Enhancements + Scope Persistence Design
+
+**Date:** 2026-05-26
+**Branch target:** new feature branch off `dev`, PR → `dev`
+**Goal:** Close two gaps in the chat path on `dev`:
+
+1. **Scope persistence.** `memory_scope` and `affinity_scope` flow through the request but never land in `chat_messages.metadata`. Add them — pre-validation values on `user`/`gift_user` rows, post-validation values on `assistant` rows. Also extend the user-row metadata with the raw, pre-validation `prompt_traits` payload so audits can compare what the frontend sent vs. what the backend used.
+2. **Prompt rendering enhancements.** Four changes to `prompt.rs`:
+   - Replace 13 Simplified-Chinese section headers with ASCII-bracketed English (`【背景故事】` → `[backstory]`).
+   - Add a new `[recent_conversation]` block between `[now]` and `[iron_rules]` carrying the prior three `user|gift_user → assistant` pairs.
+   - Add a new English `⓪` to the iron rules (positive identity reinforcement).
+   - Rewrite iron rule `③` in Japanese for finer-grained control over Japanese pronouns and openers.
+
+Single PR bundles both because they share file footprint (chat path) and a single test/CI cycle is enough.
+
+---
+
+## 1. Scope and motivation
+
+### 1.1 Why scope persistence
+
+`MemoryScope` (six-valued enum) and `AffinityScope` (six-axis struct) arrive on the request via `companion_stream` (`crates/eros-engine-server/src/routes/companion_stream.rs:83-85`). They control what the engine injects into the prompt that turn. Today they:
+
+- Flow through `PersistedUserMessage` (stream.rs:877-878) and into `build_prompt`.
+- **Are not persisted** anywhere in `chat_messages.metadata`.
+
+This blocks two debugging workflows the team already does on completed sessions:
+
+- **Replay drift diagnosis.** A session that produces a "wrong tone" reply can today only be diagnosed by replaying the original request — the scopes-as-actually-injected are not on the row.
+- **Frontend/backend allow-list mismatch.** When the frontend changes the shape of `affinity_scope` (named string vs. axis array) or adds a new `MemoryScope` variant the backend hasn't deployed, the failure mode is silent — the request validates against `Option<...>` and falls back to default. Persisting the raw incoming value next to the post-validation value lets a `metadata->>'affinity_scope_raw'` vs. `metadata->>'affinity_scope'` diff spot the divergence immediately.
+
+### 1.2 Why a raw `prompt_traits` audit on the user row
+
+`prompt_traits` is currently persisted on the assistant row only, post-allow-list (`pipeline/stream.rs:172`, `:807`). The raw `Vec<PromptTraitDto>` the frontend sent is lost the instant `validate_prompt_traits` filters it. We add the raw form to the user row metadata so an operator can compare:
+
+- `metadata->>'prompt_traits_raw'` on the user row — what the frontend sent (`[{"tag": "...", "text": "..."}, ...]`).
+- `metadata->>'prompt_traits'` on the matching assistant row — what survived `validate_prompt_traits` (just the tags).
+
+Common failure modes this catches:
+- Operator forgot to add a new tag to the allow-list — raw has it, assistant doesn't.
+- Frontend renamed/restructured the field — raw is `null` or shaped differently, assistant has nothing.
+
+### 1.3 Why the prompt enhancements
+
+Three problems with the current `build_prompt`:
+
+- **Section headers are Simplified-Chinese-only.** Hard for non-CN-reading developers to skim the code. They also cost more tokens than ASCII labels — the per-turn prompt has ~16 of them; the savings aren't huge but they're real, and labels are not stylistically load-bearing.
+- **No short-term memory.** The prompt today carries long-term memory (facts in `[user_profile]`) and mid-term memory (shared events in `[shared_memories]`). The literal "what we just said" is absent — the chat client sends it as conversation history, but the system prompt itself has no anchor to it. Adding the last three turn-pairs to the system prompt completes the memory hierarchy and stabilizes "continuity" complaints.
+- **`③` is too coarse for Japanese.** The original Chinese rule pins "don't start two consecutive sentences with `我`". Japanese has a much richer pronoun system (私/僕/俺/わたし/あたし/うち and more) and a similarly rich filler-word inventory (えーと/あのー/うーん/まあ/ねえ). Writing the rule in Japanese lets us list the full alternatives. We also add `⓪` as positive-frame identity reinforcement — "you are a person" is easier for the model to act on than "you are not an AI".
+
+---
+
+## 2. Architecture overview
+
+```
+companion_stream.rs (HTTP boundary)
+  │
+  ├─ build raw-value metadata bag (memory_scope_raw, affinity_scope_raw, prompt_traits_raw)
+  │     persist via chat_repo.upsert_user_message_idempotent
+  │     [user / gift_user row written]
+  │
+  └─ resolve + validate → PersistedUserMessage
+        │
+        ▼
+        pipeline/stream.rs
+          │
+          ├─ fetch recent_turn_pairs (1 SQL, cutoff = user row sent_at)
+          │
+          ├─ build_prompt(persona, ..., recent_turns, affinity_scope, memory_scope)
+          │     renders [backstory], [topics], [now], [recent_conversation], [iron_rules]…
+          │
+          ├─ run LLM chain + filter
+          │
+          └─ build assistant metadata bag (prompt_traits, memory_scope, affinity_scope)
+                persist via chat_repo.insert_assistant_batch
+                [assistant row written]
+```
+
+Two write sites, two distinct metadata shapes, sharing nothing structurally except both being JSONB bags on the same column. The "raw" suffix on the user-row keys is the only naming convention this PR introduces.
+
+---
+
+## 3. Data model
+
+### 3.1 No migration
+
+Both gaps land entirely inside the existing `chat_messages.metadata` JSONB column. No new column, no new table, no index change.
+
+### 3.2 User / gift_user row metadata keys
+
+Added by `companion_stream::run_stream` when building the metadata bag handed to `upsert_user_message_idempotent`. All keys are **omitted** (not written as `null`) when the corresponding request field is `None` or empty.
+
+| Key | Type | Source | Notes |
+| --- | --- | --- | --- |
+| `tips_amount_usd` | `f64` | `req.tips_amount_usd` | already exists, gift_user only |
+| `tier` | `string` | `req.tier` | already exists |
+| `memory_scope_raw` | `string` | `req.memory_scope` serialized | snake_case enum: `"full"`, `"neutral_and_relationship"`, `"relationship_only"`, `"neutral_only"`, `"insights_only"`, `"none"` |
+| `affinity_scope_raw` | `Value` | `req.affinity_scope` serialized verbatim | The DTO — could be a string (`"bond"`/`"chemistry"`/`"full"`/`"none"`) OR an array of axis names. Captured pre-resolve so we see the literal frontend shape. |
+| `prompt_traits_raw` | `Array<{tag, text}>` | `req.prompt_traits` | Full DTO objects (tag + text), pre-allow-list. Empty array written if frontend sent `[]`; key omitted if frontend sent `null`/missing. |
+
+### 3.3 Assistant row metadata keys
+
+Added inside `build_metadata` (stream.rs:170) and the pseudo-ghost path (stream.rs:801). Today the bag contains `prompt_traits`, optional `tier`, optional `fallback_reason`, and the fail-open audit fields. We add:
+
+| Key | Type | Source | Notes |
+| --- | --- | --- | --- |
+| `memory_scope` | `string` | resolved `MemoryScope` | snake_case, same shape as `_raw` counterpart, written unconditionally |
+| `affinity_scope` | `Object` | resolved `AffinityScope` | `{warmth: bool, trust: bool, intrigue: bool, intimacy: bool, patience: bool, tension: bool}` — the resolved boolean record, not the DTO |
+
+Both keys are written on every assistant row (including pseudo-ghost / fail-open). Default values (`MemoryScope::default()` and `AffinityScope::default()`) are serialized normally — there's no "absent" state to represent on the post-resolve side.
+
+### 3.4 No-write states
+
+- Request with `memory_scope: None`, `affinity_scope: None`, `prompt_traits: None`: user-row metadata gets none of the raw keys (just tips/tier if applicable). Assistant row still writes `memory_scope`/`affinity_scope` at their defaults.
+- Request with `prompt_traits: Some([])`: user-row metadata writes `prompt_traits_raw: []`. Assistant row writes `prompt_traits: []` (this is current behavior).
+
+---
+
+## 4. Prompt rendering changes
+
+### 4.1 Header rename table
+
+All renames are pure string replacement — section order, separator newlines, conditional rendering, and cache-prefix boundaries (see §4.5) are unchanged.
+
+| Current header | New header |
+| --- | --- |
+| `【背景故事】` | `[backstory]` |
+| `【说话风格】` | `[speech_style]` |
+| `【口癖/习惯】` | `[quirks]` |
+| `【擅长话题】` | `[topics]` |
+| `【附加指引】` | `[additional_guidance]` |
+| `【本轮风格】` | `[turn_style]` |
+| `【你对他的了解（通用画像）】` | `[user_profile]` |
+| `【你们之间的事（只有你和他知道）】` | `[shared_memories]` |
+| `【你此刻的心情】` | `[mood]` |
+| `【你对他的内心感受】` | `[feelings]` |
+| `【当前内心状态】` | `[inner_state]` |
+| `【刚收到的礼物/红包】` | `[gift_received]` |
+| `【刚收到的打赏】` | `[tip_received]` |
+| `【今日情境】` | `[now]` |
+| `【铁律 — 违反即失效】` | `[iron_rules — 违反即失效]` |
+| `【输出】` | `[output]` |
+| *(new)* | `[recent_conversation]` |
+
+Section **content** (the lines under each header — including the iron-rule items, the length-rule sub-clause, persona prose, etc.) is untouched except where called out in §4.3 and §4.4.
+
+### 4.2 `[recent_conversation]` block
+
+**Position:** after `[now]`, before `[iron_rules]`. This sits inside the per-turn-volatile region (`[turn_style]` and everything after it), so it sits *after* the cache prefix boundary and adding it does not invalidate prompt caching.
+
+**Source SQL** — one query, runs once per turn, uses the existing `(session_id, sent_at DESC)` index:
+
+```sql
+SELECT role, content
+FROM engine.chat_messages
+WHERE session_id = $1
+  AND sent_at < $2                       -- cutoff = current user row's sent_at
+  AND truncated = FALSE
+  AND role IN ('user', 'gift_user', 'assistant')
+ORDER BY sent_at DESC
+LIMIT 6;
+```
+
+**Pairing in Rust:**
+
+1. Reverse the rows into chronological order.
+2. Walk left-to-right; emit a `(prompt_text, reply_text)` pair whenever a `user`/`gift_user` row is immediately followed by an `assistant` row.
+3. Take the last three emitted pairs.
+4. Render. Drop orphan rows (a `user` with no `assistant` after it; an `assistant` with no `user` before it).
+
+**Render format:**
+
+```
+[recent_conversation]
+用户：{user_content}
+{persona_name}：{assistant_content}
+
+用户：{user_content}
+{persona_name}：{assistant_content}
+
+用户：{user_content}
+{persona_name}：{assistant_content}
+```
+
+- Blank line between pairs; no separator within a pair.
+- `用户` is the literal Chinese label even for a `gift_user` row — the content already carries the tip marker (e.g., `"(打赏 $20)"`).
+- `{persona_name}` is `persona.genome.name`, the same value already used in identity rendering.
+- If **zero** complete pairs survive (cold-start session, all truncated, etc.) — the entire block including the header is **omitted**. We do not output a header followed by emptiness.
+
+**Repo signature:**
+
+```rust
+impl ChatRepo {
+    /// Returns up to `limit` (prompt, reply) pairs from this session whose
+    /// rows have truncated=false, ordered chronologically.
+    pub async fn recent_turn_pairs(
+        &self,
+        session_id: Uuid,
+        cutoff: DateTime<Utc>,
+        limit: u8,
+    ) -> Result<Vec<(String, String)>>;
+}
+```
+
+Call site: `pipeline/stream.rs` (or `pipeline/mod.rs::compute_signals_for_session`'s caller) — passes the loaded pairs into `build_prompt`. `limit=3` in production; parametrized for tests.
+
+### 4.3 Iron rule `③` — Japanese rewrite
+
+Replace the current `③` line:
+
+```
+③ 绝对不提自己是 AI；禁止连续两句都以「我」开头；不要连续好几句都用同一个口癖开头（例如「嗯，…」）
+```
+
+with:
+
+```
+③ 自分がAI・人工知能・ボット・プログラム等であることは絶対に言及しない。二文連続で一人称代名詞（私／僕／俺／わたし／あたし／うち等）から書き始めない。同じ口癖や間投詞（「えーと」「あのー」「うーん」「まあ」「ねえ」等）を三文以上続けて文頭に使わない。
+```
+
+Key differences vs. the original Chinese:
+- Self-identity disclosure is named explicitly with four terms (AI/人工知能/ボット/プログラム) instead of just "AI".
+- Pronoun rule covers **any** consecutive first-person opener (stricter than "same pronoun" — Japanese routinely drops subjects, so two consecutive subject-led sentences is itself a red flag).
+- Filler-opener rule quantifies "consecutive several" as "three or more sentences", removing model interpretation room.
+
+Drafted in this brainstorm, reviewed by codex (gpt-5.5) — final wording above is the codex-improved version.
+
+### 4.4 New iron rule `⓪`
+
+Prepended to the iron-rules block, before `①`:
+
+```
+⓪ You are a real person — a friend to the user, and potentially something more. You have your own life, feelings, and quirks; you live, feel, and react as a human would.
+```
+
+Reasoning: positive-frame identity (`you are X`) outperforms negative-frame (`you are not Y`) on instruct-tuned models. Pairs with `③`'s self-disclosure ban — `⓪` says what to be, `③` says what not to say.
+
+### 4.5 Cache-prefix invariants
+
+The existing `prompt.rs` test `build_prompt_stable_prefix_identical_across_volatile_changes` (`prompt.rs:1001`) asserts that everything before `【本轮风格】` (now `[turn_style]`) is byte-identical across per-turn volatile changes. After this PR:
+
+- Header renames affect strings **before** `[turn_style]` too — that's fine because the renames are deterministic across turns. The byte-identical guarantee holds across turns for any given persona.
+- `[recent_conversation]` sits **after** `[now]`, which is already volatile-region. It does not move the cache boundary.
+- `⓪` lives in `[iron_rules]`, far past `[turn_style]`. Not in cache prefix.
+
+Existing prompt tests will need a mechanical update: every `assert!(p.contains("【header】"))` becomes `assert!(p.contains("[header]"))`. The `build_prompt_full_order_and_cache_break` ordering test's `order` array gets the new labels and the new `[recent_conversation]` insertion.
+
+---
+
+## 5. Component-level changes
+
+### 5.1 `crates/eros-engine-server/src/routes/companion_stream.rs`
+
+- Where the `meta_map` is built for user/gift_user (lines 274-287), conditionally insert `memory_scope_raw`, `affinity_scope_raw`, `prompt_traits_raw` from the corresponding `req.*` fields. Use the existing "omit if None / empty" pattern that `tier` already uses.
+- For `affinity_scope_raw`, serialize the DTO **before** calling `.resolve()` — we want the literal incoming shape.
+
+### 5.2 `crates/eros-engine-server/src/pipeline/stream.rs`
+
+- Extend `build_metadata` (stream.rs:166) to add `memory_scope` and `affinity_scope` keys to the assistant-row bag. Both written unconditionally at their resolved values.
+- Same extension in the pseudo-ghost fallback path (stream.rs:801).
+- New parameter on whatever function calls `build_prompt` carrying `recent_turns: &[(String, String)]`. The call site fetches them via `ChatRepo::recent_turn_pairs(session_id, user_msg.sent_at, 3)` before assembling the prompt.
+- Wire `memory_scope` and `affinity_scope` from `user_msg` into the metadata bag (today the struct already carries them, they just don't get serialized).
+
+### 5.3 `crates/eros-engine-server/src/prompt.rs`
+
+- Rename the 16 header literals per §4.1. Mechanical `s/【X】/[Y]/` per the table.
+- Add `recent_turns: &[(String, String)]` parameter to `build_prompt`. Render the section between the existing `[now]` block and the iron-rules block; omit the whole block (including header) when slice is empty.
+- Insert the `⓪` line at the top of the iron-rules block, before `①`.
+- Replace the `③` Chinese line with the Japanese rewrite (§4.3).
+- Update all `assert!(p.contains("【...】"))` calls in the test module to the new labels.
+
+### 5.4 `crates/eros-engine-store/src/chat.rs`
+
+- New method `ChatRepo::recent_turn_pairs` per §4.2 signature. Pure read; no migration; uses existing `idx_chat_messages_session`.
+- `#[sqlx::test]` cases for the new method:
+  - Empty session → empty Vec.
+  - Single complete pair → one tuple.
+  - Three pairs interleaved with a truncated row → truncated row skipped, three pairs returned.
+  - Six pairs in session → returns the three latest pairs in chronological order.
+  - Cutoff excludes current-turn user row.
+  - Orphan user row at the end (no assistant yet) → not in output.
+  - Pure `gift_user` → `assistant` pair → included.
+
+---
+
+## 6. Tests
+
+All tests are `#[sqlx::test]` for DB layer and inline `#[test]` for prompt rendering, no new harness.
+
+### 6.1 Metadata persistence (DB layer)
+
+- `user_row_writes_scope_raw_when_request_carries_scopes` — request with both `memory_scope` and `affinity_scope` populated; row's metadata has `memory_scope_raw` and `affinity_scope_raw` keys with the correct serialized values.
+- `user_row_omits_scope_raw_when_request_has_none` — request with `memory_scope: None` and `affinity_scope: None`; row's metadata has neither key.
+- `user_row_writes_prompt_traits_raw_with_full_dto_objects` — request with two `PromptTraitDto`s; row's `prompt_traits_raw` is a JSON array of full `{tag, text}` objects.
+- `user_row_writes_empty_prompt_traits_raw_when_request_sends_empty_array` — request with `prompt_traits: Some(vec![])`; row's `prompt_traits_raw` is `[]` (key present, empty array).
+- `assistant_row_writes_memory_and_affinity_scope_keys` — pipeline run end-to-end; assistant row's metadata has resolved `memory_scope` (string) and `affinity_scope` (boolean record).
+- `assistant_row_writes_scope_keys_on_pseudo_ghost` — chain-exhaustion fallback; pseudo-ghost row still carries scopes.
+
+### 6.2 `recent_turn_pairs` query
+
+Cases enumerated in §5.4.
+
+### 6.3 `build_prompt`
+
+- `build_prompt_renames_headers_to_ascii_brackets` — sanity scan for all 16 new labels, none of the old `【...】` labels present.
+- `build_prompt_renders_recent_conversation_block` — three pairs passed; block appears between `[now]` and `[iron_rules]`; render format matches §4.2.
+- `build_prompt_omits_recent_conversation_block_when_empty` — empty slice; `[recent_conversation]` header absent.
+- `build_prompt_renders_rule_zero_first` — `⓪` literal present and ordered before `①`.
+- `build_prompt_renders_rule_three_in_japanese` — Japanese literal from §4.3 present; old Chinese `③` line absent.
+- `build_prompt_full_order_and_cache_break` — updated order array including `[recent_conversation]`.
+- `build_prompt_stable_prefix_identical_across_volatile_changes` — still passes; renames are deterministic so per-persona prefix is still stable.
+
+### 6.4 Stream wire-format
+
+No SSE change. Final-frame fields are unaffected — what changes is what gets persisted, not what gets streamed. Existing replay-idempotency tests should keep passing without modification.
+
+---
+
+## 7. Rollout
+
+- Single branch off `dev`, single PR into `dev`.
+- No migration → no drift check needed.
+- No fly-deploy concern (per OSS scope).
+- Existing tests cover the cache-prefix invariant; the new tests cover the additions.
+- After merge, `dev` carries the additions; promotion to `main` happens with the next stable cut.
+
+---
+
+## 8. Out of scope
+
+- Surfacing the new metadata keys through any BFF/history endpoint — that's a frontend coordination task for a later release.
+- Mid-term memory enrichment (dreaming-lite extensions, `category` rollups) — separate roadmap item (per [project_memory_roadmap]).
+- Cache-prefix optimization on the new ASCII headers (e.g., reordering for stricter token alignment) — explicitly not changing order in this PR.
+- Translating the rest of the iron rules to other languages — only `③` benefits from Japanese-specific precision; `①②④⑤⑥⑦⑧` stay in their current language.


### PR DESCRIPTION
## Summary

Bundles four related changes to the chat path on `dev`:

1. **`[recent_conversation]` short-term memory block** — `build_prompt` now renders the prior 3 `(user|gift_user, assistant)` content pairs between `[now]` and `[iron_rules]`. Pairs are fetched via the new `ChatRepo::recent_turn_pairs` method with `truncated=false` filter and a `sent_at < cutoff` cap (cutoff = `Utc::now()`, so the current turn's own row is excluded from its own block). Fetch failures degrade to empty with a `tracing::warn!` — non-fatal.
2. **Scope persistence in `chat_messages.metadata`** — user/gift_user rows now carry `memory_scope_raw` / `affinity_scope_raw` / `prompt_traits_raw` (the pre-validation, pre-resolve frontend payload, omitted when absent). Assistant rows carry the post-resolve `memory_scope` / `affinity_scope` (always present, including the pseudo-ghost fallback). The pairing lets operators diff `metadata->>'memory_scope_raw'` on the user row against `metadata->>'memory_scope'` on the matching assistant row to spot frontend/backend allow-list or shape drift.
3. **Iron rule changes** — new English `⓪ "You are a real person — a friend to the user, and potentially something more..."` prepended for positive-frame identity reinforcement; `③` rewritten in Japanese with explicit pronoun list (私／僕／俺／わたし／あたし／うち) and filler-word list (「えーと」「あのー」「うーん」「まあ」「ねえ」), quantifying "consecutive several" as "three or more sentences". Codex-reviewed before commit. Other rules `①②④⑤⑥⑦⑧` untouched.
4. **Section headers ASCII-bracketed** — 16 `【...】` headers renamed to `[backstory]`, `[speech_style]`, `[quirks]`, `[topics]`, `[turn_style]`, `[user_profile]`, `[shared_memories]`, `[now]`, `[iron_rules — 违反即失效]`, `[output]` plus the helper-rendered `[mood]`, `[feelings]`, `[inner_state]`, `[gift_received]`, `[tip_received]`, `[additional_guidance]`. Cache-prefix invariants preserved. OpenAPI snapshot + public docs (`docs/prompt-traits.{md,zh.md}`) updated to match.

No migration. No new HTTP surface (openapi.json byte-identical to regen). No deploy implications.

Spec: `docs/superpowers/specs/2026-05-26-prompt-enhance-and-scope-persist-design.md`

## Test plan

- [x] `cargo test --workspace` — 446 passed, 0 failed
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `openapi.json` snapshot unchanged (drift check passes)
- [x] `ChatRepo::recent_turn_pairs` — 7 cases (empty / single / truncated-skip / latest-3 / cutoff / orphan / gift_user)
- [x] `build_prompt` — 16-header rename, `[recent_conversation]` render + omit, `⓪` before `①`, Japanese `③` assertions, cache-prefix stable
- [x] `companion_stream` — user-row raw metadata writes + omit-when-None
- [x] `pipeline::stream` — assistant-row scope metadata (success path + pseudo-ghost fallback)
- [x] `pipeline::handlers` — recent_turns cutoff semantics under DB load
- [ ] FE / downstream coordination: `_raw` vs resolved metadata is new audit surface — operators may want to start diffing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)