### PR TITLE
chore(release): v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,7 +405,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "eros-engine-core"
-version = "0.4.3-dev"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "serde",
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-llm"
-version = "0.4.3-dev"
+version = "0.5.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -436,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-server"
-version = "0.4.3-dev"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-store"
-version = "0.4.3-dev"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bs58",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.4.3-dev"
+version = "0.5.0"
 edition = "2021"
 license = "AGPL-3.0-only"
 repository = "https://github.com/etherfunlab/eros-engine"

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ eros-engine-llm   = "0.4"   # only if you want the OpenRouter + Voyage clients
 `linux/amd64` images for `eros-engine-server` are published to GitHub Container Registry on every `v*` tag (need arm64? build it yourself from `docker/Dockerfile`):
 
 ```bash
-docker pull ghcr.io/etherfunlab/eros-engine:0.4.1
+docker pull ghcr.io/etherfunlab/eros-engine:0.5.0
 # or track the latest tagged release
 docker pull ghcr.io/etherfunlab/eros-engine:latest
 ```
@@ -142,7 +142,7 @@ Minimal run (you bring Postgres + your own `.env`):
 
 ```bash
 docker run --rm -p 8080:8080 --env-file .env \
-  ghcr.io/etherfunlab/eros-engine:0.4.1 serve
+  ghcr.io/etherfunlab/eros-engine:0.5.0 serve
 ```
 
 The `docker/Dockerfile` is the same artifact used to build this image. Deploy it on any container host.

--- a/crates/eros-engine-llm/Cargo.toml
+++ b/crates/eros-engine-llm/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "openrouter", "voyage", "embeddings", "llm"]
 categories = ["api-bindings"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "0.4.3-dev" }
+eros-engine-core = { path = "../eros-engine-core", version = "0.5.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/eros-engine-server/Cargo.toml
+++ b/crates/eros-engine-server/Cargo.toml
@@ -10,9 +10,9 @@ name = "eros-engine"
 path = "src/main.rs"
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "0.4.3-dev" }
-eros-engine-llm  = { path = "../eros-engine-llm", version = "0.4.3-dev" }
-eros-engine-store = { path = "../eros-engine-store", version = "0.4.3-dev" }
+eros-engine-core = { path = "../eros-engine-core", version = "0.5.0" }
+eros-engine-llm  = { path = "../eros-engine-llm", version = "0.5.0" }
+eros-engine-store = { path = "../eros-engine-store", version = "0.5.0" }
 axum = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0-only",
       "identifier": "AGPL-3.0-only"
     },
-    "version": "0.4.3-dev"
+    "version": "0.5.0"
   },
   "servers": [
     {

--- a/crates/eros-engine-store/Cargo.toml
+++ b/crates/eros-engine-store/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "memory", "pgvector", "postgres", "sqlx"]
 categories = ["database"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "0.4.3-dev" }
+eros-engine-core = { path = "../eros-engine-core", version = "0.5.0" }
 sqlx = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
## Summary

Cuts v0.5.0. Pure version-bump PR — all content already promoted into main via #58.

Workspace + 5 path-dep pins moved from `0.4.3-dev` to `0.5.0`. `openapi.json` regenerated (`info.version` follows `CARGO_PKG_VERSION`). README docker-pull examples bumped (`:0.4.1` → `:0.5.0`).

## Why 0.5.0 (not 0.4.30 or 0.4.3)

Previous published crates land at `0.4.21`. crates.io requires strictly-increasing semver, so stylized `0.4.3` would fail the registry's ordering check. `v0.5` jumps cleanly past and also reflects the substance of this cut:

- New metadata audit surface on `chat_messages` (raw scope/traits on user rows; resolved on assistant rows)
- New schema columns from migrations 0019 (tip marker + filter audit) + 0020 (error_handling_config)
- System-prompt rewrite (ASCII headers, [recent_conversation] short-term memory, iron rules ⓪/③)
- chat_output_filter validity gate + fail-open audit
- Pseudo-ghost on chain exhaustion

## Test plan

- [x] cargo build --workspace clean
- [x] cargo clippy --workspace --all-targets -- -D warnings clean
- [x] cargo fmt --all --check clean
- [x] cargo test --workspace — 447 passed
- [x] openapi.json regen → info.version = 0.5.0
- [x] No stray 0.4.x literals in Cargo.toml / Cargo.lock / openapi.json / README

## Post-merge ops (you drive)

After this PR squash-merges:
1. fetch + reset local main to the squashed commit
2. `git tag -s v0.5.0 -m "..."`; verify with `git tag -v v0.5.0`; push tag → triggers GHCR amd64 build
3. `gh release create v0.5.0` (full release, NOT prerelease) with Features / Migrations notes
4. `cargo publish -p eros-engine-core` → `-p eros-engine-store` → `-p eros-engine-llm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)