### PR TITLE
feat(chat-vision): image input via vision describe

### DIFF
--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -528,6 +528,20 @@ pub struct ResolvedInputFilter {
     pub probability: f64,
 }
 
+/// Resolved image-describe task (`chat_vision`). Mirrors `ResolvedInputFilter`
+/// minus the per-turn probability — the trigger is "image present", decided in
+/// the stream wiring. `fallback_model` is already truncated to `retry_depth`.
+#[derive(Debug, Clone)]
+pub struct ResolvedVision {
+    pub model: String,
+    pub fallback_model: Vec<String>,
+    pub temperature: f64,
+    pub max_tokens: u32,
+    pub describe_prompt: String,
+    pub retry_depth: u32,
+    pub reasoning: Option<ReasoningConfig>,
+}
+
 impl ModelConfig {
     pub fn from_toml_str(text: &str) -> Result<Self, LlmError> {
         Ok(toml::from_str(text)?)
@@ -768,6 +782,33 @@ impl ModelConfig {
             retry_depth,
             reasoning: task_cfg.reasoning.clone(),
             probability,
+        })
+    }
+
+    /// Resolve the image-describe task. `None` (feature off) when
+    /// `[tasks.chat_vision]` is absent OR its `filter_prompt` is blank. Reuses
+    /// the generic `TaskConfig.filter_prompt` field and the standard `resolve()`
+    /// model/fallback machinery. No probability gate — image presence is the
+    /// trigger, decided in the stream wiring.
+    pub fn resolve_vision(&self) -> Option<ResolvedVision> {
+        const VISION_TASK: &str = "chat_vision";
+        let task_cfg = self.tasks.get(VISION_TASK)?;
+        let describe_prompt = task_cfg.filter_prompt.clone().unwrap_or_default();
+        if describe_prompt.trim().is_empty() {
+            return None;
+        }
+        let retry_depth = task_cfg.retry_depth.unwrap_or(1);
+        let m = self.resolve(VISION_TASK, None);
+        let mut fallback_model = m.fallback_model;
+        fallback_model.truncate(retry_depth as usize);
+        Some(ResolvedVision {
+            model: m.model,
+            fallback_model,
+            temperature: m.temperature,
+            max_tokens: m.max_tokens,
+            describe_prompt,
+            retry_depth,
+            reasoning: task_cfg.reasoning.clone(),
         })
     }
 }
@@ -2221,5 +2262,55 @@ retry_depth = 0
         let f = cfg.resolve_input_filter().expect("enabled");
         assert_eq!(f.retry_depth, 0);
         assert!(f.fallback_model.is_empty());
+    }
+
+    #[test]
+    fn resolve_vision_none_when_task_absent() {
+        let cfg = ModelConfig::from_toml_str("[tasks.chat_companion]\nmodel = \"m\"\n").unwrap();
+        assert!(cfg.resolve_vision().is_none());
+    }
+
+    #[test]
+    fn resolve_vision_none_when_prompt_blank() {
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.chat_vision]\nmodel = \"v\"\nfilter_prompt = \"   \"\n",
+        )
+        .unwrap();
+        assert!(cfg.resolve_vision().is_none());
+    }
+
+    #[test]
+    fn resolve_vision_some_truncates_fallback_to_retry_depth() {
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.chat_vision]\n\
+             model = \"v\"\n\
+             fallback = [\"f1\", \"f2\", \"f3\"]\n\
+             temperature = 0.2\n\
+             max_tokens = 400\n\
+             retry_depth = 1\n\
+             filter_prompt = \"describe as json\"\n",
+        )
+        .unwrap();
+        let r = cfg.resolve_vision().expect("vision resolves");
+        assert_eq!(r.model, "v");
+        assert_eq!(r.fallback_model, vec!["f1".to_string()]); // truncated to retry_depth=1
+        assert_eq!(r.describe_prompt, "describe as json");
+        assert_eq!(r.max_tokens, 400);
+        assert_eq!(r.retry_depth, 1);
+    }
+
+    #[test]
+    fn resolve_vision_retry_depth_zero_drops_fallback() {
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.chat_vision]\n\
+             model = \"v\"\n\
+             fallback = [\"f1\", \"f2\"]\n\
+             retry_depth = 0\n\
+             filter_prompt = \"describe as json\"\n",
+        )
+        .unwrap();
+        let r = cfg.resolve_vision().expect("vision resolves");
+        assert_eq!(r.retry_depth, 0);
+        assert!(r.fallback_model.is_empty());
     }
 }

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -51,6 +51,51 @@ pub struct ChatRequest {
     pub reasoning: Option<ReasoningConfig>,
 }
 
+/// One-shot multimodal *describe* request. Used only by the `chat_vision`
+/// pipeline stage. Builds an OpenRouter user message whose `content` is a block
+/// array (text instruction + one image_url). Keeps `ChatMessage` text-only.
+#[derive(Debug, Clone, Default)]
+pub struct VisionRequest {
+    pub model: String,
+    pub fallback_model: Vec<String>,
+    pub system_prompt: String,
+    pub image_url: String,
+    /// User's own caption (becomes the text block when non-blank).
+    pub caption: Option<String>,
+    pub temperature: f32,
+    pub max_tokens: u32,
+    pub reasoning: Option<ReasoningConfig>,
+}
+
+/// Build the OpenRouter wire body for one vision attempt against `model`. Pure
+/// (no I/O) so the block shape is unit-testable. A non-blank `caption` becomes
+/// the text block; otherwise a default describe instruction is used.
+fn build_vision_body(req: &VisionRequest, model: &str) -> serde_json::Value {
+    let text = match req.caption.as_deref().map(str::trim) {
+        Some(c) if !c.is_empty() => c.to_string(),
+        _ => "请描述这张图片的内容。".to_string(),
+    };
+    let mut body = serde_json::json!({
+        "model": model,
+        "messages": [
+            { "role": "system", "content": req.system_prompt },
+            { "role": "user", "content": [
+                { "type": "text", "text": text },
+                { "type": "image_url", "image_url": { "url": req.image_url } }
+            ]}
+        ],
+        "temperature": req.temperature,
+        "max_tokens": req.max_tokens,
+        "stream": false,
+    });
+    if let Some(r) = &req.reasoning {
+        if let Ok(v) = serde_json::to_value(r) {
+            body["reasoning"] = v;
+        }
+    }
+    body
+}
+
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct ChatResponse {
     pub reply: String,
@@ -322,6 +367,74 @@ impl OpenRouterClient {
         }
 
         Err(last_err.unwrap_or_else(|| LlmError::Config("openrouter: no models configured".into())))
+    }
+
+    /// Execute a one-shot vision describe, walking the candidate chain
+    /// (`model` + `fallback_model`) sequentially. First success wins. Mirrors
+    /// `execute`'s chain semantics. Returns the model's text reply (expected
+    /// JSON; parsing is the caller's job).
+    pub async fn execute_vision(&self, req: VisionRequest) -> Result<ChatResponse, LlmError> {
+        let candidates: Vec<&str> = std::iter::once(req.model.as_str())
+            .chain(req.fallback_model.iter().map(String::as_str))
+            .filter(|s| !s.is_empty())
+            .collect();
+        if candidates.is_empty() {
+            return Err(LlmError::Config(
+                "openrouter: vision has no models configured".into(),
+            ));
+        }
+        if self.api_key.is_empty() {
+            return Err(LlmError::Config("openrouter: api key not set".into()));
+        }
+
+        let mut last_err: Option<LlmError> = None;
+        for model in &candidates {
+            let body = build_vision_body(&req, model);
+            let resp = match self
+                .http
+                .post(&self.base_url)
+                .bearer_auth(&self.api_key)
+                .json(&body)
+                .send()
+                .await
+            {
+                Ok(r) => r,
+                Err(e) => {
+                    tracing::warn!(model = %model, error = %e, "openrouter: vision attempt failed (transport); next");
+                    last_err = Some(e.into());
+                    continue;
+                }
+            };
+            let status = resp.status();
+            if !status.is_success() {
+                let text = resp.text().await.unwrap_or_default();
+                tracing::warn!(model = %model, %status, "openrouter: vision attempt failed (status); next");
+                last_err = Some(LlmError::Status(status, text));
+                continue;
+            }
+            let parsed: WireResponse = match resp.json().await {
+                Ok(p) => p,
+                Err(e) => {
+                    tracing::warn!(model = %model, error = %e, "openrouter: vision attempt failed (decode); next");
+                    last_err = Some(e.into());
+                    continue;
+                }
+            };
+            let first_choice = parsed.choices.into_iter().next();
+            let raw = first_choice
+                .as_ref()
+                .and_then(|c| c.message.content.clone())
+                .unwrap_or_default();
+            let finish_reason = first_choice.and_then(|c| c.finish_reason);
+            return Ok(ChatResponse {
+                reply: clean_response(raw.trim()),
+                generation_id: parsed.id,
+                model: parsed.model,
+                usage: parsed.usage,
+                finish_reason,
+            });
+        }
+        Err(last_err.unwrap_or_else(|| LlmError::Config("openrouter: vision no models".into())))
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1161,6 +1274,44 @@ data: [DONE]\n\n";
         assert!(
             matches!(err, LlmError::Status(s, _) if s.as_u16() == 429),
             "expected Status(429), got {err:?}"
+        );
+    }
+
+    #[test]
+    fn build_vision_body_has_text_and_image_blocks() {
+        let req = VisionRequest {
+            model: "ignored".into(),
+            system_prompt: "sys".into(),
+            image_url: "https://x/y.png".into(),
+            caption: Some("看看这个".into()),
+            temperature: 0.2,
+            max_tokens: 400,
+            ..Default::default()
+        };
+        let body = build_vision_body(&req, "vision-model");
+        assert_eq!(body["model"], "vision-model");
+        assert_eq!(body["stream"], false);
+        assert_eq!(body["messages"][0]["role"], "system");
+        assert_eq!(body["messages"][0]["content"], "sys");
+        let content = &body["messages"][1]["content"];
+        assert_eq!(content[0]["type"], "text");
+        assert_eq!(content[0]["text"], "看看这个");
+        assert_eq!(content[1]["type"], "image_url");
+        assert_eq!(content[1]["image_url"]["url"], "https://x/y.png");
+    }
+
+    #[test]
+    fn build_vision_body_defaults_text_when_caption_blank() {
+        let req = VisionRequest {
+            image_url: "https://x/y.png".into(),
+            caption: None,
+            max_tokens: 1,
+            ..Default::default()
+        };
+        let body = build_vision_body(&req, "m");
+        assert_eq!(
+            body["messages"][1]["content"][0]["text"],
+            "请描述这张图片的内容。"
         );
     }
 

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -1405,6 +1405,12 @@
           "content": {
             "type": "string"
           },
