### PR TITLE
feat(input-filter): optional user-input rewrite filter (chat_input_filter)

### DIFF
--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -2039,7 +2039,10 @@ reasoning = { enabled = false }
         assert_eq!(f.max_tokens, 400);
         assert_eq!(
             f.reasoning,
-            Some(ReasoningConfig { enabled: Some(false), exclude: None })
+            Some(ReasoningConfig {
+                enabled: Some(false),
+                exclude: None
+            })
         );
     }
 

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -377,11 +377,12 @@ pub struct TaskConfig {
     pub model_name_display_override: Option<DisplayOverride>,
     #[serde(default)]
     pub output_filter: Option<bool>,
-    /// Global switch for the user-input rewrite filter (chat_input_filter).
+    /// Global trigger for the user-input rewrite filter (chat_input_filter).
     /// Read ONLY on [tasks.chat_companion]; task-level, no per-tier override
-    /// (unlike `output_filter`). Default false.
+    /// (unlike `output_filter`). `false`/absent ⇒ off, `true` ⇒ every turn,
+    /// `0.8` ⇒ 80% of turns. See `InputFilterTrigger`.
     #[serde(default)]
-    pub input_filter: Option<bool>,
+    pub input_filter: Option<InputFilterTrigger>,
     /// System instruction sent to the filter LLM; the assistant reply to
     /// rewrite is passed as a SEPARATE user message — this is NOT a template
     /// with placeholder substitution.
@@ -455,10 +456,63 @@ pub struct ResolvedOutputFilter {
     pub reasoning: Option<ReasoningConfig>,
 }
 
+/// Per-turn trigger for the user-input rewrite filter (`input_filter` on
+/// `[tasks.chat_companion]`). Three TOML forms: `false` (never, probability
+/// 0.0), `true` (always, probability 1.0), or a number in `[0.0, 1.0]` (e.g.
+/// `0.8` ⇒ fire on ~80% of turns). A number outside `[0.0, 1.0]` (or non-finite)
+/// is a hard config error — the load fails loudly rather than silently clamping.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct InputFilterTrigger(pub f64);
+
+impl<'de> Deserialize<'de> for InputFilterTrigger {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct TriggerVisitor;
+        impl<'de> serde::de::Visitor<'de> for TriggerVisitor {
+            type Value = InputFilterTrigger;
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("a bool, or a probability number in [0.0, 1.0]")
+            }
+            fn visit_bool<E>(self, b: bool) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(InputFilterTrigger(if b { 1.0 } else { 0.0 }))
+            }
+            fn visit_f64<E>(self, x: f64) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                if x.is_finite() && (0.0..=1.0).contains(&x) {
+                    Ok(InputFilterTrigger(x))
+                } else {
+                    Err(E::custom(format!(
+                        "input_filter probability must be between 0.0 and 1.0, got {x}"
+                    )))
+                }
+            }
+            fn visit_i64<E>(self, x: i64) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                self.visit_f64(x as f64)
+            }
+            fn visit_u64<E>(self, x: u64) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                self.visit_f64(x as f64)
+            }
+        }
+        deserializer.deserialize_any(TriggerVisitor)
+    }
+}
+
 /// Resolved user-input rewrite filter (`chat_input_filter`). Mirrors
 /// `ResolvedOutputFilter` minus `trigger`/`timing` (the input filter has no
-/// triggers and no extract-timing). `fallback_model` is already truncated to
-/// `retry_depth`.
+/// extract-timing). `fallback_model` is already truncated to `retry_depth`.
 #[derive(Debug, Clone)]
 pub struct ResolvedInputFilter {
     pub model: String,
@@ -468,6 +522,10 @@ pub struct ResolvedInputFilter {
     pub filter_prompt: String,
     pub retry_depth: u32,
     pub reasoning: Option<ReasoningConfig>,
+    /// Per-turn fire probability in `[0.0, 1.0]` (always > 0.0 here — a 0.0
+    /// trigger resolves to `None`). The stream wiring draws one coin flip per
+    /// turn and runs the filter LLM only when `draw < probability`.
+    pub probability: f64,
 }
 
 impl ModelConfig {
@@ -666,20 +724,30 @@ impl ModelConfig {
         })
     }
 
-    /// chat_companion task-level `input_filter` switch; no tier override. Default false.
-    pub fn input_filter_enabled(&self) -> bool {
+    /// chat_companion task-level `input_filter` fire probability; no tier
+    /// override. `false`/absent → 0.0, `true` → 1.0, number → that probability.
+    /// The per-turn coin flip happens in the stream wiring.
+    pub fn input_filter_probability(&self) -> f64 {
         self.tasks
             .get("chat_companion")
             .and_then(|t| t.input_filter)
-            .unwrap_or(false)
+            .map(|t| t.0)
+            .unwrap_or(0.0)
+    }
+
+    /// True when the input filter can ever fire (probability > 0.0).
+    pub fn input_filter_enabled(&self) -> bool {
+        self.input_filter_probability() > 0.0
     }
 
     /// Resolve the user-input rewrite filter. `None` (disabled) when:
-    /// chat_companion `input_filter` is false (task-level → false), OR `[tasks.chat_input_filter]`
-    /// is absent, OR its resolved `filter_prompt` is blank.
+    /// chat_companion `input_filter` probability is 0.0 (false/absent), OR
+    /// `[tasks.chat_input_filter]` is absent, OR its resolved `filter_prompt` is
+    /// blank. The carried `probability` gates the per-turn run in the wiring.
     pub fn resolve_input_filter(&self) -> Option<ResolvedInputFilter> {
         const FILTER_TASK: &str = "chat_input_filter";
-        if !self.input_filter_enabled() {
+        let probability = self.input_filter_probability();
+        if probability <= 0.0 {
             return None;
         }
         let task_cfg = self.tasks.get(FILTER_TASK)?;
@@ -699,6 +767,7 @@ impl ModelConfig {
             filter_prompt,
             retry_depth,
             reasoning: task_cfg.reasoning.clone(),
+            probability,
         })
     }
 }
@@ -1126,7 +1195,7 @@ reasoning    = { enabled = false }
         );
 
         // chat_input_filter schema lock (input-filter feature).
-        assert_eq!(chat.input_filter, Some(true));
+        assert_eq!(chat.input_filter, Some(InputFilterTrigger(1.0)));
         let inf = cfg
             .resolve_input_filter()
             .expect("input filter resolves from fixture");
@@ -1134,6 +1203,7 @@ reasoning    = { enabled = false }
         assert_eq!(inf.retry_depth, 1);
         assert_eq!(inf.max_tokens, 400);
         assert_eq!(inf.filter_prompt, "Rewrite per policy.");
+        assert_eq!(inf.probability, 1.0);
     }
 
     #[test]
@@ -2057,6 +2127,7 @@ reasoning = { enabled = false }
         assert_eq!(f.filter_prompt, "REWRITE");
         assert_eq!(f.temperature, 0.3);
         assert_eq!(f.max_tokens, 400);
+        assert_eq!(f.probability, 1.0); // `input_filter = true` ⇒ always
         assert_eq!(
             f.reasoning,
             Some(ReasoningConfig {
@@ -2064,6 +2135,70 @@ reasoning = { enabled = false }
                 exclude: None
             })
         );
+    }
+
+    #[test]
+    fn input_filter_trigger_parses_three_forms() {
+        // false ⇒ probability 0.0 (disabled)
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.chat_companion]\nmodel = \"m\"\ninput_filter = false\n",
+        )
+        .unwrap();
+        assert_eq!(cfg.input_filter_probability(), 0.0);
+        assert!(!cfg.input_filter_enabled());
+
+        // true ⇒ 1.0
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.chat_companion]\nmodel = \"m\"\ninput_filter = true\n",
+        )
+        .unwrap();
+        assert_eq!(cfg.input_filter_probability(), 1.0);
+
+        // number ⇒ that probability
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.chat_companion]\nmodel = \"m\"\ninput_filter = 0.8\n",
+        )
+        .unwrap();
+        assert_eq!(cfg.input_filter_probability(), 0.8);
+        assert!(cfg.input_filter_enabled());
+
+        // integer bounds 0 and 1 are accepted
+        let cfg =
+            ModelConfig::from_toml_str("[tasks.chat_companion]\nmodel = \"m\"\ninput_filter = 1\n")
+                .unwrap();
+        assert_eq!(cfg.input_filter_probability(), 1.0);
+    }
+
+    #[test]
+    fn input_filter_out_of_range_is_rejected() {
+        // > 1.0, < 0.0, and non-finite are hard config errors (not clamped).
+        for bad in ["1.5", "-0.2", "2", "nan", "inf"] {
+            let toml = format!("[tasks.chat_companion]\nmodel = \"m\"\ninput_filter = {bad}\n");
+            assert!(
+                ModelConfig::from_toml_str(&toml).is_err(),
+                "input_filter = {bad} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_input_filter_carries_probability_and_zero_disables() {
+        // 0.8 ⇒ Some with probability 0.8
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.chat_companion]\nmodel = \"m\"\ninput_filter = 0.8\n\
+             [tasks.chat_input_filter]\nmodel = \"f\"\nfilter_prompt = \"REWRITE\"\n",
+        )
+        .unwrap();
+        let f = cfg.resolve_input_filter().expect("enabled");
+        assert_eq!(f.probability, 0.8);
+
+        // 0.0 ⇒ None (disabled), even with a valid filter table present
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.chat_companion]\nmodel = \"m\"\ninput_filter = 0.0\n\
+             [tasks.chat_input_filter]\nmodel = \"f\"\nfilter_prompt = \"REWRITE\"\n",
+        )
+        .unwrap();
+        assert!(cfg.resolve_input_filter().is_none());
     }
 
     #[test]

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -985,6 +985,7 @@ temperature  = 0.85
 max_tokens   = 600
 description  = "AI companion chat"
 allow_traits = ["allow_politics"]
+input_filter = true
 
 [tasks.chat_companion.tiers.gold]
 model        = "x-ai/grok-4.20"
@@ -1008,6 +1009,15 @@ description  = "reserved — current PDE is rule-based"
 model        = "voyage-3-lite"
 dimensions   = 512
 description  = "reserved — Voyage hard-codes its own model"
+
+[tasks.chat_input_filter]
+model        = "openai/gpt-5.4-nano"
+fallback     = "deepseek/deepseek-chat-v3.2"
+retry_depth  = 1
+temperature  = 0.3
+max_tokens   = 400
+filter_prompt = "Rewrite per policy."
+reasoning    = { enabled = false }
 "#;
 
     #[test]
@@ -1114,6 +1124,16 @@ description  = "reserved — Voyage hard-codes its own model"
             r.allow_traits,
             Some(vec!["allow_nsfw".to_string(), "allow_politics".to_string()])
         );
