### PR TITLE
feat: insight_extraction events table + OpenRouter audit columns (B1)

### DIFF
--- a/crates/eros-engine-server/src/pipeline/post_process.rs
+++ b/crates/eros-engine-server/src/pipeline/post_process.rs
@@ -120,7 +120,7 @@ pub async fn run(
             && user_msg.chars().count() >= AFFINITY_EVAL_MIN_CHARS
             && !assistant_msg.trim().is_empty();
 
-        let (llm_deltas, reason) = if run_eval {
+        let (llm_deltas, reason, affinity_meta) = if run_eval {
             let persona_repo = PersonaRepo { pool: &state.pool };
             let affinity_repo = AffinityRepo { pool: &state.pool };
             let persona_name = match persona_repo.load_companion(instance_id).await {
@@ -145,12 +145,14 @@ pub async fn run(
                 _ => (
                     eros_engine_core::affinity::AffinityDeltas::default(),
                     String::new(),
+                    None,
                 ),
             }
         } else {
             (
                 eros_engine_core::affinity::AffinityDeltas::default(),
                 String::new(),
+                None,
             )
         };
 
@@ -169,6 +171,7 @@ pub async fn run(
             plan.action_type,
             combined,
             context,
+            affinity_meta,
         )
         .await;
     };
@@ -203,6 +206,7 @@ async fn persist_affinity(
     action: ActionType,
     deltas: eros_engine_core::affinity::AffinityDeltas,
     context: serde_json::Value,
+    meta: Option<eros_engine_store::OpenRouterCallMeta>,
 ) {
     let repo = AffinityRepo { pool: &state.pool };
 
@@ -247,7 +251,7 @@ async fn persist_affinity(
                 ActionType::Ghost => unreachable!(),
             };
             if let Err(e) = repo
-                .persist_with_event(&mut affinity, &deltas, ema_inertia, event_type, context)
+                .persist_with_event(&mut affinity, &deltas, ema_inertia, event_type, context, meta.as_ref())
                 .await
             {
                 tracing::warn!("affinity persist_with_event failed: {e}");
@@ -469,7 +473,11 @@ async fn evaluate_affinity(
     user_msg: &str,
     assistant_msg: &str,
     audit_user: Option<&str>,
-) -> (eros_engine_core::affinity::AffinityDeltas, String) {
+) -> (
+    eros_engine_core::affinity::AffinityDeltas,
+    String,
+    Option<eros_engine_store::OpenRouterCallMeta>,
+) {
     use eros_engine_core::affinity::AffinityDeltas;
 
     let prompt =
@@ -489,27 +497,32 @@ async fn evaluate_affinity(
         ..Default::default()
     };
 
-    let raw = match tokio::time::timeout(AFFINITY_EVAL_TIMEOUT, state.openrouter.execute(req)).await
+    let (raw, meta) = match tokio::time::timeout(AFFINITY_EVAL_TIMEOUT, state.openrouter.execute(req)).await
     {
         Ok(Ok(resp)) => {
             super::log_openrouter_usage(AFFINITY_TASK, Some(session_id), &resp);
-            resp.reply
+            let meta = eros_engine_store::OpenRouterCallMeta {
+                generation_id: resp.generation_id.clone(),
+                model: resp.model.clone(),
+                usage: resp.usage.clone(),
+            };
+            (resp.reply, Some(meta))
         }
         Ok(Err(e)) => {
             tracing::warn!("affinity eval LLM call failed: {e}");
-            return (AffinityDeltas::default(), String::new());
+            return (AffinityDeltas::default(), String::new(), None);
         }
         Err(_elapsed) => {
             tracing::warn!(
                 "affinity eval timed out after {AFFINITY_EVAL_TIMEOUT:?}; using rule-only deltas"
             );
-            return (AffinityDeltas::default(), String::new());
+            return (AffinityDeltas::default(), String::new(), None);
         }
     };
 
     let (deltas, reason) = parse_affinity_eval(&raw);
     tracing::debug!(affinity_reason = %reason, "affinity eval parsed");
-    (deltas, reason)
+    (deltas, reason, meta)
 }
 
 const INSIGHT_TASK: &str = "insight_extraction";

--- a/crates/eros-engine-server/src/pipeline/post_process.rs
+++ b/crates/eros-engine-server/src/pipeline/post_process.rs
@@ -199,6 +199,7 @@ pub async fn run(
 /// does not touch ghost_streak in `persist_with_event` — that's a caller
 /// responsibility because the streak reset is a pipeline-policy concern,
 /// not a row-update concern.
+#[allow(clippy::too_many_arguments)] // each arg is a distinct affinity-persist concern
 async fn persist_affinity(
     state: &AppState,
     session_id: Uuid,

--- a/crates/eros-engine-server/src/pipeline/post_process.rs
+++ b/crates/eros-engine-server/src/pipeline/post_process.rs
@@ -25,7 +25,7 @@ use eros_engine_llm::voyage::VoyageClient;
 use eros_engine_store::affinity::AffinityRepo;
 use eros_engine_store::chat::ChatRepo;
 use eros_engine_store::human_insight::HumanInsightRepo;
-use eros_engine_store::insight::InsightRepo;
+use eros_engine_store::insight::{InsightEventInsert, InsightEventRepo, InsightRepo};
 use eros_engine_store::memory::{MemoryLayer, MemoryRepo};
 use eros_engine_store::persona::PersonaRepo;
 
@@ -79,6 +79,7 @@ pub async fn run(
                     &state,
                     session_id,
                     user_id,
+                    m.message_id,
                     &user_msg,
                     &m.full_text,
                     client_id.as_deref(),
@@ -527,16 +528,39 @@ async fn evaluate_affinity(
 
 const INSIGHT_TASK: &str = "insight_extraction";
 
+/// Per-call audit captured from one insight_extraction OpenRouter call that
+/// returned a response. `None` (at the call site) means the call got no response
+/// (transport error / timeout) → no row is written.
+struct CallAudit {
+    status: &'static str,
+    payload: Option<serde_json::Value>,
+    meta: eros_engine_store::OpenRouterCallMeta,
+}
+
+fn call_meta(resp: &eros_engine_llm::openrouter::ChatResponse) -> eros_engine_store::OpenRouterCallMeta {
+    eros_engine_store::OpenRouterCallMeta {
+        generation_id: resp.generation_id.clone(),
+        model: resp.model.clone(),
+        usage: resp.usage.clone(),
+    }
+}
+
 /// Top-level entry: extract facts → structured insights → InsightRepo merge.
+/// Writes one companion_insights_events row per OpenRouter call that returned a
+/// response (facts, then structured), tied by a shared run_id. Fail-open: an
+/// audit-row insert failure only warns and never breaks the turn.
 async fn extract_insights(
     state: &AppState,
     session_id: Uuid,
     user_id: Uuid,
+    message_id: Uuid,
     user_msg: &str,
     assistant_msg: &str,
     audit_user: Option<&str>,
 ) {
-    let facts = extract_facts(
+    let run_id = Uuid::new_v4();
+
+    let (facts, facts_audit) = extract_facts(
         &state.openrouter,
         &state.model_config,
         session_id,
@@ -545,6 +569,9 @@ async fn extract_insights(
         audit_user,
     )
     .await;
+    if let Some(a) = facts_audit {
+        write_insight_event(&state.pool, run_id, user_id, session_id, message_id, "facts", a).await;
+    }
     if facts.is_empty() {
         return;
     }
@@ -558,7 +585,7 @@ async fn extract_insights(
         }
     };
 
-    let new_insights = extract_structured_insights(
+    let (new_insights, struct_audit) = extract_structured_insights(
         &state.openrouter,
         &state.model_config,
         session_id,
@@ -567,15 +594,15 @@ async fn extract_insights(
         audit_user,
     )
     .await;
+    if let Some(a) = struct_audit {
+        write_insight_event(&state.pool, run_id, user_id, session_id, message_id, "structured", a).await;
+    }
     if new_insights.as_object().is_none_or(|o| o.is_empty()) {
         return;
     }
 
     match insights_repo.merge(user_id, new_insights).await {
         Ok(row) => {
-            // Write-through: project the just-merged JSONB into the flat
-            // matching table. No extra read — merge returned the merged row.
-            // Failure only warns; it must not break the chat turn.
             let human_repo = HumanInsightRepo { pool: &state.pool };
             if let Err(e) = human_repo
                 .project_from_insights(user_id, &row.insights)
@@ -588,6 +615,33 @@ async fn extract_insights(
     }
 }
 
+/// Fail-open insert of one companion_insights_events row. Never returns an
+/// error to the caller — an audit-row failure must not break the chat turn.
+async fn write_insight_event(
+    pool: &sqlx::PgPool,
+    run_id: Uuid,
+    user_id: Uuid,
+    session_id: Uuid,
+    message_id: Uuid,
+    stage: &'static str,
+    audit: CallAudit,
+) {
+    let repo = InsightEventRepo { pool };
+    let ev = InsightEventInsert {
+        run_id,
+        user_id,
+        session_id: Some(session_id),
+        message_id: Some(message_id),
+        stage,
+        status: audit.status,
+        payload: audit.payload,
+        meta: audit.meta,
+    };
+    if let Err(e) = repo.record(ev).await {
+        tracing::warn!("insight event ({stage}) persist failed: {e}");
+    }
+}
+
 async fn extract_facts(
     llm: &OpenRouterClient,
     model_config: &ModelConfig,
@@ -595,9 +649,9 @@ async fn extract_facts(
     user_msg: &str,
     assistant_msg: &str,
     audit_user: Option<&str>,
-) -> Vec<String> {
+) -> (Vec<String>, Option<CallAudit>) {
     if user_msg.trim().is_empty() {
-        return vec![];
+        return (vec![], None);
     }
     let prompt = crate::prompt::extract_facts_prompt(user_msg, assistant_msg);
 
@@ -616,30 +670,37 @@ async fn extract_facts(
         ..Default::default()
     };
 
-    let raw = match llm.execute(req).await {
+    let (raw, meta) = match llm.execute(req).await {
         Ok(resp) => {
             super::log_openrouter_usage(INSIGHT_TASK, Some(session_id), &resp);
-            resp.reply.trim().to_string()
+            (resp.reply.trim().to_string(), call_meta(&resp))
         }
         Err(e) => {
             tracing::warn!("fact extraction LLM call failed: {e}");
-            return vec![];
+            return (vec![], None);
         }
     };
 
-    parse_facts(&raw)
-}
-
-fn parse_facts(raw: &str) -> Vec<String> {
-    if let Ok(v) = serde_json::from_str::<serde_json::Value>(raw) {
-        return extract_facts_array(&v);
-    }
-    if let Some(block) = find_json_block(raw) {
-        if let Ok(v) = serde_json::from_str::<serde_json::Value>(block) {
-            return extract_facts_array(&v);
+    // Parse once; distinguish parse_error (no JSON at all) from empty/ok.
+    let parsed = serde_json::from_str::<serde_json::Value>(&raw)
+        .ok()
+        .or_else(|| find_json_block(&raw).and_then(|b| serde_json::from_str(b).ok()));
+    match parsed {
+        Some(v) => {
+            let facts = extract_facts_array(&v);
+            let status = if facts.is_empty() { "empty" } else { "ok" };
+            let audit = CallAudit {
+                status,
+                payload: Some(serde_json::json!(facts)),
+                meta,
+            };
+            (facts, Some(audit))
         }
+        None => (
+            vec![],
+            Some(CallAudit { status: "parse_error", payload: None, meta }),
+        ),
     }
-    vec![]
 }
 
 fn extract_facts_array(v: &serde_json::Value) -> Vec<String> {
@@ -660,9 +721,10 @@ async fn extract_structured_insights(
     facts: &[String],
     existing_insights: Option<&serde_json::Value>,
     audit_user: Option<&str>,
-) -> serde_json::Value {
+) -> (serde_json::Value, Option<CallAudit>) {
+    let empty = || serde_json::Value::Object(serde_json::Map::new());
     if facts.is_empty() {
-        return serde_json::Value::Object(serde_json::Map::new());
+        return (empty(), None);
     }
 
     let prompt = crate::prompt::extract_structured_insights_prompt(facts, existing_insights);
@@ -682,27 +744,41 @@ async fn extract_structured_insights(
         ..Default::default()
     };
 
-    let raw = match llm.execute(req).await {
+    let (raw, meta) = match llm.execute(req).await {
         Ok(r) => {
             super::log_openrouter_usage(INSIGHT_TASK, Some(session_id), &r);
-            r.reply.trim().to_string()
+            (r.reply.trim().to_string(), call_meta(&r))
         }
-        Err(_) => return serde_json::Value::Object(serde_json::Map::new()),
+        Err(_) => return (empty(), None),
     };
 
-    if let Ok(v) = serde_json::from_str::<serde_json::Value>(&raw) {
-        if v.is_object() {
-            return v;
+    let parsed = serde_json::from_str::<serde_json::Value>(&raw)
+        .ok()
+        .filter(|v| v.is_object())
+        .or_else(|| {
+            find_json_block(&raw)
+                .and_then(|b| serde_json::from_str::<serde_json::Value>(b).ok())
+                .filter(|v| v.is_object())
+        });
+    match parsed {
+        Some(v) => {
+            let status = if v.as_object().is_some_and(|o| o.is_empty()) {
+                "empty"
+            } else {
+                "ok"
+            };
+            let audit = CallAudit {
+                status,
+                payload: Some(v.clone()),
+                meta,
+            };
+            (v, Some(audit))
         }
+        None => (
+            empty(),
+            Some(CallAudit { status: "parse_error", payload: None, meta }),
+        ),
     }
-    if let Some(block) = find_json_block(&raw) {
-        if let Ok(v) = serde_json::from_str::<serde_json::Value>(block) {
-            if v.is_object() {
-                return v;
-            }
-        }
-    }
-    serde_json::Value::Object(serde_json::Map::new())
 }
 
 // ─── Lead score refresh ────────────────────────────────────────────
@@ -780,25 +856,6 @@ mod tests {
             amount: 100,
         };
         assert_eq!(client_id_from_event(&event), None);
-    }
-
-    #[test]
-    fn parse_facts_empty_array() {
-        assert!(parse_facts(r#"{"facts": []}"#).is_empty());
-    }
-
-    #[test]
-    fn parse_facts_with_items() {
-        let raw = r#"{"facts": ["住在上海", "喜欢咖啡"]}"#;
-        let facts = parse_facts(raw);
-        assert_eq!(facts, vec!["住在上海".to_string(), "喜欢咖啡".to_string()]);
-    }
-
-    #[test]
-    fn parse_facts_regex_fallback_in_fenced_code() {
-        let raw = "Here you go:\n```json\n{\"facts\": [\"爱猫\"]}\n```";
-        let facts = parse_facts(raw);
-        assert_eq!(facts, vec!["爱猫".to_string()]);
     }
 
     #[test]
@@ -901,5 +958,194 @@ mod tests {
         );
         assert_eq!(c.trust, 0.0);
         assert_eq!(c.intimacy, 0.0);
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn insight_extraction_writes_two_events_sharing_run_id(pool: sqlx::PgPool) {
+        use wiremock::matchers::{body_string_contains, method, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+
+        // Stage-1 facts call → non-empty facts. Matched by a substring unique to
+        // extract_facts_prompt.
+        let facts_body = serde_json::json!({
+            "id": "gen-facts", "model": "ins/m",
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            "choices": [{"message": {"content": "{\"facts\":[\"用户在深圳工作\"]}"}}],
+        });
+        Mock::given(method("POST"))
+            .and(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("列出你对用户的新事实发现"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(facts_body))
+            .mount(&mock)
+            .await;
+
+        // Stage-2 structured call. Matched by a substring unique to
+        // extract_structured_insights_prompt.
+        let struct_body = serde_json::json!({
+            "id": "gen-struct", "model": "ins/m",
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            "choices": [{"message": {"content": "{\"city\":\"深圳\"}"}}],
+        });
+        Mock::given(method("POST"))
+            .and(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("填充以下 schema"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(struct_body))
+            .mount(&mock)
+            .await;
+
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = std::sync::Arc::new(
+            eros_engine_llm::model_config::ModelConfig::from_toml_str(
+                "[tasks.insight_extraction]\nmodel=\"ins/m\"\n",
+            )
+            .unwrap(),
+        );
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "k".into(),
+                Default::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+
+        let user_id = uuid::Uuid::new_v4();
+        let session_id = uuid::Uuid::new_v4();
+        let message_id = uuid::Uuid::new_v4();
+
+        extract_insights(&state, session_id, user_id, message_id, "我在深圳工作", "嗯嗯", None).await;
+
+        let rows: Vec<(uuid::Uuid, String, String, Option<String>)> = sqlx::query_as(
+            "SELECT run_id, stage, status, generation_id \
+             FROM engine.companion_insights_events WHERE user_id = $1 ORDER BY stage",
+        )
+        .bind(user_id)
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+        assert_eq!(rows.len(), 2, "facts + structured rows; got {rows:?}");
+        assert_eq!(rows[0].1, "facts");
+        assert_eq!(rows[1].1, "structured");
+        assert_eq!(rows[0].0, rows[1].0, "both rows share one run_id");
+        assert_eq!(rows[0].3.as_deref(), Some("gen-facts"));
+        assert_eq!(rows[1].3.as_deref(), Some("gen-struct"));
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn insight_extraction_empty_facts_writes_one_event(pool: sqlx::PgPool) {
+        use wiremock::matchers::{body_string_contains, method, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+
+        // Facts call returns an empty list ⇒ status='empty', no structured call.
+        let facts_body = serde_json::json!({
+            "id": "gen-facts", "model": "ins/m",
+            "usage": {"total_tokens": 2},
+            "choices": [{"message": {"content": "{\"facts\":[]}"}}],
+        });
+        Mock::given(method("POST"))
+            .and(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("列出你对用户的新事实发现"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(facts_body))
+            .mount(&mock)
+            .await;
+        // Structured mock must NOT be hit.
+        Mock::given(method("POST"))
+            .and(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("填充以下 schema"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+            .expect(0)
+            .mount(&mock)
+            .await;
+
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = std::sync::Arc::new(
+            eros_engine_llm::model_config::ModelConfig::from_toml_str(
+                "[tasks.insight_extraction]\nmodel=\"ins/m\"\n",
+            )
+            .unwrap(),
+        );
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "k".into(),
+                Default::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+
+        let user_id = uuid::Uuid::new_v4();
+        extract_insights(&state, uuid::Uuid::new_v4(), user_id, uuid::Uuid::new_v4(), "hi there", "嗯嗯", None).await;
+
+        let rows: Vec<(String, String)> = sqlx::query_as(
+            "SELECT stage, status FROM engine.companion_insights_events WHERE user_id = $1",
+        )
+        .bind(user_id)
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+        assert_eq!(rows.len(), 1, "only the facts row; got {rows:?}");
+        assert_eq!(rows[0].0, "facts");
+        assert_eq!(rows[0].1, "empty");
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn insight_extraction_facts_parse_error_writes_one_event(pool: sqlx::PgPool) {
+        use wiremock::matchers::{body_string_contains, method, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+
+        // Facts call returns non-JSON garbage ⇒ status='parse_error', payload NULL,
+        // and the structured call is never made.
+        let facts_body = serde_json::json!({
+            "id": "gen-facts", "model": "ins/m",
+            "usage": {"total_tokens": 2},
+            "choices": [{"message": {"content": "这不是 JSON"}}],
+        });
+        Mock::given(method("POST"))
+            .and(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("列出你对用户的新事实发现"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(facts_body))
+            .mount(&mock)
+            .await;
+        Mock::given(method("POST"))
+            .and(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("填充以下 schema"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+            .expect(0)
+            .mount(&mock)
+            .await;
+
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = std::sync::Arc::new(
+            eros_engine_llm::model_config::ModelConfig::from_toml_str(
+                "[tasks.insight_extraction]\nmodel=\"ins/m\"\n",
+            )
+            .unwrap(),
+        );
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "k".into(),
+                Default::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+
+        let user_id = uuid::Uuid::new_v4();
+        extract_insights(&state, uuid::Uuid::new_v4(), user_id, uuid::Uuid::new_v4(), "hi there", "嗯嗯", None).await;
+
+        let rows: Vec<(String, String, Option<serde_json::Value>)> = sqlx::query_as(
+            "SELECT stage, status, payload FROM engine.companion_insights_events WHERE user_id = $1",
+        )
+        .bind(user_id)
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+        assert_eq!(rows.len(), 1, "only the facts row; got {rows:?}");
+        assert_eq!(rows[0].0, "facts");
+        assert_eq!(rows[0].1, "parse_error");
+        assert_eq!(rows[0].2, None, "parse_error ⇒ NULL payload");
     }
 }

--- a/crates/eros-engine-server/src/pipeline/post_process.rs
+++ b/crates/eros-engine-server/src/pipeline/post_process.rs
@@ -252,7 +252,14 @@ async fn persist_affinity(
                 ActionType::Ghost => unreachable!(),
             };
             if let Err(e) = repo
-                .persist_with_event(&mut affinity, &deltas, ema_inertia, event_type, context, meta.as_ref())
+                .persist_with_event(
+                    &mut affinity,
+                    &deltas,
+                    ema_inertia,
+                    event_type,
+                    context,
+                    meta.as_ref(),
+                )
                 .await
             {
                 tracing::warn!("affinity persist_with_event failed: {e}");
@@ -498,28 +505,28 @@ async fn evaluate_affinity(
         ..Default::default()
     };
 
-    let (raw, meta) = match tokio::time::timeout(AFFINITY_EVAL_TIMEOUT, state.openrouter.execute(req)).await
-    {
-        Ok(Ok(resp)) => {
-            super::log_openrouter_usage(AFFINITY_TASK, Some(session_id), &resp);
-            let meta = eros_engine_store::OpenRouterCallMeta {
-                generation_id: resp.generation_id.clone(),
-                model: resp.model.clone(),
-                usage: resp.usage.clone(),
-            };
-            (resp.reply, Some(meta))
-        }
-        Ok(Err(e)) => {
-            tracing::warn!("affinity eval LLM call failed: {e}");
-            return (AffinityDeltas::default(), String::new(), None);
-        }
-        Err(_elapsed) => {
-            tracing::warn!(
+    let (raw, meta) =
+        match tokio::time::timeout(AFFINITY_EVAL_TIMEOUT, state.openrouter.execute(req)).await {
+            Ok(Ok(resp)) => {
+                super::log_openrouter_usage(AFFINITY_TASK, Some(session_id), &resp);
+                let meta = eros_engine_store::OpenRouterCallMeta {
+                    generation_id: resp.generation_id.clone(),
+                    model: resp.model.clone(),
+                    usage: resp.usage.clone(),
+                };
+                (resp.reply, Some(meta))
+            }
+            Ok(Err(e)) => {
+                tracing::warn!("affinity eval LLM call failed: {e}");
+                return (AffinityDeltas::default(), String::new(), None);
+            }
+            Err(_elapsed) => {
+                tracing::warn!(
                 "affinity eval timed out after {AFFINITY_EVAL_TIMEOUT:?}; using rule-only deltas"
             );
-            return (AffinityDeltas::default(), String::new(), None);
-        }
-    };
+                return (AffinityDeltas::default(), String::new(), None);
+            }
+        };
 
     let (deltas, reason) = parse_affinity_eval(&raw);
     tracing::debug!(affinity_reason = %reason, "affinity eval parsed");
@@ -537,7 +544,9 @@ struct CallAudit {
     meta: eros_engine_store::OpenRouterCallMeta,
 }
 
-fn call_meta(resp: &eros_engine_llm::openrouter::ChatResponse) -> eros_engine_store::OpenRouterCallMeta {
+fn call_meta(
+    resp: &eros_engine_llm::openrouter::ChatResponse,
+) -> eros_engine_store::OpenRouterCallMeta {
     eros_engine_store::OpenRouterCallMeta {
         generation_id: resp.generation_id.clone(),
         model: resp.model.clone(),
@@ -570,7 +579,16 @@ async fn extract_insights(
     )
     .await;
     if let Some(a) = facts_audit {
-        write_insight_event(&state.pool, run_id, user_id, session_id, message_id, "facts", a).await;
+        write_insight_event(
+            &state.pool,
+            run_id,
+            user_id,
+            session_id,
+            message_id,
+            "facts",
+            a,
+        )
+        .await;
     }
     if facts.is_empty() {
         return;
@@ -595,7 +613,16 @@ async fn extract_insights(
     )
     .await;
     if let Some(a) = struct_audit {
-        write_insight_event(&state.pool, run_id, user_id, session_id, message_id, "structured", a).await;
+        write_insight_event(
+            &state.pool,
+            run_id,
+            user_id,
+            session_id,
+            message_id,
+            "structured",
+            a,
+        )
+        .await;
     }
     if new_insights.as_object().is_none_or(|o| o.is_empty()) {
         return;
@@ -698,7 +725,11 @@ async fn extract_facts(
         }
         None => (
             vec![],
-            Some(CallAudit { status: "parse_error", payload: None, meta }),
+            Some(CallAudit {
+                status: "parse_error",
+                payload: None,
+                meta,
+            }),
         ),
     }
 }
@@ -776,7 +807,11 @@ async fn extract_structured_insights(
         }
         None => (
             empty(),
-            Some(CallAudit { status: "parse_error", payload: None, meta }),
+            Some(CallAudit {
+                status: "parse_error",
+                payload: None,
+                meta,
+            }),
         ),
     }
 }
@@ -1014,7 +1049,16 @@ mod tests {
         let session_id = uuid::Uuid::new_v4();
         let message_id = uuid::Uuid::new_v4();
 
-        extract_insights(&state, session_id, user_id, message_id, "我在深圳工作", "嗯嗯", None).await;
+        extract_insights(
+            &state,
+            session_id,
+            user_id,
+            message_id,
+            "我在深圳工作",
+            "嗯嗯",
+            None,
+        )
+        .await;
 
         let rows: Vec<(uuid::Uuid, String, String, Option<String>)> = sqlx::query_as(
             "SELECT run_id, stage, status, generation_id \
@@ -1076,7 +1120,16 @@ mod tests {
         );
 
         let user_id = uuid::Uuid::new_v4();
-        extract_insights(&state, uuid::Uuid::new_v4(), user_id, uuid::Uuid::new_v4(), "hi there", "嗯嗯", None).await;
+        extract_insights(
+            &state,
+            uuid::Uuid::new_v4(),
+            user_id,
+            uuid::Uuid::new_v4(),
+            "hi there",
+            "嗯嗯",
+            None,
+        )
+        .await;
 
         let rows: Vec<(String, String)> = sqlx::query_as(
             "SELECT stage, status FROM engine.companion_insights_events WHERE user_id = $1",
@@ -1134,7 +1187,16 @@ mod tests {
         );
 
         let user_id = uuid::Uuid::new_v4();
-        extract_insights(&state, uuid::Uuid::new_v4(), user_id, uuid::Uuid::new_v4(), "hi there", "嗯嗯", None).await;
+        extract_insights(
+            &state,
+            uuid::Uuid::new_v4(),
+            user_id,
+            uuid::Uuid::new_v4(),
+            "hi there",
+            "嗯嗯",
+            None,
+        )
+        .await;
 
         let rows: Vec<(String, String, Option<serde_json::Value>)> = sqlx::query_as(
             "SELECT stage, status, payload FROM engine.companion_insights_events WHERE user_id = $1",

--- a/crates/eros-engine-server/src/prompt.rs
+++ b/crates/eros-engine-server/src/prompt.rs
@@ -609,8 +609,8 @@ Do not invent or guess anything not clearly supported by the facts.
 
 /// Stage-1 insight extraction prompt: ask the LLM to mine fresh user
 /// facts from a single chat turn. Output expected as
-/// `{"facts": ["...", "..."]}` — `parse_facts` in `post_process.rs`
-/// handles regex fallback for fenced / wrapped JSON.
+/// `{"facts": ["...", "..."]}` — the inline parse in `extract_facts`
+/// (`post_process.rs`) handles the fenced / wrapped JSON fallback.
 pub fn extract_facts_prompt(user_msg: &str, assistant_msg: &str) -> String {
     format!(
         "分析以下一轮对话，列出你对用户的新事实发现（仅限用户，不是 AI）。\n\n\
@@ -626,7 +626,7 @@ pub fn extract_facts_prompt(user_msg: &str, assistant_msg: &str) -> String {
 /// a category tag. Output expected as
 /// `{"memories": [{"content": "...", "category": "fact"}, ...]}` —
 /// `parse_memory_candidates` in `pipeline::dreaming` handles the
-/// fenced-JSON fallback the same way `parse_facts` does.
+/// fenced-JSON fallback the same way `extract_facts` does.
 ///
 /// `turns` is the chronologically ordered list of `用户：X / AI：Y` lines
 /// (or whatever pre-format the caller chose); the prompt does not assume

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -751,6 +751,7 @@ async fn event_gift(
             state.config.ema_inertia,
             "gift",
             context,
+            None,
         )
         .await?;
 

--- a/crates/eros-engine-store/migrations/0025_insight_events_and_audit_cols.sql
+++ b/crates/eros-engine-store/migrations/0025_insight_events_and_audit_cols.sql
@@ -1,0 +1,54 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- engine.companion_insights_events — append-only, ONE row per OpenRouter call
+-- of insight_extraction (cost + what-was-extracted audit). A run makes up to
+-- two calls (facts → structured), tied by a shared run_id. Distinct from
+-- companion_insights_snapshot (periodic STATE history, migration 0021).
+--
+-- Also adds the OpenRouter audit trio (model/usage/generation_id, mirroring
+-- chat_messages from migration 0012) to companion_affinity_events.
+--
+-- Spec: docs/superpowers/specs/2026-06-03-insight-events-and-audit-columns-design.md
+
+CREATE TABLE engine.companion_insights_events (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    run_id        UUID NOT NULL,
+    user_id       UUID NOT NULL,
+    session_id    UUID,
+    message_id    UUID,
+    stage         TEXT NOT NULL CHECK (stage IN ('facts','structured')),
+    status        TEXT NOT NULL CHECK (status IN ('ok','empty','parse_error')),
+    payload       JSONB,
+    model         TEXT,
+    usage         JSONB,
+    generation_id TEXT,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_companion_insights_events_user_time
+    ON engine.companion_insights_events (user_id, created_at DESC);
+CREATE INDEX idx_companion_insights_events_run
+    ON engine.companion_insights_events (run_id);
+
+-- Supabase lockdown, mirroring 0021_companion_insights_snapshot.sql. REVOKEs
+-- are wrapped in pg_roles existence checks so non-Supabase Postgres (incl. the
+-- sqlx test DB, where anon/authenticated don't exist) skips them silently. The
+-- RLS enable runs unconditionally; with no policy attached, only owner
+-- (postgres) and service_role connections can touch the table.
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
+        REVOKE ALL ON engine.companion_insights_events FROM anon;
+    END IF;
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+        REVOKE ALL ON engine.companion_insights_events FROM authenticated;
+    END IF;
+END
+$$;
+
+ALTER TABLE engine.companion_insights_events ENABLE ROW LEVEL SECURITY;
+
+-- Audit trio on the existing affinity events table (nullable, no backfill).
+ALTER TABLE engine.companion_affinity_events
+    ADD COLUMN model         TEXT,
+    ADD COLUMN usage         JSONB,
+    ADD COLUMN generation_id TEXT;

--- a/crates/eros-engine-store/src/affinity.rs
+++ b/crates/eros-engine-store/src/affinity.rs
@@ -194,6 +194,7 @@ impl<'a> AffinityRepo<'a> {
         ema_inertia: f64,
         event_type: &str,
         context: serde_json::Value,
+        meta: Option<&crate::OpenRouterCallMeta>,
     ) -> Result<(), sqlx::Error> {
         let mut tx = self.pool.begin().await?;
 
@@ -254,14 +255,18 @@ impl<'a> AffinityRepo<'a> {
         let effective_json = serde_json::to_value(&effective).unwrap_or_default();
         sqlx::query(
             "INSERT INTO engine.companion_affinity_events \
-               (affinity_id, event_type, deltas, effective_deltas, context) \
-             VALUES ($1, $2, $3, $4, $5)",
+               (affinity_id, event_type, deltas, effective_deltas, context, \
+                model, usage, generation_id) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
         )
         .bind(current.id)
         .bind(event_type)
         .bind(deltas_json)
         .bind(effective_json)
         .bind(context)
+        .bind(meta.and_then(|m| m.model.clone()))
+        .bind(meta.and_then(|m| m.usage.clone()))
+        .bind(meta.and_then(|m| m.generation_id.clone()))
         .execute(&mut *tx)
         .await?;
 
@@ -370,6 +375,7 @@ mod tests {
             0.0, // no smoothing → full apply
             "message",
             serde_json::json!({ "source": "test" }),
+            None,
         )
         .await
         .unwrap();
@@ -431,7 +437,7 @@ mod tests {
             warmth: 0.4,
             ..Default::default()
         };
-        repo.persist_with_event(&mut a, &deltas, 0.8, "message", serde_json::json!({}))
+        repo.persist_with_event(&mut a, &deltas, 0.8, "message", serde_json::json!({}), None)
             .await
             .unwrap();
 
@@ -469,7 +475,7 @@ mod tests {
             trust: 5.0,
             ..Default::default()
         };
-        repo.persist_with_event(&mut a, &deltas, 0.0, "message", serde_json::json!({}))
+        repo.persist_with_event(&mut a, &deltas, 0.0, "message", serde_json::json!({}), None)
             .await
             .unwrap();
 
@@ -541,6 +547,7 @@ mod tests {
                 0.0,
                 "message",
                 serde_json::json!({}),
+                None,
             )
             .await
             .unwrap();
@@ -557,6 +564,7 @@ mod tests {
                 0.0,
                 "message",
                 serde_json::json!({}),
+                None,
             )
             .await
             .unwrap();
@@ -600,7 +608,7 @@ mod tests {
             tension: 0.3,  // 0.1 -> 0.4
             ..Default::default()
         };
-        repo.persist_with_event(&mut a, &deltas, 0.0, "message", serde_json::json!({}))
+        repo.persist_with_event(&mut a, &deltas, 0.0, "message", serde_json::json!({}), None)
             .await
             .unwrap();
         let reloaded = repo.load(session_id).await.unwrap().unwrap();
@@ -716,5 +724,46 @@ mod tests {
             .await
             .unwrap();
         assert!(repo.latest_turn_event(session_id).await.unwrap().is_none());
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn persist_with_event_stores_openrouter_audit_trio(pool: PgPool) {
+        let repo = AffinityRepo { pool: &pool };
+        let user_id = Uuid::new_v4();
+        let instance_id = Uuid::new_v4();
+        let session_id = make_session(&pool, user_id, instance_id).await;
+        let mut a = repo
+            .load_or_create(session_id, user_id, instance_id)
+            .await
+            .unwrap();
+
+        let deltas = AffinityDeltas {
+            warmth: 0.1,
+            trust: 0.0,
+            intrigue: 0.0,
+            intimacy: 0.0,
+            patience: 0.0,
+            tension: 0.0,
+        };
+        let meta = crate::OpenRouterCallMeta {
+            generation_id: Some("gen-aff".into()),
+            model: Some("aff/m".into()),
+            usage: Some(serde_json::json!({"total_tokens": 9})),
+        };
+        repo.persist_with_event(&mut a, &deltas, 0.0, "message", serde_json::json!({}), Some(&meta))
+            .await
+            .unwrap();
+
+        let row: (Option<String>, Option<String>, Option<serde_json::Value>) = sqlx::query_as(
+            "SELECT generation_id, model, usage FROM engine.companion_affinity_events \
+             WHERE affinity_id = $1",
+        )
+        .bind(a.id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(row.0.as_deref(), Some("gen-aff"));
+        assert_eq!(row.1.as_deref(), Some("aff/m"));
+        assert_eq!(row.2, Some(serde_json::json!({"total_tokens": 9})));
     }
 }

--- a/crates/eros-engine-store/src/affinity.rs
+++ b/crates/eros-engine-store/src/affinity.rs
@@ -750,9 +750,16 @@ mod tests {
             model: Some("aff/m".into()),
             usage: Some(serde_json::json!({"total_tokens": 9})),
         };
-        repo.persist_with_event(&mut a, &deltas, 0.0, "message", serde_json::json!({}), Some(&meta))
-            .await
-            .unwrap();
+        repo.persist_with_event(
+            &mut a,
+            &deltas,
+            0.0,
+            "message",
+            serde_json::json!({}),
+            Some(&meta),
+        )
+        .await
+        .unwrap();
 
         let row: (Option<String>, Option<String>, Option<serde_json::Value>) = sqlx::query_as(
             "SELECT generation_id, model, usage FROM engine.companion_affinity_events \

--- a/crates/eros-engine-store/src/insight.rs
+++ b/crates/eros-engine-store/src/insight.rs
@@ -131,6 +131,50 @@ impl<'a> InsightRepo<'a> {
     }
 }
 
+/// One `companion_insights_events` row to insert. `payload` is the facts array
+/// (`stage='facts'`) or the structured insight delta (`stage='structured'`), or
+/// `None` on a parse error.
+pub struct InsightEventInsert<'a> {
+    pub run_id: Uuid,
+    pub user_id: Uuid,
+    pub session_id: Option<Uuid>,
+    pub message_id: Option<Uuid>,
+    pub stage: &'a str,
+    pub status: &'a str,
+    pub payload: Option<serde_json::Value>,
+    pub meta: crate::OpenRouterCallMeta,
+}
+
+pub struct InsightEventRepo<'a> {
+    pub pool: &'a PgPool,
+}
+
+impl<'a> InsightEventRepo<'a> {
+    /// Append one audit row. Append-only; no FK on user_id (a row may precede
+    /// the first companion_insights row on an empty-facts run).
+    pub async fn record(&self, ev: InsightEventInsert<'_>) -> Result<(), sqlx::Error> {
+        sqlx::query(
+            "INSERT INTO engine.companion_insights_events \
+               (run_id, user_id, session_id, message_id, stage, status, payload, \
+                model, usage, generation_id) \
+             VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)",
+        )
+        .bind(ev.run_id)
+        .bind(ev.user_id)
+        .bind(ev.session_id)
+        .bind(ev.message_id)
+        .bind(ev.stage)
+        .bind(ev.status)
+        .bind(ev.payload)
+        .bind(ev.meta.model)
+        .bind(ev.meta.usage)
+        .bind(ev.meta.generation_id)
+        .execute(self.pool)
+        .await?;
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -261,6 +305,75 @@ mod tests {
                 .await
                 .unwrap();
         assert_eq!(count, 0);
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn insight_event_repo_records_rows_with_run_id_and_trio(pool: PgPool) {
+        let repo = InsightEventRepo { pool: &pool };
+        let run_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        let session_id = Uuid::new_v4();
+        let message_id = Uuid::new_v4();
+
+        repo.record(InsightEventInsert {
+            run_id,
+            user_id,
+            session_id: Some(session_id),
+            message_id: Some(message_id),
+            stage: "facts",
+            status: "ok",
+            payload: Some(serde_json::json!(["用户在深圳工作"])),
+            meta: crate::OpenRouterCallMeta {
+                generation_id: Some("gen-facts".into()),
+                model: Some("ins/m".into()),
+                usage: Some(serde_json::json!({"total_tokens": 7})),
+            },
+        })
+        .await
+        .unwrap();
+
+        repo.record(InsightEventInsert {
+            run_id,
+            user_id,
+            session_id: Some(session_id),
+            message_id: Some(message_id),
+            stage: "structured",
+            status: "parse_error",
+            payload: None,
+            meta: crate::OpenRouterCallMeta::default(),
+        })
+        .await
+        .unwrap();
+
+        // Two rows, same run_id. Also round-trip the JSONB payload + usage so a
+        // bind/column swap of the trio would be caught here, not just at the DB.
+        #[allow(clippy::type_complexity)]
+        let rows: Vec<(
+            String,
+            String,
+            Option<String>,
+            Option<serde_json::Value>,
+            Option<serde_json::Value>,
+        )> = sqlx::query_as(
+            "SELECT stage, status, generation_id, payload, usage \
+             FROM engine.companion_insights_events \
+             WHERE run_id = $1 ORDER BY stage",
+        )
+        .bind(run_id)
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].0, "facts");
+        assert_eq!(rows[0].1, "ok");
+        assert_eq!(rows[0].2.as_deref(), Some("gen-facts"));
+        assert_eq!(rows[0].3, Some(serde_json::json!(["用户在深圳工作"])));
+        assert_eq!(rows[0].4, Some(serde_json::json!({"total_tokens": 7})));
+        assert_eq!(rows[1].0, "structured");
+        assert_eq!(rows[1].1, "parse_error");
+        assert_eq!(rows[1].2, None); // default meta ⇒ NULL generation_id
+        assert_eq!(rows[1].3, None); // parse_error ⇒ NULL payload
+        assert_eq!(rows[1].4, None); // default meta ⇒ NULL usage
     }
 
     #[sqlx::test(migrations = "./migrations")]

--- a/crates/eros-engine-store/src/insight.rs
+++ b/crates/eros-engine-store/src/insight.rs
@@ -262,4 +262,33 @@ mod tests {
                 .unwrap();
         assert_eq!(count, 0);
     }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn migration_0025_creates_events_table_and_affinity_audit_cols(pool: PgPool) {
+        // companion_insights_events exists with every column.
+        sqlx::query(
+            "INSERT INTO engine.companion_insights_events \
+               (run_id, user_id, session_id, message_id, stage, status, payload, model, usage, generation_id) \
+             VALUES ($1,$2,$3,$4,'facts','ok','[]'::jsonb,'m','{}'::jsonb,'g')",
+        )
+        .bind(Uuid::new_v4())
+        .bind(Uuid::new_v4())
+        .bind(Uuid::new_v4())
+        .bind(Uuid::new_v4())
+        .execute(&pool)
+        .await
+        .expect("insert into companion_insights_events");
+
+        let n: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM engine.companion_insights_events")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(n, 1);
+
+        // companion_affinity_events now has the audit trio (select compiles ⇒ columns exist).
+        let _ = sqlx::query("SELECT model, usage, generation_id FROM engine.companion_affinity_events")
+            .fetch_all(&pool)
+            .await
+            .expect("affinity audit columns exist");
+    }
 }

--- a/crates/eros-engine-store/src/insight.rs
+++ b/crates/eros-engine-store/src/insight.rs
@@ -399,9 +399,10 @@ mod tests {
         assert_eq!(n, 1);
 
         // companion_affinity_events now has the audit trio (select compiles ⇒ columns exist).
-        let _ = sqlx::query("SELECT model, usage, generation_id FROM engine.companion_affinity_events")
-            .fetch_all(&pool)
-            .await
-            .expect("affinity audit columns exist");
+        let _ =
+            sqlx::query("SELECT model, usage, generation_id FROM engine.companion_affinity_events")
+                .fetch_all(&pool)
+                .await
+                .expect("affinity audit columns exist");
     }
 }

--- a/crates/eros-engine-store/src/lib.rs
+++ b/crates/eros-engine-store/src/lib.rs
@@ -12,6 +12,16 @@ pub mod pool;
 
 pub use sqlx::PgPool;
 
+/// OpenRouter call metadata captured for the audit columns on event tables
+/// (`companion_insights_events`, `companion_affinity_events`). All optional —
+/// a non-LLM event (e.g. a gift affinity event) carries the default (all None).
+#[derive(Debug, Clone, Default)]
+pub struct OpenRouterCallMeta {
+    pub generation_id: Option<String>,
+    pub model: Option<String>,
+    pub usage: Option<serde_json::Value>,
+}
+
 #[cfg(test)]
 mod migration_tests {
     use sqlx::PgPool;

--- a/docs/superpowers/specs/2026-06-03-insight-events-and-audit-columns-design.md
+++ b/docs/superpowers/specs/2026-06-03-insight-events-and-audit-columns-design.md
@@ -1,0 +1,253 @@
+# eros-engine — Insight extraction events + OpenRouter audit columns (Spec B1)
+
+**Status**: design, pending implementation plan
+**Target release**: `0.5.x` dev track. **One migration (`0025`).**
+**Scope**: a new append-only `companion_insights_events` audit table — **one row per
+OpenRouter call** of `insight_extraction` — plus `model` / `usage` / `generation_id`
+audit columns on both `companion_insights_events` (new) and `companion_affinity_events`
+(existing), wired from the affinity + insight call sites.
+
+This is **Spec B1**, the first of two specs splitting the original "Spec B" extraction
+overhaul. **Spec B2** (extraction prompt precision, config-driven extraction prompts,
+and the `location` / `nationality` / `hometown` geo-schema fields) is designed separately.
+
+---
+
+## 0. Background
+
+### What item 1 + item 2 ask for
+
+1. **Item 1** — add a `companion_insights_events` table that records each
+   `insight_extraction` run, mirroring how `affinity_evaluation` writes
+   `companion_affinity_events`.
+2. **Item 2** — give both `companion_insights_events` (new) and
+   `companion_affinity_events` (existing) the OpenRouter `generation_id`, `model`, and
+   `usage` of the call that produced the row.
+
+### The affinity precedent (the pattern item 1 mirrors)
+
+`affinity_evaluation` runs once per qualifying reply turn, makes **one** OpenRouter call,
+and `persist_with_event` (`crates/eros-engine-store/src/affinity.rs` @ ~L190-273) writes
+**one** `companion_affinity_events` row (`event_type`, `deltas`, `effective_deltas`,
+`context`, `created_at`; created in `0002_affinity.sql`, widened by
+`0014_affinity_effective_deltas.sql`). The OpenRouter `generation_id` / `model` / `usage`
+are currently **only logged** (`log_openrouter_usage`, `crates/eros-engine-server/src/pipeline/mod.rs`
+@ ~L25-54) — never persisted.
+
+### Why `insight_extraction` is not a 1:1 mirror
+
+`insight_extraction` runs per produced assistant message (`extract_insights`,
+`crates/eros-engine-server/src/pipeline/post_process.rs` @ ~L518) and makes **two**
+OpenRouter calls:
+
+1. **`facts`** — `extract_facts` → `{"facts":[...]}` (stage-1 fact list).
+2. **`structured`** — `extract_structured_insights` → a JSON object matching
+   `COMPANION_INSIGHTS_SCHEMA`, which is then `InsightRepo::merge`d into
+   `companion_insights.insights` and projected into `human_insights`.
+
+Each call has its own `generation_id` / `model` / `usage`. **Decision: one row per
+OpenRouter call**, discriminated by a `stage` column, so each row carries exactly one
+clean audit trio. A `run_id` (generated once per run) ties the two rows of one run
+together.
+
+### Two conventions this reuses
+
+- **The audit-column trio already exists.** `chat_messages` carries
+  `model TEXT` / `usage JSONB` / `generation_id TEXT` (migration `0012_chat_streaming.sql`).
+  The new columns mirror those names and types exactly.
+- **The Supabase lockdown boilerplate.** New sensitive tables (`0013`+, e.g.
+  `0021_companion_insights_snapshot.sql`) `REVOKE` from `anon` / `authenticated` (wrapped
+  in `pg_roles` existence guards so non-Supabase / sqlx-test Postgres skips silently) and
+  `ENABLE ROW LEVEL SECURITY`. `companion_insights_events` follows the same pattern.
+
+### Not redundant with `companion_insights_snapshot`
+
+`companion_insights_snapshot` (`0021`) is a periodic **state** history (the full
+`insights` JSONB + `training_level`, one row per user per sweeper fire).
+`companion_insights_events` is a per-**call** audit log (what each extraction call cost
+and produced). Same family, different grain — both append-only, both retained.
+
+---
+
+## 1. Goals / non-goals
+
+**Goals**
+- Persist a durable, cost-faithful audit row for **every OpenRouter call** that
+  `insight_extraction` makes that **returns a response** — including calls whose output
+  was empty (no new facts) or failed to parse (the call still spent tokens).
+- Carry `generation_id` / `model` / `usage` on both `companion_insights_events` and
+  `companion_affinity_events`.
+- Group the two calls of one run via a shared `run_id`.
+
+**Non-goals (out of scope)**
+- Any read path — no API / BFF / dashboard surface for these events. Write-only audit
+  for now.
+- No backfill of existing `companion_affinity_events` rows (the new columns stay `NULL`
+  on pre-migration rows).
+- `memory_extraction` (`dreaming.rs`) gets **no** events table and **no** audit columns —
+  items 1 + 2 name only `insight_extraction` (insights) and `affinity_evaluation`
+  (affinity).
+- No change to `companion_insights_snapshot`, `companion_insights`, or `human_insights`
+  schema (geo-schema work is Spec B2).
+- Transport errors (an OpenRouter call that returns **no** response — network / 4xx) are
+  still only logged, not rowed (there is no `generation_id` / `usage` to record).
+
+---
+
+## 2. Schema — migration `0025`
+
+One migration file, `crates/eros-engine-store/migrations/0025_insight_events_and_audit_cols.sql`:
+
+### 2a. New table `companion_insights_events`
+
+```sql
+CREATE TABLE engine.companion_insights_events (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    run_id        UUID NOT NULL,             -- shared by both calls of one insight_extraction run
+    user_id       UUID NOT NULL,             -- plain UUID, NO foreign key (see note)
+    session_id    UUID,                      -- tracing: the session the turn came from
+    message_id    UUID,                      -- tracing: the assistant turn that triggered extraction
+    stage         TEXT NOT NULL CHECK (stage IN ('facts','structured')),
+    status        TEXT NOT NULL CHECK (status IN ('ok','empty','parse_error')),
+    payload       JSONB,                     -- facts[] (facts) | insight delta (structured) | NULL (parse_error)
+    model         TEXT,                      -- ┐ mirror chat_messages.{model, usage,
+    usage         JSONB,                     -- ┤ generation_id} (migration 0012)
+    generation_id TEXT,                      -- ┘
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_companion_insights_events_user_time
+    ON engine.companion_insights_events (user_id, created_at DESC);
+CREATE INDEX idx_companion_insights_events_run
+    ON engine.companion_insights_events (run_id);
+
+-- Supabase lockdown, mirroring 0021_companion_insights_snapshot.sql.
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
+        REVOKE ALL ON engine.companion_insights_events FROM anon;
+    END IF;
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+        REVOKE ALL ON engine.companion_insights_events FROM authenticated;
+    END IF;
+END
+$$;
+
+ALTER TABLE engine.companion_insights_events ENABLE ROW LEVEL SECURITY;
+```
+
+Notes:
+- **No FK on `user_id`** (deliberate): a run whose `facts` call returns `{"facts":[]}`
+  writes a `stage='facts', status='empty'` row even though no `InsightRepo::merge`
+  happened, so a `companion_insights` row may not exist yet — a FK to
+  `companion_insights(user_id)` would violate. This table is a decoupled audit log.
+  (Contrast `companion_affinity_events`, which FKs to `companion_affinity` because that
+  parent row always exists before an event.) `session_id` / `message_id` are likewise
+  plain UUIDs for tracing, no FK.
+- `payload` for `stage='structured'` is the **returned schema-fill delta** (the object
+  `extract_structured_insights` parsed), not the post-merge `companion_insights` state.
+- `status`: `ok` (non-empty parsed output), `empty` (parsed but no content — `{"facts":[]}`
+  / `{}`), `parse_error` (response did not parse; `payload` is `NULL`).
+
+### 2b. `companion_affinity_events` ALTER (item 2 on the existing table)
+
+```sql
+ALTER TABLE engine.companion_affinity_events
+    ADD COLUMN model         TEXT,
+    ADD COLUMN usage         JSONB,
+    ADD COLUMN generation_id TEXT;
+```
+
+All nullable; no backfill. Pre-migration rows keep `NULL` in the three new columns.
+
+---
+
+## 3. Call-site wiring
+
+### 3a. `run_id`
+
+Generate `let run_id = Uuid::new_v4();` once at the top of `extract_insights`
+(`post_process.rs` @ ~L518) and thread it into both the `facts` and `structured` event
+writes so both rows of the run share it.
+
+### 3b. Affinity (`companion_affinity_events`)
+
+`evaluate_affinity` (`post_process.rs` @ ~L464-513) already holds the `ChatResponse`
+(`resp`, @ ~L492) whose `generation_id` / `model` / `usage` fields exist on the struct
+(`crates/eros-engine-llm/src/openrouter.rs` @ ~L100-114). Thread the trio into
+`persist_with_event` / `persist_affinity` (`affinity.rs` @ ~L190-273) and bind them into
+the **existing** `INSERT INTO engine.companion_affinity_events (...)` (@ ~L255-266). The
+trio rides the insert affinity already performs — no new statement, no new failure point.
+
+### 3c. Insights (`companion_insights_events`)
+
+After each `execute` in `extract_facts` (@ ~L578-618) and `extract_structured_insights`
+(@ ~L643-693), capture the `ChatResponse` trio, compute `status`, and write one
+`companion_insights_events` row via a new store method (e.g.
+`InsightEventRepo::record(&self, ev: InsightEventInsert)` in
+`crates/eros-engine-store/src/`, or a method on the existing `InsightRepo`):
+
+- **`facts` row:** `stage='facts'`, `payload = <the facts JSON array>`,
+  `status = ok | empty | parse_error`.
+- **`structured` row:** `stage='structured'`, `payload = <the returned insight delta
+  object>`, `status` likewise.
+
+`run_id` / `user_id` / `session_id` / `message_id` (the produced assistant message) come
+from the `extract_insights` call-site context. The `structured` call only runs when the
+`facts` stage produced facts; a run can therefore legitimately write **one** row (facts,
+empty) or **two** rows (facts + structured).
+
+### 3d. Status mapping
+
+| Call outcome | `status` | `payload` |
+|---|---|---|
+| parsed, non-empty | `ok` | the parsed facts[] / delta object |
+| parsed, empty (`{"facts":[]}` / `{}`) | `empty` | the empty array / object |
+| response did not parse | `parse_error` | `NULL` |
+| no response (network / 4xx) | — (logged only, no row) | — |
+
+---
+
+## 4. Error handling — fail-open
+
+Writing a `companion_insights_events` row is **best-effort**: an insert failure must
+**never** break the reply or the extraction path — log a `tracing::warn!` and continue,
+matching the existing post-process fail-open posture (extraction is already wrapped so a
+failure degrades silently). The affinity audit columns ride the existing affinity insert,
+so they add no new failure point.
+
+---
+
+## 5. Testing / verification
+
+- **Migration** applies cleanly; `companion_insights_events` exists with all columns +
+  indexes; `companion_affinity_events` has the three new columns.
+- **Store unit tests** (`#[sqlx::test]`): insert + read back a `companion_insights_events`
+  row for each `(stage, status)` combination, asserting `run_id` ties two rows; an
+  affinity persist test asserts the trio is stored on the affinity event row (extend an
+  existing affinity test or add one).
+- **Pipeline test** (mocked OpenRouter via wiremock): a normal `extract_insights` run
+  writes **2** rows (`facts` + `structured`) sharing one `run_id`, each with the served
+  `model` / `usage` / `generation_id`; an empty-facts run writes **1** row
+  (`stage='facts', status='empty'`) and no `structured` row.
+- **Gate:** `cargo fmt` / `clippy --workspace -D warnings` / `test --workspace`
+  (DB tests via `.test-env`). `openapi.json` unchanged (no DTO/route change — write-only
+  audit, no read surface).
+
+---
+
+## 6. Files touched
+
+- `crates/eros-engine-store/migrations/0025_insight_events_and_audit_cols.sql` — new
+  table + the affinity ALTER.
+- `crates/eros-engine-store/src/affinity.rs` — thread + bind the audit trio in
+  `persist_with_event`.
+- `crates/eros-engine-store/src/` (insights repo module) — new `InsightEventRepo` /
+  insert method + its types.
+- `crates/eros-engine-server/src/pipeline/post_process.rs` — generate `run_id`; capture
+  the `ChatResponse` trio in `extract_facts` / `extract_structured_insights` / affinity;
+  write the insight event rows; thread context (`user_id` / `session_id` / `message_id`).
+- Tests alongside the above.
+
+No change to `companion_insights`, `human_insights`, the extraction prompts, or
+`model_config` — all of that is Spec B2.


### PR DESCRIPTION
## Summary

Spec **B1** of the extraction-pipeline work — OpenRouter call auditing. Adds a durable, cost-faithful audit trail for the insight/affinity LLM calls.

- **Migration 0025:** new append-only `engine.companion_insights_events` — **one row per OpenRouter call** of `insight_extraction` (`run_id` ties the two calls of a run; `stage` ∈ {facts, structured}; `status` ∈ {ok, empty, parse_error}; `payload` JSONB; `model`/`usage`/`generation_id`). Plus `ALTER companion_affinity_events` to add the same `model`/`usage`/`generation_id` trio (nullable, no backfill). Supabase lockdown + RLS, mirroring `0021`.
- **Store:** shared `OpenRouterCallMeta { generation_id, model, usage }`; `InsightEventRepo::record`; `AffinityRepo::persist_with_event` gains an optional `meta` bound into its existing affinity-events INSERT.
- **Pipeline (`post_process`):** `evaluate_affinity` threads the trio into the affinity write; `extract_facts`/`extract_structured_insights` return `(data, Option<CallAudit>)`; `extract_insights` generates one `run_id` and writes one row per **returned** call (cost-faithful — empty/parse_error calls still get a row; transport errors do not), **fail-open** (an audit-row failure never aborts the turn).

## Design decisions
- **Per-call rows** (not per-run): each row carries exactly one clean `generation_id`/`model`/`usage`; `run_id` groups them.
- **No FK on `user_id`:** an empty-facts run writes a row before any `companion_insights` row exists, so a FK would violate. Decoupled audit log.
- The audit trio mirrors the existing `chat_messages.{model, usage, generation_id}` convention (migration 0012).

## Non-goals (deferred / out of scope)
No read API/BFF/dashboard (write-only audit); no backfill of old affinity rows; `memory_extraction` untouched; no `companion_insights`/`human_insights` schema or extraction-prompt changes — the geo-schema + attribution + config-driven-prompt work is **Spec B2**.

## Notes
- No `openapi.json` change (no DTO/route). One migration (0025).
- Spec: `docs/superpowers/specs/2026-06-03-insight-events-and-audit-columns-design.md`

## Test plan
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` — core 49 / llm 91 / server 246 / store 88, all pass (6 new tests: migration smoke, repo per-(stage,status) round-trip, affinity trio persistence, normal=2-rows/empty=1-row/parse_error=1-row pipeline)
- [x] `codex exec review --base dev` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)