+          "image_url": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "memory_scope": {
             "type": [
               "string",

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -86,6 +86,62 @@ pub(crate) fn effective_user_text(msg: &eros_engine_store::chat::ChatMessage) ->
     }
 }
 
+/// Build the `[用户发送了一张图片]` preamble from a stored `metadata.vision`
+/// object. Returns `None` when `description` is absent/blank (not a usable
+/// describe). Blank optional fields are omitted line-by-line.
+fn build_image_preamble(vision: &serde_json::Value) -> Option<String> {
+    let field = |k: &str| {
+        vision
+            .get(k)
+            .and_then(|x| x.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+    };
+    let description = field("description")?;
+    let mut lines = vec![
+        "[用户发送了一张图片]".to_string(),
+        format!("画面：{description}"),
+    ];
+    if let Some(t) = field("ocr_text") {
+        lines.push(format!("文字：{t}"));
+    }
+    if let Some(p) = field("people") {
+        lines.push(format!("人物：{p}"));
+    }
+    if let Some(s) = field("scene") {
+        lines.push(format!("场景：{s}"));
+    }
+    Some(lines.join("\n"))
+}
+
+/// What the MAIN chat model should see for a user row: an optional image
+/// preamble (from `metadata.vision`, or a neutral placeholder when an image was
+/// sent but not described) folded onto `effective_user_text(msg)`. A plain text
+/// turn (no `vision`, no `image_url`) returns the effective text unchanged.
+pub(crate) fn model_facing_user_text(msg: &eros_engine_store::chat::ChatMessage) -> String {
+    let base = effective_user_text(msg);
+    let meta = msg.metadata.as_ref();
+    let preamble = meta
+        .and_then(|m| m.get("vision"))
+        .and_then(|v| build_image_preamble(v))
+        .or_else(|| {
+            // Image sent but not described (vision failed) → neutral placeholder.
+            meta.and_then(|m| m.get("image_url"))
+                .map(|_| "[用户发送了一张图片，但内容无法识别]".to_string())
+        });
+    match preamble {
+        Some(p) => {
+            let body = if base.trim().is_empty() {
+                "[用户未附文字]"
+            } else {
+                base
+            };
+            format!("{p}\n\n{body}")
+        }
+        None => base.to_string(),
+    }
+}
+
 /// Materialise a ChatRequest from a pre-resolved model + system prompt +
 /// chronological history. `audit` carries the caller's OpenRouter passthrough
 /// when the driving event was a `UserMessage`; gift / proactive pass `None`.
@@ -101,11 +157,12 @@ fn assemble_chat_request(
         content: system_prompt,
     });
     for msg in history {
-        // User rows feed the EFFECTIVE text (input-filter rewrite when present);
-        // assistant rows always feed `content` (their pre_filter_content is the
-        // pre-output-filter original and must never re-enter the prompt).
+        // User rows feed the MODEL-FACING text (image preamble folded onto the
+        // effective text when an image was attached); assistant rows always feed
+        // `content` (their pre_filter_content is the pre-output-filter original
+        // and must never re-enter the prompt).
         let content = match msg.role.as_str() {
-            "user" => effective_user_text(&msg).to_string(),
+            "user" => model_facing_user_text(&msg),
             "assistant" => msg.content,
             _ => continue,
         };
@@ -1394,6 +1451,57 @@ mod tests {
         assert_eq!(effective_user_text(&row), "有意义的问题");
         row.pre_filter_content = Some("   ".into()); // blank → fall back to content
         assert_eq!(effective_user_text(&row), "1111");
+    }
+
+    fn user_row_meta(
+        content: &str,
+        metadata: serde_json::Value,
+    ) -> eros_engine_store::chat::ChatMessage {
+        let mut r = user_row(content, None);
+        r.metadata = Some(metadata);
+        r
+    }
+
+    #[test]
+    fn model_facing_text_folds_vision_preamble() {
+        let row = user_row_meta(
+            "看看这个",
+            serde_json::json!({
+                "image_url": "https://x/y.png",
+                "vision": { "description": "一只猫", "ocr_text": "", "people": "", "scene": "客厅" }
+            }),
+        );
+        let t = model_facing_user_text(&row);
+        assert!(t.contains("[用户发送了一张图片]"));
+        assert!(t.contains("画面：一只猫"));
+        assert!(t.contains("场景：客厅"));
+        assert!(!t.contains("文字：")); // blank ocr dropped
+        assert!(t.ends_with("看看这个"));
+    }
+
+    #[test]
+    fn model_facing_text_image_only_uses_placeholder_body() {
+        let row = user_row_meta(
+            "",
+            serde_json::json!({ "image_url": "https://x/y.png", "vision": { "description": "日落" } }),
+        );
+        let t = model_facing_user_text(&row);
+        assert!(t.contains("画面：日落"));
+        assert!(t.ends_with("[用户未附文字]"));
+    }
+
+    #[test]
+    fn model_facing_text_undescribed_image_placeholder() {
+        let row = user_row_meta("hi", serde_json::json!({ "image_url": "https://x/y.png" }));
+        let t = model_facing_user_text(&row);
+        assert!(t.contains("无法识别"));
+        assert!(t.ends_with("hi"));
+    }
+
+    #[test]
+    fn model_facing_text_plain_turn_unchanged() {
+        let row = user_row("普通消息", None);
+        assert_eq!(model_facing_user_text(&row), "普通消息");
     }
 
     /// End-to-end check of the cutoff semantics that `fetch_recent_turn_pairs`

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -1382,6 +1382,7 @@ mod tests {
             generation_id: None,
             assistant_action_type: None,
             pre_filter_content: pre.map(|s| s.to_string()),
+            metadata: None,
         }
     }
 

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -142,6 +142,27 @@ pub(crate) fn model_facing_user_text(msg: &eros_engine_store::chat::ChatMessage)
     }
 }
 
+/// Recall query text for a user row: the caption (`effective_user_text`) when
+/// non-blank, else the vision `description` for an image-only turn so memory
+/// recall can match the photo's content instead of running on empty text. Used
+/// ONLY for the recall/embedding query — the prompt path uses
+/// `model_facing_user_text` (which folds the full preamble).
+pub(crate) fn recall_query_text(msg: &eros_engine_store::chat::ChatMessage) -> String {
+    let caption = effective_user_text(msg);
+    if !caption.trim().is_empty() {
+        return caption.to_string();
+    }
+    msg.metadata
+        .as_ref()
+        .and_then(|m| m.get("vision"))
+        .and_then(|v| v.get("description"))
+        .and_then(|d| d.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .unwrap_or_default()
+}
+
 /// Materialise a ChatRequest from a pre-resolved model + system prompt +
 /// chronological history. `audit` carries the caller's OpenRouter passthrough
 /// when the driving event was a `UserMessage`; gift / proactive pass `None`.
@@ -498,15 +519,15 @@ pub(super) async fn build_reply_request(
     let chat_repo = ChatRepo { pool: &state.pool };
     let history = chat_repo.history(session_id, HISTORY_WINDOW, 0).await?;
 
-    // The model and recall both see the EFFECTIVE text for the current user
-    // turn: if the input filter rewrote it, the rewrite is persisted on the
-    // row's pre_filter_content, so derive query_text from history rather than
-    // the raw event content.
+    // Recall query for the current user turn: the effective caption, or — for an
+    // image-only turn — the vision description (recall_query_text), so a photo
+    // with no caption still retrieves relevant memories. The MAIN prompt path
+    // separately folds the full image preamble via model_facing_user_text.
     let query_text: String = history
         .iter()
         .rev()
         .find(|m| m.id == user_message_id && m.role == "user")
-        .map(|m| effective_user_text(m).to_string())
+        .map(recall_query_text)
         .unwrap_or_else(|| match &input.event {
             Event::UserMessage { content, .. } => content.clone(),
             _ => String::new(),
@@ -1502,6 +1523,36 @@ mod tests {
     fn model_facing_text_plain_turn_unchanged() {
         let row = user_row("普通消息", None);
         assert_eq!(model_facing_user_text(&row), "普通消息");
+    }
+
+    #[test]
+    fn recall_query_prefers_caption() {
+        let row = user_row_meta(
+            "你看这个",
+            serde_json::json!({ "vision": { "description": "一只猫" } }),
+        );
+        assert_eq!(recall_query_text(&row), "你看这个");
+    }
+
+    #[test]
+    fn recall_query_falls_back_to_description_when_caption_blank() {
+        let row = user_row_meta(
+            "",
+            serde_json::json!({ "image_url": "https://x/y.png", "vision": { "description": "一只猫在沙滩" } }),
+        );
+        assert_eq!(recall_query_text(&row), "一只猫在沙滩");
+    }
+
+    #[test]
+    fn recall_query_empty_when_no_caption_no_vision() {
+        let row = user_row("", None);
+        assert_eq!(recall_query_text(&row), "");
+    }
+
+    #[test]
+    fn recall_query_plain_text_turn() {
+        let row = user_row("普通消息", None);
+        assert_eq!(recall_query_text(&row), "普通消息");
     }
 
     /// End-to-end check of the cutoff semantics that `fetch_recent_turn_pairs`

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -123,7 +123,7 @@ pub(crate) fn model_facing_user_text(msg: &eros_engine_store::chat::ChatMessage)
     let meta = msg.metadata.as_ref();
     let preamble = meta
         .and_then(|m| m.get("vision"))
-        .and_then(|v| build_image_preamble(v))
+        .and_then(build_image_preamble)
         .or_else(|| {
             // Image sent but not described (vision failed) → neutral placeholder.
             meta.and_then(|m| m.get("image_url"))

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -1090,6 +1090,9 @@ pub struct PersistedUserMessage {
     pub memory_scope: eros_engine_core::scope::MemoryScope,
     pub affinity_scope: eros_engine_core::scope::AffinityScope,
     pub tips_amount_usd: Option<f64>,
+    /// The image URL the client attached to this turn (`https`/`http`), or
+    /// `None` for a text/tip-only turn. Drives the `chat_vision` pre-stage.
+    pub image_url: Option<String>,
 }
 
 /// Produce a stream of `ProtocolFrame` events for a single burst. The
@@ -1735,6 +1738,7 @@ mod tests {
                 memory_scope: Default::default(),
                 affinity_scope: Default::default(),
                 tips_amount_usd: None,
+                image_url: None,
             },
         )
         .collect()
@@ -1868,6 +1872,7 @@ data: [DONE]\n\n";
                 memory_scope: Default::default(),
                 affinity_scope: Default::default(),
                 tips_amount_usd: None,
+                image_url: None,
             },
         )
         .collect()
@@ -1951,6 +1956,7 @@ data: [DONE]\n\n";
                 memory_scope: Default::default(),
                 affinity_scope: Default::default(),
                 tips_amount_usd: None,
+                image_url: None,
             },
         )
         .collect()
@@ -2050,6 +2056,7 @@ data: [DONE]\n\n";
                 memory_scope: Default::default(),
                 affinity_scope: Default::default(),
                 tips_amount_usd: None,
+                image_url: None,
             },
         )
         .collect()
