### PR TITLE
fix(server): tip turns reach the model (gift_user prompt fix) + run_stream e2e tests

### DIFF
--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -163,6 +163,15 @@ pub(crate) fn recall_query_text(msg: &eros_engine_store::chat::ChatMessage) -> S
         .unwrap_or_default()
 }
 
+/// A `gift_user` row is a TIP (not a legacy in-app Gift Event) iff its metadata
+/// carries `tips_amount_usd`. Mirrors the `signals_count` gate in `pipeline/mod.rs`
+/// so tips and legacy gifts are classified identically across the pipeline.
+fn is_tip_row(msg: &eros_engine_store::chat::ChatMessage) -> bool {
+    msg.metadata
+        .as_ref()
+        .is_some_and(|m| m.get("tips_amount_usd").is_some())
+}
+
 /// Materialise a ChatRequest from a pre-resolved model + system prompt +
 /// chronological history. `audit` carries the caller's OpenRouter passthrough
 /// when the driving event was a `UserMessage`; gift / proactive pass `None`.
@@ -178,14 +187,19 @@ fn assemble_chat_request(
         content: system_prompt,
     });
     for msg in history {
-        // User + gift_user (tip) rows feed the MODEL-FACING text and are emitted
+        // User + TIP gift_user rows feed the MODEL-FACING text and are emitted
         // under the "user" role — a tip turn IS a user turn to the model (OpenRouter
-        // only knows system/user/assistant). Dropping gift_user rows here made tip
-        // turns invisible, so the model parroted history. Assistant rows always feed
-        // `content` (their pre_filter_content is the pre-output-filter original and
-        // must never re-enter the prompt).
+        // only knows system/user/assistant). Dropping the tip turn here made it
+        // invisible, so the model parroted history. The gate matches the
+        // `signals_count` convention (mod.rs): only `gift_user` rows carrying
+        // `tips_amount_usd` are tips; legacy in-app Gift Event rows (a bare gift
+        // label, no tip metadata) stay dropped — see the open issue on splitting
+        // `gift_user` / legacy Gift Events. Assistant rows always feed `content`
+        // (their pre_filter_content is the pre-output-filter original and must
+        // never re-enter the prompt).
         let (role, content) = match msg.role.as_str() {
-            "user" | "gift_user" => ("user", model_facing_user_text(&msg)),
+            "user" => ("user", model_facing_user_text(&msg)),
+            "gift_user" if is_tip_row(&msg) => ("user", model_facing_user_text(&msg)),
             "assistant" => ("assistant", msg.content),
             _ => continue,
         };
@@ -1525,6 +1539,61 @@ mod tests {
     fn model_facing_text_plain_turn_unchanged() {
         let row = user_row("普通消息", None);
         assert_eq!(model_facing_user_text(&row), "普通消息");
+    }
+
+    #[test]
+    fn assemble_includes_tip_gift_but_drops_legacy_gift() {
+        use eros_engine_llm::model_config::ResolvedModel;
+
+        // TIP gift_user (metadata carries tips_amount_usd) → promoted to a user msg.
+        let mut tip = user_row("(打赏 $5)", None);
+        tip.role = "gift_user".into();
+        tip.metadata = Some(serde_json::json!({ "tips_amount_usd": 5.0 }));
+        // LEGACY in-app Gift Event (bare label, no tip metadata) → stays dropped.
+        let mut legacy = user_row("rose", None);
+        legacy.role = "gift_user".into();
+        legacy.metadata = None;
+        let plain = user_row("普通消息", None);
+        let mut assistant = user_row("回复", None);
+        assistant.role = "assistant".into();
+
+        let resolved = ResolvedModel {
+            model: "m".into(),
+            fallback_model: vec![],
+            temperature: 0.7,
+            max_tokens: 100,
+            allow_traits: None,
+            reasoning: None,
+            retry_depth: 0,
+        };
+        let req = assemble_chat_request(
+            resolved,
+            "SYS".into(),
+            vec![tip, legacy, plain, assistant],
+            None,
+        );
+
+        let user_contents: Vec<&str> = req
+            .messages
+            .iter()
+            .filter(|m| m.role == "user")
+            .map(|m| m.content.as_str())
+            .collect();
+        assert!(
+            user_contents.contains(&"(打赏 $5)"),
+            "tip gift_user must be promoted under the user role: {user_contents:?}"
+        );
+        assert!(user_contents.contains(&"普通消息"));
+        assert!(
+            !req.messages.iter().any(|m| m.content == "rose"),
+            "legacy (no-tip) gift_user must stay dropped from the prompt"
+        );
+        // No `gift_user` role ever reaches the wire (OpenRouter knows only
+        // system/user/assistant).
+        assert!(req
+            .messages
+            .iter()
+            .all(|m| matches!(m.role.as_str(), "system" | "user" | "assistant")));
     }
 
     #[test]

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -178,17 +178,19 @@ fn assemble_chat_request(
         content: system_prompt,
     });
     for msg in history {
-        // User rows feed the MODEL-FACING text (image preamble folded onto the
-        // effective text when an image was attached); assistant rows always feed
-        // `content` (their pre_filter_content is the pre-output-filter original
-        // and must never re-enter the prompt).
-        let content = match msg.role.as_str() {
-            "user" => model_facing_user_text(&msg),
-            "assistant" => msg.content,
+        // User + gift_user (tip) rows feed the MODEL-FACING text and are emitted
+        // under the "user" role — a tip turn IS a user turn to the model (OpenRouter
+        // only knows system/user/assistant). Dropping gift_user rows here made tip
+        // turns invisible, so the model parroted history. Assistant rows always feed
+        // `content` (their pre_filter_content is the pre-output-filter original and
+        // must never re-enter the prompt).
+        let (role, content) = match msg.role.as_str() {
+            "user" | "gift_user" => ("user", model_facing_user_text(&msg)),
+            "assistant" => ("assistant", msg.content),
             _ => continue,
         };
         messages.push(ChatMessage {
-            role: msg.role,
+            role: role.to_string(),
             content,
         });
     }

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -3944,7 +3944,9 @@ data: [DONE]\n\n";
             "tip turn must reach the model (chat mock requires the tip text in the body); got frames {frames:?}"
         );
         assert!(
-            !frames.iter().any(|f| matches!(f, ProtocolFrame::Error { .. })),
+            !frames
+                .iter()
+                .any(|f| matches!(f, ProtocolFrame::Error { .. })),
             "no error frame expected on a tip turn; got frames {frames:?}"
         );
     }
