### PR TITLE
feat(filter): filter_triggers config-as-declared reshape

### DIFF
--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -195,24 +195,30 @@ pub struct OutputFilterTrigger {
     pub traits: Option<TraitPredicate>,
 }
 
-/// Detail of which predicates a turn matched. Each field present ⇒ that
-/// predicate was configured **and** passed. Serialises to JSONB for
-/// `chat_messages.filter_triggers`; absent fields skip serialization so the
-/// stored shape matches the spec (only fired predicates appear).
-#[derive(Debug, Clone, PartialEq, serde::Serialize)]
-pub struct TriggerHits {
+/// Which predicates fired this turn, echoing the **source config verbatim**
+/// (config-as-declared). Serialises to JSONB for
+/// `chat_messages.filter_triggers`; absent fields skip serialization so only
+/// configured-and-fired predicates appear. An all-`None` value (empty trigger
+/// that always fires) serialises to `{}` and `is_empty()` is true — the
+/// stream layer maps that to SQL `NULL`.
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize)]
+pub struct FiredPredicates {
+    /// The configured probability `p` (NOT the per-turn draw).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub random: Option<RandomHit>,
+    pub random: Option<f64>,
+    /// The configured model allowlist (NOT just the matched id).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub models: Option<String>,
+    pub models: Option<Vec<String>>,
+    /// The configured trait predicate `{ any, when }` (NOT observed tags).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub traits: Option<Vec<String>>,
+    pub traits: Option<TraitPredicate>,
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize)]
-pub struct RandomHit {
-    pub p: f64,
-    pub draw: f64,
+impl FiredPredicates {
+    /// True when no predicate was configured (empty/always-fire trigger).
+    pub fn is_empty(&self) -> bool {
+        self.random.is_none() && self.models.is_none() && self.traits.is_none()
+    }
 }
 
 impl OutputFilterTrigger {
@@ -228,43 +234,26 @@ impl OutputFilterTrigger {
         random_ok && self.traits_pass(trait_tags)
     }
 
-    /// Per-attempt decision. Returns `Some(hits)` when the trigger fires for
-    /// this attempt, with hit detail; `None` otherwise. Hits serialise to
-    /// `chat_messages.filter_triggers` JSONB on write.
+    /// Per-attempt decision. Returns `Some(fired)` when the trigger fires for
+    /// this attempt, echoing the configured predicates verbatim; `None`
+    /// otherwise. `fired` serialises to `chat_messages.filter_triggers` JSONB
+    /// on write (empty ⇒ SQL NULL, handled by the stream layer).
     pub fn should_filter(
         &self,
         model_id: &str,
         trait_tags: &[&str],
         random_draw: Option<f64>,
-    ) -> Option<TriggerHits> {
+    ) -> Option<FiredPredicates> {
         if !self.turn_level_pass(random_draw, trait_tags) {
             return None;
         }
         if !self.models_pass(model_id) {
             return None;
         }
-        Some(TriggerHits {
-            random: match (self.random, random_draw) {
-                (Some(p), Some(d)) => Some(RandomHit { p, draw: d }),
-                _ => None,
-            },
-            models: self
-                .models
-                .as_ref()
-                .filter(|list| list.iter().any(|m| m == model_id))
-                .map(|_| model_id.to_string()),
-            traits: self.traits.as_ref().map(|tp| match tp.when {
-                // Present: record which tags from `tp.any` were actually seen.
-                TraitWhen::Present => tp
-                    .any
-                    .iter()
-                    .filter(|tag| trait_tags.contains(&tag.as_str()))
-                    .cloned()
-                    .collect::<Vec<String>>(),
-                // Absent: the predicate fires because the tags are NOT present.
-                // Nothing to enumerate; record an empty vec.
-                TraitWhen::Absent => Vec::new(),
-            }),
+        Some(FiredPredicates {
+            random: self.random,
+            models: self.models.clone(),
+            traits: self.traits.clone(),
         })
     }
 
@@ -291,7 +280,7 @@ impl OutputFilterTrigger {
 /// Trait-match predicate: the predicate passes when at least one tag in `any`
 /// is present among the turn's prompt traits (`when = present`) or absent
 /// (`when = absent`).
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, serde::Serialize)]
 pub struct TraitPredicate {
     #[serde(default)]
     pub any: Vec<String>,
@@ -299,7 +288,7 @@ pub struct TraitPredicate {
     pub when: TraitWhen,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, serde::Serialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum TraitWhen {
     #[default]
@@ -1628,7 +1617,7 @@ trigger = { traits = { any = ["a"] } }
     }
 
     #[test]
-    fn should_filter_returns_hits_on_match() {
+    fn should_filter_returns_fired_config_on_match() {
         let t = OutputFilterTrigger {
             random: Some(0.3),
             models: Some(vec!["x/y".into()]),
@@ -1637,13 +1626,19 @@ trigger = { traits = { any = ["a"] } }
                 when: TraitWhen::Present,
             }),
         };
-        let hits = t
+        let fired = t
             .should_filter("x/y", &["nsfw"], Some(0.18))
             .expect("should fire");
-        assert_eq!(hits.random.as_ref().unwrap().p, 0.3);
-        assert_eq!(hits.random.as_ref().unwrap().draw, 0.18);
-        assert_eq!(hits.models.as_deref(), Some("x/y"));
-        assert_eq!(hits.traits.as_deref(), Some(&["nsfw".to_string()][..]));
+        // Echoes config verbatim — NOT observed values.
+        assert_eq!(fired.random, Some(0.3));
+        assert_eq!(fired.models.as_deref(), Some(&["x/y".to_string()][..]));
+        assert_eq!(
+            fired.traits,
+            Some(TraitPredicate {
+                any: vec!["nsfw".into()],
+                when: TraitWhen::Present,
+            })
+        );
     }
 
     #[test]
@@ -1673,7 +1668,7 @@ trigger = { traits = { any = ["a"] } }
     }
 
     #[test]
-    fn should_filter_traits_absent_predicate_returns_empty_traits_vec() {
+    fn should_filter_traits_absent_echoes_config_not_empty_vec() {
         let t = OutputFilterTrigger {
             random: None,
             models: None,
@@ -1682,22 +1677,35 @@ trigger = { traits = { any = ["a"] } }
                 when: TraitWhen::Absent,
             }),
         };
-        // "nsfw" not in tags → predicate passes; traits hit recorded as empty vec.
-        let hits = t.should_filter("m", &["sfw"], None).expect("fires");
-        assert_eq!(hits.traits.as_deref(), Some(&[][..]));
+        // "nsfw" not in tags → predicate passes; the FIRED record echoes the
+        // configured {any, when}, so a reader sees `when="absent"` directly.
+        let fired = t.should_filter("m", &["sfw"], None).expect("fires");
+        assert_eq!(
+            fired.traits,
+            Some(TraitPredicate {
+                any: vec!["nsfw".into()],
+                when: TraitWhen::Absent,
+            })
+        );
     }
 
     #[test]
-    fn trigger_hits_serializes_only_fired_fields() {
-        let hits = TriggerHits {
-            random: Some(RandomHit { p: 0.3, draw: 0.18 }),
+    fn fired_predicates_serializes_only_fired_fields() {
+        let fired = FiredPredicates {
+            random: Some(0.3),
             models: None,
-            traits: Some(vec!["nsfw_boost".into()]),
+            traits: Some(TraitPredicate {
+                any: vec!["nsfw_boost".into()],
+                when: TraitWhen::Absent,
+            }),
         };
-        let v = serde_json::to_value(&hits).unwrap();
-        assert!(v.get("random").is_some());
+        let v = serde_json::to_value(&fired).unwrap();
+        assert_eq!(v["random"], serde_json::json!(0.3));
         assert!(v.get("models").is_none(), "absent fields skipped");
-        assert_eq!(v["traits"], serde_json::json!(["nsfw_boost"]));
+        assert_eq!(
+            v["traits"],
+            serde_json::json!({ "any": ["nsfw_boost"], "when": "absent" })
+        );
     }
 
     #[test]
@@ -1715,15 +1723,12 @@ trigger = { traits = { any = ["a"] } }
     }
 
     #[test]
-    fn trigger_hits_empty_serializes_to_empty_object() {
-        // Spec §4.2: when an always-fire trigger (no configured predicates)
-        // is recorded, filter_triggers JSONB must be `{}` — not `{"random":null, ...}`.
-        let hits = TriggerHits {
-            random: None,
-            models: None,
-            traits: None,
-        };
-        let v = serde_json::to_value(&hits).unwrap();
+    fn fired_predicates_empty_serializes_to_empty_object_and_is_empty() {
+        // Empty/always-fire trigger: no configured predicates. Serialises to
+        // `{}` and is_empty() is true; the stream layer maps that to SQL NULL.
+        let fired = FiredPredicates::default();
+        assert!(fired.is_empty());
+        let v = serde_json::to_value(&fired).unwrap();
         assert_eq!(v, serde_json::json!({}));
     }
 

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0-only",
       "identifier": "AGPL-3.0-only"
     },
-    "version": "0.4.3-dev"
+    "version": "0.5.1-dev"
   },
   "servers": [
     {

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -460,11 +460,19 @@ fn drive_chat_burst(
                         o.filtered = true;
                         o.retries_filter = out.retries_filter;
                         drop(o); // release MutexGuard before the yield below — must not cross suspension point
+                        // Empty/always-fire trigger serialises to `{}`; substitute
+                        // JSON null so the store layer's guard lands SQL NULL. A
+                        // reader tells "filter ran" from "filter absent" via filter_model.
+                        let filter_triggers = if h.is_empty() {
+                            serde_json::Value::Null
+                        } else {
+                            serde_json::to_value(&h)
+                                .expect("FiredPredicates Serialize is infallible")
+                        };
                         let audit = eros_engine_store::chat::FilterAudit {
                             pre_filter_content: acc.clone(),
                             filter_model: out.filter_model,
-                            filter_triggers: serde_json::to_value(&h)
-                                .expect("TriggerHits Serialize is infallible"),
+                            filter_triggers,
                             f_client_msg_id: out.f_client_msg_id,
                             f_generation_id: out.f_generation_id,
                         };

--- a/crates/eros-engine-store/migrations/0022_filter_triggers_wipe_legacy_shape.sql
+++ b/crates/eros-engine-store/migrations/0022_filter_triggers_wipe_legacy_shape.sql
@@ -7,9 +7,11 @@
 -- signal is preserved on the row via filter_model NOT NULL; only the
 -- per-predicate detail is lost.
 --
+-- This runs at the v0.5.1 upgrade, before any new-shape row can exist, so
+-- every non-null filter_triggers is legacy — wipe on that condition alone.
+--
 -- Spec: docs/superpowers/specs/2026-05-29-engine-cleanup-and-snapshot-design.md §2
 
 UPDATE engine.chat_messages
    SET filter_triggers = NULL
- WHERE filter_model    IS NOT NULL
-   AND filter_triggers IS NOT NULL;
+ WHERE filter_triggers IS NOT NULL;

--- a/crates/eros-engine-store/migrations/0022_filter_triggers_wipe_legacy_shape.sql
+++ b/crates/eros-engine-store/migrations/0022_filter_triggers_wipe_legacy_shape.sql
@@ -1,0 +1,15 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- v0.5.1 ships a new shape for engine.chat_messages.filter_triggers
+-- (config-as-declared). The legacy shape (random as {p,draw}, models as a
+-- single id, traits as an observed tag array) cannot be reconstructed back
+-- to source TOML because observed values do not carry the `when` mode. Null
+-- the legacy audit so readers never see mixed shapes. The "filter ran"
+-- signal is preserved on the row via filter_model NOT NULL; only the
+-- per-predicate detail is lost.
+--
+-- Spec: docs/superpowers/specs/2026-05-29-engine-cleanup-and-snapshot-design.md §2
+
+UPDATE engine.chat_messages
+   SET filter_triggers = NULL
+ WHERE filter_model    IS NOT NULL
+   AND filter_triggers IS NOT NULL;

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -552,7 +552,11 @@ impl<'a> ChatRepo<'a> {
                     Some(a) => (
                         Some(a.pre_filter_content.as_str()),
                         Some(a.filter_model.as_str()),
-                        Some(&a.filter_triggers),
+                        // JSON null and SQL NULL are equivalent "no predicate data"
+                        // for this audit column; normalize JSON null to SQL NULL so
+                        // `filter_triggers IS NULL` is a clean "no predicates fired"
+                        // probe. (Binding Value::Null would otherwise write JSONB 'null'.)
+                        (!a.filter_triggers.is_null()).then_some(&a.filter_triggers),
                         Some(a.f_client_msg_id.as_str()),
                         a.f_generation_id.as_deref(),
                     ),
@@ -1058,9 +1062,9 @@ mod tests {
         };
 
         let triggers = serde_json::json!({
-            "random": { "p": 0.3, "draw": 0.18 },
-            "models": "deepseek/deepseek-v4-flash",
-            "traits": ["nsfw_boost"]
+            "random": 0.3,
+            "models": ["deepseek/deepseek-v4-flash"],
+            "traits": { "any": ["nsfw_boost"], "when": "absent" }
         });
         let row = AssistantInsert {
             id: Uuid::new_v4(),
@@ -1233,6 +1237,62 @@ mod tests {
         assert!(
             f_gen.is_none(),
             "f_generation_id should be NULL when None inside Some(FilterAudit)"
+        );
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn assistant_batch_filter_triggers_json_null_persists_as_sql_null(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let s = repo
+            .create_session(Uuid::new_v4(), Uuid::new_v4())
+            .await
+            .unwrap();
+        let user_msg_id = match repo
+            .upsert_user_message_idempotent(s.id, "hi", "01J0000000000000000000004A", "user", None)
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            other => panic!("{other:?}"),
+        };
+        // Empty-trigger case: filter ran (filter_model set) but no predicates
+        // fired, so filter_triggers is JSON null → must land as SQL NULL.
+        let row = AssistantInsert {
+            id: Uuid::new_v4(),
+            content: "filtered empty-trigger".into(),
+            assistant_action_type: "reply".into(),
+            continues_from_message_id: None,
+            truncated: false,
+            model: Some("anthropic/claude-sonnet-4.6".into()),
+            usage: None,
+            generation_id: Some("gen_chat_xyz".into()),
+            filter_audit: Some(FilterAudit {
+                pre_filter_content: "raw".into(),
+                filter_model: "anthropic/claude-haiku-4.5".into(),
+                filter_triggers: serde_json::Value::Null,
+                f_client_msg_id: "f_01J0000000000000000000004Z".into(),
+                f_generation_id: None,
+            }),
+            metadata: None,
+        };
+        repo.insert_assistant_batch(s.id, user_msg_id, &[row])
+            .await
+            .unwrap();
+        // filter_triggers IS NULL (SQL NULL), but filter_model IS NOT NULL —
+        // the "filter ran with no predicates" signal.
+        let (triggers_is_null, model_is_set): (bool, bool) = sqlx::query_as(
+            "SELECT filter_triggers IS NULL, filter_model IS NOT NULL \
+             FROM engine.chat_messages \
+             WHERE role='assistant' AND session_id=$1",
+        )
+        .bind(s.id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert!(triggers_is_null, "JSON null must persist as SQL NULL");
+        assert!(
+            model_is_set,
+            "filter_model retained as the filter-ran signal"
         );
     }
 

--- a/docs/superpowers/specs/2026-05-26-tip-role-and-filter-audit-design.md
+++ b/docs/superpowers/specs/2026-05-26-tip-role-and-filter-audit-design.md
@@ -267,6 +267,14 @@ not five independent `Option`s.
 | `f_client_msg_id` | Engine-generated ULID, prefix `f_`, created **once per logical filter call** before invoking `execute()`; reused across the filter's internal fallback retries | Used as an idempotency / trace key by ops; unique per `(session_id, f_client_msg_id)`. |
 | `f_generation_id` | `ChatResponse.generation_id` from the filter LLM call | OpenRouter generation id for the filter call. |
 
+> **Update (2026-05-29, v0.5.1):** The `TriggerHits`/observed-value shape below
+> is superseded by `2026-05-29-engine-cleanup-and-snapshot-design.md` §2.
+> `filter_triggers` now echoes the **source predicate config verbatim**
+> (`random` = configured `p`; `models` = configured allowlist; `traits` =
+> configured `{any, when}`). An empty/always-fire trigger persists SQL `NULL`
+> (not `{}`); "filter ran" is read from `filter_model IS NOT NULL`. Legacy-shape
+> rows were wiped by migration 0022.
+
 `filter_triggers` JSON shape — **only fired predicates appear**:
 
 ```json

--- a/docs/superpowers/specs/2026-05-29-engine-cleanup-and-snapshot-design.md
+++ b/docs/superpowers/specs/2026-05-29-engine-cleanup-and-snapshot-design.md
@@ -197,11 +197,13 @@ New migration `0022_filter_triggers_wipe_legacy_shape.sql`:
 -- values do not carry the `when` mode. Drop the legacy audit so readers
 -- never see mixed shapes. The "filter ran" signal is preserved on the row
 -- via filter_model NOT NULL; only the predicate detail is lost.
+--
+-- This runs at the v0.5.1 upgrade, before any new-shape row can exist, so
+-- every non-null filter_triggers is legacy — wipe on that condition alone.
 
 UPDATE engine.chat_messages
    SET filter_triggers = NULL
- WHERE filter_model     IS NOT NULL
-   AND filter_triggers  IS NOT NULL;
+ WHERE filter_triggers IS NOT NULL;
 ```
 
 ### Documentation


### PR DESCRIPTION
## Summary
Reshapes `engine.chat_messages.filter_triggers` JSONB from the mixed config-plus-observed format to **predicate config-as-declared** — each fired output-filter predicate echoes its source TOML config verbatim:
- `random` = configured probability `p` (was `{p, draw}`)
- `models` = configured allowlist (was the single matched id)
- `traits` = configured `{any, when}` struct (was an observed tag array; `when="absent"` was previously indistinguishable from an empty match)

An empty/always-fire trigger now persists SQL `NULL` (was `{}`); "filter ran" is recoverable via `filter_model IS NOT NULL`. Legacy-shape rows are wiped by migration 0022.

This is **PR2 of the v0.5.1 sequence**: snapshot (#62, merged) → filter_triggers reshape (this) → NFT-ownership teardown (next). Spec: `docs/superpowers/specs/2026-05-29-engine-cleanup-and-snapshot-design.md` §2.

## Changes
- `eros-engine-llm/model_config.rs`: `TriggerHits`/`RandomHit` → `FiredPredicates` (clones config); `Serialize` on `TraitPredicate`/`TraitWhen`; `should_filter` → `Option<FiredPredicates>`.
- `eros-engine-store/chat.rs`: bind guard maps a `Value::Null` `filter_triggers` to SQL `NULL` (binding `Value::Null` would otherwise write JSONB `'null'`).
- `eros-engine-server/pipeline/stream.rs`: empty fired-predicates → `Value::Null`, else serialized config.
- migration `0022_filter_triggers_wipe_legacy_shape.sql`: wipes pre-existing (legacy) `filter_triggers` rows.
- doc: supersede banner on the 2026-05-26 tip-role spec.
- openapi snapshot regen — **version-only diff** (`0.4.3-dev` → `0.5.1-dev`), clearing drift inherited from #62; §2 adds no HTTP surface (`filter_triggers` is operator-side audit, not in any DTO).

## Design note (deviation from spec, intentional)
Spec §2 claimed `Value::Null` binds to SQL NULL automatically — it does not for sqlx+JSONB (writes `'null'`). Kept `FilterAudit.filter_triggers: Value` (per spec's type) but added a tested bind-layer guard normalizing JSON-null → SQL NULL. Migration predicate simplified to `WHERE filter_triggers IS NOT NULL` (the `filter_model` condition is redundant at upgrade time when all rows are legacy).

## Test plan
- [x] `model_config` unit tests: random/models/traits-present/traits-absent echo config; serialization shape (`random` scalar, `models` array, `traits` `{any, when}` snake_case); empty → `{}` + `is_empty()`
- [x] `chat.rs` `sqlx::test`: `Value::Null` persists as SQL NULL (not JSONB `'null'`) with `filter_model` retained; non-null round-trips unchanged
- [x] migration 0022 applies cleanly across the full chain
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` — core 49 / llm 78 / server 233 / store 98, 0 failed
- [x] OpenAPI snapshot regenerated, version-only diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)