### PR TITLE
chore(server): mark eros-engine-server publish = false

### DIFF
--- a/crates/eros-engine-server/Cargo.toml
+++ b/crates/eros-engine-server/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+# Binary crate — distributed as the GHCR image, NOT a crates.io library.
+# `cargo publish` (workspace or `-p eros-engine-server`) refuses it outright.
+publish = false
 
 [[bin]]
 name = "eros-engine"


### PR DESCRIPTION
`eros-engine-server` is the **binary crate** — distributed as the GHCR image, never published to crates.io (only `eros-engine-core` / `-llm` / `-store` are). It also has no `description`, so a publish would fail anyway — but this makes the intent explicit and enforced: `cargo publish` (workspace or `-p eros-engine-server`) now refuses it outright instead of relying on the operator remembering to skip it.

Verified: `cargo publish -p eros-engine-server --dry-run` → `error: eros-engine-server cannot be published`. Build + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)