### PR TITLE
feat(persona)!: reshape persona_genomes to chat-data-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,6 @@ All `/comp/*` routes require `Authorization: Bearer <Supabase JWT>` by default.
 
 Highlights:
 
-- `GET  /comp/personas` — list active persona genomes.
 - `POST /comp/chat/start` — open a chat session against a persona.
 - `POST /comp/chat/{session_id}/message/stream` — **the** chat turn endpoint: token-by-token Server-Sent Events (SSE) streaming. (The old blocking synchronous `/message` endpoint was removed in 0.3 — SSE is now the only chat path.)
 - `GET  /comp/chat/{session_id}/history` — paginated chat history.

--- a/README.zh.md
+++ b/README.zh.md
@@ -151,7 +151,6 @@ Server 默認監聽 `0.0.0.0:8080`。Scalar API docs 在 `/docs`，OpenAPI JSON 
 
 重點 endpoint：
 
-- `GET  /comp/personas`——列出啟用中的 persona genomes。
 - `POST /comp/chat/start`——對指定 persona 開啟 chat session。
 - `POST /comp/chat/{session_id}/message/stream`——**唯一**的聊天輪 endpoint：逐 token 的 Server-Sent Events (SSE) 串流。（舊的阻塞式同步 `/message` endpoint 已在 0.3 移除——SSE 現在是唯一的聊天路徑。）
 - `GET  /comp/chat/{session_id}/history`——分頁讀聊天歷史。

--- a/crates/eros-engine-core/src/pde.rs
+++ b/crates/eros-engine-core/src/pde.rs
@@ -179,9 +179,7 @@ mod tests {
                 name: "Mia".into(),
                 system_prompt: "You are Mia.".into(),
                 tip_personality: Some("normal".into()),
-                avatar_url: None,
                 art_metadata: serde_json::json!({}),
-                is_active: true,
             },
             instance: PersonaInstance {
                 id: iid,

--- a/crates/eros-engine-core/src/persona.rs
+++ b/crates/eros-engine-core/src/persona.rs
@@ -9,9 +9,7 @@ pub struct PersonaGenome {
     pub name: String,
     pub system_prompt: String,
     pub tip_personality: Option<String>,
-    pub avatar_url: Option<String>,
     pub art_metadata: Value, // JSONB: gender/age/mbti/backstory/speech_style/quirks/topics/model
-    pub is_active: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -629,35 +629,6 @@
         ]
       }
     },
-    "/comp/personas": {
-      "get": {
-        "tags": [
-          "companion"
-        ],
-        "summary": "List active platform-owned persona genomes available for new sessions.",
-        "operationId": "list_personas",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListPersonasResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "missing or invalid bearer"
-          }
-        },
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
     "/comp/user/{user_id}/profile": {
       "get": {
         "tags": [
@@ -1200,20 +1171,6 @@
           }
         }
       },
-      "ListPersonasResponse": {
-        "type": "object",
-        "required": [
-          "personas"
-        ],
-        "properties": {
-          "personas": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PersonaGenomeDto"
-            }
-          }
-        }
-      },
       "ListSessionsResponse": {
         "type": "object",
         "required": [
@@ -1261,47 +1218,6 @@
               "null"
             ],
             "description": "Free-form caller identifier (recommended: hash of internal user id).\n`chars ≤ 256`. Forwarded as OpenRouter wire `user`."
-          }
-        }
-      },
-      "PersonaGenomeDto": {
-        "type": "object",
-        "description": "Genome row exposed on `GET /comp/personas`. Matches\n`eros_engine_core::persona::PersonaGenome` field-for-field but with\n`ToSchema` so utoipa can render it.",
-        "required": [
-          "id",
-          "name",
-          "system_prompt",
-          "art_metadata",
-          "is_active"
-        ],
-        "properties": {
-          "art_metadata": {
-            "type": "object"
-          },
-          "avatar_url": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "is_active": {
-            "type": "boolean"
-          },
-          "name": {
-            "type": "string"
-          },
-          "system_prompt": {
-            "type": "string"
-          },
-          "tip_personality": {
-            "type": [
-              "string",
-              "null"
-            ]
           }
         }
       },

--- a/crates/eros-engine-server/src/main.rs
+++ b/crates/eros-engine-server/src/main.rs
@@ -89,15 +89,15 @@ fn run_print_openapi() -> Result<()> {
 }
 
 /// Read a directory of `*.toml` persona files and insert each into