@@ -2364,6 +2371,7 @@ data: [DONE]\n\n";
                 memory_scope: Default::default(),
                 affinity_scope: Default::default(),
                 tips_amount_usd: None,
+                image_url: None,
             },
         )
         .collect()
@@ -2486,6 +2494,7 @@ data: [DONE]\n\n";
                 memory_scope: Default::default(),
                 affinity_scope: Default::default(),
                 tips_amount_usd: None,
+                image_url: None,
             },
         )
         .collect()
@@ -2621,6 +2630,7 @@ data: [DONE]\n\n";
                 memory_scope: Default::default(),
                 affinity_scope: Default::default(),
                 tips_amount_usd: None,
+                image_url: None,
             },
         )
         .collect()
@@ -2771,6 +2781,7 @@ data: [DONE]\n\n";
                 memory_scope: Default::default(),
                 affinity_scope: Default::default(),
                 tips_amount_usd: None,
+                image_url: None,
             },
         )
         .collect()
@@ -2883,6 +2894,7 @@ data: [DONE]\n\n";
                 memory_scope: Default::default(),
                 affinity_scope: Default::default(),
                 tips_amount_usd: None,
+                image_url: None,
             },
         )
         .collect()
@@ -2976,6 +2988,7 @@ data: [DONE]\n\n";
                 memory_scope: Default::default(),
                 affinity_scope: Default::default(),
                 tips_amount_usd: Some(20.0),
+                image_url: None,
             },
         )
         .collect()
@@ -3081,6 +3094,7 @@ data: [DONE]\n\n";
                 memory_scope: Default::default(),
                 affinity_scope: Default::default(),
                 tips_amount_usd: None,
+                image_url: None,
             },
         )
         .collect()
@@ -3188,6 +3202,7 @@ data: [DONE]\n\n";
                 memory_scope: Default::default(),
                 affinity_scope: Default::default(),
                 tips_amount_usd: None,
+                image_url: None,
             },
         )
         .collect()
@@ -3314,6 +3329,7 @@ data: [DONE]\n\n";
                 memory_scope: Default::default(),
                 affinity_scope: Default::default(),
                 tips_amount_usd: None,
+                image_url: None,
             },
         )
         .collect()
@@ -3513,6 +3529,7 @@ data: [DONE]\n\n";
                 memory_scope: Default::default(),
                 affinity_scope: Default::default(),
                 tips_amount_usd: None,
+                image_url: None,
             },
         )
         .collect()
@@ -3655,6 +3672,7 @@ data: [DONE]\n\n";
                 memory_scope: Default::default(),
                 affinity_scope: Default::default(),
                 tips_amount_usd: None,
+                image_url: None,
             },
         )
         .collect()

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -1779,6 +1779,7 @@ mod tests {
             generation_id: Some("gen-1".into()),
             assistant_action_type: Some("reply".into()),
             pre_filter_content: None,
+            metadata: None,
         };
 
         let frames: Vec<ProtocolFrame> =
@@ -2084,6 +2085,7 @@ data: [DONE]\n\n";
             generation_id: None,
             assistant_action_type: Some("reply".into()),
             pre_filter_content: None,