+
+        // chat_input_filter schema lock (input-filter feature).
+        assert_eq!(chat.input_filter, Some(true));
+        let inf = cfg
+            .resolve_input_filter()
+            .expect("input filter resolves from fixture");
+        assert_eq!(inf.model, "openai/gpt-5.4-nano");
+        assert_eq!(inf.retry_depth, 1);
+        assert_eq!(inf.max_tokens, 400);
+        assert_eq!(inf.filter_prompt, "Rewrite per policy.");
     }
 
     #[test]

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -377,6 +377,11 @@ pub struct TaskConfig {
     pub model_name_display_override: Option<DisplayOverride>,
     #[serde(default)]
     pub output_filter: Option<bool>,
+    /// Global switch for the user-input rewrite filter (chat_input_filter).
+    /// Read ONLY on [tasks.chat_companion]; task-level, no per-tier override
+    /// (unlike `output_filter`). Default false.
+    #[serde(default)]
+    pub input_filter: Option<bool>,
     /// System instruction sent to the filter LLM; the assistant reply to
     /// rewrite is passed as a SEPARATE user message — this is NOT a template
     /// with placeholder substitution.
@@ -447,6 +452,21 @@ pub struct ResolvedOutputFilter {
     /// Reasoning config forwarded from `[tasks.chat_output_filter]`. Task-level
     /// only (no per-tier override), consistent with `chat_companion`'s own
     /// `reasoning` field shape.
+    pub reasoning: Option<ReasoningConfig>,
+}
+
+/// Resolved user-input rewrite filter (`chat_input_filter`). Mirrors
+/// `ResolvedOutputFilter` minus `trigger`/`timing` (the input filter has no
+/// triggers and no extract-timing). `fallback_model` is already truncated to
+/// `retry_depth`.
+#[derive(Debug, Clone)]
+pub struct ResolvedInputFilter {
+    pub model: String,
+    pub fallback_model: Vec<String>,
+    pub temperature: f64,
+    pub max_tokens: u32,
+    pub filter_prompt: String,
+    pub retry_depth: u32,
     pub reasoning: Option<ReasoningConfig>,
 }
 
@@ -643,6 +663,42 @@ impl ModelConfig {
             timing,
             retry_depth,
             reasoning,
+        })
+    }
+
+    /// chat_companion task-level `input_filter` switch; no tier override. Default false.
+    pub fn input_filter_enabled(&self) -> bool {
+        self.tasks
+            .get("chat_companion")
+            .and_then(|t| t.input_filter)
+            .unwrap_or(false)
+    }
+
+    /// Resolve the user-input rewrite filter. `None` (disabled) when:
+    /// chat_companion `input_filter` is false (task-level → false), OR `[tasks.chat_input_filter]`
+    /// is absent, OR its resolved `filter_prompt` is blank.
+    pub fn resolve_input_filter(&self) -> Option<ResolvedInputFilter> {
+        const FILTER_TASK: &str = "chat_input_filter";
+        if !self.input_filter_enabled() {
+            return None;
+        }
+        let task_cfg = self.tasks.get(FILTER_TASK)?;
+        let filter_prompt = task_cfg.filter_prompt.clone().unwrap_or_default();
+        if filter_prompt.trim().is_empty() {
+            return None;
+        }
+        let retry_depth = task_cfg.retry_depth.unwrap_or(1);
+        let m = self.resolve(FILTER_TASK, None);
+        let mut fallback_model = m.fallback_model;
+        fallback_model.truncate(retry_depth as usize);
+        Some(ResolvedInputFilter {
+            model: m.model,
+            fallback_model,
+            temperature: m.temperature,
+            max_tokens: m.max_tokens,
+            filter_prompt,
+            retry_depth,
+            reasoning: task_cfg.reasoning.clone(),
         })
     }
 }
@@ -1922,5 +1978,90 @@ model = "gold/m"
         assert_eq!(rg.model, "gold/m"); // tier model
         assert_eq!(rg.filter_prompt, "DEFAULT"); // fell back to default block (#5)
         assert_eq!(rg.timing, FilterTiming::AfterExtract); // default timing
+    }
+
+    #[test]
+    fn resolve_input_filter_disabled_when_switch_off() {
+        let toml = r#"
+[tasks.chat_companion]
+model = "m"
+[tasks.chat_input_filter]
+model = "f"
+filter_prompt = "REWRITE"
+"#;
+        let cfg = ModelConfig::from_toml_str(toml).unwrap();
+        assert!(!cfg.input_filter_enabled());
+        assert!(cfg.resolve_input_filter().is_none());
+    }
+
+    #[test]
+    fn resolve_input_filter_none_when_table_absent_or_blank_prompt() {
+        // switch on, table absent
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.chat_companion]\nmodel = \"m\"\ninput_filter = true\n",
+        )
+        .unwrap();
+        assert!(cfg.input_filter_enabled());
+        assert!(cfg.resolve_input_filter().is_none());
+
+        // switch on, table present, blank prompt
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.chat_companion]\nmodel = \"m\"\ninput_filter = true\n\
+             [tasks.chat_input_filter]\nmodel = \"f\"\nfilter_prompt = \"   \"\n",
+        )
+        .unwrap();
+        assert!(cfg.resolve_input_filter().is_none());
+    }
+
+    #[test]
+    fn resolve_input_filter_some_when_enabled() {
+        let toml = r#"
+[tasks.chat_companion]
+model = "m"
+input_filter = true
+[tasks.chat_input_filter]
+model = "fast/in"
+fallback = ["fb1", "fb2"]
+retry_depth = 1
+temperature = 0.3
+max_tokens = 400
+filter_prompt = "REWRITE"
+reasoning = { enabled = false }
+"#;
+        let cfg = ModelConfig::from_toml_str(toml).unwrap();
+        let f = cfg.resolve_input_filter().expect("enabled");
+        assert_eq!(f.model, "fast/in");
+        // fallback truncated to retry_depth = 1
+        assert_eq!(f.fallback_model, vec!["fb1".to_string()]);
+        assert_eq!(f.retry_depth, 1);
+        assert_eq!(f.filter_prompt, "REWRITE");
+        assert_eq!(f.temperature, 0.3);
+        assert_eq!(f.max_tokens, 400);
+        assert_eq!(
+            f.reasoning,
+            Some(ReasoningConfig { enabled: Some(false), exclude: None })
+        );
+    }
+
+    #[test]
+    fn resolve_input_filter_retry_depth_zero_drops_fallback() {
+        // retry_depth = 0 ⇒ primary only, no fallback (mirrors the output
+        // filter's retry_depth=0 edge case).
+        let cfg = ModelConfig::from_toml_str(
+            r#"
+[tasks.chat_companion]
+model = "m"
+input_filter = true
+[tasks.chat_input_filter]
+model = "fast/in"
+fallback = ["a", "b"]
+filter_prompt = "REWRITE"
+retry_depth = 0
+"#,
+        )
+        .unwrap();
+        let f = cfg.resolve_input_filter().expect("enabled");
+        assert_eq!(f.retry_depth, 0);
+        assert!(f.fallback_model.is_empty());
     }
 }

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -74,6 +74,18 @@ pub(in crate::pipeline) fn audit_from_event(event: &Event) -> Option<&LlmAudit> 
     }
 }
 
+/// Effective model-facing text for a user-side history row: the input-filter
+/// rewrite (`pre_filter_content`) when present and non-blank, else the original
+/// `content`. Assistant rows must NOT use this (their `pre_filter_content` is
+/// the pre-OUTPUT-filter original); `assemble_chat_request` routes assistant
+/// rows to `content` directly.
+fn effective_user_text(msg: &eros_engine_store::chat::ChatMessage) -> &str {
+    match msg.pre_filter_content.as_deref() {
+        Some(s) if !s.trim().is_empty() => s,
+        _ => &msg.content,
+    }
+}
+
 /// Materialise a ChatRequest from a pre-resolved model + system prompt +
 /// chronological history. `audit` carries the caller's OpenRouter passthrough
 /// when the driving event was a `UserMessage`; gift / proactive pass `None`.
@@ -89,13 +101,18 @@ fn assemble_chat_request(
         content: system_prompt,
     });
     for msg in history {
-        match msg.role.as_str() {
-            "user" | "assistant" => messages.push(ChatMessage {
-                role: msg.role,
-                content: msg.content,
-            }),
+        // User rows feed the EFFECTIVE text (input-filter rewrite when present);
+        // assistant rows always feed `content` (their pre_filter_content is the
+        // pre-output-filter original and must never re-enter the prompt).
+        let content = match msg.role.as_str() {
+            "user" => effective_user_text(&msg).to_string(),
+            "assistant" => msg.content,
             _ => continue,
-        }
+        };
+        messages.push(ChatMessage {
+            role: msg.role,
+            content,
+        });
     }
 
     let (audit_user, audit_session, audit_metadata) = audit