@@ -4116,7 +4118,9 @@ data: [DONE]\n\n";
             "describe must reach the chat model (mock requires it in the body); got {frames:?}"
         );
         assert!(
-            !frames.iter().any(|f| matches!(f, ProtocolFrame::Error { .. })),
+            !frames
+                .iter()
+                .any(|f| matches!(f, ProtocolFrame::Error { .. })),
             "no error frame expected on a vision turn; got frames {frames:?}"
         );
 

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -3895,7 +3895,10 @@ data: [DONE]\n\n";
             ),
         );
 
-        // A tip-only turn: persisted as role='gift_user' with the "(打赏 $X)" marker.
+        // A tip-only turn: persisted as role='gift_user' with the "(打赏 $X)" marker
+        // and tip metadata (`tips_amount_usd`) — the prompt gate promotes only tip
+        // gift_user rows, so the metadata must be present (as production persists it).
+        let tip_meta = serde_json::json!({ "tips_amount_usd": 0.5 });
         let chat_repo = ChatRepo { pool: &pool };
         let umid = match chat_repo
             .upsert_user_message_idempotent(
@@ -3903,7 +3906,7 @@ data: [DONE]\n\n";
                 "(打赏 $0.5)",
                 "01J8888888888888888888888B",
                 "gift_user",
-                None,
+                Some(&tip_meta),
             )
             .await
             .unwrap()

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -4005,4 +4005,132 @@ data: [DONE]\n\n";
             Some("refusal_pattern")
         );
     }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn vision_turn_folds_description_and_persists(pool: PgPool) {
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+        use futures_util::StreamExt;
+        use wiremock::matchers::{body_string_contains, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+
+        // Vision model ("vis/m"): non-streaming JSON describe.
+        let describe = "{\"description\":\"一只猫在沙滩\",\"ocr_text\":\"\",\"people\":\"\",\"scene\":\"海边\"}";
+        let vis_body = serde_json::json!({
+            "id": "gv", "model": "vis/m",
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            "choices": [{"message": {"content": describe}}],
+        });
+        // Lower priority (2) than the chat mock: the two matchers are disjoint
+        // today, but pinning priorities keeps dispatch deterministic if the prompt
+        // preamble ever grows to mention the vision model name.
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("vis/m"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(vis_body))
+            .with_priority(2)
+            .mount(&mock)
+            .await;
+
+        // Chat model ("deepseek/x"): SSE, matches ONLY when the body carries the
+        // folded description — proves the describe reached the main prompt.
+        let chat_body = "data: {\"choices\":[{\"delta\":{\"content\":\"REPLY\"}}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1,\"total_tokens\":2},\"id\":\"g\",\"model\":\"deepseek/x\"}\n\ndata: [DONE]\n\n";
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("deepseek/x"))
+            .and(body_string_contains("一只猫在沙滩"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(chat_body, "text/event-stream"),
+            )
+            .with_priority(1)
+            .mount(&mock)
+            .await;
+
+        let user_id = Uuid::new_v4();
+        let (_g, instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = std::sync::Arc::new(
+            eros_engine_llm::model_config::ModelConfig::from_toml_str(
+                "[tasks.chat_companion]\nmodel=\"deepseek/x\"\n\
+                 [tasks.chat_vision]\nmodel=\"vis/m\"\nfilter_prompt=\"DESCRIBE\"\n",
+            )
+            .unwrap(),
+        );
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "k".into(),
+                Default::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+
+        // Image-only turn: role='user', empty content, metadata carries image_url.
+        let seed_meta = serde_json::json!({ "image_url": "https://x/y.png" });
+        let chat_repo = ChatRepo { pool: &pool };
+        let umid = match chat_repo
+            .upsert_user_message_idempotent(
+                session_id,
+                "",
+                "01J9999999999999999999999E",
+                "user",
+                Some(&seed_meta),
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
+
+        let frames: Vec<ProtocolFrame> = run_stream(
+            std::sync::Arc::new(state),
+            PersistedUserMessage {
+                user_message_id: umid,
+                session_id,
+                user_id,
+                instance_id,
+                content: "".into(),
+                prompt_traits: vec![],
+                audit: None,
+                tier: None,
+                memory_scope: Default::default(),
+                affinity_scope: Default::default(),
+                tips_amount_usd: None,
+                image_url: Some("https://x/y.png".into()),
+            },
+        )
+        .collect()
+        .await;
+
+        let deltas: String = frames
+            .iter()
+            .filter_map(|f| match f {
+                ProtocolFrame::Delta { content, .. } => Some(content.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            deltas.contains("REPLY"),
+            "describe must reach the chat model (mock requires it in the body); got {frames:?}"
+        );
+        assert!(
+            !frames.iter().any(|f| matches!(f, ProtocolFrame::Error { .. })),
+            "no error frame expected on a vision turn; got frames {frames:?}"
+        );
+
+        // metadata.vision persisted on the user row.
+        let meta: Option<serde_json::Value> =
+            sqlx::query_scalar("SELECT metadata FROM engine.chat_messages WHERE id = $1")
+                .bind(umid)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            meta.unwrap()["vision"]["description"],
+            "一只猫在沙滩",
+            "vision describe must be merged into the user row metadata"
+        );
+    }
 }

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -1322,8 +1322,8 @@ pub fn run_stream(
                 // undescribed image). Run-once is guaranteed by the upsert
                 // idempotency gate — run_stream only runs on a fresh Insert.
                 // Skip tipped turns (same as the input filter): a tip persists as
-                // role='gift_user', which set_user_image_vision can't update and
-                // the prompt drops anyway — describing it would waste the call.
+                // role='gift_user' and carries no image (tip+image is rejected at
+                // validation), so describing it would waste the call.
                 if !is_gift && user_msg.tips_amount_usd.is_none() {
                     if let (Some(image_url), Some(v)) = (
                         user_msg.image_url.as_deref(),
@@ -1350,9 +1350,9 @@ pub fn run_stream(
                 // rewrite is persisted on the user row's pre_filter_content;
                 // build_reply_request then feeds the EFFECTIVE text to the model
                 // and recall. Fail-open: any non-rewrite outcome is a no-op.
-                // Skip tipped turns too: a tip persists as role='gift_user', which
-                // set_user_input_rewrite can't update and the prompt drops anyway —
-                // running the filter there is a wasted LLM call.
+                // Skip tipped turns too: a tip persists as role='gift_user' whose
+                // "(打赏 $X)" marker / typed message should reach the model as-is,
+                // not be rewritten by the filter — running it would waste the call.
                 if !is_gift && user_msg.tips_amount_usd.is_none() {
                     // Per-turn probability gate: `input_filter = 0.8` ⇒ fire on
                     // ~80% of turns; `true` ⇒ probability 1.0 ⇒ always (gen::<f64>()
@@ -3851,6 +3851,102 @@ data: [DONE]\n\n";
             "malformed primary verdict must keep original (no fallback walk); got {pre:?}"
         );
         assert!(fmodel.is_none(), "no filter model stamped; got {fmodel:?}");
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn tip_turn_reaches_model_not_parrot(pool: PgPool) {
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+        use futures_util::StreamExt;
+        use wiremock::matchers::{body_string_contains, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+
+        // Chat model replies ONLY when the request body carries the tip turn
+        // ("(打赏"). A REPLY delta therefore proves the gift_user turn reached the
+        // model (pre-fix it is dropped, so the mock never matches → no REPLY).
+        let chat_body = "data: {\"choices\":[{\"delta\":{\"content\":\"REPLY\"}}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1,\"total_tokens\":2},\"id\":\"g\",\"model\":\"deepseek/x\"}\n\ndata: [DONE]\n\n";
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("deepseek/x"))
+            .and(body_string_contains("(打赏"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(chat_body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+
+        let user_id = Uuid::new_v4();
+        let (_g, instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = std::sync::Arc::new(
+            eros_engine_llm::model_config::ModelConfig::from_toml_str(
+                "[tasks.chat_companion]\nmodel=\"deepseek/x\"\n",
+            )
+            .unwrap(),
+        );
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "k".into(),
+                Default::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+
+        // A tip-only turn: persisted as role='gift_user' with the "(打赏 $X)" marker.
+        let chat_repo = ChatRepo { pool: &pool };
+        let umid = match chat_repo
+            .upsert_user_message_idempotent(
+                session_id,
+                "(打赏 $0.5)",
+                "01J8888888888888888888888B",
+                "gift_user",
+                None,
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
+
+        let frames: Vec<ProtocolFrame> = run_stream(
+            std::sync::Arc::new(state),
+            PersistedUserMessage {
+                user_message_id: umid,
+                session_id,
+                user_id,
+                instance_id,
+                content: "(打赏 $0.5)".into(),
+                prompt_traits: vec![],
+                audit: None,
+                tier: None,
+                memory_scope: Default::default(),
+                affinity_scope: Default::default(),
+                tips_amount_usd: Some(0.5),
+                image_url: None,
+            },
+        )
+        .collect()
+        .await;
+
+        let deltas: String = frames
+            .iter()
+            .filter_map(|f| match f {
+                ProtocolFrame::Delta { content, .. } => Some(content.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            deltas.contains("REPLY"),
+            "tip turn must reach the model (chat mock requires the tip text in the body); got frames {frames:?}"
+        );
+        assert!(
+            !frames.iter().any(|f| matches!(f, ProtocolFrame::Error { .. })),
+            "no error frame expected on a tip turn; got frames {frames:?}"
+        );
     }
 
     #[test]

--- a/docs/superpowers/specs/2026-06-03-tip-parrot-fix-and-run-stream-e2e-design.md
+++ b/docs/superpowers/specs/2026-06-03-tip-parrot-fix-and-run-stream-e2e-design.md
@@ -1,0 +1,201 @@
+# eros-engine — Tip-turn parrot fix + `run_stream` e2e tests (Spec)
+
+**Status**: design, pending implementation plan
+**Target release**: `0.5.x` dev track. **No migration.**
+**Scope**: a localized bug fix (`gift_user` rows dropped from the model prompt) plus
+two end-to-end `#[sqlx::test]`s driving `run_stream` with a mocked OpenRouter.
+This is **Spec A** of a two-spec split; the larger extraction-pipeline overhaul
+(insight events, audit columns, schema fields, prompt precision, config-driven
+extraction prompts) is **Spec B**, designed separately.
+
+---
+
+## 0. Background
+
+### The bug (item 6)
+
+When a user sends a **tip** (打赏), the companion's reply **parrots the recent
+conversation** instead of responding to the current turn. Reported example
+(AI = Yumi): `（轻笑着摇头）我这里是宁波啊。你没看见我刚才在提宁波的图书馆吗？` —
+the model re-asserts facts from earlier turns rather than reacting.
+
+It was observed for tips **< $1**, but the root cause is **amount-independent**.
+
+### Root cause (confirmed in code)
+
+1. A tip attached to a user message is routed `ActionType::Reply` (never ghost),
+   unconditionally — `crates/eros-engine-core/src/pde.rs:38-54`. No amount branch.
+2. The route persists the turn as **`role = 'gift_user'`** with content equal to
+   the typed message, or `"(打赏 $X)"` when no text was sent —
+   `crates/eros-engine-server/src/routes/companion_stream.rs:364-371`.
+3. `assemble_chat_request` builds the model's message list from history but only
+   maps `"user"` and `"assistant"` rows; **`gift_user` hits the `_ => continue`
+   arm and is dropped** — `crates/eros-engine-server/src/pipeline/handlers.rs:185-189`:
+   ```rust
+   let content = match msg.role.as_str() {
+       "user" => model_facing_user_text(&msg),
+       "assistant" => msg.content,
+       _ => continue,            // ← gift_user dropped
+   };
+   ```
+4. Because the just-inserted tip turn is a `gift_user` row, the model receives the
+   system prompt (with the `[tip_received]` block appended at `handlers.rs:625`) and
+   history that **ends at the previous turn** — there is no fresh user turn to answer,
+   so the model continues / parrots the thread. Same failure class as the
+   `chat_input_filter` motivation (a turn with no model-visible content makes the
+   model echo history).
+
+`fmt_amount` (`prompt.rs:273-279`) formats sub-$1 amounts correctly
+(`0.50` → `"0.50"`); there is no degenerate-formatting contribution. Small tips
+simply surface the bug most often because they usually carry no text.
+
+### Why this is Spec A (with the e2e tests)
+
+The fix is a few lines but touches the core prompt-assembly path, and the repo had
+**no end-to-end `run_stream` test** asserting that a turn's content actually
+reaches the model (the prior chat-vision work flagged this gap). Bundling the fix
+with two e2e tests gives the tip fix a regression guard and closes the flagged
+gap in one focused, fast-to-ship spec.
+
+---
+
+## 1. Goals / non-goals
+
+**Goals**
+- A tip turn's content (typed message, or the `"(打赏 $X)"` marker for a
+  tip-only turn) reaches the chat model, so the companion reacts to the tip
+  instead of parroting history.
+- Two `#[sqlx::test]`s driving `run_stream` end-to-end against a mocked
+  OpenRouter: (a) the tip-fix regression, (b) the chat-vision image path.
+
+**Non-goals (out of scope — deferred to Spec B or later)**
+- Any change to the recall `query_text` path (`handlers.rs:505`). For a tip turn
+  it falls back to the driving event's content; this is a minor recall nuance, not
+  the parrot bug. Spec B owns recall-query work.
+- Changing `[tip_received]` wording, tip tiers, or `fmt_amount`.
+- The extraction-pipeline overhaul (Spec B).
+
+---
+
+## 2. The fix (item 6)
+
+**File**: `crates/eros-engine-server/src/pipeline/handlers.rs`, `assemble_chat_request`
+(@ ~L180-194).
+
+Treat `gift_user` the same as `user`, and emit it to the model under the `"user"`
+role (OpenRouter only understands `system`/`user`/`assistant`). Replace the loop
+body:
+
+```rust
+for msg in history {
+    // User + gift_user (tip) rows feed the MODEL-FACING text; tip turns are user
+    // turns to the model. Assistant rows always feed `content`.
+    let (role, content) = match msg.role.as_str() {
+        "user" | "gift_user" => ("user", model_facing_user_text(&msg)),
+        "assistant" => ("assistant", msg.content),
+        _ => continue,
+    };
+    messages.push(ChatMessage {
+        role: role.to_string(),
+        content,
+    });
+}
+```
+
+Notes:
+- `model_facing_user_text` on a `gift_user` row returns `effective_user_text`
+  (just `content`, since the input filter skips tipped turns and `image_url`+tip
+  is rejected, so there is never a vision preamble). So a tip-with-message shows
+  the message; a tip-only turn shows `"(打赏 $X)"`.
+- Past `gift_user` rows in the history window also become visible now — correct;
+  they were silently vanishing before.
+- The `[tip_received]` system context (`handlers.rs:617-626`) is unchanged.
+
+**Regression check on existing tests**: confirm no existing test asserts that
+`gift_user` rows are *absent* from the assembled prompt; update any that do to the
+new (correct) behavior.
+
+---
+
+## 3. e2e `#[sqlx::test]`s (item 0)
+
+Both live in the `crates/eros-engine-server/src/pipeline/stream.rs` test module and
+mirror `input_filter_rewrites_meaningless_turn` (@ ~L3588): `wiremock::MockServer`
+for OpenRouter, `crate::routes::companion::test_state(pool)` with `openrouter` +
+`model_config` overridden, `seed_persona_and_session`, a `ChatRepo` upsert, then
+`run_stream(Arc::new(state), user_msg).collect().await` and assertions on frames +
+persisted rows. Mocks are routed by `body_string_contains(...)`.
+
+### 3a. Tip-fix regression — `tip_turn_reaches_model_not_parrot`
+
+- Config: `[tasks.chat_companion] model="deepseek/x"` (no filters needed).
+- Seed persona/session. Upsert a `gift_user` row:
+  ```rust
+  chat_repo.upsert_user_message_idempotent(
+      session_id, "(打赏 $0.5)", "<26+ char client id>", "gift_user", None).await
+  ```
+- `PersistedUserMessage { content: "(打赏 $0.5)".into(), tips_amount_usd: Some(0.5),
+  image_url: None, .. }`.
+- Chat mock matches **only** when the request body contains `"(打赏"` and replies an
+  SSE delta `"REPLY"`. Because the mock requires the tip turn's text in the body, a
+  `REPLY` delta proves the tip turn reached the model:
+  ```rust
+  Mock::given(wm_path("/api/v1/chat/completions"))
+      .and(body_string_contains("deepseek/x"))
+      .and(body_string_contains("(打赏"))   // ← proves the gift_user turn is in the prompt
+      .respond_with(/* SSE delta "REPLY" + [DONE] */)
+  ```
+- Assert: collected `Delta` frames contain `"REPLY"`; no `Error` frame.
+  (Pre-fix, the body would not contain `"(打赏"` → mock would not match → the test
+  fails, which is the regression guard.)
+
+### 3b. chat-vision path — `vision_turn_folds_description_and_persists`
+
+- Config:
+  ```
+  [tasks.chat_companion] model="deepseek/x"
+  [tasks.chat_vision] model="vis/m" filter_prompt="DESCRIBE"
+  ```
+- Two mocks:
+  - Vision model `"vis/m"` (non-streaming JSON) returns a describe object, e.g.
+    `{"description":"一只猫在沙滩","ocr_text":"","people":"","scene":"海边"}`.
+  - Chat model `"deepseek/x"` (SSE) matches **only** when the body contains
+    `"一只猫在沙滩"` (the folded description) and replies a delta `"REPLY"`.
+- Upsert a `user` row (empty content ok) seeded with
+  `metadata = {"image_url":"https://x/y.png"}`; `PersistedUserMessage { content:
+  "".into(), image_url: Some("https://x/y.png".into()), .. }`.
+- Assert:
+  - `Delta` frames contain `"REPLY"` (the description reached the chat model).
+  - The user row's `metadata.vision.description == "一只猫在沙滩"` (persisted via
+    `set_user_image_vision`):
+    ```rust
+    let meta: Option<serde_json::Value> = sqlx::query_scalar(
+        "SELECT metadata FROM engine.chat_messages WHERE id = $1").bind(umid)...;
+    assert_eq!(meta.unwrap()["vision"]["description"], "一只猫在沙滩");
+    ```
+  - No `Error` frame.
+
+> Note: `run_stream` builds the `DecisionInput`/`Event` from `PersistedUserMessage`
+> (incl. `tips_amount_usd` and `image_url`); these tests exercise that wiring. If a
+> helper to construct the test `PersistedUserMessage` does not already exist, build
+> it inline as the sibling tests do.
+
+---
+
+## 4. Testing / verification
+
+- `tip_turn_reaches_model_not_parrot` — passes with the fix, would fail without it.
+- `vision_turn_folds_description_and_persists` — passes with the existing
+  chat-vision pipeline + the fix (unaffected); first e2e coverage of that path.
+- Existing `stream.rs` tests stay green (adjust any that assumed `gift_user`
+  invisibility).
+- PR gate: `cargo fmt` / `clippy --workspace -D warnings` / `test --workspace`
+  (DB tests via `.test-env`). No `openapi.json` change (no DTO/route change). No
+  migration.
+
+## 5. Files touched
+
+- `crates/eros-engine-server/src/pipeline/handlers.rs` — the `gift_user` mapping in
+  `assemble_chat_request`.
+- `crates/eros-engine-server/src/pipeline/stream.rs` — two new `#[sqlx::test]`s
+  (+ any helper).


### PR DESCRIPTION
## Summary

- **Bug fix:** Tip turns (打赏, persisted as `role='gift_user'`) were dropped from the chat model's prompt in `assemble_chat_request` (the history loop mapped only `user`/`assistant`; `gift_user` hit `_ => continue`). The model never saw the current tip turn and **parroted earlier conversation**. Now **tip** `gift_user` rows are promoted into the prompt under the `user` role (OpenRouter only knows system/user/assistant).
- **Gated to tips only (codex P2):** Only `gift_user` rows carrying `tips_amount_usd` metadata are promoted — matching the existing `signals_count` convention (`pipeline/mod.rs`). Legacy in-app **Gift Event** rows (bare label, no tip metadata) stay dropped; whether to unify/remove `gift_user` + legacy Gift Events is deferred to #72.
- **Tests (first e2e `run_stream` coverage):**
  - `tip_turn_reaches_model_not_parrot` — regression guard; the chat mock matches **only** when the body carries the tip text `"(打赏"`, so a `REPLY` delta proves the tip turn reached the prompt.
  - `vision_turn_folds_description_and_persists` — e2e of the merged `chat_vision` path (describe folded into the prompt + persisted to `metadata.vision`).
  - `assemble_includes_tip_gift_but_drops_legacy_gift` — unit test: tip promoted / legacy dropped / no `gift_user` role on the wire.

## Notes
- No migration. No `openapi.json` change (no DTO/route change).
- Spec: `docs/superpowers/specs/2026-06-03-tip-parrot-fix-and-run-stream-e2e-design.md`
- Follow-up discussion: #72

## Test plan
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` — core 49 / llm 91 / server 246 / store 85, all pass
- [x] `codex exec review --base dev` — clean (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)