+            metadata: None,
         };
 
         let meta_model = |frames: &[ProtocolFrame]| -> Option<String> {

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -1321,7 +1321,10 @@ pub fn run_stream(
                 // failure keeps the turn text-only (placeholder covers an
                 // undescribed image). Run-once is guaranteed by the upsert
                 // idempotency gate — run_stream only runs on a fresh Insert.
-                if !is_gift {
+                // Skip tipped turns (same as the input filter): a tip persists as
+                // role='gift_user', which set_user_image_vision can't update and
+                // the prompt drops anyway — describing it would waste the call.
+                if !is_gift && user_msg.tips_amount_usd.is_none() {
                     if let (Some(image_url), Some(v)) = (
                         user_msg.image_url.as_deref(),
                         state.model_config.resolve_vision(),

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -1302,6 +1302,34 @@ pub fn run_stream(
             }
             ActionType::Reply | ActionType::GiftReaction => {
                 let is_gift = matches!(plan.action_type, ActionType::GiftReaction);
+                // ── Image describe (chat_vision) — Reply turns with an image ──
+                // Runs before the input filter; both may fire (orthogonal). The
+                // describe result is merged into metadata.vision; the prompt
+                // builder folds it via model_facing_user_text. Fail-open: any
+                // failure keeps the turn text-only (placeholder covers an
+                // undescribed image). Run-once is guaranteed by the upsert
+                // idempotency gate — run_stream only runs on a fresh Insert.
+                if !is_gift {
+                    if let (Some(image_url), Some(v)) = (
+                        user_msg.image_url.as_deref(),
+                        state.model_config.resolve_vision(),
+                    ) {
+                        if let Some(out) = run_vision(&state, &v, image_url, &user_msg.content).await
+                        {
+                            if let Err(e) = chat_repo
+                                .set_user_image_vision(
+                                    user_msg.user_message_id,
+                                    &out.vision,
+                                    &out.vision_model,
+                                    out.v_generation_id.as_deref(),
+                                )
+                                .await
+                            {
+                                tracing::warn!("stream: chat_vision metadata persist failed: {e}");
+                            }
+                        }
+                    }
+                }
                 // ── User-input rewrite filter (Reply turns only) ──────────────
                 // Runs after the idempotency gate, before prompt assembly. The
                 // rewrite is persisted on the user row's pre_filter_content;

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -875,18 +875,18 @@ async fn run_vision(
         max_tokens: v.max_tokens,
         reasoning: v.reasoning.clone(),
     };
-    let resp = match tokio::time::timeout(FILTER_TIMEOUT, state.openrouter.execute_vision(req)).await
-    {
-        Ok(Ok(r)) => r,
-        Ok(Err(e)) => {
-            tracing::warn!(error = %e, "chat_vision: model error; keep text-only");
-            return None;
-        }
-        Err(_) => {
-            tracing::warn!("chat_vision: timeout; keep text-only");
-            return None;
-        }
-    };
+    let resp =
+        match tokio::time::timeout(FILTER_TIMEOUT, state.openrouter.execute_vision(req)).await {
+            Ok(Ok(r)) => r,
+            Ok(Err(e)) => {
+                tracing::warn!(error = %e, "chat_vision: model error; keep text-only");
+                return None;
+            }
+            Err(_) => {
+                tracing::warn!("chat_vision: timeout; keep text-only");
+                return None;
+            }
+        };
     super::log_openrouter_usage("chat_vision", None, &resp);
     let text = resp.reply.trim().to_string();
     if text.is_empty() {
@@ -3859,7 +3859,10 @@ data: [DONE]\n\n";
             people: None,
             scene: None,
         };
-        assert_eq!(image_vision_invalidity(&blank, None), Some("blank_description"));
+        assert_eq!(
+            image_vision_invalidity(&blank, None),
+            Some("blank_description")
+        );
         let ok = ImageVision {
             description: "x".into(),
             ocr_text: None,
@@ -3886,6 +3889,9 @@ data: [DONE]\n\n";
             people: None,
             scene: None,
         };
-        assert_eq!(image_vision_invalidity(&refusal, None), Some("refusal_pattern"));
+        assert_eq!(
+            image_vision_invalidity(&refusal, None),
+            Some("refusal_pattern")
+        );
     }
 }

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -853,10 +853,11 @@ struct VisionOutcome {
 }
 
 /// Run the `chat_vision` describe over the image. Returns `Some(VisionOutcome)`
-/// only on a valid parse; every failure (transport, timeout, empty, unparseable,
-/// invalid) returns `None` ⇒ caller keeps the turn text-only and the placeholder
-/// path covers the undescribed image. `execute_vision` walks the model fallback
-/// chain internally, so this issues exactly one call.
+/// only on a valid parse. Walks the configured model chain, trying the next model
+/// on any failure (transport, timeout, empty, unparseable, invalid); returns Some
+/// only on a valid describe. Any failure keeps the turn text-only and the
+/// placeholder path covers the undescribed image. Each call passes a single model
+/// (no internal fallback) so content-level failures also advance the chain.
 async fn run_vision(
     state: &AppState,
     v: &eros_engine_llm::model_config::ResolvedVision,
@@ -865,51 +866,62 @@ async fn run_vision(
 ) -> Option<VisionOutcome> {
     use eros_engine_llm::openrouter::VisionRequest;
     let caption = caption.trim();
-    let req = VisionRequest {
-        model: v.model.clone(),
-        fallback_model: v.fallback_model.clone(),
-        system_prompt: v.describe_prompt.clone(),
-        image_url: image_url.to_string(),
-        caption: (!caption.is_empty()).then(|| caption.to_string()),
-        temperature: v.temperature as f32,
-        max_tokens: v.max_tokens,
-        reasoning: v.reasoning.clone(),
-    };
-    let resp =
-        match tokio::time::timeout(FILTER_TIMEOUT, state.openrouter.execute_vision(req)).await {
+    // Walk [primary, ...fallback] ourselves so a content-level failure (empty /
+    // unparseable / invalid describe) advances to the next model — execute_vision
+    // only walks the chain on transport/HTTP/decode errors, and it cannot know the
+    // ImageVision schema. Each call passes a SINGLE model (no internal fallback).
+    let chain: Vec<String> = std::iter::once(v.model.clone())
+        .chain(v.fallback_model.iter().cloned())
+        .collect();
+    for model_id in &chain {
+        let req = VisionRequest {
+            model: model_id.clone(),
+            fallback_model: vec![],
+            system_prompt: v.describe_prompt.clone(),
+            image_url: image_url.to_string(),
+            caption: (!caption.is_empty()).then(|| caption.to_string()),
+            temperature: v.temperature as f32,
+            max_tokens: v.max_tokens,
+            reasoning: v.reasoning.clone(),
+        };
+        let resp = match tokio::time::timeout(FILTER_TIMEOUT, state.openrouter.execute_vision(req))
+            .await
+        {
             Ok(Ok(r)) => r,
             Ok(Err(e)) => {
-                tracing::warn!(error = %e, "chat_vision: model error; keep text-only");
-                return None;
+                tracing::warn!(model = %model_id, error = %e, "chat_vision: model error; next");
+                continue;
             }
             Err(_) => {
-                tracing::warn!("chat_vision: timeout; keep text-only");
-                return None;
+                tracing::warn!(model = %model_id, "chat_vision: timeout; next");
+                continue;
             }
         };
-    super::log_openrouter_usage("chat_vision", None, &resp);
-    let text = resp.reply.trim().to_string();
-    if text.is_empty() {
-        tracing::warn!("chat_vision: empty reply; keep text-only");
-        return None;
-    }
-    let vision = match parse_image_vision(&text) {
-        Some(v) => v,
-        None => {
-            tracing::warn!("chat_vision: unparseable describe JSON; keep text-only");
-            return None;
+        super::log_openrouter_usage("chat_vision", None, &resp);
+        let text = resp.reply.trim().to_string();
+        if text.is_empty() {
+            tracing::warn!(model = %model_id, "chat_vision: empty reply; next");
+            continue;
         }
-    };
-    if let Some(reason) = image_vision_invalidity(&vision, resp.finish_reason.as_deref()) {
-        tracing::warn!(invalidity = %reason, "chat_vision: invalid describe; keep text-only");
-        return None;
+        let vision = match parse_image_vision(&text) {
+            Some(parsed) => parsed,
+            None => {
+                tracing::warn!(model = %model_id, "chat_vision: unparseable describe JSON; next");
+                continue;
+            }
+        };
+        if let Some(reason) = image_vision_invalidity(&vision, resp.finish_reason.as_deref()) {
+            tracing::warn!(model = %model_id, invalidity = %reason, "chat_vision: invalid describe; next");
+            continue;
+        }
+        let vision_model = resp.model.unwrap_or_else(|| model_id.clone());
+        return Some(VisionOutcome {
+            vision: serde_json::to_value(&vision).unwrap_or(serde_json::Value::Null),
+            vision_model,
+            v_generation_id: resp.generation_id,
+        });
     }
-    let vision_model = resp.model.unwrap_or_else(|| v.model.clone());
-    Some(VisionOutcome {
-        vision: serde_json::to_value(&vision).unwrap_or(serde_json::Value::Null),
-        vision_model,
-        v_generation_id: resp.generation_id,
-    })
+    None
 }
 
 /// Validity gate for an INPUT rewrite's `content`. Unlike

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -807,6 +807,111 @@ fn parse_input_filter_verdict(text: &str) -> Option<InputFilterVerdict> {
         })
 }
 
+/// Fixed schema the `chat_vision` describe model must emit. `description` is
+/// required; the optional fields are dropped from the injected preamble when
+/// blank (see `model_facing_user_text`).
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+struct ImageVision {
+    description: String,
+    #[serde(default)]
+    ocr_text: Option<String>,
+    #[serde(default)]
+    people: Option<String>,
+    #[serde(default)]
+    scene: Option<String>,
+}
+
+/// Parse the describe reply: direct JSON first, then a balanced JSON block
+/// embedded in prose (mirrors `parse_input_filter_verdict`).
+fn parse_image_vision(text: &str) -> Option<ImageVision> {
+    serde_json::from_str::<ImageVision>(text).ok().or_else(|| {
+        super::post_process::find_json_block(text)
+            .and_then(|b| serde_json::from_str::<ImageVision>(b).ok())
+    })
+}
+
+/// Validity gate for a parsed describe. Reject a `content_filter` finish reason,
+/// a blank `description`, or a refusal-shaped description.
+fn image_vision_invalidity(v: &ImageVision, finish_reason: Option<&str>) -> Option<&'static str> {
+    if finish_reason == Some("content_filter") {
+        return Some("content_filter");
+    }
+    if v.description.trim().is_empty() {
+        return Some("blank_description");
+    }
+    if refusal_in_head(&v.description) {
+        return Some("refusal_pattern");
+    }
+    None
+}
+
+/// Outcome of a successful describe — the JSON to persist + audit.
+struct VisionOutcome {
+    vision: serde_json::Value,
+    vision_model: String,
+    v_generation_id: Option<String>,
+}
+
+/// Run the `chat_vision` describe over the image. Returns `Some(VisionOutcome)`
+/// only on a valid parse; every failure (transport, timeout, empty, unparseable,
+/// invalid) returns `None` ⇒ caller keeps the turn text-only and the placeholder
+/// path covers the undescribed image. `execute_vision` walks the model fallback
+/// chain internally, so this issues exactly one call.
+async fn run_vision(
+    state: &AppState,
+    v: &eros_engine_llm::model_config::ResolvedVision,
+    image_url: &str,
+    caption: &str,
+) -> Option<VisionOutcome> {
+    use eros_engine_llm::openrouter::VisionRequest;
+    let caption = caption.trim();
+    let req = VisionRequest {
+        model: v.model.clone(),
+        fallback_model: v.fallback_model.clone(),
+        system_prompt: v.describe_prompt.clone(),
+        image_url: image_url.to_string(),
+        caption: (!caption.is_empty()).then(|| caption.to_string()),
+        temperature: v.temperature as f32,
+        max_tokens: v.max_tokens,
+        reasoning: v.reasoning.clone(),
+    };
+    let resp = match tokio::time::timeout(FILTER_TIMEOUT, state.openrouter.execute_vision(req)).await
+    {
+        Ok(Ok(r)) => r,
+        Ok(Err(e)) => {
+            tracing::warn!(error = %e, "chat_vision: model error; keep text-only");
+            return None;
+        }
+        Err(_) => {
+            tracing::warn!("chat_vision: timeout; keep text-only");
+            return None;
+        }
+    };
+    super::log_openrouter_usage("chat_vision", None, &resp);
+    let text = resp.reply.trim().to_string();
+    if text.is_empty() {
+        tracing::warn!("chat_vision: empty reply; keep text-only");
+        return None;
+    }
+    let vision = match parse_image_vision(&text) {
+        Some(v) => v,
+        None => {
+            tracing::warn!("chat_vision: unparseable describe JSON; keep text-only");
+            return None;
+        }
+    };
+    if let Some(reason) = image_vision_invalidity(&vision, resp.finish_reason.as_deref()) {
+        tracing::warn!(invalidity = %reason, "chat_vision: invalid describe; keep text-only");
+        return None;
+    }
+    let vision_model = resp.model.unwrap_or_else(|| v.model.clone());
+    Some(VisionOutcome {
+        vision: serde_json::to_value(&vision).unwrap_or(serde_json::Value::Null),
+        vision_model,
+        v_generation_id: resp.generation_id,
+    })
+}
+
 /// Validity gate for an INPUT rewrite's `content`. Unlike
 /// `filter_output_invalidity`, there is NO minimum-length floor — a rewritten
 /// user message is naturally short (often < 80 chars). Only a `content_filter`
@@ -3703,5 +3808,56 @@ data: [DONE]\n\n";
             "malformed primary verdict must keep original (no fallback walk); got {pre:?}"
         );
         assert!(fmodel.is_none(), "no filter model stamped; got {fmodel:?}");
+    }
+
+    #[test]
+    fn parse_image_vision_direct_json() {
+        let v = parse_image_vision(r#"{"description":"a cat","ocr_text":"hi"}"#).unwrap();
+        assert_eq!(v.description, "a cat");
+        assert_eq!(v.ocr_text.as_deref(), Some("hi"));
+    }
+
+    #[test]
+    fn parse_image_vision_embedded_block() {
+        let v = parse_image_vision("noise {\"description\":\"dog\"} tail").unwrap();
+        assert_eq!(v.description, "dog");
+    }
+
+    #[test]
+    fn image_vision_invalidity_flags_blank_and_filter() {
+        let blank = ImageVision {
+            description: "  ".into(),
+            ocr_text: None,
+            people: None,
+            scene: None,
+        };
+        assert_eq!(image_vision_invalidity(&blank, None), Some("blank_description"));
+        let ok = ImageVision {
+            description: "x".into(),
+            ocr_text: None,
+            people: None,
+            scene: None,
+        };
+        assert_eq!(
+            image_vision_invalidity(&ok, Some("content_filter")),
+            Some("content_filter")
+        );
+        assert_eq!(image_vision_invalidity(&ok, None), None);
+
+        // content_filter early-return wins over blank_description.
+        assert_eq!(
+            image_vision_invalidity(&blank, Some("content_filter")),
+            Some("content_filter"), // content_filter wins over blank_description
+        );
+
+        // Refusal-shaped description is rejected as refusal_pattern.
+        // String reused from `rewrite_content_invalidity_rejects_refusal_and_content_filter`.
+        let refusal = ImageVision {
+            description: "对不起，我无法满足你的要求".into(),
+            ocr_text: None,
+            people: None,
+            scene: None,
+        };
+        assert_eq!(image_vision_invalidity(&refusal, None), Some("refusal_pattern"));
     }
 }

--- a/crates/eros-engine-server/src/routes/companion_stream.rs
+++ b/crates/eros-engine-server/src/routes/companion_stream.rs
@@ -194,6 +194,15 @@ fn validate_payload(req: &StreamSendRequest) -> Result<(), AppError> {
         }
     }
     if let Some(url) = req.image_url.as_deref() {
+        if req.tips_amount_usd.is_some() {
+            return Err(AppError::StreamPre(StreamPreError {
+                status: StatusCode::UNPROCESSABLE_ENTITY,
+                code: "unprocessable",
+                message: "image_url cannot be combined with tips_amount_usd".into(),
+                user_message: "图片消息暂不支持同时打赏".into(),
+                original_user_message_id: None,
+            }));
+        }
         if !image_url_is_valid(url) {
             return Err(AppError::StreamPre(StreamPreError {
                 status: StatusCode::UNPROCESSABLE_ENTITY,
@@ -918,5 +927,13 @@ mod validate_payload_tests {
         assert!(!image_url_is_valid("http:// "));
         assert!(!image_url_is_valid("ftp://x/y.png"));
         assert!(!image_url_is_valid(""));
+    }
+
+    #[test]
+    fn tip_plus_image_rejected() {
+        let mut r = base();
+        r.tips_amount_usd = Some(1.0);
+        r.image_url = Some("https://x/y.png".into());
+        assert!(validate_payload(&r).is_err());
     }
 }

--- a/crates/eros-engine-server/src/routes/companion_stream.rs
+++ b/crates/eros-engine-server/src/routes/companion_stream.rs
@@ -284,7 +284,7 @@ pub async fn send_message_stream(
             })
         })?;
 
-    // Build metadata: conditionally include tips_amount_usd and tier.
+    // Build metadata: conditionally include tips_amount_usd, tier, and image_url.
     // tier is omitted entirely (not written as null) when absent — keeps JSONB shape sparse.
     let mut meta_map = serde_json::Map::new();
     if let Some(amount) = req.tips_amount_usd {
@@ -292,6 +292,9 @@ pub async fn send_message_stream(
     }
     if let Some(t) = req.tier.as_deref() {
         meta_map.insert("tier".into(), serde_json::json!(t));
+    }
+    if let Some(url) = req.image_url.as_deref() {
+        meta_map.insert("image_url".into(), serde_json::json!(url));
     }
     // Pre-validation, pre-resolve raw snapshot of what the frontend sent.
     // The `_raw` suffix distinguishes these from the post-resolve `memory_scope`
@@ -368,6 +371,7 @@ pub async fn send_message_stream(
                     memory_scope,
                     affinity_scope,
                     tips_amount_usd: req.tips_amount_usd,
+                    image_url: req.image_url.clone(),
                 };
                 Box::pin(run_stream(state_arc, user_msg))
             }

--- a/crates/eros-engine-server/src/routes/companion_stream.rs
+++ b/crates/eros-engine-server/src/routes/companion_stream.rs
@@ -29,6 +29,7 @@ use crate::state::AppState;
 
 const MAX_CONTENT_CHARS: usize = 4096;
 const MAX_TIER_LEN: usize = 32;
+const MAX_IMAGE_URL_LEN: usize = 2048;
 const MAX_TIP_USD: f64 = 1_000_000.0;
 const MIN_CLIENT_MSG_ID_LEN: usize = 26;
 const MAX_CLIENT_MSG_ID_LEN: usize = 36;
@@ -85,6 +86,8 @@ pub struct StreamSendRequest {
     pub affinity_scope: Option<AffinityScopeDto>,
     #[serde(default)]
     pub tips_amount_usd: Option<f64>,
+    #[serde(default)]
+    pub image_url: Option<String>,
 }
 
 /// Pre-stream error body per spec §1.3. Schema-only struct for utoipa;
@@ -99,8 +102,8 @@ pub struct StreamPreErrorBody {
 }
 
 fn validate_payload(req: &StreamSendRequest) -> Result<(), AppError> {
-    // Content may be empty only when a tip is attached (a tip is a button tap).
-    if req.content.is_empty() && req.tips_amount_usd.is_none() {
+    // Content may be empty only when a tip or an image is attached.
+    if req.content.is_empty() && req.tips_amount_usd.is_none() && req.image_url.is_none() {
         return Err(AppError::StreamPre(StreamPreError {
             status: StatusCode::UNPROCESSABLE_ENTITY,
             code: "unprocessable",
@@ -165,6 +168,19 @@ fn validate_payload(req: &StreamSendRequest) -> Result<(), AppError> {
                 code: "invalid_payload",
                 message: format!("tier must match [a-z0-9_]{{1,{MAX_TIER_LEN}}}"),
                 user_message: "请求无效".into(),
+                original_user_message_id: None,
+            }));
+        }
+    }
+    if let Some(url) = req.image_url.as_deref() {
+        let ok = url.len() <= MAX_IMAGE_URL_LEN
+            && (url.starts_with("https://") || url.starts_with("http://"));
+        if !ok {
+            return Err(AppError::StreamPre(StreamPreError {
+                status: StatusCode::UNPROCESSABLE_ENTITY,
+                code: "unprocessable",
+                message: format!("image_url must be http(s) and <= {MAX_IMAGE_URL_LEN} chars"),
+                user_message: "图片链接无效".into(),
                 original_user_message_id: None,
             }));
         }
@@ -430,6 +446,7 @@ mod tests {
             memory_scope: None,
             affinity_scope: None,
             tips_amount_usd: None,
+            image_url: None,
         }
     }
 
@@ -443,6 +460,7 @@ mod tests {
             memory_scope: None,
             affinity_scope: None,
             tips_amount_usd: amount,
+            image_url: None,
         }
     }
 
@@ -787,5 +805,70 @@ mod tests {
             stored.is_none(),
             "metadata must be NULL when no fields present"
         );
+    }
+}
+
+#[cfg(test)]
+mod validate_payload_tests {
+    use super::*;
+
+    fn base() -> StreamSendRequest {
+        StreamSendRequest {
+            content: "hi".into(),
+            client_msg_id: "01J0000000000000000000000A".into(),
+            prompt_traits: None,
+            audit: None,
+            tier: None,
+            memory_scope: None,
+            affinity_scope: None,
+            tips_amount_usd: None,
+            image_url: None,
+        }
+    }
+
+    #[test]
+    fn empty_content_ok_with_image() {
+        let mut r = base();
+        r.content = String::new();
+        r.image_url = Some("https://x/y.png".into());
+        assert!(validate_payload(&r).is_ok());
+    }
+
+    #[test]
+    fn empty_content_rejected_without_image_or_tip() {
+        let mut r = base();
+        r.content = String::new();
+        assert!(validate_payload(&r).is_err());
+    }
+
+    #[test]
+    fn bad_image_url_scheme_rejected() {
+        let mut r = base();
+        r.image_url = Some("ftp://x/y.png".into());
+        assert!(validate_payload(&r).is_err());
+    }
+
+    #[test]
+    fn good_https_image_url_ok() {
+        let mut r = base();
+        r.image_url = Some("https://x/y.png".into());
+        assert!(validate_payload(&r).is_ok());
+    }
+
+    #[test]
+    fn http_scheme_image_url_ok() {
+        let mut r = base();
+        r.image_url = Some("http://x/y.png".into());
+        assert!(validate_payload(&r).is_ok());
+    }
+
+    #[test]
+    fn over_length_image_url_rejected() {
+        let mut r = base();
+        // 2048 is the max; build a URL longer than that.
+        let long = format!("https://x/{}", "a".repeat(MAX_IMAGE_URL_LEN));
+        assert!(long.len() > MAX_IMAGE_URL_LEN);
+        r.image_url = Some(long);
+        assert!(validate_payload(&r).is_err());
     }
 }

--- a/crates/eros-engine-server/src/routes/companion_stream.rs
+++ b/crates/eros-engine-server/src/routes/companion_stream.rs
@@ -101,6 +101,27 @@ pub struct StreamPreErrorBody {
     pub original_user_message_id: Option<String>,
 }
 
+/// True when `url` is an absolute http(s) URL with a non-empty, whitespace-free
+/// host and within the length cap. Dependency-free: we never dereference the URL
+/// (it is forwarded to the vision model), so we only require a plausible host —
+/// not full RFC-3986 parsing.
+fn image_url_is_valid(url: &str) -> bool {
+    if url.is_empty() || url.len() > MAX_IMAGE_URL_LEN {
+        return false;
+    }
+    let rest = match url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))
+    {
+        Some(r) => r,
+        None => return false,
+    };
+    // Host = everything up to the first '/', '?' or '#'. Reject empty or
+    // whitespace-containing hosts ("https://", "http:// ", "http:// x").
+    let host = rest.split(['/', '?', '#']).next().unwrap_or("");
+    !host.is_empty() && !host.chars().any(char::is_whitespace)
+}
+
 fn validate_payload(req: &StreamSendRequest) -> Result<(), AppError> {
     // Content may be empty only when a tip or an image is attached.
     if req.content.is_empty() && req.tips_amount_usd.is_none() && req.image_url.is_none() {
@@ -173,13 +194,11 @@ fn validate_payload(req: &StreamSendRequest) -> Result<(), AppError> {
         }
     }
     if let Some(url) = req.image_url.as_deref() {
-        let ok = url.len() <= MAX_IMAGE_URL_LEN
-            && (url.starts_with("https://") || url.starts_with("http://"));
-        if !ok {
+        if !image_url_is_valid(url) {
             return Err(AppError::StreamPre(StreamPreError {
                 status: StatusCode::UNPROCESSABLE_ENTITY,
                 code: "unprocessable",
-                message: format!("image_url must be http(s) and <= {MAX_IMAGE_URL_LEN} chars"),
+                message: format!("image_url must be an absolute http(s) URL with a host and <= {MAX_IMAGE_URL_LEN} chars"),
                 user_message: "图片链接无效".into(),
                 original_user_message_id: None,
             }));
@@ -874,5 +893,30 @@ mod validate_payload_tests {
         assert!(long.len() > MAX_IMAGE_URL_LEN);
         r.image_url = Some(long);
         assert!(validate_payload(&r).is_err());
+    }
+
+    #[test]
+    fn image_url_no_host_rejected() {
+        let mut r = base();
+        r.content = String::new();
+        r.image_url = Some("https://".into());
+        assert!(validate_payload(&r).is_err());
+    }
+
+    #[test]
+    fn image_url_whitespace_host_rejected() {
+        let mut r = base();
+        r.image_url = Some("https:// example.com/y.png".into());
+        assert!(validate_payload(&r).is_err());
+    }
+
+    #[test]
+    fn image_url_is_valid_unit() {
+        assert!(image_url_is_valid("https://x/y.png"));
+        assert!(image_url_is_valid("http://example.com/a.jpg"));
+        assert!(!image_url_is_valid("https://"));
+        assert!(!image_url_is_valid("http:// "));
+        assert!(!image_url_is_valid("ftp://x/y.png"));
+        assert!(!image_url_is_valid(""));
     }
 }

--- a/crates/eros-engine-server/src/routes/companion_stream.rs
+++ b/crates/eros-engine-server/src/routes/companion_stream.rs
@@ -101,12 +101,17 @@ pub struct StreamPreErrorBody {
     pub original_user_message_id: Option<String>,
 }
 
-/// True when `url` is an absolute http(s) URL with a non-empty, whitespace-free
-/// host and within the length cap. Dependency-free: we never dereference the URL
-/// (it is forwarded to the vision model), so we only require a plausible host —
-/// not full RFC-3986 parsing.
+/// True when `url` is an absolute http(s) URL with a non-empty host, no
+/// whitespace anywhere, and within the length cap. Dependency-free: we never
+/// dereference the URL (it is forwarded to the vision model), so we only require
+/// a plausible, whitespace-free absolute URL — not full RFC-3986 parsing.
 fn image_url_is_valid(url: &str) -> bool {
     if url.is_empty() || url.len() > MAX_IMAGE_URL_LEN {
+        return false;
+    }
+    // A URL never contains whitespace — reject it anywhere (host, path, query),
+    // not just the host segment.
+    if url.chars().any(char::is_whitespace) {
         return false;
     }
     let rest = match url
@@ -116,10 +121,9 @@ fn image_url_is_valid(url: &str) -> bool {
         Some(r) => r,
         None => return false,
     };
-    // Host = everything up to the first '/', '?' or '#'. Reject empty or
-    // whitespace-containing hosts ("https://", "http:// ", "http:// x").
+    // Require a non-empty host (reject "https://").
     let host = rest.split(['/', '?', '#']).next().unwrap_or("");
-    !host.is_empty() && !host.chars().any(char::is_whitespace)
+    !host.is_empty()
 }
 
 fn validate_payload(req: &StreamSendRequest) -> Result<(), AppError> {
@@ -927,6 +931,14 @@ mod validate_payload_tests {
         assert!(!image_url_is_valid("http:// "));
         assert!(!image_url_is_valid("ftp://x/y.png"));
         assert!(!image_url_is_valid(""));
+        assert!(!image_url_is_valid("https://example.com/a b.png"));
+    }
+
+    #[test]
+    fn image_url_with_space_in_path_rejected() {
+        let mut r = base();
+        r.image_url = Some("https://example.com/a b.png".into());
+        assert!(validate_payload(&r).is_err());
     }
 
     #[test]

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -61,6 +61,12 @@ pub struct ChatMessage {
     /// pre-OUTPUT-filter original) — see chat_input_filter design.
     #[serde(default)]
     pub pre_filter_content: Option<String>,
+    /// Freeform per-row metadata (JSONB). Carries tip amount + raw scopes and,
+    /// for image turns, `image_url` plus the `chat_vision` describe result under
+    /// `vision`. Nullable in the table ⇒ `Option`. Exposed so the pipeline can
+    /// read `metadata.vision` when rendering model-facing user text.
+    #[serde(default)]
+    pub metadata: Option<serde_json::Value>,
 }
 
 /// Projection-narrowed `ChatMessage` for BFF / UI-rendering paths that
@@ -1943,5 +1949,31 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(pairs, vec![("u1".to_string(), "a1".to_string())]);
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn history_row_exposes_metadata_column(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let user_id = Uuid::new_v4();
+        let instance_id = Uuid::new_v4();
+        let s = repo.create_session(user_id, instance_id).await.unwrap();
+
+        let meta = serde_json::json!({ "image_url": "https://x/y.png" });
+        repo.upsert_user_message_idempotent(
+            s.id,
+            "hi",
+            "01J0000000000000000000000A",
+            "user",
+            Some(&meta),
+        )
+        .await
+        .unwrap();
+
+        let rows = repo.history(s.id, 10, 0).await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0].metadata.as_ref().unwrap()["image_url"],
+            "https://x/y.png"
+        );
     }
 }

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -579,6 +579,34 @@ impl<'a> ChatRepo<'a> {
         Ok(())
     }
 
+    /// Merge a `chat_vision` describe result into a `role='user'` row's
+    /// metadata. Top-level JSONB merge; `COALESCE` handles a NULL metadata
+    /// column. Leaves `content`, `pre_filter_content`, and existing keys (e.g.
+    /// `image_url`) intact.
+    pub async fn set_user_image_vision(
+        &self,
+        user_message_id: Uuid,
+        vision: &serde_json::Value,
+        vision_model: &str,
+        generation_id: Option<&str>,
+    ) -> Result<(), sqlx::Error> {
+        let patch = serde_json::json!({
+            "vision": vision,
+            "vision_model": vision_model,
+            "vision_generation_id": generation_id,
+        });
+        sqlx::query(
+            "UPDATE engine.chat_messages \
+             SET metadata = COALESCE(metadata, '{}'::jsonb) || $2 \
+             WHERE id = $1 AND role = 'user'",
+        )
+        .bind(user_message_id)
+        .bind(patch)
+        .execute(self.pool)
+        .await?;
+        Ok(())
+    }
+
     /// Persist a burst of assistant messages keyed back to the driving user
     /// message. Caller picks the ULID-shaped `id` so the streamed `meta.message_id`
     /// matches the DB row. Bumps `last_active_at` once at the end.
@@ -1975,5 +2003,44 @@ mod tests {
             rows[0].metadata.as_ref().unwrap()["image_url"],
             "https://x/y.png"
         );
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn set_user_image_vision_merges_and_preserves(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let user_id = Uuid::new_v4();
+        let instance_id = Uuid::new_v4();
+        let s = repo.create_session(user_id, instance_id).await.unwrap();
+
+        let seed = serde_json::json!({ "image_url": "https://x/y.png" });
+        let outcome = repo
+            .upsert_user_message_idempotent(
+                s.id,
+                "",
+                "01J000000000000000000VISION",
+                "user",
+                Some(&seed),
+            )
+            .await
+            .unwrap();
+        let uid = match outcome {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            other => panic!("expected Inserted, got {other:?}"),
+        };
+
+        let vision = serde_json::json!({
+            "description": "a cat", "ocr_text": "", "people": "", "scene": "indoors"
+        });
+        repo.set_user_image_vision(uid, &vision, "vision-model", Some("gen-1"))
+            .await
+            .unwrap();
+
+        let rows = repo.history(s.id, 10, 0).await.unwrap();
+        let meta = rows[0].metadata.as_ref().unwrap();
+        assert_eq!(meta["image_url"], "https://x/y.png"); // preserved
+        assert_eq!(meta["vision"]["description"], "a cat");
+        assert_eq!(meta["vision_model"], "vision-model");
+        assert_eq!(meta["vision_generation_id"], "gen-1");
+        assert_eq!(rows[0].content, ""); // untouched
     }
 }