@@ -424,10 +441,19 @@ pub(super) async fn build_reply_request(
     let chat_repo = ChatRepo { pool: &state.pool };
     let history = chat_repo.history(session_id, HISTORY_WINDOW, 0).await?;
 
-    let query_text = match &input.event {
-        Event::UserMessage { content, .. } => content.as_str(),
-        _ => "",
-    };
+    // The model and recall both see the EFFECTIVE text for the current user
+    // turn: if the input filter rewrote it, the rewrite is persisted on the
+    // row's pre_filter_content, so derive query_text from history rather than
+    // the raw event content.
+    let query_text: String = history
+        .iter()
+        .rev()
+        .find(|m| m.id == user_message_id && m.role == "user")
+        .map(|m| effective_user_text(m).to_string())
+        .unwrap_or_else(|| match &input.event {
+            Event::UserMessage { content, .. } => content.clone(),
+            _ => String::new(),
+        });
 
     let (memory_scope, affinity_scope) = match &input.event {
         Event::UserMessage {
@@ -457,7 +483,7 @@ pub(super) async fn build_reply_request(
     }
 
     let (mut profile_groups, relationship_facts) =
-        recall_memory(state, user_id, instance_id, query_text, x_on, y_on).await;
+        recall_memory(state, user_id, instance_id, &query_text, x_on, y_on).await;
 
     let insight_bullets = load_human_insight_bullets(&state.pool, user_id, mem_mode).await;
     if !insight_bullets.is_empty() {
@@ -1337,6 +1363,36 @@ mod tests {
         let (kept, dropped) = filter_traits(&traits, Some(&allow));
         assert_eq!(kept.len(), 2);
         assert!(dropped.is_empty());
+    }
+
+    fn user_row(content: &str, pre: Option<&str>) -> eros_engine_store::chat::ChatMessage {
+        eros_engine_store::chat::ChatMessage {
+            id: uuid::Uuid::new_v4(),
+            session_id: uuid::Uuid::new_v4(),
+            role: "user".into(),
+            content: content.into(),
+            sent_at: chrono::Utc::now(),
+            client_msg_id: None,
+            ghost_decision: false,
+            user_message_id: None,
+            continues_from_message_id: None,
+            truncated: false,
+            model: None,
+            usage: None,
+            generation_id: None,
+            assistant_action_type: None,
+            pre_filter_content: pre.map(|s| s.to_string()),
+        }
+    }
+
+    #[test]
+    fn effective_user_text_prefers_nonblank_rewrite() {
+        let mut row = user_row("1111", None);
+        assert_eq!(effective_user_text(&row), "1111");
+        row.pre_filter_content = Some("有意义的问题".into());
+        assert_eq!(effective_user_text(&row), "有意义的问题");
+        row.pre_filter_content = Some("   ".into()); // blank → fall back to content
+        assert_eq!(effective_user_text(&row), "1111");
     }
 
     /// End-to-end check of the cutoff semantics that `fetch_recent_turn_pairs`

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -79,7 +79,7 @@ pub(in crate::pipeline) fn audit_from_event(event: &Event) -> Option<&LlmAudit> 
 /// `content`. Assistant rows must NOT use this (their `pre_filter_content` is
 /// the pre-OUTPUT-filter original); `assemble_chat_request` routes assistant
 /// rows to `content` directly.
-fn effective_user_text(msg: &eros_engine_store::chat::ChatMessage) -> &str {
+pub(crate) fn effective_user_text(msg: &eros_engine_store::chat::ChatMessage) -> &str {
     match msg.pre_filter_content.as_deref() {
         Some(s) if !s.trim().is_empty() => s,
         _ => &msg.content,

--- a/crates/eros-engine-server/src/pipeline/post_process.rs
+++ b/crates/eros-engine-server/src/pipeline/post_process.rs
@@ -340,7 +340,7 @@ async fn embed_and_upsert(
 /// Locate the first balanced `{...}` block in `raw`. Returned as a borrowed
 /// slice. Replaces the gateway's `regex::Regex::new(r"(?s)\{.*\}")` so the
 /// OSS server crate doesn't pick up a `regex` dependency just for this.
-fn find_json_block(raw: &str) -> Option<&str> {
+pub(crate) fn find_json_block(raw: &str) -> Option<&str> {
     let bytes = raw.as_bytes();
     let start = bytes.iter().position(|&b| b == b'{')?;
     // Walk forward, tracking nesting depth + string state, to find the

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -1559,6 +1559,7 @@ mod tests {
             })),
             generation_id: Some("gen-1".into()),
             assistant_action_type: Some("reply".into()),
+            pre_filter_content: None,
         };
 
         let frames: Vec<ProtocolFrame> =
@@ -1863,6 +1864,7 @@ data: [DONE]\n\n";
             usage: None,
             generation_id: None,
             assistant_action_type: Some("reply".into()),
+            pre_filter_content: None,
         };
 
         let meta_model = |frames: &[ProtocolFrame]| -> Option<String> {

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -1193,7 +1193,10 @@ pub fn run_stream(
                 // rewrite is persisted on the user row's pre_filter_content;
                 // build_reply_request then feeds the EFFECTIVE text to the model
                 // and recall. Fail-open: any non-rewrite outcome is a no-op.
-                if !is_gift {
+                // Skip tipped turns too: a tip persists as role='gift_user', which
+                // set_user_input_rewrite can't update and the prompt drops anyway —
+                // running the filter there is a wasted LLM call.
+                if !is_gift && user_msg.tips_amount_usd.is_none() {
                     if let Some(f) = state.model_config.resolve_input_filter() {
                         // Note: this issues its own small (8-row) history fetch;
                         // build_reply_request below fetches history again (20 rows).

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -3530,6 +3530,9 @@ data: [DONE]\n\n";
         assert_eq!(content, "1111", "client-visible content must stay original");
         assert_eq!(pre.as_deref(), Some("那你平常都怎么放松呀？"));
         assert_eq!(fmodel.as_deref(), Some("infilt/m"));
-        assert_eq!(triggers, Some(serde_json::json!({"reason": "meaningless digits"})));
+        assert_eq!(
+            triggers,
+            Some(serde_json::json!({"reason": "meaningless digits"}))
+        );
     }
 }

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -636,6 +636,17 @@ const REFUSAL_HEAD_SCAN_CHARS: usize = 120;
 /// as `"refusal_pattern"` (if a refusal verb appears) or `"too_short"`.
 const MIN_FILTERED_OUTPUT_CHARS: usize = 80;
 
+/// True when a refusal phrase appears in the leading `REFUSAL_HEAD_SCAN_CHARS`
+/// (lowercased) of `text`. Shared by the output and input validity gates.
+fn refusal_in_head(text: &str) -> bool {
+    let head_lower: String = text
+        .chars()
+        .take(REFUSAL_HEAD_SCAN_CHARS)
+        .flat_map(char::to_lowercase)
+        .collect();
+    REFUSAL_PATTERNS_HEAD.iter().any(|p| head_lower.contains(p))
+}
+
 /// Check whether a filter LLM response should be rejected by the validity gate.
 ///
 /// Returns `Some(reason_label)` when the output is invalid, `None` when valid.
@@ -653,19 +664,8 @@ fn filter_output_invalidity(text: &str, finish_reason: Option<&str>) -> Option<&
         return Some("content_filter");
     }
     let total_chars = text.chars().count();
-    // ASCII-case-insensitive matching: lowercase the head (and the short-text
-    // body below) once so models that emit `"as an ai ..."` or `"I'M SORRY"`
-    // are caught.  `to_lowercase` is Unicode-aware; CJK code points are
-    // unchanged, so the Chinese patterns still match exactly.
-    let head_lower: String = text
-        .chars()
-        .take(REFUSAL_HEAD_SCAN_CHARS)
-        .flat_map(char::to_lowercase)
-        .collect();
-    for pat in REFUSAL_PATTERNS_HEAD {
-        if head_lower.contains(pat) {
-            return Some("refusal_pattern");
-        }
+    if refusal_in_head(text) {
+        return Some("refusal_pattern");
     }
     if total_chars < MIN_FILTERED_OUTPUT_CHARS {
         let text_lower = text.to_lowercase();
@@ -780,6 +780,174 @@ async fn run_output_filter(
         f_client_msg_id,
         attempts,
     })
+}
+
+// ── Input filter (user-input rewrite) ────────────────────────────────────────
+
+/// Parsed verdict from the input-filter LLM. `rewrite=false` ⇒ keep the
+/// original input; `rewrite=true` ⇒ use `content` (with `reason` for audit).
+#[derive(Debug, Clone, serde::Deserialize)]
+struct InputFilterVerdict {
+    #[serde(default)]
+    rewrite: bool,
+    #[serde(default)]
+    content: Option<String>,
+    #[serde(default)]
+    reason: Option<String>,
+}
+
+/// Parse the filter reply into a verdict: direct JSON first, then a balanced
+/// JSON block embedded in prose (mirrors post_process extraction parsing).
+fn parse_input_filter_verdict(text: &str) -> Option<InputFilterVerdict> {
+    serde_json::from_str::<InputFilterVerdict>(text)
+        .ok()
+        .or_else(|| {
+            super::post_process::find_json_block(text)
+                .and_then(|b| serde_json::from_str::<InputFilterVerdict>(b).ok())
+        })
+}
+
+/// Validity gate for an INPUT rewrite's `content`. Unlike
+/// `filter_output_invalidity`, there is NO minimum-length floor — a rewritten
+/// user message is naturally short (often < 80 chars). Only a `content_filter`
+/// finish reason or a refusal-shaped head is rejected.
+fn rewrite_content_invalidity(text: &str, finish_reason: Option<&str>) -> Option<&'static str> {
+    if finish_reason == Some("content_filter") {
+        return Some("content_filter");
+    }
+    if refusal_in_head(text) {
+        return Some("refusal_pattern");
+    }
+    None
+}
+
+/// Outcome of a successful input rewrite (`None` ⇒ keep the original input).
+#[derive(Debug, Clone)]
+struct InputRewrite {
+    rewritten_text: String,
+    filter_model: String,
+    reason: Option<String>,
+    f_generation_id: Option<String>,
+}
+
+/// Recent rows fed to the rewrite LLM as `[最近对话]` context.
+const INPUT_FILTER_CONTEXT_TURNS: i64 = 8;
+
+/// Build the compact transcript block for the input filter, excluding the turn
+/// being rewritten. Best-effort: a DB error yields an empty transcript.
+async fn build_input_filter_transcript(
+    chat_repo: &ChatRepo<'_>,
+    session_id: Uuid,
+    current_user_message_id: Uuid,
+) -> String {
+    let rows = chat_repo
+        .history(session_id, INPUT_FILTER_CONTEXT_TURNS, 0)
+        .await
+        .unwrap_or_default();
+    let mut lines = Vec::new();
+    for m in rows {
+        if m.id == current_user_message_id {
+            continue;
+        }
+        // User/gift rows use the EFFECTIVE text (a prior turn's own rewrite when
+        // present) so the filter sees the same conversation the chat model does;
+        // assistant rows use content (their pre_filter_content means the opposite).
+        let (label, text) = match m.role.as_str() {
+            "user" | "gift_user" => ("用户", crate::pipeline::handlers::effective_user_text(&m)),
+            "assistant" => ("AI", m.content.as_str()),
+            _ => continue,
+        };
+        lines.push(format!("{label}: {text}"));
+    }
+    lines.join("\n")
+}
+
+/// Run the input-filter LLM over the raw user input with recent context.
+/// Returns `Some(InputRewrite)` ONLY when the model explicitly asked to rewrite
+/// with valid content; every other outcome (keep verdict, parse failure,
+/// refusal, error, timeout, empty) returns `None` ⇒ caller uses the original.
+/// Note: a `{"rewrite": false}` verdict is a DEFINITIVE keep — it returns `None`
+/// immediately and does NOT try the remaining fallback models.
+async fn run_input_filter(
+    state: &AppState,
+    f: &eros_engine_llm::model_config::ResolvedInputFilter,
+    recent_transcript: &str,
+    raw_input: &str,
+) -> Option<InputRewrite> {
+    use eros_engine_llm::openrouter::{ChatMessage, ChatRequest};
+    let transcript = if recent_transcript.trim().is_empty() {
+        "（无）"
+    } else {
+        recent_transcript
+    };
+    let user_payload = format!("[最近对话]\n{transcript}\n\n[用户最新输入]\n{raw_input}");
+    let chain: Vec<String> = std::iter::once(f.model.clone())
+        .chain(f.fallback_model.iter().cloned())
+        .collect();
+    for model_id in &chain {
+        let req = ChatRequest {
+            model: model_id.clone(),
+            fallback_model: vec![],
+            messages: vec![
+                ChatMessage {
+                    role: "system".into(),
+                    content: f.filter_prompt.clone(),
+                },
+                ChatMessage {
+                    role: "user".into(),
+                    content: user_payload.clone(),
+                },
+            ],
+            temperature: f.temperature as f32,
+            max_tokens: f.max_tokens,
+            reasoning: f.reasoning.clone(),
+            ..Default::default()
+        };
+        let resp = match tokio::time::timeout(FILTER_TIMEOUT, state.openrouter.execute(req)).await {
+            Ok(Ok(r)) => r,
+            Ok(Err(e)) => {
+                tracing::warn!(model = %model_id, error = %e, "input-filter: model error; next");
+                continue;
+            }
+            Err(_) => {
+                tracing::warn!(model = %model_id, "input-filter: timeout; next");
+                continue;
+            }
+        };
+        super::log_openrouter_usage("chat_input_filter", None, &resp);
+        let text = resp.reply.trim().to_string();
+        if text.is_empty() {
+            tracing::warn!(model = %model_id, "input-filter: empty reply; next");
+            continue;
+        }
+        let verdict = match parse_input_filter_verdict(&text) {
+            Some(v) => v,
+            None => {
+                tracing::warn!(model = %model_id, "input-filter: unparseable verdict; next");
+                continue;
+            }
+        };
+        if !verdict.rewrite {
+            return None; // meaningful → keep (definitive)
+        }
+        let content = verdict.content.unwrap_or_default().trim().to_string();
+        if content.is_empty() {
+            tracing::warn!(model = %model_id, "input-filter: rewrite=true but blank content; next");
+            continue;
+        }
+        if let Some(reason) = rewrite_content_invalidity(&content, resp.finish_reason.as_deref()) {
+            tracing::warn!(model = %model_id, invalidity = %reason, "input-filter: invalid rewrite content; next");
+            continue;
+        }
+        let filter_model = resp.model.unwrap_or_else(|| model_id.clone());
+        return Some(InputRewrite {
+            rewritten_text: content,
+            filter_model,
+            reason: verdict.reason.filter(|r| !r.trim().is_empty()),
+            f_generation_id: resp.generation_id,
+        });
+    }
+    None // chain exhausted → keep
 }
 
 /// Try to emit a pseudo-ghost on chain exhaustion.
@@ -1020,6 +1188,40 @@ pub fn run_stream(
             }
             ActionType::Reply | ActionType::GiftReaction => {
                 let is_gift = matches!(plan.action_type, ActionType::GiftReaction);
+                // ── User-input rewrite filter (Reply turns only) ──────────────
+                // Runs after the idempotency gate, before prompt assembly. The
+                // rewrite is persisted on the user row's pre_filter_content;
+                // build_reply_request then feeds the EFFECTIVE text to the model
+                // and recall. Fail-open: any non-rewrite outcome is a no-op.
+                if !is_gift {
+                    if let Some(f) = state.model_config.resolve_input_filter() {
+                        // Note: this issues its own small (8-row) history fetch;
+                        // build_reply_request below fetches history again (20 rows).
+                        // Two round-trips per reply turn — acceptable, not a hot loop.
+                        let transcript = build_input_filter_transcript(
+                            &chat_repo,
+                            user_msg.session_id,
+                            user_msg.user_message_id,
+                        )
+                        .await;
+                        if let Some(rw) =
+                            run_input_filter(&state, &f, &transcript, &user_msg.content).await
+                        {
+                            if let Err(e) = chat_repo
+                                .set_user_input_rewrite(
+                                    user_msg.user_message_id,
+                                    &rw.rewritten_text,
+                                    &rw.filter_model,
+                                    rw.reason.as_deref(),
+                                    rw.f_generation_id.as_deref(),
+                                )
+                                .await
+                            {
+                                tracing::warn!("stream: input-filter rewrite persist failed: {e}");
+                            }
+                        }
+                    }
+                }
                 let req_res = if is_gift {
                     crate::pipeline::handlers::build_gift_request(
                         &state, &input, &plan,
@@ -3151,5 +3353,183 @@ data: [DONE]\n\n";
                 serde_json::json!(false)
             );
         }
+    }
+
+    #[test]
+    fn parse_input_filter_verdict_direct_and_embedded() {
+        let v = parse_input_filter_verdict(r#"{"rewrite": false}"#).unwrap();
+        assert!(!v.rewrite);
+
+        let v = parse_input_filter_verdict(
+            r#"prefix {"rewrite": true, "content": "你好呀", "reason": "noise"} suffix"#,
+        )
+        .unwrap();
+        assert!(v.rewrite);
+        assert_eq!(v.content.as_deref(), Some("你好呀"));
+        assert_eq!(v.reason.as_deref(), Some("noise"));
+    }
+
+    #[test]
+    fn parse_input_filter_verdict_unparseable_is_none() {
+        assert!(parse_input_filter_verdict("not json at all").is_none());
+    }
+
+    #[test]
+    fn parse_input_filter_verdict_rewrite_false_keeps_with_content_ignored() {
+        // rewrite=false is a keep; any content field is parsed but irrelevant.
+        let v = parse_input_filter_verdict(r#"{"rewrite": false, "content": "ignored"}"#).unwrap();
+        assert!(!v.rewrite);
+        assert_eq!(v.content.as_deref(), Some("ignored"));
+    }
+
+    #[test]
+    fn rewrite_content_invalidity_accepts_short_user_line() {
+        // A short rewrite (< 80 chars) must NOT be rejected — there is no
+        // length floor (unlike filter_output_invalidity).
+        assert!(rewrite_content_invalidity("那你平常都怎么放松呀？", None).is_none());
+    }
+
+    #[test]
+    fn rewrite_content_invalidity_rejects_refusal_and_content_filter() {
+        assert_eq!(
+            rewrite_content_invalidity("对不起，我无法满足你的要求", None),
+            Some("refusal_pattern")
+        );
+        assert_eq!(
+            rewrite_content_invalidity("你好", Some("content_filter")),
+            Some("content_filter")
+        );
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn input_filter_rewrites_meaningless_turn(pool: PgPool) {
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+        use futures_util::StreamExt;
+        use wiremock::matchers::{body_string_contains, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+
+        // Input-filter model ("infilt/m") returns a JSON verdict via the
+        // non-streaming execute() path (JSON completion object). The rewritten
+        // user line is a JSON string inside `content`.
+        let verdict = serde_json::json!({
+            "rewrite": true,
+            "content": "那你平常都怎么放松呀？",
+            "reason": "meaningless digits"
+        })
+        .to_string();
+        let infilt_body = serde_json::json!({
+            "id": "gi", "model": "infilt/m",
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            "choices": [{"message": {"content": verdict}}],
+        });
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("infilt/m"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(infilt_body))
+            .mount(&mock)
+            .await;
+
+        // Chat model ("deepseek/x") — REQUIRE the rewritten text in the request
+        // body, proving the rewrite went to pre_filter_content; build_reply_request
+        // then feeds the EFFECTIVE text to the model. If the wiring is broken,
+        // this mock won't match → no REPLY delta.
+        let chat_body = "data: {\"choices\":[{\"delta\":{\"content\":\"REPLY\"}}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1,\"total_tokens\":2},\"id\":\"g\",\"model\":\"deepseek/x\"}\n\ndata: [DONE]\n\n";
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("deepseek/x"))
+            .and(body_string_contains("那你平常都怎么放松呀？"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(chat_body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+
+        let user_id = Uuid::new_v4();
+        let (_g, instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = std::sync::Arc::new(
+            eros_engine_llm::model_config::ModelConfig::from_toml_str(
+                "[tasks.chat_companion]\nmodel=\"deepseek/x\"\ninput_filter=true\n\
+                 [tasks.chat_input_filter]\nmodel=\"infilt/m\"\nfilter_prompt=\"REWRITE\"\n",
+            )
+            .unwrap(),
+        );
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "k".into(),
+                Default::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+
+        let chat_repo = ChatRepo { pool: &pool };
+        let umid = match chat_repo
+            .upsert_user_message_idempotent(
+                session_id,
+                "1111",
+                "01J7777777777777777777777A",
+                "user",
+                None,
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
+
+        let frames: Vec<ProtocolFrame> = run_stream(
+            std::sync::Arc::new(state),
+            PersistedUserMessage {
+                user_message_id: umid,
+                session_id,
+                user_id,
+                instance_id,
+                content: "1111".into(),
+                prompt_traits: vec![],
+                audit: None,
+                tier: None,
+                memory_scope: Default::default(),
+                affinity_scope: Default::default(),
+                tips_amount_usd: None,
+            },
+        )
+        .collect()
+        .await;
+
+        // The chat mock only matches when the body carries the rewrite, so a
+        // REPLY delta proves the model saw the effective (rewritten) input.
+        let deltas: String = frames
+            .iter()
+            .filter_map(|f| match f {
+                ProtocolFrame::Delta { content, .. } => Some(content.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            deltas.contains("REPLY"),
+            "chat model must have been called with the rewritten input; got {deltas:?}"
+        );
+
+        // content preserved; rewrite + audit stamped on the user row.
+        let (content, pre, fmodel, triggers): (
+            String,
+            Option<String>,
+            Option<String>,
+            Option<serde_json::Value>,
+        ) = sqlx::query_as(
+            "SELECT content, pre_filter_content, filter_model, filter_triggers \
+             FROM engine.chat_messages WHERE id = $1",
+        )
+        .bind(umid)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(content, "1111", "client-visible content must stay original");
+        assert_eq!(pre.as_deref(), Some("那你平常都怎么放松呀？"));
+        assert_eq!(fmodel.as_deref(), Some("infilt/m"));
+        assert_eq!(triggers, Some(serde_json::json!({"reason": "meaningless digits"})));
     }
 }

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -864,10 +864,12 @@ async fn build_input_filter_transcript(
 
 /// Run the input-filter LLM over the raw user input with recent context.
 /// Returns `Some(InputRewrite)` ONLY when the model explicitly asked to rewrite
-/// with valid content; every other outcome (keep verdict, parse failure,
-/// refusal, error, timeout, empty) returns `None` ⇒ caller uses the original.
-/// Note: a `{"rewrite": false}` verdict is a DEFINITIVE keep — it returns `None`
-/// immediately and does NOT try the remaining fallback models.
+/// with valid content; every other outcome returns `None` ⇒ caller uses the
+/// original. The fallback chain is walked ONLY on transport-level failures
+/// (error / timeout / empty reply). A CONTENT-level non-success — `{"rewrite":
+/// false}`, an unparseable verdict, blank content, or a refusal — is a
+/// DEFINITIVE keep: it returns `None` immediately and does NOT try the remaining
+/// models, so a fallback can never rewrite a message the primary left alone.
 async fn run_input_filter(
     state: &AppState,
     f: &eros_engine_llm::model_config::ResolvedInputFilter,
@@ -920,11 +922,15 @@ async fn run_input_filter(
             tracing::warn!(model = %model_id, "input-filter: empty reply; next");
             continue;
         }
+        // Content-level non-success ⇒ DEFINITIVE keep (return None, no chain
+        // walk). The model responded but not with a usable rewrite; walking to a
+        // fallback here would risk rewriting a meaningful message the primary
+        // left alone. Only transport failures above (error/timeout/empty) walk.
         let verdict = match parse_input_filter_verdict(&text) {
             Some(v) => v,
             None => {
-                tracing::warn!(model = %model_id, "input-filter: unparseable verdict; next");
-                continue;
+                tracing::warn!(model = %model_id, "input-filter: unparseable verdict; keep original");
+                return None;
             }
         };
         if !verdict.rewrite {
@@ -932,12 +938,12 @@ async fn run_input_filter(
         }
         let content = verdict.content.unwrap_or_default().trim().to_string();
         if content.is_empty() {
-            tracing::warn!(model = %model_id, "input-filter: rewrite=true but blank content; next");
-            continue;
+            tracing::warn!(model = %model_id, "input-filter: rewrite=true but blank content; keep original");
+            return None;
         }
         if let Some(reason) = rewrite_content_invalidity(&content, resp.finish_reason.as_deref()) {
-            tracing::warn!(model = %model_id, invalidity = %reason, "input-filter: invalid rewrite content; next");
-            continue;
+            tracing::warn!(model = %model_id, invalidity = %reason, "input-filter: invalid rewrite content; keep original");
+            return None;
         }
         let filter_model = resp.model.unwrap_or_else(|| model_id.clone());
         return Some(InputRewrite {
@@ -3545,5 +3551,137 @@ data: [DONE]\n\n";
             triggers,
             Some(serde_json::json!({"reason": "meaningless digits"}))
         );
+    }
+
+    // Regression (codex P2): a content-level non-verdict from the primary
+    // input-filter model (here: unparseable prose) must be a DEFINITIVE keep —
+    // the chain must NOT walk to the fallback, even though the fallback would
+    // happily rewrite. Otherwise a meaningful message could be rewritten by a
+    // later model the primary effectively declined to touch.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn input_filter_malformed_primary_keeps_original_no_chain_walk(pool: PgPool) {
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+        use futures_util::StreamExt;
+        use wiremock::matchers::{body_string_contains, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+
+        // Primary filter model returns UNPARSEABLE prose (no JSON object).
+        let primary_body = serde_json::json!({
+            "id": "gp", "model": "infilt/primary",
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            "choices": [{"message": {"content": "Looks fine to me, leaving it as is."}}],
+        });
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("infilt/primary"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(primary_body))
+            .mount(&mock)
+            .await;
+
+        // Fallback model WOULD rewrite — if the chain wrongly walked, the user
+        // row's pre_filter_content would end up set to this. The fix means this
+        // mock is never reached.
+        let fallback_body = serde_json::json!({
+            "id": "gfb", "model": "infilt/fallback",
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            "choices": [{"message": {"content": "{\"rewrite\": true, \"content\": \"FALLBACK REWRITE\"}"}}],
+        });
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("infilt/fallback"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(fallback_body))
+            .mount(&mock)
+            .await;
+
+        // Chat model — the prompt carries the ORIGINAL (meaningful) message.
+        let chat_body = "data: {\"choices\":[{\"delta\":{\"content\":\"REPLY\"}}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1,\"total_tokens\":2},\"id\":\"g\",\"model\":\"deepseek/x\"}\n\ndata: [DONE]\n\n";
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("deepseek/x"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(chat_body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+
+        let user_id = Uuid::new_v4();
+        let (_g, instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = std::sync::Arc::new(
+            eros_engine_llm::model_config::ModelConfig::from_toml_str(
+                "[tasks.chat_companion]\nmodel=\"deepseek/x\"\ninput_filter=true\n\
+                 [tasks.chat_input_filter]\nmodel=\"infilt/primary\"\nfallback=[\"infilt/fallback\"]\nfilter_prompt=\"REWRITE\"\n",
+            )
+            .unwrap(),
+        );
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "k".into(),
+                Default::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+
+        let chat_repo = ChatRepo { pool: &pool };
+        let umid = match chat_repo
+            .upsert_user_message_idempotent(
+                session_id,
+                "hello there friend",
+                "01J8888888888888888888888A",
+                "user",
+                None,
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
+
+        let frames: Vec<ProtocolFrame> = run_stream(
+            std::sync::Arc::new(state),
+            PersistedUserMessage {
+                user_message_id: umid,
+                session_id,
+                user_id,
+                instance_id,
+                content: "hello there friend".into(),
+                prompt_traits: vec![],
+                audit: None,
+                tier: None,
+                memory_scope: Default::default(),
+                affinity_scope: Default::default(),
+                tips_amount_usd: None,
+            },
+        )
+        .collect()
+        .await;
+
+        let deltas: String = frames
+            .iter()
+            .filter_map(|f| match f {
+                ProtocolFrame::Delta { content, .. } => Some(content.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(deltas.contains("REPLY"), "turn must complete normally");
+
+        // The original is kept and NO rewrite is stamped — proving the chain did
+        // not walk to the (rewrite-producing) fallback on the malformed verdict.
+        let (content, pre, fmodel): (String, Option<String>, Option<String>) = sqlx::query_as(
+            "SELECT content, pre_filter_content, filter_model \
+             FROM engine.chat_messages WHERE id = $1",
+        )
+        .bind(umid)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(content, "hello there friend");
+        assert!(
+            pre.is_none(),
+            "malformed primary verdict must keep original (no fallback walk); got {pre:?}"
+        );
+        assert!(fmodel.is_none(), "no filter model stamped; got {fmodel:?}");
     }
 }

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -1197,7 +1197,15 @@ pub fn run_stream(
                 // set_user_input_rewrite can't update and the prompt drops anyway —
                 // running the filter there is a wasted LLM call.
                 if !is_gift && user_msg.tips_amount_usd.is_none() {
-                    if let Some(f) = state.model_config.resolve_input_filter() {
+                    // Per-turn probability gate: `input_filter = 0.8` ⇒ fire on
+                    // ~80% of turns; `true` ⇒ probability 1.0 ⇒ always (gen::<f64>()
+                    // is in [0,1), so `< 1.0` always fires); `false` ⇒ resolve
+                    // returns None and we never get here.
+                    if let Some(f) = state
+                        .model_config
+                        .resolve_input_filter()
+                        .filter(|f| rand::thread_rng().gen::<f64>() < f.probability)
+                    {
                         // Note: this issues its own small (8-row) history fetch;
                         // build_reply_request below fetches history again (20 rows).
                         // Two round-trips per reply turn — acceptable, not a hot loop.

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -55,6 +55,12 @@ pub struct ChatMessage {
     pub generation_id: Option<String>,
     #[serde(default)]
     pub assistant_action_type: Option<String>,
+    /// Input-filter rewrite of a `role='user'` row: the model-facing effective
+    /// text when the user's original was rewritten (NULL otherwise). On
+    /// assistant rows this column holds the OPPOSITE direction (the
+    /// pre-OUTPUT-filter original) — see chat_input_filter design.
+    #[serde(default)]
+    pub pre_filter_content: Option<String>,
 }
 
 /// Projection-narrowed `ChatMessage` for BFF / UI-rendering paths that
@@ -528,6 +534,40 @@ impl<'a> ChatRepo<'a> {
              WHERE id = $1 AND role = 'user' AND ghost_decision = false",
         )
         .bind(user_message_id)
+        .execute(self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Stamp an input-filter rewrite onto an existing `role='user'` row. The
+    /// original text in `content` is left untouched (the client always sees the
+    /// original); the rewrite lands in `pre_filter_content` (model-facing).
+    /// `reason`, when non-blank, is stored as `filter_triggers = {"reason": …}`.
+    /// `f_client_msg_id` stays NULL — the user row is updated in place rather
+    /// than inserting a separate filter row.
+    pub async fn set_user_input_rewrite(
+        &self,
+        user_message_id: Uuid,
+        pre_filter_content: &str,
+        filter_model: &str,
+        reason: Option<&str>,
+        f_generation_id: Option<&str>,
+    ) -> Result<(), sqlx::Error> {
+        let filter_triggers: Option<serde_json::Value> = reason
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(|r| serde_json::json!({ "reason": r }));
+        sqlx::query(
+            "UPDATE engine.chat_messages \
+             SET pre_filter_content = $2, filter_model = $3, \
+                 filter_triggers = $4, f_generation_id = $5 \
+             WHERE id = $1 AND role = 'user'",
+        )
+        .bind(user_message_id)
+        .bind(pre_filter_content)
+        .bind(filter_model)
+        .bind(filter_triggers)
+        .bind(f_generation_id)
         .execute(self.pool)
         .await?;
         Ok(())
@@ -1734,6 +1774,93 @@ mod tests {
             pairs,
             vec![("(打赏 $20)".to_string(), "thanks!".to_string())]
         );
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn set_user_input_rewrite_stamps_audit_keeps_content(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let session = repo
+            .create_session(Uuid::new_v4(), Uuid::new_v4())
+            .await
+            .unwrap();
+        let umid = match repo
+            .upsert_user_message_idempotent(
+                session.id,
+                "1111",
+                "01J0000000000000000000000A",
+                "user",
+                None,
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
+
+        repo.set_user_input_rewrite(
+            umid,
+            "那你平常都怎么放松呀？",
+            "fast/in",
+            Some("meaningless digits"),
+            Some("gen-x"),
+        )
+        .await
+        .unwrap();
+
+        let (content, pre, model, triggers, fgen): (
+            String,
+            Option<String>,
+            Option<String>,
+            Option<serde_json::Value>,
+            Option<String>,
+        ) = sqlx::query_as(
+            "SELECT content, pre_filter_content, filter_model, filter_triggers, f_generation_id \
+             FROM engine.chat_messages WHERE id = $1",
+        )
+        .bind(umid)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(content, "1111", "original content must be preserved");
+        assert_eq!(pre.as_deref(), Some("那你平常都怎么放松呀？"));
+        assert_eq!(model.as_deref(), Some("fast/in"));
+        assert_eq!(triggers, Some(serde_json::json!({"reason": "meaningless digits"})));
+        assert_eq!(fgen.as_deref(), Some("gen-x"));
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn set_user_input_rewrite_blank_reason_leaves_triggers_null(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let session = repo
+            .create_session(Uuid::new_v4(), Uuid::new_v4())
+            .await
+            .unwrap();
+        let umid = match repo
+            .upsert_user_message_idempotent(
+                session.id,
+                "????",
+                "01J0000000000000000000000B",
+                "user",
+                None,
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
+        repo.set_user_input_rewrite(umid, "你今天过得怎么样？", "fast/in", Some("  "), None)
+            .await
+            .unwrap();
+        let triggers: Option<serde_json::Value> =
+            sqlx::query_scalar("SELECT filter_triggers FROM engine.chat_messages WHERE id = $1")
+                .bind(umid)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert!(triggers.is_none(), "blank reason → SQL NULL filter_triggers");
     }
 
     #[sqlx::test(migrations = "./migrations")]

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -1826,7 +1826,10 @@ mod tests {
         assert_eq!(content, "1111", "original content must be preserved");
         assert_eq!(pre.as_deref(), Some("那你平常都怎么放松呀？"));
         assert_eq!(model.as_deref(), Some("fast/in"));
-        assert_eq!(triggers, Some(serde_json::json!({"reason": "meaningless digits"})));
+        assert_eq!(
+            triggers,
+            Some(serde_json::json!({"reason": "meaningless digits"}))
+        );
         assert_eq!(fgen.as_deref(), Some("gen-x"));
     }
 
@@ -1860,7 +1863,10 @@ mod tests {
                 .fetch_one(&pool)
                 .await
                 .unwrap();
-        assert!(triggers.is_none(), "blank reason → SQL NULL filter_triggers");
+        assert!(
+            triggers.is_none(),
+            "blank reason → SQL NULL filter_triggers"
+        );
     }
 
     #[sqlx::test(migrations = "./migrations")]

--- a/docs/model-config.md
+++ b/docs/model-config.md
@@ -48,7 +48,7 @@ Field details:
 | `tasks.<name>.max_tokens` | `u32` | no | Per-task token cap. No per-tier override. |
 | `tasks.<name>.allow_traits` | `Array<String>` | no | Prompt-trait allow-list for this task (three-state: absent = no gating; `[]` = drop all traits; `["a","b"]` = whitelist). Used when no matching tier block is found. |
 | `tasks.<name>.tiers.<tier>` | sub-table | no | Per-tier overrides. May set `model`, `fallback`, and/or `allow_traits`. Does not override `temperature` or `max_tokens`. |
-| `tasks.chat_companion.input_filter` | `bool` | no | Global switch for the user-input rewrite filter. Task-level only on `chat_companion` (no per-tier override). Default `false`. See "`input_filter`". |
+| `tasks.chat_companion.input_filter` | `bool` \| `f64` | no | Global trigger for the user-input rewrite filter. Task-level only on `chat_companion` (no per-tier override). `false`/absent = off, `true` = every turn, `0.8` = ~80% of turns (a number outside `[0.0, 1.0]` is rejected). See "`input_filter`". |
 | `tasks.<name>.description` | `String` | no | Documentation field, ignored by code. |
 | `tasks.<name>.dimensions` | `u32` | no | Embedding-only. Ignored by chat / insight tasks. |
 
@@ -191,10 +191,13 @@ when the frame is emitted.
 
 ### `input_filter` — user-input rewrite (chat task only)
 
-`input_filter` is a boolean flag on `[tasks.chat_companion]` (default `false`,
-task-level only — no per-tier override). When on, every user **Reply** turn is
-passed to a second LLM (`[tasks.chat_input_filter]`) BEFORE generation. The
-filter returns a JSON verdict:
+`input_filter` is a trigger on `[tasks.chat_companion]` (default `false`,
+task-level only — no per-tier override). It accepts a **bool or a probability**:
+`false` = off, `true` = every turn (= `1.0`), `0.8` = a per-turn coin flip that
+fires on ~80% of turns. A number outside `[0.0, 1.0]` (or non-finite) is rejected
+at config-load time. When it fires for a user **Reply** turn, that turn is passed
+to a second LLM (`[tasks.chat_input_filter]`) BEFORE generation. The filter
+returns a JSON verdict:
 
 - `{"rewrite": false}` — the input is meaningful; the engine uses it verbatim.
 - `{"rewrite": true, "content": "…", "reason": "…"}` — the input was meaningless
@@ -206,10 +209,11 @@ client. A rewrite is stored in `pre_filter_content` (model-facing only),
 model and memory recall see the effective text (`pre_filter_content ?? content`)
 for user rows; extraction (insight/memory/affinity) keeps reading the original.
 
-The filter runs only when BOTH `input_filter = true` AND `[tasks.chat_input_filter]`
-exists with a non-blank `filter_prompt`. It is **fail-open**: any error, timeout,
-unparseable verdict, or refusal leaves the original input untouched. Pick a fast,
-cheap model — it runs on every user turn before generation.
+The filter runs only when `input_filter` fires (`true`, or the per-turn draw
+passes its probability) AND `[tasks.chat_input_filter]` exists with a non-blank
+`filter_prompt`. It is **fail-open**: any error, timeout, unparseable verdict, or
+refusal leaves the original input untouched. Pick a fast, cheap model — at
+`input_filter = true` it runs on every user turn before generation.
 
 #### `[tasks.chat_input_filter]` fields
 

--- a/docs/model-config.md
+++ b/docs/model-config.md
@@ -48,6 +48,7 @@ Field details:
 | `tasks.<name>.max_tokens` | `u32` | no | Per-task token cap. No per-tier override. |
 | `tasks.<name>.allow_traits` | `Array<String>` | no | Prompt-trait allow-list for this task (three-state: absent = no gating; `[]` = drop all traits; `["a","b"]` = whitelist). Used when no matching tier block is found. |
 | `tasks.<name>.tiers.<tier>` | sub-table | no | Per-tier overrides. May set `model`, `fallback`, and/or `allow_traits`. Does not override `temperature` or `max_tokens`. |
+| `tasks.chat_companion.input_filter` | `bool` | no | Global switch for the user-input rewrite filter. Task-level only on `chat_companion` (no per-tier override). Default `false`. See "`input_filter`". |
 | `tasks.<name>.description` | `String` | no | Documentation field, ignored by code. |
 | `tasks.<name>.dimensions` | `u32` | no | Embedding-only. Ignored by chat / insight tasks. |
 
@@ -187,6 +188,35 @@ when the frame is emitted.
 | `retries_filter` | `u32` | Number of fallback retries consumed by the filter model call (0 = primary succeeded or filter did not run). |
 | `prompt_injected` | `Array<String>` \| `null` | Trait tags that were injected into the prompt this turn, or `null` if none. Independent of the filter. |
 | `tier` | `String` \| `null` | Echo of the `tier` field from the request, or `null` if none was sent. Independent of the filter. |
+
+### `input_filter` — user-input rewrite (chat task only)
+
+`input_filter` is a boolean flag on `[tasks.chat_companion]` (default `false`,
+task-level only — no per-tier override). When on, every user **Reply** turn is
+passed to a second LLM (`[tasks.chat_input_filter]`) BEFORE generation. The
+filter returns a JSON verdict:
+
+- `{"rewrite": false}` — the input is meaningful; the engine uses it verbatim.
+- `{"rewrite": true, "content": "…", "reason": "…"}` — the input was meaningless
+  (e.g. `1111`, `？？？`, key-mashing); the engine uses `content` instead.
+
+The user's **original** text is always persisted as `content` and shown to the
+client. A rewrite is stored in `pre_filter_content` (model-facing only),
+`filter_model`, `f_generation_id`, and `filter_triggers = {"reason": …}`. The
+model and memory recall see the effective text (`pre_filter_content ?? content`)
+for user rows; extraction (insight/memory/affinity) keeps reading the original.
+
+The filter runs only when BOTH `input_filter = true` AND `[tasks.chat_input_filter]`
+exists with a non-blank `filter_prompt`. It is **fail-open**: any error, timeout,
+unparseable verdict, or refusal leaves the original input untouched. Pick a fast,
+cheap model — it runs on every user turn before generation.
+
+#### `[tasks.chat_input_filter]` fields
+
+Reuses the standard task shape: `model`, `fallback`, `retry_depth` (default 1),
+`temperature`, `max_tokens`, `filter_prompt`, `reasoning` (default off in the
+example). `trigger`, `timing`, `tiers`, and `allow_traits` are ignored (the
+input filter has no triggers, timing, or tiers).
 
 ## Task names
 

--- a/docs/superpowers/specs/2026-06-02-chat-input-filter-design.md
+++ b/docs/superpowers/specs/2026-06-02-chat-input-filter-design.md
@@ -1,0 +1,508 @@
+# eros-engine — Chat user-input rewrite filter (`chat_input_filter`) (Spec)
+
+**Status**: design, pending implementation plan
+**Target release**: `0.5.x` dev track (`0.5.3-dev`). **No migration** — reuses the
+`engine.chat_messages` audit columns added in `0019_chat_tip_marker_and_filter_audit.sql`.
+**Audience**: anyone implementing the optional user-input rewrite path that mirrors
+`chat_output_filter` (`2026-05-25-chat-output-filter-design.md`) on the input side.
+
+---
+
+## 0. Background
+
+### The bug
+
+The companion builds each chat prompt from `[system persona] + history + current
+user turn`. When the current user turn carries **no communicative intent** —
+`1111`, `？？？`, key-mashing, punctuation noise — the model has nothing to
+respond to, so it latches onto the surrounding history and **parrots back things
+the user (or the companion) said earlier**. From the user's seat this reads as
+the companion "repeating itself."
+
+The fix: when a user turn is meaningless, **rewrite it into one natural,
+context-appropriate user message before it reaches `tasks.chat_companion`**, so
+the model has a real thing to answer. When the turn is already meaningful, leave
+it untouched.
+
+Hard constraint: **the persisted `content` and the client-visible message must
+always remain the user's original text.** If the user typed `1111`, they must see
+`1111` in their history — never the rewrite. The rewrite is an internal,
+model-only substitution.
+
+### Why this mirrors `chat_output_filter` but is not identical
+
+`chat_output_filter` rewrites the **assistant reply** before the client sees it.
+It is:
+- stateless (the filter LLM sees only the single reply to rewrite),
+- gated by a `trigger` (random / models / traits) and per-tier `output_filter`,
+- timing-aware (`before_extract` / `after_extract`).
+
+The input filter is the input-side analogue, but deliberately simpler and
+different where the problem differs:
+- **Context-aware** — to rewrite `1111` into something *natural*, the filter LLM
+  needs the recent conversation, not just the bare token.
+- **One global switch, no tiers, no `trigger`** — it is either on or off for the
+  whole deployment.
+- **LLM is the sole decider via a JSON verdict** — never a heuristic, never an
+  echo. This guarantees zero false positives on normal short messages
+  (`嗯` / `好啊` / `在吗` / genuine short questions): the LLM is explicitly told to
+  return `{"rewrite": false}` for anything meaningful, and the engine then uses
+  the original verbatim.
+
+---
+
+## 1. Goals / non-goals
+
+**Goals**
+- Optional, off-by-default user-input rewrite, configured like `chat_output_filter`.
+- A single global switch (`input_filter = true` on `[tasks.chat_companion]`).
+- Original text always persisted as `content` and shown to the client.
+- Rewritten text persisted in the existing `pre_filter_content` audit column and
+  fed to the model for the current turn **and** future turns' history.
+- Fail-open: a slow / broken / refusing filter LLM never blocks or corrupts a reply.
+
+**Non-goals**
+- No per-tier or `trigger`-gated input filtering (YAGNI; one global switch).
+- No new DB columns or migration (the `0019` audit columns already exist and are
+  always NULL on `role='user'` rows today).
+- No change to what the extraction pipeline (insight / memory / affinity) reads —
+  it continues to read the **original** user text (see §6).
+- No client/protocol change — the rewrite is invisible to the wire.
+
+---
+
+## 2. Config surface — `model_config.toml`
+
+### 2.1 Global switch on `[tasks.chat_companion]`
+
+Add one task-level boolean, mirroring `output_filter`, **task-level only (no
+per-tier override)**:
+
+```toml
+[tasks.chat_companion]
+# ... existing fields ...
+input_filter = true        # global default: false
+```
+
+### 2.2 The filter task block `[tasks.chat_input_filter]`
+
+Reuses the existing `TaskConfig` shape (`model` / `fallback` / `retry_depth` /
+`temperature` / `max_tokens` / `filter_prompt` / `reasoning`). `trigger`,
+`timing`, `tiers`, and `allow_traits` are **ignored** if present (input filter has
+no triggers, no timing, no tiers).
+
+Shipped commented-out / OFF in `examples/model_config.toml`, in the same
+documented style as the `chat_output_filter` block:
+
+```toml
+# ── Optional user-input rewrite filter (OFF by default) ──────────────────────
+# Rewrites a MEANINGLESS user turn (e.g. "1111", "？？？", key-mashing) into one
+# natural, context-appropriate user message before it reaches chat_companion, so
+# the companion answers a real message instead of parroting history. Meaningful
+# turns — including short ones like "嗯"/"好啊"/"在吗" and genuine short
+# questions — are left untouched.
+#
+# Enable with a single global switch on [tasks.chat_companion]:
+#   [tasks.chat_companion]
+#   input_filter = true                  # global default: false
+#
+# The filter runs only if BOTH input_filter is true AND this table exists with a
+# non-blank filter_prompt; otherwise it is inert. The user's ORIGINAL text is
+# always what is persisted (content) and shown to the client; the rewrite is
+# stored separately in pre_filter_content and seen only by the model.
+#
+# Pick a fast, cheap model — this runs on every user turn before generation.
+# Recommended: google/gemini-3.1-flash-lite or deepseek/deepseek-v4-flash.
+#[tasks.chat_input_filter]
+#model        = "google/gemini-3.1-flash-lite"
+#fallback     = ["deepseek/deepseek-v4-flash"]
+#retry_depth  = 1
+#temperature  = 0.3
+#max_tokens   = 400
+# Reasoning is OFF by default for this task (the filter only needs a short JSON
+# verdict; reasoning adds latency/cost for no benefit). Same shape as
+# OpenRouter's `reasoning` object — flip to `{ enabled = true }` to opt in.
+#reasoning    = { enabled = false }
+#filter_prompt = """
+#You are an input-cleaning filter for a companion chat. You receive the recent
+#conversation and the user's latest input. Decide whether the latest input is a
+#meaningful message.
+#
+#- If it IS meaningful (any real intent, INCLUDING short replies like "嗯",
+#  "好啊", "在吗", or a short question), respond EXACTLY:
+#    {"rewrite": false}
+#- If it is NOT meaningful (random characters, key-mashing, repeated chars,
+#  punctuation-only noise), rewrite it into ONE short, natural user message that
+#  fits the conversation, and give a brief reason for the rewrite. Respond EXACTLY:
+#    {"rewrite": true, "content": "<the rewritten user message>", "reason": "<why it was meaningless / basis for the rewrite>"}
+#
+# Output JSON only. No explanation outside the JSON, no code fences.
+#"""
+```
+
+---
+
+## 3. Resolver — `crates/eros-engine-llm/src/model_config.rs`
+
+Mirror `resolve_output_filter`, minus `trigger` / `timing` / tier.
+
+### 3.1 New struct
+
+```rust
+#[derive(Debug, Clone)]
+pub struct ResolvedInputFilter {
+    pub model: String,
+    pub fallback_model: Vec<String>, // already truncated to retry_depth
+    pub temperature: f64,
+    pub max_tokens: u32,
+    pub filter_prompt: String,
+    pub retry_depth: u32,
+    pub reasoning: Option<ReasoningConfig>,
+}
+```
+
+### 3.2 New field on `TaskConfig`
+
+```rust
+/// Global switch for the user-input rewrite filter. Task-level only on
+/// chat_companion (no per-tier override, unlike `output_filter`). Default false.
+#[serde(default)]
+pub input_filter: Option<bool>,
+```
+
+### 3.3 New methods on `ModelConfig`
+
+```rust
+/// chat_companion `input_filter` (task-level → false). No tier param.
+pub fn input_filter_enabled(&self) -> bool {
+    self.tasks
+        .get("chat_companion")
+        .and_then(|t| t.input_filter)
+        .unwrap_or(false)
+}
+
+/// Resolve the input filter. `None` (disabled) when: chat_companion
+/// `input_filter` is false, OR `[tasks.chat_input_filter]` is absent, OR its
+/// `filter_prompt` is blank.
+pub fn resolve_input_filter(&self) -> Option<ResolvedInputFilter> {
+    const FILTER_TASK: &str = "chat_input_filter";
+    if !self.input_filter_enabled() {
+        return None;
+    }
+    let task_cfg = self.tasks.get(FILTER_TASK)?;
+    let filter_prompt = task_cfg.filter_prompt.clone().unwrap_or_default();
+    if filter_prompt.trim().is_empty() {
+        return None;
+    }
+    let retry_depth = task_cfg.retry_depth.unwrap_or(1);
+    let m = self.resolve(FILTER_TASK, None);
+    let mut fallback_model = m.fallback_model;
+    fallback_model.truncate(retry_depth as usize);
+    Some(ResolvedInputFilter {
+        model: m.model,
+        fallback_model,
+        temperature: m.temperature,
+        max_tokens: m.max_tokens,
+        filter_prompt,
+        retry_depth,
+        reasoning: task_cfg.reasoning.clone(),
+    })
+}
+```
+
+---
+
+## 4. JSON contract + `run_input_filter`
+
+### 4.1 Contract
+
+The filter LLM returns **JSON only**. Two shapes:
+
+```json
+{"rewrite": false}
+{"rewrite": true, "content": "<改写后的用户消息>", "reason": "<改写依据>"}
+```
+
+`reason` is required only when `rewrite == true`; it is captured for audit and
+persisted to the `filter_triggers` column (see §6). A missing/blank `reason` does
+**not** block the rewrite — `content` is what matters; `filter_triggers` is then
+left NULL.
+
+Parsing reuses the existing tolerant path
+(`serde_json::from_str(raw).or_else(|| find_json_block(raw)...)`, as in
+`post_process.rs`).
+
+**The engine never uses an echoed original.** "Keep" carries no text; the engine
+falls back to the raw input it already holds. This removes any chance that the
+filter model silently drops, truncates, or safety-mangles a legitimate message —
+the engine only ever takes the filter's text when `rewrite == true`.
+
+### 4.2 Decision table (all non-rewrite paths ⇒ use original, stamp nothing)
+
+| Filter outcome | Action |
+|---|---|
+| JSON parse fails (neither `from_str` nor `find_json_block`) | keep → original |
+| `rewrite` missing or `!= true` | keep → original |
+| `rewrite == true`, `content` missing / blank / whitespace | keep → original |
+| `rewrite == true`, `content` fails the refusal gate (`rewrite_content_invalidity`) | keep → original |
+| model error / timeout / empty reply (per chain entry) | walk to next entry; chain exhausts ⇒ keep → original |
+| `rewrite == true`, `content` valid | **rewrite** → use `content` |
+
+> **Validity gate:** the input filter uses a dedicated `rewrite_content_invalidity`
+> (refusal-head scan + `content_filter` finish reason), **not** the output
+> filter's `filter_output_invalidity` — the latter enforces an 80-char minimum
+> (`MIN_FILTERED_OUTPUT_CHARS`) that would reject every (naturally short)
+> rewritten user message as `too_short`. The input gate has no length floor.
+
+### 4.3 Function
+
+In `stream.rs`, structured like `run_output_filter`:
+
+```rust
+struct InputRewrite {
+    rewritten_text: String,           // -> content's replacement (model-only)
+    filter_model: String,             // -> filter_model
+    reason: Option<String>,           // -> filter_triggers = {"reason": ...} (NULL if absent)
+    f_generation_id: Option<String>,  // -> f_generation_id (always passed through)
+}
+
+/// Returns Some(rewrite) only when the filter LLM explicitly asked to rewrite
+/// with valid content. Every other outcome returns None (caller uses the
+/// original input). Never errors out of the chat path.
+async fn run_input_filter(
+    state: &AppState,
+    f: &ResolvedInputFilter,
+    recent_transcript: &str,
+    raw_input: &str,
+) -> Option<InputRewrite>
+```
+
+- **System message** = `f.filter_prompt` (operator policy).
+- `reasoning: f.reasoning.clone()` is forwarded on the request (default off via
+  the example config; see §2.2).
+- **User message** = engine-formatted payload: a compact recent-transcript block
+  (last few `用户:` / `AI:` turns, same labelling as `dreaming.rs`) followed by the
+  raw latest input, clearly delimited. The engine only *formats context*; the
+  *task* lives in `filter_prompt` (mirrors output filter: system=policy,
+  user=payload).
+- Walks the depth-capped fallback chain with a per-model timeout
+  (reuse `FILTER_TIMEOUT`), applying §4.2 per entry.
+
+---
+
+## 5. Execution placement (Axis B1) — inside `run_stream`, after the idempotency gate
+
+### 5.1 Current flow (unchanged entry points)
+
+1. `companion_stream::send_message_stream` → `upsert_user_message_idempotent` (the
+   **idempotency gate**): `Inserted` ⇒ generate; `DuplicateInProgress` / `Replay`
+   ⇒ do **not** generate.
+2. Only `Inserted` reaches `run_stream`.
+
+### 5.2 New step (Reply turns only)
+
+Near the top of `run_stream`, before prompt assembly, **for `UserMessage`-driven
+Reply turns only** (not gift / proactive):
+
+1. `let Some(f) = state.model_config.resolve_input_filter() else { /* skip */ }`.
+2. Build `recent_transcript` from a recent-history slice (reuse the history fetch
+   `run_stream`/handlers already perform where practical; otherwise a small
+   `history(session_id, K, 0)` slice).
+3. `run_input_filter(&state, &f, &recent_transcript, &user_msg.content)`.
+4. On `Some(rewrite)`: `UPDATE` the user row to set `pre_filter_content` +
+   `filter_model` (see §6), **before** the handler fetches history for prompt
+   assembly, so the rewritten text is picked up via the new `ChatMessage` field
+   (§7). `content` is untouched.
+5. On `None`: no-op (original input flows through unchanged).
+
+### 5.3 Why B1 (vs running before the idempotency gate)
+
+- Runs **exactly once per genuinely-new turn** — replays/duplicates never reach
+  `run_stream`, so retries/reconnects never re-pay the filter LLM call.
+- Lives beside `run_output_filter`; the whole filter feature is in one file.
+- Invariant: **the input filter runs iff a reply is generated.**
+
+Cost of B1: one extra `UPDATE` per real rewrite. Accepted (cheap, bounded).
+
+### 5.4 New store method
+
+```rust
+/// Stamp the input-filter rewrite onto an existing user row. content is left
+/// untouched (the client always sees the original). f_client_msg_id stays NULL
+/// (the user row is updated in place rather than inserting a separate filter
+/// row). `reason`, when present, is stored as `filter_triggers = {"reason": ...}`.
+pub async fn set_user_input_rewrite(
+    &self,
+    user_message_id: Uuid,
+    pre_filter_content: &str,        // the rewritten effective text
+    filter_model: &str,
+    reason: Option<&str>,            // -> filter_triggers {"reason": ...}, NULL if None/blank
+    f_generation_id: Option<&str>,
+) -> Result<(), sqlx::Error>;
+```
+
+---
+
+## 6. Persistence — reuse the `0019` audit columns on the `role='user'` row
+
+| Column | User row (input filter) | Assistant row (output filter, today) |
+|---|---|---|
+| `content` | **original** user text (shown to client) | filtered reply (shown to client) |
+| `pre_filter_content` | **rewritten** effective text (model-only) | original pre-filter reply |
+| `filter_model` | rewrite model that produced `pre_filter_content` | output-filter model |
+| `filter_triggers` | `{"reason": "<llm rewrite reason>"}` (NULL if no/blank reason) | fired predicates JSONB |
+| `f_generation_id` | rewrite call's OpenRouter generation id (always stamped) | output-filter generation id |
+| `f_client_msg_id` | NULL (row updated in place) | per output-filter call |
+
+**Documented semantic note (important):** on a **user** row, `pre_filter_content`
+holds the *post*-rewrite effective text — the **inverse direction** of an
+assistant row, where it holds the *pre*-filter original. Same columns, opposite
+filter. This is the intended reuse (these columns are otherwise always NULL on
+`role='user'` rows), not a bug.
+
+Only a real rewrite stamps these columns. A "keep" verdict leaves all of them
+NULL — the original `content` already is the effective text, so there is nothing
+to store.
+
+---
+
+## 7. Prompt + recall wiring
+
+### 7.1 `ChatMessage` gains the column
+
+```rust
+// crates/eros-engine-store/src/chat.rs — struct ChatMessage
+#[serde(default)]
+pub pre_filter_content: Option<String>,
+```
+
+`history()` uses `SELECT *`, so `FromRow` maps the existing column with no SQL
+change.
+
+### 7.2 Effective-text selection (user rows only)
+
+Define effective text for a history row:
+
+```
+effective(msg) =
+    if msg.role in {"user", "gift_user"}: msg.pre_filter_content.filter(non-blank) ?? msg.content
+    else (assistant): msg.content
+```
+
+- `assemble_chat_request` (`handlers.rs`) feeds `effective(msg)` to the model.
+- The memory-recall **query text** (`handlers.rs` ~L583, currently the latest
+  `role=="user"` row's `content`) uses `effective(...)` too — recall on `1111` is
+  as useless as a reply to it.
+- **Assistant rows are untouched** — this preserves `chat_output_filter`'s
+  `content = filtered` contract; we must NOT feed assistant `pre_filter_content`
+  (the unfiltered reply) back into history.
+
+Because effective-text selection keys on the persisted column, it applies
+uniformly to the **current turn** (just stamped in §5) and to **all past
+meaningless turns**, which is what actually drains the "meaningless token sits in
+history → repetition" mechanism.
+
+### 7.3 Client read path unchanged
+
+`history_slim` (BFF/UI) selects only `content` — the client always sees the
+original. No change.
+
+---
+
+## 8. Extraction / post-process reads the original
+
+Insight / memory / affinity extraction continue to read **`content`** (original),
+mirroring `chat_output_filter`'s default `after_extract`. Rationale:
+
+- A rewrite is an inference, not a fact. Extracting "memories" from fabricated
+  text would seed false profile/relationship rows.
+- The affinity "non-trivial user message" gate (`post_process.rs` ~L116) should
+  keep seeing the trivial original and skip scoring noise — correct behaviour.
+
+No change to post-process is required: it already reads `content`, and `content`
+stays original.
+
+---
+
+## 9. Fail-open + latency
+
+- **Fail-open**: every §4.2 non-rewrite outcome degrades to the original input.
+  A broken/slow/refusing filter LLM reproduces today's behaviour for that turn
+  (the repetition bug may surface), but **never blocks or corrupts** the reply.
+- **Latency**: "every turn calls the LLM" puts one rewrite round-trip (with recent
+  history) on the critical path before generation. This is the accepted cost of
+  the zero-false-positive design; mitigated by recommending a fast/cheap filter
+  model and by the per-model `FILTER_TIMEOUT`.
+
+---
+
+## 10. No migration
+
+The `pre_filter_content`, `filter_model`, `filter_triggers`, `f_generation_id`,
+`f_client_msg_id` columns already exist (`0019`). This feature only starts
+**writing** `pre_filter_content` / `filter_model` / `filter_triggers` (the
+`{"reason": ...}` audit) / `f_generation_id` on `role='user'` rows and
+**reading** `pre_filter_content` in prompt assembly. No schema change.
+
+---
+
+## 11. Testing
+
+**Unit (`model_config.rs`)**
+- `resolve_input_filter`: `None` when switch off / table absent / blank prompt;
+  `Some` with correct model/fallback (truncated to `retry_depth`)/prompt when on.
+- `input_filter_enabled`: default false; true when set.
+- Compat fixture / committed-example parse test updated to include
+  `chat_input_filter` + `input_filter` (schema lock).
+
+**Unit (`stream.rs`)**
+- JSON decision table (§4.2): `{"rewrite":false}` ⇒ None; `{"rewrite":true,
+  "content":"x"}` ⇒ Some; missing/blank `content` ⇒ None; refusal `content`
+  (caught by `rewrite_content_invalidity`) ⇒ None; unparseable ⇒ None;
+  `find_json_block` fallback path ⇒ Some.
+- `reason` extraction: `{"rewrite":true,"content":"x","reason":"r"}` ⇒
+  `reason = Some("r")`; reason absent/blank ⇒ `reason = None`.
+- effective-text selection: user row with `pre_filter_content` ⇒ rewritten;
+  user row without ⇒ original; assistant row ⇒ always `content`.
+
+**Integration (`#[sqlx::test]`)**
+- Rewrite turn: `content` stays original; `pre_filter_content` + `filter_model` +
+  `f_generation_id` stamped; `filter_triggers` = `{"reason": ...}` when the
+  verdict carried a reason (NULL when it did not); assembled prompt (and recall
+  query) use the rewritten text.
+- Keep turn: all audit columns NULL, prompt uses original.
+- Filter-off (no switch / blank prompt): behaviour byte-identical to today.
+- Past-turn carry-through: a prior rewritten user row feeds its rewrite into a
+  later turn's history.
+- `history_slim` still returns original `content` for a rewritten row.
+
+---
+
+## 12. Docs
+
+- `docs/model-config.md`: add `chat_input_filter` + `input_filter` to the stability
+  table (§ "Stability commitments") and a short section describing the global
+  switch, JSON contract, and column reuse.
+- `examples/model_config.toml`: the commented-out block in §2.2.
+- Release notes link this spec (per the OSS specs-are-public convention).
+
+---
+
+## 13. Stability commitments
+
+- `input_filter` (bool, `[tasks.chat_companion]`, task-level) and
+  `[tasks.chat_input_filter]` (reusing the `TaskConfig` shape) join the committed
+  0.x config schema. Adding optional fields stays compatible; renaming/removing
+  or making required breaks the compat fixture test.
+- JSON contract field names (`rewrite`, `content`, `reason`) are an
+  engine↔filter-prompt contract documented in the example `filter_prompt`;
+  changing them is a prompt+engine change, not a public API break (operators own
+  their `filter_prompt`).
+
+---
+
+## 14. Open questions
+
+None blocking. Possible future extensions (explicitly out of scope here):
+per-tier enablement, a `trigger`-style gate, or a `timing`-style toggle to let
+extraction read the rewrite. All deferred under YAGNI until a real need appears.

--- a/docs/superpowers/specs/2026-06-02-chat-input-filter-design.md
+++ b/docs/superpowers/specs/2026-06-02-chat-input-filter-design.md
@@ -514,6 +514,9 @@ The `pre_filter_content`, `filter_model`, `filter_triggers`, `f_generation_id`,
   verdict carried a reason (NULL when it did not); assembled prompt (and recall
   query) use the rewritten text.
 - Keep turn: all audit columns NULL, prompt uses original.
+- Malformed primary verdict + rewrite-producing fallback configured: the original
+  is kept and no rewrite is stamped — the chain does NOT walk on a content-level
+  non-verdict (only transport failures walk; see §4.2).
 - Filter-off (no switch / blank prompt): behaviour byte-identical to today.
 - Past-turn carry-through: a prior rewritten user row feeds its rewrite into a
   later turn's history.

--- a/docs/superpowers/specs/2026-06-02-chat-input-filter-design.md
+++ b/docs/superpowers/specs/2026-06-02-chat-input-filter-design.md
@@ -55,7 +55,8 @@ different where the problem differs:
 
 **Goals**
 - Optional, off-by-default user-input rewrite, configured like `chat_output_filter`.
-- A single global switch (`input_filter = true` on `[tasks.chat_companion]`).
+- A single global trigger (`input_filter` on `[tasks.chat_companion]`) accepting a
+  bool or a per-turn probability (`true`/`false`/`0.8`).
 - Original text always persisted as `content` and shown to the client.
 - Rewritten text persisted in the existing `pre_filter_content` audit column and
   fed to the model for the current turn **and** future turns' history.
@@ -73,16 +74,26 @@ different where the problem differs:
 
 ## 2. Config surface — `model_config.toml`
 
-### 2.1 Global switch on `[tasks.chat_companion]`
+### 2.1 Global trigger on `[tasks.chat_companion]`
 
-Add one task-level boolean, mirroring `output_filter`, **task-level only (no
-per-tier override)**:
+Add one task-level trigger, **task-level only (no per-tier override)**. It
+accepts a bool **or** a probability (a custom-`Deserialize` newtype
+`InputFilterTrigger(f64)`, like the file's other multi-form values):
 
 ```toml
 [tasks.chat_companion]
 # ... existing fields ...
-input_filter = true        # global default: false
+input_filter = false   # off (default)
+# input_filter = true  # always (= 1.0)
+# input_filter = 0.8   # per-turn coin flip — fire on ~80% of turns
 ```
+
+Semantics: `false`/absent → `0.0` (off), `true` → `1.0` (always), a number →
+that probability. A number **outside `[0.0, 1.0]`** (or non-finite) is a hard
+config error — the load fails loudly rather than silently clamping.
+`resolve_input_filter()` returns `None` when the probability is `0.0` and carries
+the probability otherwise; the stream wiring draws one coin flip per turn
+(`rand < probability`) before running the filter LLM.
 
 ### 2.2 The filter task block `[tasks.chat_input_filter]`
 
@@ -146,9 +157,14 @@ documented style as the `chat_output_filter` block:
 
 Mirror `resolve_output_filter`, minus `trigger` / `timing` / tier.
 
-### 3.1 New struct
+### 3.1 New structs
 
 ```rust
+/// Three TOML forms: false (0.0), true (1.0), or a number in [0.0, 1.0].
+/// Out-of-range / non-finite numbers are a hard deserialize error (no clamp).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct InputFilterTrigger(pub f64); // custom Deserialize (bool | number)
+
 #[derive(Debug, Clone)]
 pub struct ResolvedInputFilter {
     pub model: String,
@@ -158,35 +174,49 @@ pub struct ResolvedInputFilter {
     pub filter_prompt: String,
     pub retry_depth: u32,
     pub reasoning: Option<ReasoningConfig>,
+    pub probability: f64, // per-turn fire probability, always > 0.0 here
 }
 ```
+
+`InputFilterTrigger` implements `Deserialize` via a `Visitor`: `visit_bool` →
+`1.0`/`0.0`; `visit_f64`/`visit_i64`/`visit_u64` accept only finite values in
+`[0.0, 1.0]`, else `Err(custom(...))`.
 
 ### 3.2 New field on `TaskConfig`
 
 ```rust
-/// Global switch for the user-input rewrite filter. Task-level only on
-/// chat_companion (no per-tier override, unlike `output_filter`). Default false.
+/// Global trigger for the user-input rewrite filter. Task-level only on
+/// chat_companion (no per-tier override). false/absent ⇒ off, true ⇒ every
+/// turn, 0.8 ⇒ 80% of turns.
 #[serde(default)]
-pub input_filter: Option<bool>,
+pub input_filter: Option<InputFilterTrigger>,
 ```
 
 ### 3.3 New methods on `ModelConfig`
 
 ```rust
-/// chat_companion `input_filter` (task-level → false). No tier param.
-pub fn input_filter_enabled(&self) -> bool {
+/// chat_companion `input_filter` fire probability: false/absent → 0.0,
+/// true → 1.0, number → that probability. No tier param.
+pub fn input_filter_probability(&self) -> f64 {
     self.tasks
         .get("chat_companion")
         .and_then(|t| t.input_filter)
-        .unwrap_or(false)
+        .map(|t| t.0)
+        .unwrap_or(0.0)
 }
 
-/// Resolve the input filter. `None` (disabled) when: chat_companion
-/// `input_filter` is false, OR `[tasks.chat_input_filter]` is absent, OR its
-/// `filter_prompt` is blank.
+/// True when the filter can ever fire (probability > 0.0).
+pub fn input_filter_enabled(&self) -> bool {
+    self.input_filter_probability() > 0.0
+}
+
+/// Resolve the input filter. `None` (disabled) when: probability is 0.0
+/// (false/absent), OR `[tasks.chat_input_filter]` is absent, OR its
+/// `filter_prompt` is blank. The carried `probability` gates the per-turn run.
 pub fn resolve_input_filter(&self) -> Option<ResolvedInputFilter> {
     const FILTER_TASK: &str = "chat_input_filter";
-    if !self.input_filter_enabled() {
+    let probability = self.input_filter_probability();
+    if probability <= 0.0 {
         return None;
     }
     let task_cfg = self.tasks.get(FILTER_TASK)?;
@@ -206,6 +236,7 @@ pub fn resolve_input_filter(&self) -> Option<ResolvedInputFilter> {
         filter_prompt,
         retry_depth,
         reasoning: task_cfg.reasoning.clone(),
+        probability,
     })
 }
 ```
@@ -304,7 +335,14 @@ async fn run_input_filter(
 Near the top of `run_stream`, before prompt assembly, **for `UserMessage`-driven
 Reply turns only** (not gift / proactive):
 
-1. `let Some(f) = state.model_config.resolve_input_filter() else { /* skip */ }`.
+0. Skip on tipped turns (`user_msg.tips_amount_usd.is_some()`): a tip persists as
+   `role='gift_user'`, which `set_user_input_rewrite` can't update and the prompt
+   drops anyway — running the filter there is a wasted LLM call.
+1. `let Some(f) = state.model_config.resolve_input_filter()` then apply the
+   **per-turn probability gate**: keep `f` only when
+   `rand::thread_rng().gen::<f64>() < f.probability` (e.g. via `Option::filter`).
+   `true` ⇒ `probability = 1.0` ⇒ always; `0.8` ⇒ ~80%; `false` ⇒ resolve already
+   returned `None`. Skip otherwise.
 2. Build `recent_transcript` from a recent-history slice (reuse the history fetch
    `run_stream`/handlers already perform where practical; otherwise a small
    `history(session_id, K, 0)` slice).
@@ -449,9 +487,14 @@ The `pre_filter_content`, `filter_model`, `filter_triggers`, `f_generation_id`,
 ## 11. Testing
 
 **Unit (`model_config.rs`)**
-- `resolve_input_filter`: `None` when switch off / table absent / blank prompt;
-  `Some` with correct model/fallback (truncated to `retry_depth`)/prompt when on.
-- `input_filter_enabled`: default false; true when set.
+- `resolve_input_filter`: `None` when probability 0.0 / table absent / blank
+  prompt; `Some` with correct model/fallback (truncated to `retry_depth`)/prompt
+  /`probability` when on.
+- `InputFilterTrigger` parsing: `false`→0.0, `true`→1.0, `0.8`→0.8, integer
+  `0`/`1` accepted; out-of-range (`1.5`, `-0.2`, `2`, `nan`, `inf`) is a hard
+  load error.
+- `input_filter_enabled` / `input_filter_probability`: default 0.0/false; carry
+  the configured probability.
 - Compat fixture / committed-example parse test updated to include
   `chat_input_filter` + `input_filter` (schema lock).
 

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -108,6 +108,48 @@ model_name_display_override = true
 # (NOT temperature/max_tokens — those are task-level only, like every other task)
 #filter_prompt = "..."
 
+# ── Optional user-input rewrite filter (OFF by default) ──────────────────────
+# Rewrites a MEANINGLESS user turn (e.g. "1111", "？？？", key-mashing) into one
+# natural, context-appropriate user message before it reaches chat_companion, so
+# the companion answers a real message instead of parroting history. Meaningful
+# turns — including short ones like "嗯"/"好啊"/"在吗" and genuine short
+# questions — are left untouched.
+#
+# Enable with a single global switch on [tasks.chat_companion]:
+#   [tasks.chat_companion]
+#   input_filter = true                  # global default: false
+#
+# The filter runs only if BOTH input_filter is true AND this table exists with a
+# non-blank filter_prompt; otherwise it is inert. The user's ORIGINAL text is
+# always persisted (content) and shown to the client; the rewrite is stored
+# separately in pre_filter_content and seen only by the model.
+#
+# Pick a fast, cheap model — this runs on every user turn before generation.
+# Recommended: google/gemini-3.1-flash-lite or deepseek/deepseek-v4-flash.
+#[tasks.chat_input_filter]
+#model        = "google/gemini-3.1-flash-lite"
+#fallback     = ["deepseek/deepseek-v4-flash"]
+#retry_depth  = 1
+#temperature  = 0.3
+#max_tokens   = 400
+# Reasoning is OFF by default here (the filter only needs a short JSON verdict).
+#reasoning    = { enabled = false }
+#filter_prompt = """
+#You are an input-cleaning filter for a companion chat. You receive the recent
+#conversation and the user's latest input. Decide whether the latest input is a
+#meaningful message.
+#
+#- If it IS meaningful (any real intent, INCLUDING short replies like "嗯",
+#  "好啊", "在吗", or a short question), respond EXACTLY:
+#    {"rewrite": false}
+#- If it is NOT meaningful (random characters, key-mashing, repeated chars,
+#  punctuation-only noise), rewrite it into ONE short, natural user message that
+#  fits the conversation, and give a brief reason. Respond EXACTLY:
+#    {"rewrite": true, "content": "<the rewritten user message>", "reason": "<why it was meaningless>"}
+#
+# Output JSON only. No explanation outside the JSON, no code fences.
+#"""
+
 [tasks.insight_extraction]
 model = "anthropic/claude-haiku-4.5"
 fallback = ["deepseek/deepseek-v4-flash","google/gemini-3.1-flash-lite"]

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -115,12 +115,17 @@ model_name_display_override = true
 # turns — including short ones like "嗯"/"好啊"/"在吗" and genuine short
 # questions — are left untouched.
 #
-# Enable with a single global switch on [tasks.chat_companion]:
+# Enable with a single global switch on [tasks.chat_companion]. It accepts a
+# bool OR a probability:
 #   [tasks.chat_companion]
-#   input_filter = true                  # global default: false
+#   input_filter = false   # off (default)
+#   input_filter = true    # run on every user turn (= 1.0)
+#   input_filter = 0.8     # run on ~80% of user turns
+# A number outside [0.0, 1.0] (or non-finite) is rejected at load time.
 #
-# The filter runs only if BOTH input_filter is true AND this table exists with a
-# non-blank filter_prompt; otherwise it is inert. The user's ORIGINAL text is
+# The filter runs only if BOTH input_filter fires (true/probability) AND this
+# table exists with a non-blank filter_prompt; otherwise it is inert. The user's
+# ORIGINAL text is
 # always persisted (content) and shown to the client; the rewrite is stored
 # separately in pre_filter_content and seen only by the model.
 #


### PR DESCRIPTION
## Summary

Adds an optional, **off-by-default** user-input rewrite filter — the input-side mirror of `chat_output_filter`. When a user types something meaningless (`1111`, `？？？`, key-mashing), a fast second LLM rewrites it into one natural, context-aware user message before it reaches `chat_companion`, so the companion answers a real message instead of parroting history. Meaningful turns (including short ones like `嗯`/`好啊`/`在吗`) pass through untouched.

- **Config:** single global switch `input_filter = true` on `[tasks.chat_companion]` + a `[tasks.chat_input_filter]` block (no tiers, no trigger). Inert unless enabled with a non-blank `filter_prompt`. **No migration** — reuses the `0019` audit columns.
- **Contract:** the filter LLM returns a JSON verdict — `{"rewrite": false}` (engine uses the original verbatim, never an echo) or `{"rewrite": true, "content": "…", "reason": "…"}`. The LLM is the sole decider, so normal short messages are never falsely rewritten.
- **Storage:** the user's **original** text always stays in `content` (and is all the client/BFF ever sees); the rewrite goes to `pre_filter_content` (model-facing), with `filter_model` / `f_generation_id` / `filter_triggers = {"reason": …}` for audit. The prompt + memory recall use the effective text (`pre_filter_content ?? content`) for user rows; **extraction (insight/memory/affinity) keeps reading the original.**
- **Robustness:** fail-open everywhere (error/timeout/unparseable/refusal ⇒ original used; never blocks a reply). Runs once per real Reply turn (after the idempotency gate); tipped (`gift_user`) turns are skipped.

Spec: `docs/superpowers/specs/2026-06-02-chat-input-filter-design.md`

## Test Plan

- [x] Unit: resolver on/off/blank-prompt + `retry_depth`; JSON verdict parsing (direct + embedded + unparseable); floor-free `rewrite_content_invalidity` (accepts short rewrites, rejects refusals); effective-text selection (user vs assistant); store round-trip (content preserved, audit stamped, blank-reason → NULL); `COMPAT_FIXTURE` schema lock.
- [x] Integration (`#[sqlx::test]` + wiremock): a meaningless turn is rewritten — `content` stays original, `pre_filter_content`/`filter_model`/`filter_triggers` stamped, and the chat model is called with the rewritten text.
- [x] Full local gate: `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace` (434 pass / 0 fail), OpenAPI unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)