### PR TITLE
feat: section-presence toggle for insight_extraction / memory_extraction

### DIFF
--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -860,6 +860,26 @@ impl ModelConfig {
             reasoning: m.reasoning,
         })
     }
+
+    /// Boot-time validation for the two extraction tasks. A task **section that
+    /// is present** must carry a usable `filter_prompt` (else `Err`); an
+    /// **absent section** means that extraction is simply off (`Ok`). Returns a
+    /// ready-to-print message naming the first misconfigured task.
+    ///
+    /// Scoped to `insight_extraction` / `memory_extraction` — the only tasks the
+    /// boot gate makes mandatory-when-present.
+    pub fn validate_extraction_prompts(&self) -> Result<(), String> {
+        for name in ["insight_extraction", "memory_extraction"] {
+            if self.tasks.contains_key(name) && self.resolve_extract(name).is_none() {
+                return Err(format!(
+                    "[tasks.{name}] is present but its filter_prompt is unset — eros-engine \
+                     refuses to boot. Set a filter_prompt, or remove the [tasks.{name}] \
+                     section to disable {name}."
+                ));
+            }
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -2418,5 +2438,67 @@ retry_depth = 0
         let r = cfg.resolve_insight_extract().expect("resolves");
         assert_eq!(r.retry_depth, 2);
         assert_eq!(r.fallback_model, vec!["f1".to_string(), "f2".to_string()]);
+    }
+
+    #[test]
+    fn validate_extraction_absent_sections_ok() {
+        // Neither extraction section present → both features off → Ok.
+        let toml = r#"
+[tasks.chat_companion]
+model = "m"
+"#;
+        let cfg = ModelConfig::from_toml_str(toml).unwrap();
+        assert!(cfg.validate_extraction_prompts().is_ok());
+    }
+
+    #[test]
+    fn validate_extraction_present_with_prompt_ok() {
+        let toml = r#"
+[tasks.insight_extraction]
+model = "m"
+filter_prompt = "extract facts"
+
+[tasks.memory_extraction]
+model = "m"
+filter_prompt = "extract memories"
+"#;
+        let cfg = ModelConfig::from_toml_str(toml).unwrap();
+        assert!(cfg.validate_extraction_prompts().is_ok());
+    }
+
+    #[test]
+    fn validate_extraction_present_without_prompt_errors() {
+        let toml = r#"
+[tasks.insight_extraction]
+model = "m"
+"#;
+        let cfg = ModelConfig::from_toml_str(toml).unwrap();
+        let err = cfg.validate_extraction_prompts().unwrap_err();
+        assert!(
+            err.contains("insight_extraction"),
+            "msg names the task: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_extraction_present_blank_prompt_errors() {
+        let toml = r#"
+[tasks.memory_extraction]
+model = "m"
+filter_prompt = "   "
+"#;
+        let cfg = ModelConfig::from_toml_str(toml).unwrap();
+        let err = cfg.validate_extraction_prompts().unwrap_err();
+        assert!(
+            err.contains("memory_extraction"),
+            "msg names the task: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_memory_extract_none_when_section_absent() {
+        // Guards the dreaming sweeper's early-return condition (a later task).
+        let cfg = ModelConfig::from_toml_str("[tasks.chat_companion]\nmodel = \"m\"\n").unwrap();
+        assert!(cfg.resolve_memory_extract().is_none());
     }
 }

--- a/crates/eros-engine-server/src/main.rs
+++ b/crates/eros-engine-server/src/main.rs
@@ -274,22 +274,14 @@ async fn run_server() -> Result<()> {
             .with_context(|| format!("model_config parse failed: {model_config_path}"))?,
     );
 
-    // Required extraction prompts (Spec B2). Unlike input/output/vision filters
-    // (which silently no-op when unset), the extraction prompts are mandatory:
-    // refuse to boot rather than silently run with no instruction. Mirrors the
-    // VOYAGE_API_KEY loud-fail above. Placed in the serve path only (the
-    // print-openapi / backfill subcommands return before reaching here).
-    if model_config.resolve_insight_extract().is_none() {
-        anyhow::bail!(
-            "insight_extraction filter_prompt is unset — eros-engine refuses to boot \
-             (the insight-extraction prompt is required; see examples/model_config.toml)"
-        );
-    }
-    if model_config.resolve_memory_extract().is_none() {
-        anyhow::bail!(
-            "memory_extraction filter_prompt is unset — eros-engine refuses to boot \
-             (the memory-extraction prompt is required; see examples/model_config.toml)"
-        );
+    // Extraction prompts are required ONLY when the task section exists. A
+    // missing [tasks.*_extraction] section means that extraction is off — the
+    // engine boots and runs without it. A present section with a blank/absent
+    // filter_prompt is a misconfiguration we refuse to boot on. Placed in the
+    // serve path only (the print-openapi / backfill subcommands return before
+    // reaching here).
+    if let Err(msg) = model_config.validate_extraction_prompts() {
+        anyhow::bail!(msg);
     }
 
     let state = AppState {
@@ -341,19 +333,17 @@ async fn run_server() -> Result<()> {
 mod tests {
     use eros_engine_llm::model_config::ModelConfig;
 
-    /// The committed example config is the dev/prod boot default; it MUST satisfy
-    /// the Spec B2 boot gate (both extraction prompts present), or `main` bails.
+    /// The committed example config is the dev/prod boot default; it MUST pass the
+    /// extraction boot gate (both sections present with non-blank filter_prompts),
+    /// or `main` bails.
     #[test]
     fn shipped_model_config_satisfies_extraction_boot_gate() {
         let text = include_str!("../../../examples/model_config.toml");
         let cfg = ModelConfig::from_toml_str(text).expect("examples/model_config.toml parses");
         assert!(
-            cfg.resolve_insight_extract().is_some(),
-            "insight_extraction filter_prompt must be set in examples/model_config.toml"
-        );
-        assert!(
-            cfg.resolve_memory_extract().is_some(),
-            "memory_extraction filter_prompt must be set in examples/model_config.toml"
+            cfg.validate_extraction_prompts().is_ok(),
+            "shipped config must pass the extraction boot gate: {:?}",
+            cfg.validate_extraction_prompts()
         );
     }
 }

--- a/crates/eros-engine-server/src/pipeline/dreaming.rs
+++ b/crates/eros-engine-server/src/pipeline/dreaming.rs
@@ -59,6 +59,14 @@ pub async fn sweeper(state: AppState) {
         tracing::info!("dreaming sweeper disabled (DREAMING_DISABLED=1 or tick=0)");
         return;
     }
+    // memory_extraction is omittable: a missing [tasks.memory_extraction] section
+    // (or a blank filter_prompt, which would have boot-failed) resolves to None.
+    // Post-boot, None ⟺ the section is absent ⟺ the feature is off — go inert so
+    // we never claim sessions and retry-loop the per-row no-stamp path.
+    if state.model_config.resolve_memory_extract().is_none() {
+        tracing::info!("memory_extraction not configured — dreaming sweeper inert");
+        return;
+    }
     tracing::info!(?interval, ?idle, ?claim_stale, "dreaming sweeper starting");
 
     let mut tick = tokio::time::interval(interval);

--- a/docs/model-config.md
+++ b/docs/model-config.md
@@ -239,6 +239,26 @@ A `[tasks.<name>]` entry is only meaningful if the engine actually calls `model_
 
 Anything else is either reserved for a future feature (`pde_decision`) or vestigial (`embedding` — Voyage doesn't go through this path).
 
+### Enabling / disabling extraction
+
+`insight_extraction` (per-turn fact mining) and `memory_extraction` (session-end
+dreaming sweeper) are controlled by the **presence of their `[tasks.*_extraction]`
+section**:
+
+- **Section present** → `filter_prompt` is **required**; the server refuses to boot
+  if it is blank or absent.
+- **Section absent** → that extraction is **off**. The engine boots and runs without
+  it (`insight_extraction` is skipped per turn; the dreaming sweeper stays inert).
+
+> **Behavior change (0.6.x):** earlier releases made both sections mandatory (an
+> absent section boot-failed). They are now optional-by-omission. The shipped
+> `examples/model_config.toml` keeps both sections, so the default — both
+> extractions on — is unchanged.
+
+`reasoning` works the same as on every task — omit it to let the model decide,
+`reasoning = { enabled = false }` to force reasoning off, `{ enabled = true }` to
+force it on.
+
 ## Resolution rules
 
 For `model` and `fallback`:

--- a/docs/model-config.zh.md
+++ b/docs/model-config.zh.md
@@ -67,6 +67,22 @@ allow_traits = ["tag_a"]                    # 可选,该 tier 覆盖任务级 al
 
 其它要么是给未来功能留的位置 (`pde_decision`),要么是 vestigial (`embedding` —— Voyage 完全不走这条路径)。
 
+### 开启 / 关闭抽取任务
+
+`insight_extraction`（逐轮事实抽取）和 `memory_extraction`（会话结束时的 dreaming
+sweeper）由对应 `[tasks.*_extraction]` **段落是否存在**控制：
+
+- **段落存在** → `filter_prompt` 为**必填**；为空或缺失时服务器拒绝启动。
+- **段落缺失** → 对应抽取**关闭**。引擎正常启动并运行（逐轮的 `insight_extraction`
+  被跳过；dreaming sweeper 保持空转不工作）。
+
+> **行为变更（0.6.x）：** 旧版本把这两个段落设为必填（缺段落会启动失败）。现在改为
+> 缺省即关闭。随仓库发布的 `examples/model_config.toml` 仍保留两个段落，所以默认行为
+> （两个抽取都开启）不变。
+
+`reasoning` 与其他任务一致：不写 → 由模型决定；`reasoning = { enabled = false }` →
+强制关闭推理；`{ enabled = true }` → 强制开启。
+
 ## 解析优先级
 
 `model` 和 `fallback`:

--- a/docs/superpowers/specs/2026-06-03-extraction-enable-disable-design.md
+++ b/docs/superpowers/specs/2026-06-03-extraction-enable-disable-design.md
@@ -1,0 +1,181 @@
+# eros-engine — section-presence toggle for `insight_extraction` / `memory_extraction`
+
+**Status**: design, pending implementation plan
+**Target release**: `0.6.x` dev track. **No migration.**
+**Scope**: let an operator turn `insight_extraction` and/or `memory_extraction` off by
+**omitting** the task section, while keeping today's "present ⇒ `filter_prompt` required"
+boot guarantee. No new config field, no schema relaxation. Reasoning control on extraction
+tasks already exists and is only documented here.
+
+---
+
+## 0. Background
+
+The OSS engine runs two LLM extraction tasks driven by `model_config.toml`:
+
+- **`insight_extraction`** (facts stage) — inline, per chat turn, in
+  `pipeline::post_process` (`post_process.rs:678`). Pulls structured user facts.
+- **`memory_extraction`** — background, via the dreaming-lite `sweeper`
+  (`pipeline::dreaming`, `dreaming.rs:170`). Classifies idle sessions into
+  `companion_memories` rows.
+
+Both read their system prompt from `filter_prompt` (Spec B2, PR #75) and are currently
+**mandatory**: the server refuses to boot if either section is missing or its `filter_prompt`
+is unset.
+
+### What this spec changes
+
+An operator may want to run the engine **without** one or both extraction tasks (cost,
+privacy, a deployment that does its own profiling). The switch is the **presence of the task
+section**:
+
+- **Section present** → `filter_prompt` is required; boot-fail if it is blank/absent (today's
+  behavior, now scoped to "when the section exists").
+- **Section absent** → the corresponding extraction feature is **off**; the engine boots and
+  runs without it (no error).
+
+This is a deliberate behavior change from Spec B2, where an absent section boot-failed. The
+shipped `examples/model_config.toml` keeps both sections (with prompts), so default behavior
+— both extractions on — is unchanged; only an operator who deletes a section turns it off.
+
+### The three original requirements, mapped
+
+1. **Disable an extraction task** — delete its `[tasks.*_extraction]` section. (No `enabled`
+   field; the earlier `enabled = true/false` design is dropped.)
+2. **When the section is present, `filter_prompt` is required or boot fails** — the existing
+   gate (`main.rs:282-293`), re-scoped to fire only when the section exists.
+3. **`reasoning = { enabled = false }` on extraction tasks** — **already implemented.** No
+   code change; documentation only. See §4.
+
+### Current state (verified)
+
+- **`TaskConfig`** (`model_config.rs:346-402`): `model: ModelSpec` is required; a generic
+  `reasoning: Option<ReasoningConfig>` (line 372) is inherited by every task. **Unchanged by
+  this spec** — no new field, `model` stays required (to enable a task you write a full
+  section; to disable you omit it, so there is no partial "disabled" section to support).
+- **`tasks`** is a public field (`pub tasks: HashMap<String, TaskConfig>`, line 409), so
+  section presence is observable as `model_config.tasks.contains_key(name)`.
+- **`resolve_extract(task)`** (`model_config.rs:846-862`) returns `None` when the section is
+  absent **or** `filter_prompt` is blank; otherwise builds `ResolvedExtract` (already carrying
+  `reasoning: m.reasoning`). **Unchanged by this spec.**
+- **Boot gate** (`main.rs:282-293`): currently `bail!` whenever `resolve_*_extract().is_none()`
+  — i.e. mandatory. This is what changes (§2).
+- **Call sites already forward reasoning** to the wire: `post_process.rs:701`,
+  `dreaming.rs:192`. Requirement 3 works end-to-end today.
+- **Disabled runtime paths**:
+  - `post_process.rs:678` — `let Some(resolved) = resolve_insight_extract() else { return
+    (vec![], None); }`. A `None` already skips cleanly; inline per turn, no retry concept.
+  - `dreaming.rs:170-175` — a `None` returns `Err(...)` which deliberately does **not** stamp
+    `classified_at`, so the row retries next tick. With `memory_extraction` now omittable, the
+    sweeper would otherwise retry forever — handled in §3.
+- **`sweeper`** (`dreaming.rs:54-74`) already early-returns when `dreaming_tick` is zero; the
+  "memory_extraction absent" early-return mirrors that guard.
+- **Tests**: `shipped_model_config_satisfies_extraction_boot_gate` (`main.rs:346`) asserts the
+  shipped config resolves both extractions — stays green (shipped config keeps both sections).
+  `compat_fixture_locks_full_schema` (`model_config.rs:1182`) — unaffected (no schema change).
+
+---
+
+## 1. Schema — no change
+
+No new field. `model` stays required. The only "config surface" change is **semantic**: a
+missing `[tasks.insight_extraction]` or `[tasks.memory_extraction]` section is now valid and
+means "feature off," rather than a boot error.
+
+## 2. Boot gate (`main.rs`) — requirement 1 + 2
+
+Replace the unconditional gate with a presence-scoped one:
+
+```rust
+// Extraction prompts are required ONLY when the task section exists. A missing
+// section now means "this extraction is off" (boots fine). A present section
+// with no usable filter_prompt is a misconfiguration → refuse to boot.
+for name in ["insight_extraction", "memory_extraction"] {
+    if model_config.tasks.contains_key(name) && resolve_extract_by_name(name).is_none() {
+        anyhow::bail!(
+            "[tasks.{name}] is present but its filter_prompt is unset — eros-engine refuses \
+             to boot. Set a filter_prompt in {model_config_path}, or remove the \
+             [tasks.{name}] section to disable {name}."
+        );
+    }
+}
+```
+
+`resolve_extract_by_name` is the existing `resolve_insight_extract()` / `resolve_memory_extract()`
+pair (inlined, or a tiny `match`). Truth table per task:
+
+| `[tasks.X]` section | `filter_prompt` | `contains_key` | `resolve.is_none()` | Result |
+|---|---|---|---|---|
+| present | set | true | false | **on** |
+| present | blank/absent | true | true | **boot error** |
+| absent | — | false | true | **off** (gate skipped) |
+
+Because the bail is guarded by `contains_key`, the only way to reach it is a present section
+whose `resolve` is `None`, which (section present) can only be a blank/absent `filter_prompt`.
+
+## 3. Runtime when off
+
+- **`insight_extraction`** (`post_process.rs`): no change. Absent section ⇒
+  `resolve_insight_extract()` → `None` → existing `return (vec![], None)`.
+- **`memory_extraction`** (`dreaming::sweeper`): add an early-return at sweeper start, after
+  the existing `interval.is_zero()` guard:
+
+  ```rust
+  if state.model_config.resolve_memory_extract().is_none() {
+      tracing::info!("memory_extraction not configured — dreaming sweeper inert");
+      return;
+  }
+  ```
+
+  Safe and unambiguous: post-boot, `resolve_memory_extract().is_none()` ⟺ the section is
+  absent (a present-but-blank section would have failed the boot gate). The sweeper never
+  claims rows, so the per-row `Err`-no-stamp path (which stays a pure defensive guard) can't
+  loop. Sessions keep `classified_at = NULL`; re-adding the section later makes them eligible
+  again.
+
+## 4. Reasoning (requirement 3) — documentation only
+
+Already works: `TaskConfig.reasoning` is parsed, `resolve_extract` forwards it, and both call
+sites pass it to the OpenRouter request. Three states:
+
+```toml
+# (reasoning omitted)            → param omitted, model's own default  ← default (Q1: option A)
+reasoning = { enabled = true }   → force reasoning on
+reasoning = { enabled = false }  → force reasoning off
+```
+
+No code change. `examples/model_config.toml` gets a commented `# reasoning = { enabled =
+false }` on both extraction tasks; docs describe the three states.
+
+## 5. Docs + examples
+
+- **`examples/model_config.toml`**: keep both extraction sections (default = on). Add a short
+  comment on each — "remove this section to disable; `filter_prompt` is required while it is
+  present" — plus a commented `# reasoning = { enabled = false }`.
+- **`docs/model-config.md`** + **`docs/model-config.zh.md`** (new insertions in 简体中文 per the
+  zh-doc convention): document the section-presence rule (present ⇒ `filter_prompt` required,
+  boot-fail otherwise; absent ⇒ feature off), call out that this changed from the previous
+  mandatory behavior, and document the reasoning three-state.
+
+## 6. Testing
+
+Boot gate (`main.rs` tests, or a `ModelConfig`-level validation helper if extracted):
+- Section present + `filter_prompt` set ⇒ gate passes.
+- Section present + blank/absent `filter_prompt` ⇒ gate trips (assert via `contains_key &&
+  resolve.is_none()`).
+- Section **absent** ⇒ gate passes (feature off) — the key new case.
+- `shipped_model_config_satisfies_extraction_boot_gate` stays green.
+
+Resolve (`model_config.rs`): existing `resolve_*_extract()` behavior is unchanged; add/keep a
+test that an absent section ⇒ `None` and a present+prompt section ⇒ `Some`.
+
+Sweeper: a focused test that `resolve_memory_extract()` is `None` when the section is absent
+(the early-return condition); a full sweeper-inert integration test only if it fits the
+existing dreaming harness without a live DB.
+
+## 7. Out of scope / non-goals
+
+- No `enabled` field, no per-task generic enable/disable, no `model`-optional relaxation
+  (all dropped from the earlier draft of this spec).
+- No change to reasoning forwarding (already done).
+- No migration, API surface, or OpenAPI change.

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -184,8 +184,13 @@ model = "anthropic/claude-haiku-4.5"
 fallback = ["deepseek/deepseek-v4-flash","google/gemini-3.1-flash-lite"]
 temperature = 0.2
 max_tokens = 400
+# Remove this entire [tasks.insight_extraction] section to disable per-turn fact
+# extraction. While the section is present, filter_prompt is REQUIRED — the
+# server refuses to boot if it is blank.
+# Optional: force the extraction model's reasoning off (default = model decides).
+#reasoning = { enabled = false }
 # Facts-stage system instruction. The server sends the turn ("用户: …\nAI: …")
-# as a separate user message. REQUIRED — the server refuses to boot if blank.
+# as a separate user message.
 filter_prompt = """
 你是事实提取器，只分析【真人用户】，从这一轮对话中提取关于用户的新事实发现。
 
@@ -208,8 +213,13 @@ model = "anthropic/claude-haiku-4.5"
 fallback = ["deepseek/deepseek-v4-flash","google/gemini-3.1-flash-lite"]
 temperature = 0.2
 max_tokens = 800
+# Remove this entire [tasks.memory_extraction] section to disable session-end
+# memory extraction (the dreaming sweeper then stays inert). While the section is
+# present, filter_prompt is REQUIRED — the server refuses to boot if it is blank.
+# Optional: force the extraction model's reasoning off (default = model decides).
+#reasoning = { enabled = false }
 # Memory-extraction system instruction. The server sends the conversation
-# (用户：X / AI：Y lines) as a separate user message. REQUIRED — boot fails if blank.
+# (用户：X / AI：Y lines) as a separate user message.
 filter_prompt = """
 你从一段已结束的对话中，提取 0-10 条值得长期记住的、关于【真人用户】的记忆条目，每条带一个 category 标签。
 


### PR DESCRIPTION
Implements `docs/superpowers/specs/2026-06-03-extraction-enable-disable-design.md`.

## What
Disable an extraction task by **omitting** its `[tasks.*_extraction]` section in `model_config.toml`:

| `[tasks.X_extraction]` | `filter_prompt` | Result |
|---|---|---|
| present | set | **on** |
| present | blank/absent | **boot-fail** |
| absent | — | **off** (no error) |

- **`validate_extraction_prompts()`** (`model_config.rs`) — present section ⇒ `filter_prompt` required; absent ⇒ off. Unit-tested (no DB).
- **Boot gate** (`main.rs`) — replaces the old *unconditional* gate; bails only on present-but-blank.
- **Dreaming sweeper** (`dreaming.rs`) — goes inert when `memory_extraction` is absent, so it never claims sessions / retry-loops.
- **`insight_extraction`** path already skips cleanly on `None` — no change.
- **Reasoning** on extraction tasks already worked end-to-end — documented only (omit / `{enabled=true}` / `{enabled=false}`).

**No new config field, no schema change** (`model` stays required). `reasoning` is unchanged.

## ⚠️ Behavior change (0.6.x)
Earlier releases made both sections mandatory (an absent section boot-failed). They are now optional-by-omission. The shipped `examples/model_config.toml` keeps both sections, so the **default — both extractions on — is unchanged**.

## Verification (local)
- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test -p eros-engine-llm --lib` ✓ 101/101 (incl. 5 new)
- server boot-gate test ✓; OpenAPI snapshot ✓ no drift
- (DB-backed integration tests run in CI)

Built via subagent-driven execution with per-task spec + code-quality review and a final comprehensive review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)