--- a/docs/superpowers/specs/2026-06-02-chat-vision-image-input-design.md
+++ b/docs/superpowers/specs/2026-06-02-chat-vision-image-input-design.md
@@ -3,7 +3,7 @@
 **Status**: design, pending implementation plan
 **Target release**: `0.5.x` dev track (`0.5.3-dev`). **No migration** — image URL and
 the extracted description ride on the existing `engine.chat_messages.metadata`
-JSONB column (added in migration `0012`). No new columns.
+JSONB column (added in migration `0019`). No new columns.
 **Audience**: anyone implementing image input on `POST /comp/chat/{session_id}/message/stream`.
 Mirrors the `chat_input_filter` pre-stage (`2026-06-02-chat-input-filter-design.md`)
 on the image side.

--- a/docs/superpowers/specs/2026-06-02-chat-vision-image-input-design.md
+++ b/docs/superpowers/specs/2026-06-02-chat-vision-image-input-design.md
@@ -117,6 +117,11 @@ pub image_url: Option<String>,
       → 422 "请输入一条消息"
   }
   ```
+- **No tip + image:** `image_url` combined with `tips_amount_usd` is rejected with
+  `422` (`user_message: "图片消息暂不支持同时打赏"`). Tip turns persist as
+  `gift_user`, which don't feed the main prompt, so an image there would be
+  silently dropped — reject it explicitly instead. Images are a normal-Reply-turn
+  feature only.
 - `MAX_CONTENT_CHARS` (4096) still applies to the caption.
 
 The `image_url` is stored on the user row at upsert time (see §7); it is **not**

--- a/docs/superpowers/specs/2026-06-02-chat-vision-image-input-design.md
+++ b/docs/superpowers/specs/2026-06-02-chat-vision-image-input-design.md
@@ -385,6 +385,14 @@ remembered by the main model):
 - `build_input_filter_transcript` — the input filter sees typed captions only
   for v1 (non-goal §1).
 
+**Recall query** (`build_reply_request` — separate from the prompt path):
+The recall/embedding query for the current user turn uses `recall_query_text`
+(not `effective_user_text`). `recall_query_text` returns the caption when
+non-blank; for an image-only turn (blank caption) it falls back to the vision
+`description` so memory recall matches the photo's content instead of running
+on empty text. The MAIN prompt path is unaffected — it still folds the full
+image preamble via `model_facing_user_text`.
+
 Edge case: a non-image text turn has neither `vision` nor `image_url` in
 metadata → `model_facing_user_text` returns `base`, i.e. identical to today.
 

--- a/docs/superpowers/specs/2026-06-02-chat-vision-image-input-design.md
+++ b/docs/superpowers/specs/2026-06-02-chat-vision-image-input-design.md
@@ -1,0 +1,438 @@
+# eros-engine — Chat image input via vision describe (`chat_vision`) (Spec)
+
+**Status**: design, pending implementation plan
+**Target release**: `0.5.x` dev track (`0.5.3-dev`). **No migration** — image URL and
+the extracted description ride on the existing `engine.chat_messages.metadata`
+JSONB column (added in migration `0012`). No new columns.
+**Audience**: anyone implementing image input on `POST /comp/chat/{session_id}/message/stream`.
+Mirrors the `chat_input_filter` pre-stage (`2026-06-02-chat-input-filter-design.md`)
+on the image side.
+
+---
+
+## 0. Background
+
+### The feature
+
+`chat/stream` today accepts a single `content: String` user turn and is fully
+text-only end to end — `openrouter::ChatMessage { role, content: String }` has no
+content blocks, no `image_url`. We want the user to be able to send an **image**
+to their companion.
+
+We do **not** send the image to the main chat model directly. Instead, a
+**two-step** flow:
+
+1. The image is analysed by a **vision model** (its own OpenRouter call), which
+   returns a **fixed-schema JSON** description of the image.
+2. That description is **folded into the user message text** the main chat model
+   (`tasks.chat_companion`) sees. The main chat model stays **text-only** — it
+   never receives image bytes or `image_url`.
+
+This keeps the main-chat invariant ("the companion model is driven by plain
+text") intact, gives downstream a structured, auditable description of every
+image, and lets the vision model be swapped/configured independently of the chat
+model.
+
+### Why this mirrors `chat_input_filter`
+
+`chat_input_filter` (#70) is the direct precedent. It is an **input-augmentation
+pre-stage** that runs inside `run_stream`, after the idempotency gate and before
+`build_reply_request`: it issues a secondary OpenRouter call, parses a JSON
+verdict, and changes the text the main model sees — while the **persisted,
+client-visible `content` stays the user's original**.
+
+The vision stage is the same shape, with these deliberate differences:
+
+| | `chat_input_filter` | `chat_vision` |
+|---|---|---|
+| Trigger | per-turn **probability** coin flip | **deterministic** — fires iff `image_url` present |
+| Input | typed caption + recent transcript | the image URL (+ optional caption) |
+| Secondary call | text-only `execute()` | **multimodal** `execute_vision()` |
+| Output | `{rewrite, content, reason}` verdict | fixed `{description, ocr_text, people, scene}` |
+| Where stored | `pre_filter_content` (replaces text) | `metadata.vision` (augments, never touches `pre_filter_content`) |
+| On failure | fail-open: keep original | fail-open: inject a neutral placeholder |
+
+The two stages are **orthogonal and both may run on the same turn**: vision
+describes the image, the input filter still only rewrites the typed caption. They
+do not write the same column.
+
+### eros-engine scope boundary
+
+eros-engine is OSS and does not own storage or deploy. The client uploads the
+image to **its own** storage and sends eros-engine an **`https` URL**. The engine
+never receives or stores image bytes — it forwards the URL to the vision model
+and persists the URL + extracted description only.
+
+---
+
+## 1. Goals / non-goals
+
+**Goals**
+- Optional, off-by-default image input on `chat/stream`, configured via a new
+  `[tasks.chat_vision]` task — absent task ⇒ feature off ⇒ existing text-only
+  behaviour byte-for-byte unchanged (backward compatible).
+- A single optional `image_url: Option<String>` field on `StreamSendRequest`
+  (one image per turn).
+- The image is described by a vision model into a fixed JSON schema
+  `{description, ocr_text, people, scene}`, which is folded into the
+  model-facing user text for both the current turn and history.
+- The persisted, client-visible `content` always stays the user's original text
+  (empty when the user sent an image with no caption).
+- Fail-open: any vision failure degrades gracefully; the turn always produces a
+  reply.
+- The image description survives into later turns' history, so the companion
+  "remembers" the photo.
+
+**Non-goals (explicitly out of scope — YAGNI)**
+- Multiple images per turn (single image only).
+- A `safety`/NSFW field in the schema.
+- Native multimodal pass-through to the **main** chat model.
+- Engine-side image upload / storage / byte handling.
+- A dedicated client-visible "analysing image" protocol frame.
+- Feeding the image description into the `chat_input_filter` transcript (the
+  input filter keeps seeing only typed captions for v1).
+
+---
+
+## 2. API surface — `StreamSendRequest`
+
+Add one optional field (`crates/eros-engine-server/src/routes/companion_stream.rs`,
+`StreamSendRequest` @ ~L72):
+
+```rust
+#[serde(default)]
+pub image_url: Option<String>,
+```
+
+**Validation** (extend `validate_payload` @ ~L101):
+
+- When `image_url` is `Some`:
+  - must parse as an absolute `http`/`https` URL,
+  - length ≤ `MAX_IMAGE_URL_LEN` (2048), else `422 unprocessable`
+    (`user_message: "图片链接无效"`).
+- **Empty-content rule** (existing): `content` may be empty only when a tip is
+  attached. Extend so `content` may also be empty when `image_url` is present:
+  ```
+  if req.content.is_empty() && req.tips_amount_usd.is_none() && req.image_url.is_none() {
+      → 422 "请输入一条消息"
+  }
+  ```
+- `MAX_CONTENT_CHARS` (4096) still applies to the caption.
+
+The `image_url` is stored on the user row at upsert time (see §7); it is **not**
+otherwise echoed in protocol frames.
+
+OpenAPI: regenerate `openapi.json` after the DTO change (PR gate).
+
+---
+
+## 3. Vision sub-call — multimodal path in `openrouter.rs`
+
+The two-step flow still requires the **vision call itself** to be multimodal. The
+main `ChatMessage { content: String }` stays unchanged; add a **dedicated
+vision-only** entry point used by nobody but the `chat_vision` stage.
+
+New in `crates/eros-engine-llm/src/openrouter.rs`:
+
+```rust
+/// One-shot multimodal describe call. Builds an OpenRouter user message whose
+/// `content` is an array of blocks: a text instruction + one image_url block.
+/// Returns the model's text reply (expected to be JSON; parsing is the caller's
+/// job). Non-streaming.
+pub async fn execute_vision(&self, req: VisionRequest) -> Result<ChatResponse, LlmError>;
+
+pub struct VisionRequest {
+    pub model: String,
+    pub fallback_model: Vec<String>,   // sequential chain, like ChatRequest
+    pub system_prompt: String,         // the describe instruction
+    pub image_url: String,
+    pub caption: Option<String>,       // user's own caption, if any (helps grounding)
+    pub temperature: f32,
+    pub max_tokens: u32,
+    pub reasoning: Option<ReasoningConfig>,
+}
+```
+
+Wire body for the single call (per chain entry):
+
+```json
+{
+  "model": "<model>",
+  "messages": [
+    { "role": "system", "content": "<system_prompt>" },
+    { "role": "user", "content": [
+        { "type": "text", "text": "<caption or a default 描述这张图片 instruction>" },
+        { "type": "image_url", "image_url": { "url": "<image_url>" } }
+    ]}
+  ],
+  "temperature": <t>, "max_tokens": <n>, "reasoning": <opt>
+}
+```
+
+- The fallback chain is walked on **transport-level** failures (error / timeout /
+  empty reply), identical to `execute()`’s chain walk. A content-level
+  non-success (unparseable JSON) is handled by the caller in §6.
+- Reuse the existing app-attribution headers and `ChatResponse`
+  (`reply`, `generation_id`, `model`, `finish_reason`).
+- Log usage via `super::log_openrouter_usage("chat_vision", None, &resp)` so the
+  vision call shows up in OpenRouter audit alongside the other non-chat tasks.
+
+> Implementation note: keep `ChatMessage` text-only. The block-array body lives
+> in a private wire struct local to `execute_vision`, so the public text-only
+> contract of `ChatMessage`/`ChatRequest` is untouched.
+
+---
+
+## 4. Fixed schema (engine-defined, parsed & validated)
+
+In the pipeline (`pipeline/stream.rs`, next to the input-filter helpers):
+
+```rust
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct ImageVision {
+    description: String,            // required: 画面 / 主体 / 在发生什么
+    #[serde(default)]
+    ocr_text: Option<String>,      // 图中文字; None/blank ⇒ omitted
+    #[serde(default)]
+    people: Option<String>,        // 是否有人物 + 表情 / 情绪
+    #[serde(default)]
+    scene: Option<String>,         // 场景 / 地点 / 氛围
+}
+```
+
+**Parsing** reuses the input-filter two-pass approach:
+`serde_json::from_str` first, then `post_process::find_json_block` on a JSON
+block embedded in prose.
+
+**Validity gate**: a parse is *valid* only when `description` is non-blank
+(after trim). `ocr_text` / `people` / `scene` are optional; blank ⇒ treated as
+absent and dropped from the injected preamble. A `content_filter` finish reason
+or a refusal-shaped reply ⇒ invalid (mirror `rewrite_content_invalidity`).
+
+---
+
+## 5. Config — `[tasks.chat_vision]`
+
+New task block, same machinery as `chat_input_filter` / `chat_output_filter`
+(`crates/eros-engine-llm/src/model_config.rs`):
+
+```toml
+[tasks.chat_vision]
+model = "..."                 # a vision-capable model id on OpenRouter
+fallback_model = ["..."]      # optional; truncated to retry_depth
+temperature = 0.2
+max_tokens = 400
+retry_depth = 1
+filter_prompt = """
+你是图像识别助手。只输出 JSON，字段：
+{ "description": "...", "ocr_text": "...", "people": "...", "scene": "..." }
+没有文字/人物/场景信息时对应字段留空字符串。不要输出 JSON 以外的任何内容。
+"""
+```
+
+Add:
+
+```rust
+pub struct ResolvedVision {
+    pub model: String,
+    pub fallback_model: Vec<String>,   // truncated to retry_depth
+    pub temperature: f64,
+    pub max_tokens: u32,
+    pub describe_prompt: String,       // from filter_prompt
+    pub retry_depth: u32,
+    pub reasoning: Option<ReasoningConfig>,
+}
+
+/// `None` (feature off) when `[tasks.chat_vision]` is absent OR its resolved
+/// `filter_prompt` is blank. No `chat_companion` toggle and no probability —
+/// presence of the task block is the switch; the per-turn trigger is "image_url
+/// present" (§6), decided in the wiring, not here.
+pub fn resolve_vision(&self) -> Option<ResolvedVision>;
+```
+
+Mirror `resolve_input_filter` (read task, blank-prompt guard, truncate fallback
+to `retry_depth`, default `retry_depth = 1`). Unlike the input filter there is
+**no** `[tasks.chat_companion]` probability gate — image presence is the gate.
+
+`describe_prompt` reads from the **existing `TaskConfig.filter_prompt` field**
+(`model_config.rs:390`) — the same generic key `chat_output_filter` /
+`chat_input_filter` already use. **No `TaskConfig` struct change**: do not add a
+new prompt field for `chat_vision`.
+
+Also add a `chat_vision` example block to `examples/model_config.toml`.
+
+---
+
+## 6. Pipeline pre-stage (`run_stream`, Reply branch)
+
+Insertion point: `pipeline/stream.rs`, in the `ActionType::Reply | GiftReaction`
+arm, **after** the idempotency gate, **adjacent to** the input-filter block
+(@ ~L1195–1241). Run vision **before** the input filter.
+
+```text
+if Reply turn AND user_msg has image_url AND not already described:
+    f = state.model_config.resolve_vision()?            // None ⇒ skip (feature off)
+    resp = run_vision(state, &f, &image_url, caption)   // walks fallback chain
+    if Some(ImageVision) parsed & valid:
+        chat_repo.set_user_image_vision(user_message_id, &vision_json,
+                                        &vision_model, generation_id)   // §7
+    // else: persist nothing → §9 placeholder path covers it
+```
+
+- **Trigger**: fires iff the user row carries `image_url` (not gift, not tip-only).
+  No probability.
+- **`run_vision`** mirrors `run_input_filter`: walk `[primary, ...fallback]`,
+  `tokio::time::timeout(FILTER_TIMEOUT, execute_vision(...))`, `continue` on
+  transport failure, parse+validate per §4. Returns `Some(ImageVision + audit)`
+  only on a valid parse; otherwise `None`.
+- **Idempotency / run-once**: skip the call when the user row already has
+  `metadata.vision` (a resumed/retried in-progress turn) — the vision call is
+  paid once per image. Replay outcomes never reach this branch at all.
+
+---
+
+## 7. Persistence / data model (no migration)
+
+Everything rides on `engine.chat_messages.metadata` (JSONB).
+
+**At upsert** (`upsert_user_message_idempotent`, `chat.rs` @ ~L451 — already
+takes `metadata: Option<&serde_json::Value>`): when the request has `image_url`,
+seed the user row’s metadata with it:
+
+```json
+{ "image_url": "https://..." }   // merged with any existing tip metadata
+```
+
+**After a successful describe**, a new store method merges the result in
+(top-level JSONB merge via `metadata || $2`, leaving `image_url` and any tip keys
+intact):
+
+```rust
+/// chat.rs — merge the vision result into the user row's metadata. Does NOT
+/// touch content or pre_filter_content.
+pub async fn set_user_image_vision(
+    &self,
+    user_message_id: Uuid,
+    vision: &serde_json::Value,     // {description, ocr_text, people, scene}
+    vision_model: &str,
+    generation_id: Option<&str>,
+) -> Result<(), StoreError>;
+// UPDATE engine.chat_messages
+//   SET metadata = metadata || jsonb_build_object(
+//       'vision', $2, 'vision_model', $3, 'vision_generation_id', $4)
+// WHERE id = $1 AND role = 'user';
+```
+
+Resulting user-row metadata after a described image turn:
+
+```json
+{
+  "image_url": "https://...",
+  "vision": { "description": "...", "ocr_text": "...", "people": "...", "scene": "..." },
+  "vision_model": "...",
+  "vision_generation_id": "..."
+}
+```
+
+`content` and `pre_filter_content` are untouched by this stage.
+
+---
+
+## 8. Injection fold — model-facing text
+
+Introduce a shared helper next to `effective_user_text`
+(`pipeline/handlers.rs` @ ~L82) that layers the image preamble **on top of** the
+input-filter rewrite:
+
+```rust
+/// What the MAIN chat model should see for a user row: optional image preamble
+/// (built from metadata.vision, or a placeholder when an image was sent but not
+/// described) followed by effective_user_text(msg).
+pub(crate) fn model_facing_user_text(msg: &ChatMessage) -> String;
+```
+
+Logic:
+1. `base = effective_user_text(msg)` (handles input-filter `pre_filter_content`).
+2. If `metadata.vision` present → build the preamble from its non-blank fields.
+3. Else if `metadata.image_url` present but no `vision` → placeholder preamble
+   `[用户发送了一张图片，但内容无法识别]`.
+4. Else → return `base` unchanged.
+5. Return `preamble + "\n\n" + (base if non-empty else "[用户未附文字]")`.
+
+Preamble template (engine-owned constant; blank lines omitted):
+
+```
+[用户发送了一张图片]
+画面：{description}
+文字：{ocr_text}     ← omit line if blank
+人物：{people}       ← omit line if blank
+场景：{scene}        ← omit line if blank
+```
+
+**Call sites to switch to `model_facing_user_text`** (so past image turns are
+remembered by the main model):
+- `build_reply_request` — current user turn + its history rendering of `user`
+  rows.
+- Any other history/transcript builder that feeds the **main** chat model and
+  currently calls `effective_user_text` on `user` rows.
+
+**Left unchanged** (keep plain `effective_user_text`):
+- `build_input_filter_transcript` — the input filter sees typed captions only
+  for v1 (non-goal §1).
+
+Edge case: a non-image text turn has neither `vision` nor `image_url` in
+metadata → `model_facing_user_text` returns `base`, i.e. identical to today.
+
+---
+
+## 9. Failure & idempotency (fail-open)
+
+- **Vision chain exhausted / unparseable / invalid** → nothing written to
+  `metadata.vision`. At assembly, `model_facing_user_text` sees `image_url`
+  without `vision` and injects the neutral placeholder (§8 step 3). The main
+  model still replies; a present caption carries the turn. The stream **never
+  hard-fails** because of vision.
+- **Run-once**: keyed on `metadata.vision` already present → skip re-running on a
+  retried/resumed turn. Replay (`UpsertUserOutcome::Replay`) short-circuits
+  before the Reply branch, so a completed turn never re-pays for vision.
+- **Latency**: an image turn adds one synchronous vision round-trip before the
+  main burst starts (same cost profile as an input-filter turn). Acceptable; not
+  a hot loop.
+
+---
+
+## 10. Testing
+
+- `model_config`: `resolve_vision` returns `None` when task absent / prompt
+  blank; returns truncated fallback chain at `retry_depth`.
+- Schema parse: direct JSON, embedded JSON block, blank `description` rejected,
+  optional fields dropped when blank, refusal/`content_filter` rejected.
+- `validate_payload`: `image_url` required-shape (http/https, length), empty
+  `content` allowed with image, rejected without image/tip.
+- `set_user_image_vision`: merges `vision`/`vision_model`/`vision_generation_id`
+  into metadata, leaves `content` / `pre_filter_content` / `image_url` intact.
+- `model_facing_user_text`: described image → full preamble + caption; image,
+  no caption → preamble + `[用户未附文字]`; image, no vision → placeholder;
+  plain text turn → unchanged.
+- Wiring: vision skipped when no `image_url`; skipped when `metadata.vision`
+  already present; orthogonal to input filter (both may fire).
+
+---
+
+## 11. Files touched / PR checklist
+
+- `crates/eros-engine-server/src/routes/companion_stream.rs` — `image_url` field
+  + validation, store on upsert.
+- `crates/eros-engine-llm/src/openrouter.rs` — `VisionRequest` + `execute_vision`.
+- `crates/eros-engine-llm/src/model_config.rs` — `ResolvedVision` + `resolve_vision`.
+- `crates/eros-engine-server/src/pipeline/stream.rs` — `ImageVision`, `run_vision`,
+  pre-stage wiring.
+- `crates/eros-engine-server/src/pipeline/handlers.rs` — `model_facing_user_text`;
+  swap main-model call sites.
+- `crates/eros-engine-store/src/chat.rs` — `set_user_image_vision`; seed
+  `image_url` on upsert metadata.
+- `examples/model_config.toml` — `[tasks.chat_vision]` example.
+- Regenerate `openapi.json`.
+- **No SQL migration.**
+- PR gate: `cargo fmt` / `clippy` / `test` / openapi check (per repo release flow).
+```

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -155,6 +155,30 @@ model_name_display_override = true
 # Output JSON only. No explanation outside the JSON, no code fences.
 #"""
 