-/// `engine.persona_genomes`. Idempotent: rows are matched by `name`,
-/// so re-running won't duplicate or overwrite.
+/// `engine.persona_genomes`. Idempotent: rows are matched by `name`, so
+/// re-running won't create duplicate rows — an existing row is updated in
+/// place (id stable, content refreshed, FK references preserved).
 async fn run_seed_personas(dir: &str) -> Result<()> {
     use serde::Deserialize;
 
     #[derive(Debug, Deserialize)]
     struct PersonaFile {
         name: String,
-        avatar_url: Option<String>,
         tip_personality: Option<String>,
         system_prompt: String,
         #[serde(default)]
@@ -127,9 +127,7 @@ async fn run_seed_personas(dir: &str) -> Result<()> {
                 &f.name,
                 &f.system_prompt,
                 f.tip_personality.as_deref(),
-                f.avatar_url.as_deref(),
                 f.art_metadata,
-                true,
             )
             .await
             .with_context(|| format!("upsert {}", f.name))?;

--- a/crates/eros-engine-server/src/pipeline/mod.rs
+++ b/crates/eros-engine-server/src/pipeline/mod.rs
@@ -131,8 +131,8 @@ mod tests {
     /// the chat_messages FK is satisfied. Returns (genome_id, instance_id, session_id).
     async fn seed_session(pool: &PgPool, user_id: Uuid) -> (Uuid, Uuid, Uuid) {
         let genome_id: Uuid = sqlx::query_scalar(
-            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata, is_active) \
-             VALUES ('SignalsTest', 'sp', '{}'::jsonb, true) RETURNING id",
+            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata) \
+             VALUES ('SignalsTest', 'sp', '{}'::jsonb) RETURNING id",
         )
         .fetch_one(pool)
         .await

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -1448,8 +1448,8 @@ mod tests {
 
     async fn seed_persona_and_session(pool: &PgPool, user_id: Uuid) -> (Uuid, Uuid, Uuid) {
         let genome_id: Uuid = sqlx::query_scalar(
-            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata, is_active) \
-             VALUES ('GhostTest', 'sp', '{}'::jsonb, true) RETURNING id",
+            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata) \
+             VALUES ('GhostTest', 'sp', '{}'::jsonb) RETURNING id",
         )
         .fetch_one(pool)
         .await

--- a/crates/eros-engine-server/src/prompt.rs
+++ b/crates/eros-engine-server/src/prompt.rs
@@ -706,7 +706,6 @@ mod tests {
                 name: "Aria".into(),
                 system_prompt: "p".into(),
                 tip_personality: Some("normal".into()),
-                avatar_url: None,
                 art_metadata: serde_json::json!({
                     "age": 24,
                     "mbti": "INFP",
@@ -715,7 +714,6 @@ mod tests {
                     "quirks": ["q1"],
                     "topics": ["t1"]
                 }),
-                is_active: true,
             },
             instance: PersonaInstance {
                 id: uid,

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -481,9 +481,6 @@ pub(crate) async fn resolve_or_create_session(
             )?;
 
             let gate = gate.ok_or_else(|| AppError::NotFound("genome not found".into()))?;
-            if !gate.is_active {
-                return Err(AppError::BadRequest("genome is not active".into()));
-            }
 
             let iid = match existing_instance {
                 Some(iid) => iid,

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -887,8 +887,8 @@ pub(crate) mod testutil {
 
     pub(crate) async fn seed_genome(pool: &PgPool, name: &str) -> Uuid {
         sqlx::query_scalar::<_, Uuid>(
-            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata, is_active) \
-             VALUES ($1, 'you are a companion', '{}'::jsonb, true) RETURNING id",
+            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata) \
+             VALUES ($1, 'you are a companion', '{}'::jsonb) RETURNING id",
         )
         .bind(name)
         .fetch_one(pool)

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -72,26 +72,6 @@ const MAX_LLM_AUDIT_METADATA_VALUE_CHARS: usize = 512;
 
 // ─── DTOs ───────────────────────────────────────────────────────────
 
-/// Genome row exposed on `GET /comp/personas`. Matches
-/// `eros_engine_core::persona::PersonaGenome` field-for-field but with
-/// `ToSchema` so utoipa can render it.
-#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
-pub struct PersonaGenomeDto {
-    pub id: Uuid,
-    pub name: String,
-    pub system_prompt: String,
-    pub tip_personality: Option<String>,
-    pub avatar_url: Option<String>,
-    #[schema(value_type = Object)]
-    pub art_metadata: serde_json::Value,
-    pub is_active: bool,
-}
-
-#[derive(Debug, Serialize, utoipa::ToSchema)]
-pub struct ListPersonasResponse {
-    pub personas: Vec<PersonaGenomeDto>,
-}
-
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct StartChatRequest {
     /// Optional explicit instance id. If absent, the server picks (or
@@ -448,38 +428,6 @@ pub(crate) fn validate_llm_audit(dto: Option<LlmAuditDto>) -> Result<Option<LlmA
 
 // ─── Handlers ───────────────────────────────────────────────────────
 
-/// List active platform-owned persona genomes available for new sessions.
-#[utoipa::path(
-    get,
-    path = "/comp/personas",
-    tag = "companion",
-    responses(
-        (status = 200, body = ListPersonasResponse),
-        (status = 401, description = "missing or invalid bearer")
-    ),
-    security(("bearer" = []))
-)]
-async fn list_personas(
-    State(state): State<AppState>,
-    Extension(AuthUser(_user_id)): Extension<AuthUser>,
-) -> Result<Json<ListPersonasResponse>, AppError> {
-    let repo = PersonaRepo { pool: &state.pool };
-    let genomes = repo.list_active().await?;
-    let personas = genomes
-        .into_iter()
-        .map(|g| PersonaGenomeDto {
-            id: g.id,
-            name: g.name,
-            system_prompt: g.system_prompt,
-            tip_personality: g.tip_personality,
-            avatar_url: g.avatar_url,
-            art_metadata: g.art_metadata,
-            is_active: g.is_active,
-        })
-        .collect();
-    Ok(Json(ListPersonasResponse { personas }))
-}
-
 /// Output of `resolve_or_create_session`. Carries everything either the
 /// canonical `start_chat` or the BFF `bff_start_chat` needs to build its
 /// response. `is_new` is `true` when this call **created** the session row,
@@ -821,7 +769,6 @@ async fn event_gift(
 
 pub fn router() -> OpenApiRouter<AppState> {
     OpenApiRouter::new()
-        .routes(routes!(list_personas))
         .routes(routes!(start_chat))
         .routes(routes!(get_history))
         .routes(routes!(list_sessions))
@@ -1010,44 +957,19 @@ mod tests {
     // ─── Test 2: protected route rejects requests without bearer ────
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
-    async fn comp_personas_401_without_bearer(pool: PgPool) {
+    async fn protected_route_401_without_bearer(pool: PgPool) {
         let state = test_state(pool);
         let mut app = build_router(state);
 
         let req = Request::builder()
-            .uri("/comp/personas")
+            .uri(format!("/comp/chat/{}/sessions", Uuid::new_v4()))
             .body(Body::empty())
             .unwrap();
         let (status, _body) = send_request(&mut app, req).await;
         assert_eq!(status, StatusCode::UNAUTHORIZED);
     }
 
-    // ─── Test 3: GET /comp/personas returns active genomes ──────────
-
-    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
-    async fn comp_personas_returns_active_genomes(pool: PgPool) {
-        let _g = seed_genome(&pool, "Aria").await;
-        let state = test_state(pool);
-        let mut app = build_router(state);
-        let token = mint_test_jwt(Uuid::new_v4());
-
-        let req = Request::builder()
-            .uri("/comp/personas")
-            .header(header::AUTHORIZATION, format!("Bearer {token}"))
-            .body(Body::empty())
-            .unwrap();
-        let (status, body) = send_request(&mut app, req).await;
-        assert_eq!(status, StatusCode::OK);
-        let names: Vec<&str> = body["personas"]
-            .as_array()
-            .expect("array")
-            .iter()
-            .map(|p| p["name"].as_str().unwrap())
-            .collect();
-        assert!(names.contains(&"Aria"), "expected Aria in {names:?}");
-    }
-
-    // ─── Test 4: start_chat creates a session for the JWT user ──────
+    // ─── Test 3: start_chat creates a session for the JWT user ──────
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
     async fn start_chat_creates_session_for_jwt_user_id(pool: PgPool) {
@@ -1084,7 +1006,7 @@ mod tests {
         assert_eq!(row_user_id, user_id);
     }
 
-    // ─── Test 5: cross-user GET /chat/{user_id}/sessions → 403 ──────
+    // ─── Test 4: cross-user GET /chat/{user_id}/sessions → 403 ──────
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
     async fn get_sessions_403_when_path_user_id_differs_from_jwt(pool: PgPool) {
@@ -1104,7 +1026,7 @@ mod tests {
         assert_eq!(status, StatusCode::FORBIDDEN);
     }
 
-    // ─── Test 6: event/gift appends gift_user message + emits event ──
+    // ─── Test 5: event/gift appends gift_user message + emits event ──
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
     async fn event_gift_appends_message_and_emits_event(pool: PgPool) {

--- a/crates/eros-engine-server/src/routes/companion_stream.rs
+++ b/crates/eros-engine-server/src/routes/companion_stream.rs
@@ -529,8 +529,8 @@ mod tests {
     async fn stream_422_when_content_empty(pool: PgPool) {
         let user_id = Uuid::new_v4();
         let genome_id: Uuid = sqlx::query_scalar(
-            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata, is_active) \
-             VALUES ('S', 'p', '{}'::jsonb, true) RETURNING id",
+            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata) \
+             VALUES ('S', 'p', '{}'::jsonb) RETURNING id",
         )
         .fetch_one(&pool)
         .await
@@ -572,8 +572,8 @@ mod tests {
     async fn stream_400_when_tier_malformed(pool: PgPool) {
         let user_id = Uuid::new_v4();
         let genome_id: Uuid = sqlx::query_scalar(
-            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata, is_active) \
-             VALUES ('S', 'p', '{}'::jsonb, true) RETURNING id",
+            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata) \
+             VALUES ('S', 'p', '{}'::jsonb) RETURNING id",
         )
         .fetch_one(&pool)
         .await
@@ -619,8 +619,8 @@ mod tests {
         use eros_engine_store::chat::{AssistantInsert, ChatRepo, UpsertUserOutcome};
         let user_id = Uuid::new_v4();
         let genome_id: Uuid = sqlx::query_scalar(
-            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata, is_active) \
-             VALUES ('R', 'p', '{}'::jsonb, true) RETURNING id",
+            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata) \
+             VALUES ('R', 'p', '{}'::jsonb) RETURNING id",
         )
         .fetch_one(&pool)
         .await

--- a/crates/eros-engine-store/migrations/0024_persona_genomes_chat_data_only.sql
+++ b/crates/eros-engine-store/migrations/0024_persona_genomes_chat_data_only.sql
@@ -1,0 +1,9 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- DESTRUCTIVE. BREAKING. Strips persona_genomes to chat-relevant fields.
+-- engine no longer judges persona availability or stores display data;
+-- catalog / availability / avatar are downstream concerns keyed by genome_id.
+--
+-- Spec: docs/superpowers/specs/2026-06-01-persona-genomes-chat-data-only-design.md
+
+ALTER TABLE engine.persona_genomes DROP COLUMN IF EXISTS is_active;
+ALTER TABLE engine.persona_genomes DROP COLUMN IF EXISTS avatar_url;

--- a/crates/eros-engine-store/src/lib.rs
+++ b/crates/eros-engine-store/src/lib.rs
@@ -203,4 +203,36 @@ mod migration_tests {
         .unwrap();
         assert!(pg_exists, "persona_genomes table must survive");
     }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn migration_0024_strips_persona_genomes_to_chat_data(pool: PgPool) {
+        for col in ["is_active", "avatar_url"] {
+            let exists: bool = sqlx::query_scalar(
+                "SELECT EXISTS (SELECT 1 FROM information_schema.columns \
+                 WHERE table_schema = 'engine' AND table_name = 'persona_genomes' \
+                   AND column_name = $1)",
+            )
+            .bind(col)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+            assert!(
+                !exists,
+                "persona_genomes.{col} must be dropped by migration 0024"
+            );
+        }
+        // The chat-relevant columns survive.
+        for col in ["name", "system_prompt", "tip_personality", "art_metadata"] {
+            let exists: bool = sqlx::query_scalar(
+                "SELECT EXISTS (SELECT 1 FROM information_schema.columns \
+                 WHERE table_schema = 'engine' AND table_name = 'persona_genomes' \
+                   AND column_name = $1)",
+            )
+            .bind(col)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+            assert!(exists, "persona_genomes.{col} must survive migration 0024");
+        }
+    }
 }

--- a/crates/eros-engine-store/src/persona.rs
+++ b/crates/eros-engine-store/src/persona.rs
@@ -12,9 +12,7 @@ struct GenomeRow {
     name: String,
     system_prompt: String,
     tip_personality: Option<String>,
-    avatar_url: Option<String>,
     art_metadata: serde_json::Value,
-    is_active: bool,
 }
 
 /// Narrow gate-field view of a genome for the chat-start path: just
@@ -44,9 +42,7 @@ impl From<GenomeRow> for PersonaGenome {
             name: r.name,
             system_prompt: r.system_prompt,
             tip_personality: r.tip_personality,
-            avatar_url: r.avatar_url,
             art_metadata: r.art_metadata,
-            is_active: r.is_active,
         }
     }
 }
@@ -78,8 +74,8 @@ pub struct PersonaRepo<'a> {
 impl<'a> PersonaRepo<'a> {
     pub async fn get_genome(&self, genome_id: Uuid) -> Result<Option<PersonaGenome>, sqlx::Error> {
         let row = sqlx::query_as::<_, GenomeRow>(
-            "SELECT id, name, system_prompt, tip_personality, avatar_url, \
-                    art_metadata, is_active \
+            "SELECT id, name, system_prompt, tip_personality, \
+                    art_metadata \
              FROM engine.persona_genomes \
              WHERE id = $1",
         )
@@ -120,9 +116,7 @@ impl<'a> PersonaRepo<'a> {
             name: String,
             system_prompt: String,
             tip_personality: Option<String>,
-            avatar_url: Option<String>,
             art_metadata: serde_json::Value,
-            is_active: bool,
         }
 
         let row = sqlx::query_as::<_, Joined>(
@@ -135,9 +129,7 @@ impl<'a> PersonaRepo<'a> {
                 pg.name        AS name, \
                 pg.system_prompt    AS system_prompt, \
                 pg.tip_personality  AS tip_personality, \
-                pg.avatar_url       AS avatar_url, \
-                pg.art_metadata     AS art_metadata, \
-                pg.is_active        AS is_active \
+                pg.art_metadata     AS art_metadata \
              FROM engine.persona_instances pi \
              JOIN engine.persona_genomes pg ON pg.id = pi.genome_id \
              WHERE pi.id = $1 AND pi.status = 'active'",
@@ -153,9 +145,7 @@ impl<'a> PersonaRepo<'a> {
                 name: r.name,
                 system_prompt: r.system_prompt,
                 tip_personality: r.tip_personality,
-                avatar_url: r.avatar_url,
                 art_metadata: r.art_metadata,
-                is_active: r.is_active,
             },
             instance: PersonaInstance {
                 id: r.instance_id,
@@ -196,9 +186,7 @@ impl<'a> PersonaRepo<'a> {
         name: &str,
         system_prompt: &str,
         tip_personality: Option<&str>,
-        avatar_url: Option<&str>,
         art_metadata: serde_json::Value,
-        is_active: bool,
     ) -> Result<(Uuid, bool), sqlx::Error> {
         if let Some(id) =
             sqlx::query_scalar::<_, Uuid>("SELECT id FROM engine.persona_genomes WHERE name = $1")
@@ -210,32 +198,26 @@ impl<'a> PersonaRepo<'a> {
                 "UPDATE engine.persona_genomes SET \
                     system_prompt = $2, \
                     tip_personality = $3, \
-                    avatar_url = $4, \
-                    art_metadata = $5, \
-                    is_active = $6 \
+                    art_metadata = $4 \
                  WHERE id = $1",
             )
             .bind(id)
             .bind(system_prompt)
             .bind(tip_personality)
-            .bind(avatar_url)
             .bind(art_metadata)
-            .bind(is_active)
             .execute(self.pool)
             .await?;
             return Ok((id, false));
         }
         let id = sqlx::query_scalar::<_, Uuid>(
             "INSERT INTO engine.persona_genomes \
-                (name, system_prompt, tip_personality, avatar_url, art_metadata, is_active) \
-             VALUES ($1, $2, $3, $4, $5, $6) RETURNING id",
+                (name, system_prompt, tip_personality, art_metadata) \
+             VALUES ($1, $2, $3, $4) RETURNING id",
         )
         .bind(name)
         .bind(system_prompt)
         .bind(tip_personality)
-        .bind(avatar_url)
         .bind(art_metadata)
-        .bind(is_active)
         .fetch_one(self.pool)
         .await?;
         Ok((id, true))
@@ -302,20 +284,14 @@ impl<'a> PersonaRepo<'a> {
 mod tests {
     use super::*;
 
-    async fn insert_genome(
-        pool: &PgPool,
-        name: &str,
-        is_active: bool,
-        art: serde_json::Value,
-    ) -> Uuid {
+    async fn insert_genome(pool: &PgPool, name: &str, art: serde_json::Value) -> Uuid {
         sqlx::query_scalar::<_, Uuid>(
-            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata, is_active) \
-             VALUES ($1, $2, $3, $4) RETURNING id",
+            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata) \
+             VALUES ($1, $2, $3) RETURNING id",
         )
         .bind(name)
         .bind("you are a companion")
         .bind(art)
-        .bind(is_active)
         .fetch_one(pool)
         .await
         .unwrap()
@@ -324,7 +300,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn get_genome_returns_full_record(pool: PgPool) {
         let repo = PersonaRepo { pool: &pool };
-        let id = insert_genome(&pool, "Nova", true, serde_json::json!({ "mbti": "INFP" })).await;
+        let id = insert_genome(&pool, "Nova", serde_json::json!({ "mbti": "INFP" })).await;
 
         let g = repo.get_genome(id).await.unwrap().unwrap();
         assert_eq!(g.name, "Nova");
@@ -338,7 +314,7 @@ mod tests {
     async fn create_instance_and_load_companion(pool: PgPool) {
         let repo = PersonaRepo { pool: &pool };
         let owner = Uuid::new_v4();
-        let genome_id = insert_genome(&pool, "Echo", true, serde_json::json!({ "age": 27 })).await;
+        let genome_id = insert_genome(&pool, "Echo", serde_json::json!({ "age": 27 })).await;
 
         let instance_id = repo.create_instance(genome_id, owner).await.unwrap();
 
@@ -381,7 +357,7 @@ mod tests {
     async fn find_active_instance_skips_archived_and_missing(pool: PgPool) {
         let repo = PersonaRepo { pool: &pool };
         let owner = Uuid::new_v4();
-        let genome_id = insert_genome(&pool, "Echo", true, serde_json::json!({})).await;
+        let genome_id = insert_genome(&pool, "Echo", serde_json::json!({})).await;
 
         // none yet
         assert!(repo
@@ -414,7 +390,7 @@ mod tests {
     async fn load_companion_skips_non_active_instances(pool: PgPool) {
         let repo = PersonaRepo { pool: &pool };
         let owner = Uuid::new_v4();
-        let genome_id = insert_genome(&pool, "Echo", true, serde_json::json!({})).await;
+        let genome_id = insert_genome(&pool, "Echo", serde_json::json!({})).await;
         let instance_id = repo.create_instance(genome_id, owner).await.unwrap();
 
         sqlx::query("UPDATE engine.persona_instances SET status = 'archived' WHERE id = $1")
@@ -433,8 +409,8 @@ mod tests {
         let owner = Uuid::new_v4();
         let genome_id = sqlx::query_scalar::<_, Uuid>(
             "INSERT INTO engine.persona_genomes \
-                (name, system_prompt, art_metadata, is_active) \
-             VALUES ('Nova', 'p', '{}'::jsonb, true) RETURNING id",
+                (name, system_prompt, art_metadata) \
+             VALUES ('Nova', 'p', '{}'::jsonb) RETURNING id",
         )
         .fetch_one(&pool)
         .await
@@ -467,7 +443,7 @@ mod tests {
         // upsert must reactivate the SAME row instead.
         let repo = PersonaRepo { pool: &pool };
         let owner = Uuid::new_v4();
-        let genome_id = insert_genome(&pool, "Echo", true, serde_json::json!({})).await;
+        let genome_id = insert_genome(&pool, "Echo", serde_json::json!({})).await;
 
         // first call creates
         let iid = repo.ensure_active_instance(genome_id, owner).await.unwrap();

--- a/crates/eros-engine-store/src/persona.rs
+++ b/crates/eros-engine-store/src/persona.rs
@@ -17,13 +17,12 @@ struct GenomeRow {
     is_active: bool,
 }
 
-/// Narrow gate-fields view of a genome for the chat-start path: the two
-/// fields `resolve_or_create_session` needs — `name` (response) and
-/// `is_active` (400 check) — in one row. Folds the former `get_genome` read.
+/// Narrow gate-field view of a genome for the chat-start path: just
+/// `name` (used in the response). The engine no longer gates on
+/// availability, so existence of the row is the only check.
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct GenomeGate {
     pub name: String,
-    pub is_active: bool,
 }
 
 /// Gate-fields view for the explicit-`instance_id` chat-start path: owner
@@ -96,7 +95,7 @@ impl<'a> PersonaRepo<'a> {
         genome_id: Uuid,
     ) -> Result<Option<GenomeGate>, sqlx::Error> {
         sqlx::query_as::<_, GenomeGate>(
-            "SELECT name, is_active \
+            "SELECT name \
              FROM engine.persona_genomes WHERE id = $1",
         )
         .bind(genome_id)
@@ -356,27 +355,19 @@ mod tests {
     }
 
     #[sqlx::test(migrations = "./migrations")]
-    async fn get_genome_gate_returns_name_and_active(pool: PgPool) {
+    async fn get_genome_gate_returns_name(pool: PgPool) {
         let repo = PersonaRepo { pool: &pool };
 
-        // legacy genome → is_active true
-        let legacy = insert_genome(&pool, "Legacy", true, serde_json::json!({})).await;
-        let g = repo.get_genome_gate(legacy).await.unwrap().unwrap();
-        assert_eq!(g.name, "Legacy");
-        assert!(g.is_active);
-
-        // inactive genome → is_active false
-        let inactive = sqlx::query_scalar::<_, Uuid>(
-            "INSERT INTO engine.persona_genomes \
-                (name, system_prompt, art_metadata, is_active) \
-             VALUES ('NftGenome', 'sp', '{}'::jsonb, false) RETURNING id",
+        let id = sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata) \
+             VALUES ('Legacy', 'sp', '{}'::jsonb) RETURNING id",
         )
         .fetch_one(&pool)
         .await
         .unwrap();
-        let g2 = repo.get_genome_gate(inactive).await.unwrap().unwrap();
-        assert_eq!(g2.name, "NftGenome");
-        assert!(!g2.is_active);
+
+        let g = repo.get_genome_gate(id).await.unwrap().unwrap();
+        assert_eq!(g.name, "Legacy");
 
         // missing → None
         assert!(repo

--- a/crates/eros-engine-store/src/persona.rs
+++ b/crates/eros-engine-store/src/persona.rs
@@ -77,20 +77,6 @@ pub struct PersonaRepo<'a> {
 }
 
 impl<'a> PersonaRepo<'a> {
-    /// Active platform genomes, ordered by name.
-    pub async fn list_active(&self) -> Result<Vec<PersonaGenome>, sqlx::Error> {
-        let rows = sqlx::query_as::<_, GenomeRow>(
-            "SELECT id, name, system_prompt, tip_personality, avatar_url, \
-                    art_metadata, is_active \
-             FROM engine.persona_genomes \
-             WHERE is_active = true \
-             ORDER BY name",
-        )
-        .fetch_all(self.pool)
-        .await?;
-        Ok(rows.into_iter().map(PersonaGenome::from).collect())
-    }
-
     pub async fn get_genome(&self, genome_id: Uuid) -> Result<Option<PersonaGenome>, sqlx::Error> {
         let row = sqlx::query_as::<_, GenomeRow>(
             "SELECT id, name, system_prompt, tip_personality, avatar_url, \
@@ -334,21 +320,6 @@ mod tests {
         .fetch_one(pool)
         .await
         .unwrap()
-    }
-
-    #[sqlx::test(migrations = "./migrations")]
-    async fn list_active_filters_by_is_active(pool: PgPool) {
-        let repo = PersonaRepo { pool: &pool };
-        let _g_active1 = insert_genome(&pool, "Aria", true, serde_json::json!({})).await;
-        let _g_inactive = insert_genome(&pool, "Boris", false, serde_json::json!({})).await;
-        let _g_active2 = insert_genome(&pool, "Cara", true, serde_json::json!({})).await;
-
-        let active = repo.list_active().await.unwrap();
-        assert_eq!(active.len(), 2);
-        // ordered by name
-        assert_eq!(active[0].name, "Aria");
-        assert_eq!(active[1].name, "Cara");
-        assert!(active.iter().all(|g| g.is_active));
     }
 
     #[sqlx::test(migrations = "./migrations")]

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -31,33 +31,6 @@ curl http://localhost:8080/healthz
 }
 ```
 
-## Personas
-
-### `GET /comp/personas`
-
-List active persona genomes. Auth required.
-
-```bash
-curl -H "Authorization: Bearer $JWT" \
-  http://localhost:8080/comp/personas
-```
-
-```json
-{
-  "personas": [
-    {
-      "id": "11d6a45a-1fd9-4fe6-a943-3f049035eb68",
-      "name": "Aria",
-      "system_prompt": "…",
-      "tip_personality": "warm-but-reserved",
-      "avatar_url": "https://avatars.etherfun.xyz/aria.png",
-      "art_metadata": { "age": 27, "mbti": "INFJ", "model": "x-ai/grok-4-fast", … },
-      "is_active": true
-    }
-  ]
-}
-```
-
 ## Chat lifecycle
 
 ### `POST /comp/chat/start`

--- a/docs/api-reference.zh.md
+++ b/docs/api-reference.zh.md
@@ -31,33 +31,6 @@ curl http://localhost:8080/healthz
 }
 ```
 
-## 人格
-
-### `GET /comp/personas`
-
-列出所有處於 active 狀態的人格基因。需鑒權。
-
-```bash
-curl -H "Authorization: Bearer $JWT" \
-  http://localhost:8080/comp/personas
-```
-
-```json
-{
-  "personas": [
-    {
-      "id": "11d6a45a-1fd9-4fe6-a943-3f049035eb68",
-      "name": "Aria",
-      "system_prompt": "…",
-      "tip_personality": "warm-but-reserved",
-      "avatar_url": "https://avatars.etherfun.xyz/aria.png",
-      "art_metadata": { "age": 27, "mbti": "INFJ", "model": "x-ai/grok-4-fast", … },
-      "is_active": true
-    }
-  ]
-}
-```
-
 ## 對話生命周期
 
 ### `POST /comp/chat/start`

--- a/docs/superpowers/specs/2026-06-01-persona-genomes-chat-data-only-design.md
+++ b/docs/superpowers/specs/2026-06-01-persona-genomes-chat-data-only-design.md
@@ -1,0 +1,182 @@
+# persona_genomes: chat-data-only reshape
+
+`engine.persona_genomes` carries two columns that exist for an availability
+judgment engine should not be making: `is_active` (a boolean usability gate)
+and `avatar_url` (display data engine never reads). Both encode "is this
+persona usable / how is it shown" — a downstream concern. This slice strips
+the table down to the fields the chat pipeline actually consumes and removes
+the engine's persona-availability surface entirely.
+
+After this change the engine no longer answers "which personas exist" or
+"can this persona be used." It stores chat data keyed by `genome_id`; the
+downstream owns the catalog, availability, creator attribution, public/private
+state, and avatars, keyed by the `genome_id` it learned at seed time.
+
+Single slice, single PR onto `dev`. Breaking (schema + API). Mirrors the
+`0023_drop_nft_ownership_stack` precedent: engine sheds a responsibility that
+belongs downstream.
+
+---
+
+## Final schema
+
+```
+engine.persona_genomes (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name            TEXT NOT NULL,
+    system_prompt   TEXT NOT NULL,
+    tip_personality TEXT,
+    art_metadata    JSONB NOT NULL DEFAULT '{}',
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+)
+```
+
+Exactly the fields the chat pipeline reads: `name` (response + prompt),
+`system_prompt` (prompt), `tip_personality` (gift/tip reaction directives),
+`art_metadata` (gender/age/mbti/backstory/… plucked into the prompt).
+
+**Dropped:** `is_active`, `avatar_url`. **Not added:** `metadata`.
+
+### Why no `metadata` column
+
+The original idea was a `metadata` JSONB for downstream availability logic
+(creator name, public/private). But with `GET /comp/personas` removed (below),
+engine returns zero genome data over HTTP — nothing would read an engine-side
+`metadata`. Downstream already owns its catalog; it stores creator /
+public-private in its own tables keyed by `genome_id`. An engine column the
+engine never reads and never exposes is dead weight. So: not added.
+
+`persona_instances` is untouched — `(genome_id, owner_uid, status)` remains the
+per-user instance model the chat pipeline relies on.
+
+---
+
+## Behavioral changes (both breaking)
+
+1. **No genome API.** `GET /comp/personas` is removed. It was the *only*
+   endpoint that read genome data (there is no `GET /comp/personas/{id}`), so
+   the engine now exposes no genome data over HTTP at all. Genome fields are
+   internal-only, consumed inside the chat pipeline via `load_companion`.
+
+2. **No availability gate.** The `genome_id` path of
+   `resolve_or_create_session` stops returning `400 "genome is not active"`.
+   It now only checks existence: a genome row that exists → chat starts; a
+   missing `genome_id` → `404 "genome not found"` (unchanged). The engine no
+   longer judges whether a persona may be used — downstream gates that before
+   it ever sends a `genome_id`.
+
+---
+
+## Migration
+
+New migration `0024_persona_genomes_chat_data_only.sql`:
+
+```sql
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Spec: docs/superpowers/specs/2026-06-01-persona-genomes-chat-data-only-design.md
+--
+-- DESTRUCTIVE. BREAKING. Strips persona_genomes to chat-relevant fields.
+-- engine no longer judges persona availability or stores display data;
+-- catalog / availability / avatar are downstream concerns keyed by genome_id.
+
+ALTER TABLE engine.persona_genomes DROP COLUMN IF EXISTS is_active;
+ALTER TABLE engine.persona_genomes DROP COLUMN IF EXISTS avatar_url;
+```
+
+Notes:
+- Irreversible. `avatar_url` values are gone after this runs — a deployment
+  that wants to keep them must export them out of `persona_genomes` first.
+  Engine offers no preservation path because it never owned avatars as data.
+- The `0013_supabase_lockdown` REVOKE/RLS statements that name
+  `engine.persona_genomes` are unaffected (the table still exists).
+- The `0024` number assumes this lands as the next migration; if another
+  migration merges first, it becomes the next unused number at merge time.
+
+---
+
+## Files edited
+
+### core — `crates/eros-engine-core/src/persona.rs`
+- `PersonaGenome`: remove `avatar_url` and `is_active` fields.
+
+### core — `crates/eros-engine-core/src/pde.rs`
+- Fixture `PersonaGenome` literal (~line 181): drop the `avatar_url` and
+  `is_active` lines.
+
+### store — `crates/eros-engine-store/src/persona.rs`
+- `GenomeRow`: remove `avatar_url`, `is_active`.
+- `From<GenomeRow> for PersonaGenome`: remove the two field mappings.
+- `GenomeGate`: remove `is_active` → struct carries `name` only. (Kept as a
+  struct rather than collapsing to `query_scalar::<String>` for symmetry with
+  `InstanceGate` and a stable call site.)
+- `get_genome`: drop `avatar_url, is_active` from the SELECT. **Kept** — it is
+  test-only today, but retained as the single-genome read for a possible
+  future single-genome endpoint.
+- `get_genome_gate`: SELECT `name` only.
+- `load_companion`: drop `avatar_url, is_active` from the `Joined` struct, the
+  SELECT, and the `PersonaGenome { … }` construction.
+- `upsert_genome`: remove the `avatar_url` and `is_active` parameters and the
+  corresponding INSERT/UPDATE columns (seed always passed `is_active = true`).
+- **Remove `list_active`** entirely — its only non-test caller was the dropped
+  endpoint.
+- Tests: remove `list_active_filters_by_is_active`. In
+  `get_genome_gate_returns_name_and_active`, drop the `is_active` assertions
+  and the inactive-genome branch (rename to reflect "returns name"). Update the
+  `insert_genome` test helper and any raw INSERTs to the new column set.
+
+### server — `crates/eros-engine-server/src/routes/companion.rs`
+- Remove `PersonaGenomeDto`, `ListPersonasResponse`, the `list_personas`
+  handler, its `#[utoipa::path]`, and `routes!(list_personas)` from `router()`.
+- In `resolve_or_create_session`: remove the
+  `if !gate.is_active { return Err(BadRequest("genome is not active")) }`
+  block. The `gate.ok_or_else(NotFound)` existence check stays.
+- Tests: remove `comp_personas_401_without_bearer` and
+  `comp_personas_returns_active_genomes`. Update `seed_genome` (~line 946) to
+  the new column set. No server test asserts the inactive-genome 400, so
+  nothing else changes here; `start_chat_passes_for_legacy_genome` stays. (The
+  only `is_active`-based coverage is the store-layer `get_genome_gate` test
+  already handled above.)
+
+### server — `crates/eros-engine-server/src/main.rs`
+- `run_seed_personas` → `PersonaFile`: remove the `avatar_url` field. Existing
+  persona TOML files that still set `avatar_url` keep parsing — `PersonaFile`
+  has no `deny_unknown_fields`, so the key is silently ignored.
+- `upsert_genome(...)` call: drop the `f.avatar_url.as_deref()` and the
+  trailing `true` (is_active) arguments.
+
+### server — `crates/eros-engine-server/src/prompt.rs`
+- `fixture_persona` `PersonaGenome` literal (~lines 709/718): drop `avatar_url`
+  and `is_active`.
+
+### server — test-fixture INSERTs
+Each inserts `(name, system_prompt, art_metadata, is_active)` — drop the
+`is_active` column and its bound value:
+- `crates/eros-engine-server/src/routes/companion_stream.rs` (3 sites)
+- `crates/eros-engine-server/src/pipeline/mod.rs`
+- `crates/eros-engine-server/src/pipeline/stream.rs`
+
+### OpenAPI — `crates/eros-engine-server/openapi.json`
+- Regenerate via the `print-openapi` path (`cargo run -- print-openapi` or the
+  repo's existing generation command). Removes the `/comp/personas` path and
+  the `PersonaGenome`(Dto) + `ListPersonasResponse` schemas. CI's openapi
+  drift check must pass.
+
+### Docs / README
+- Remove `GET /comp/personas` from any API listing.
+- seed-personas TOML docs: drop `avatar_url`; note availability/catalog is the
+  downstream's responsibility.
+
+---
+
+## Out of scope / deferred
+- `persona_instances` shape, `status` semantics — untouched.
+- A future single-genome read endpoint — `get_genome` is retained so it is a
+  thin handler away, but no endpoint is added now.
+- Version bump (this is breaking; workspace is `0.5.2-dev`). Per the release
+  rule, the bump and tag are decided at release time, not here.
+
+## Testing
+- `cargo fmt`, `clippy`, `cargo test` (sqlx tests run the new migration).
+- Regenerate and diff `openapi.json`; confirm CI drift check is green.
+- Confirm seeding still works against an existing persona TOML that contains a
+  now-ignored `avatar_url` key.

--- a/examples/personas/aria.toml
+++ b/examples/personas/aria.toml
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 name = "Aria"
-avatar_url = "https://avatars.etherfun.xyz/aria.png"
 tip_personality = "warm-but-reserved"
 
 system_prompt = """

--- a/examples/personas/kenji.toml
+++ b/examples/personas/kenji.toml
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 name = "Kenji"
-avatar_url = "https://avatars.etherfun.xyz/kenji.png"
 tip_personality = "deadpan-grateful"
 
 system_prompt = """

--- a/examples/personas/miel.toml
+++ b/examples/personas/miel.toml
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 name = "Miel"
-avatar_url = "https://avatars.etherfun.xyz/miel.png"
 tip_personality = "playful-grateful-then-shy"
 
 system_prompt = """


### PR DESCRIPTION
Strips `engine.persona_genomes` to the fields the chat pipeline actually uses and removes the engine's persona-availability surface entirely. Catalog / availability / creator / avatar become downstream concerns, keyed by `genome_id`.

## What changed
- **Drop `is_active`** (availability gate) and **`avatar_url`** (display data) from `PersonaGenome` and every consumer.
- **Remove `GET /comp/personas`** — the only endpoint exposing genome data over HTTP — plus its DTOs and `PersonaRepo::list_active()`. Engine now exposes zero genome data over HTTP.
- **Drop the chat-start availability gate**: `resolve_or_create_session` no longer returns `400 "genome is not active"`. Existence-only — `404` if the genome row is missing.
- **No `metadata` column added** — downstream owns persona catalog/availability in its own store.
- **Migration `0024`** (destructive) drops the two columns; docs + example persona TOMLs updated.

Final schema: `id, name, system_prompt, tip_personality, art_metadata, created_at`.

## ⚠️ BREAKING
- `GET /comp/personas` removed.
- chat-start no longer rejects "inactive" genomes (downstream gates before sending a `genome_id`).
- `persona_genomes.is_active` and `.avatar_url` dropped — migration `0024` is destructive; `avatar_url` is **not** preserved (export first if a live deployment needs it).

## Test plan
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` — 421 pass (incl. `migration_0024_strips_persona_genomes_to_chat_data`)
- [x] OpenAPI snapshot regenerated, no drift
- [ ] Codex review
- [ ] CI green

Spec: `docs/superpowers/specs/2026-06-01-persona-genomes-chat-data-only-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)