+# ── Image input (chat_vision) ────────────────────────────────────────────────
+# When a chat/stream turn carries an `image_url`, the image is described by a
+# vision model into a fixed JSON schema and the description is folded into the
+# user text the main chat model sees. The main chat model stays text-only.
+#
+# Feature is OFF unless this table exists with a non-blank filter_prompt.
+# The fixed schema is: { "description", "ocr_text", "people", "scene" }.
+# Pick a vision-capable model.
+#[tasks.chat_vision]
+#model        = "google/gemini-3.1-flash-lite"
+#fallback     = ["openai/gpt-5.1-mini"]
+#retry_depth  = 1
+#temperature  = 0.2
+#max_tokens   = 400
+#reasoning    = { enabled = false }
+#filter_prompt = """
+#你是图像识别助手。只输出 JSON，字段：
+#  "description": 画面/主体/正在发生什么（必填）
+#  "ocr_text":    图中文字；没有则空字符串
+#  "people":      是否有人物、表情/情绪；没有则空字符串
+#  "scene":       场景/地点/氛围；没有则空字符串
+#不要输出 JSON 以外的任何内容，不要代码围栏。
+#"""
+
 [tasks.insight_extraction]
 model = "anthropic/claude-haiku-4.5"
 fallback = ["deepseek/deepseek-v4-flash","google/gemini-3.1-flash-lite"]


### PR DESCRIPTION
## Summary

Lets a `chat/stream` turn carry a single image (`https` URL). A vision model (`[tasks.chat_vision]`) describes it into a fixed JSON schema, and the description is folded into the user text the **main chat model** sees — the main chat model stays **text-only**. Mirrors the `chat_input_filter` pre-stage; fail-open; **no SQL migration** (rides the existing `engine.chat_messages.metadata` JSONB column).

Spec: `docs/superpowers/specs/2026-06-02-chat-vision-image-input-design.md`

### Data flow
`StreamSendRequest.image_url` → validate → seed `metadata.image_url` at upsert → `PersistedUserMessage.image_url` → `run_stream` Reply pre-stage (gated on image + `resolve_vision()`) → `run_vision` → multimodal `execute_vision` → `parse_image_vision` + validity gate → `set_user_image_vision` merges `metadata.vision` → `build_reply_request` refetches history → `model_facing_user_text` folds the preamble for the current turn **and** history → main (text-only) model.

### Key points
- **Text-only invariant:** only the vision sub-call is multimodal; `openrouter::ChatMessage` is unchanged.
- **Fixed schema:** `{description, ocr_text, people, scene}` (no safety field).
- **Fail-open:** any vision failure keeps the turn text-only; an undescribed image gets a neutral placeholder.
- **Off by default:** absent `[tasks.chat_vision]` ⇒ behavior byte-for-byte unchanged.
- **Single image; engine stores no bytes** (forwards the URL only) — consistent with the OSS scope.

## Test Plan
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` green (incl. DB-backed `#[sqlx::test]` via `.test-env`)
- [x] OpenAPI snapshot regenerated, no drift (`image_url` added to `StreamSendRequest`)
- [ ] codex review (`--base dev`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)