### PR TITLE
feat(pde): persona injection + structured output (audit 22 §6)

### DIFF
--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -416,6 +416,11 @@ pub struct TaskConfig {
     /// (other tasks ignore it), like `input_filter`/`dimensions`.
     #[serde(default)]
     pub ghosting: Option<bool>,
+    /// PDE-only: send `response_format = json_schema` on the judge request to
+    /// raise JSON adherence. Absent/`true` ⇒ on; `false` ⇒ off (escape hatch for
+    /// a provider that rejects the param). Read only on `[tasks.pde_decision]`.
+    #[serde(default)]
+    pub structured_output: Option<bool>,
     /// Per-tier overrides keyed by tier name. Empty for tasks that don't tier.
     #[serde(default)]
     pub tiers: HashMap<String, TierConfig>,
@@ -580,6 +585,7 @@ pub struct ResolvedPde {
     pub decision_prompt: String,
     pub retry_depth: u32,
     pub reasoning: Option<ReasoningConfig>,
+    pub structured_output: bool,
 }
 
 /// Resolved extraction task (`insight_extraction` facts stage / `memory_extraction`).
@@ -899,6 +905,7 @@ impl ModelConfig {
             decision_prompt,
             retry_depth,
             reasoning: task_cfg.reasoning.clone(),
+            structured_output: task_cfg.structured_output.unwrap_or(true),
         })
     }
 
@@ -1267,8 +1274,9 @@ model         = "x-ai/grok-4-mini"
 temperature   = 0.5
 max_tokens    = 200
 description   = "LLM decision layer"
-filter_prompt = "Decide the action and inner_state."
-ghosting      = false
+filter_prompt    = "Decide the action and inner_state."
+ghosting         = false
+structured_output = true
 
 [tasks.embedding]
 model        = "voyage-3-lite"
@@ -2632,6 +2640,20 @@ filter_prompt = "   "
         let p = cfg.resolve_pde().expect("resolves");
         assert_eq!(p.model, "m");
         assert_eq!(p.decision_prompt, "decide");
+    }
+
+    #[test]
+    fn resolve_pde_structured_output_default_true_else_field() {
+        // absent → true
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.pde_decision]\nmodel = \"m\"\nfilter_prompt = \"d\"\n",
+        ).unwrap();
+        assert!(cfg.resolve_pde().unwrap().structured_output);
+        // explicit false → false
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.pde_decision]\nmodel = \"m\"\nfilter_prompt = \"d\"\nstructured_output = false\n",
+        ).unwrap();
+        assert!(!cfg.resolve_pde().unwrap().structured_output);
     }
 
     #[test]

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -2647,7 +2647,8 @@ filter_prompt = "   "
         // absent → true
         let cfg = ModelConfig::from_toml_str(
             "[tasks.pde_decision]\nmodel = \"m\"\nfilter_prompt = \"d\"\n",
-        ).unwrap();
+        )
+        .unwrap();
         assert!(cfg.resolve_pde().unwrap().structured_output);
         // explicit false → false
         let cfg = ModelConfig::from_toml_str(

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -55,6 +55,9 @@ pub struct ChatRequest {
     /// Reasoning config forwarded to OpenRouter. `None` → omit the param;
     /// `Some(cfg)` → send the `reasoning` object verbatim.
     pub reasoning: Option<ReasoningConfig>,
+    /// PDE-only: OpenRouter `response_format` (e.g. a json_schema object).
+    /// `None` ⇒ omitted. Opaque passthrough; the caller builds the schema.
+    pub response_format: Option<serde_json::Value>,
 }
 
 /// One-shot multimodal *describe* request. Used only by the `chat_vision`
@@ -155,6 +158,8 @@ struct WireRequest<'a> {
     reasoning: Option<&'a ReasoningConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     provider: Option<ProviderPrefs<'a>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    response_format: Option<&'a serde_json::Value>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -404,6 +409,7 @@ impl OpenRouterClient {
                     req.session_id.as_deref(),
                     req.metadata.as_ref(),
                     req.reasoning.as_ref(),
+                    req.response_format.as_ref(),
                 )
                 .await
             {
@@ -601,6 +607,7 @@ impl OpenRouterClient {
         req_session_id: Option<&str>,
         req_metadata: Option<&serde_json::Map<String, serde_json::Value>>,
         req_reasoning: Option<&ReasoningConfig>,
+        req_response_format: Option<&serde_json::Value>,
     ) -> Result<ChatResponse, LlmError> {
         if self.api_key.is_empty() {
             return Err(LlmError::Config("openrouter: api key not set".into()));
@@ -620,6 +627,7 @@ impl OpenRouterClient {
             metadata: req_metadata,
             reasoning: req_reasoning,
             provider: self.provider_prefs(),
+            response_format: req_response_format,
         };
 
         let resp = self
@@ -697,6 +705,7 @@ impl OpenRouterClient {
             metadata: req.metadata.as_ref(),
             reasoning: req.reasoning.as_ref(),
             provider: self.provider_prefs(),
+            response_format: None,
         };
 
         let resp = self
@@ -976,6 +985,7 @@ mod tests {
             metadata: req.metadata.as_ref(),
             reasoning: None,
             provider: None,
+            response_format: None,
         };
         let s = serde_json::to_string(&wire).unwrap();
         assert!(!s.contains("\"user\":"), "user key must be absent: {s}");
@@ -1020,6 +1030,7 @@ mod tests {
             metadata: req.metadata.as_ref(),
             reasoning: None,
             provider: None,
+            response_format: None,
         };
         let s = serde_json::to_string(&wire).unwrap();
         assert!(s.contains("\"user\":\"u_abc\""), "{s}");
@@ -1545,6 +1556,7 @@ data: [DONE]\n\n";
             metadata: None,
             reasoning: Some(&cfg),
             provider: None,
+            response_format: None,
         };
         let s = serde_json::to_string(&wire).unwrap();
         assert!(
@@ -1567,6 +1579,7 @@ data: [DONE]\n\n";
             metadata: None,
             reasoning: None,
             provider: None,
+            response_format: None,
         };
         let s_none = serde_json::to_string(&wire_none).unwrap();
         assert!(
@@ -1616,6 +1629,31 @@ data: [DONE]\n\n";
     }
 
     #[test]
+    fn wire_request_serializes_response_format_only_when_present() {
+        let messages: Vec<ChatMessage> = vec![];
+        let rf = serde_json::json!({"type": "json_schema"});
+        let wire = WireRequest {
+            model: "m", messages: &messages, temperature: 0.0,
+            top_p: None, frequency_penalty: None, presence_penalty: None,
+            max_tokens: 16, stream: false, user: None, session_id: None,
+            metadata: None, reasoning: None, provider: None,
+            response_format: Some(&rf),
+        };
+        let s = serde_json::to_string(&wire).unwrap();
+        assert!(s.contains("\"response_format\":{\"type\":\"json_schema\"}"), "{s}");
+
+        let wire_none = WireRequest {
+            model: "m", messages: &messages, temperature: 0.0,
+            top_p: None, frequency_penalty: None, presence_penalty: None,
+            max_tokens: 16, stream: false, user: None, session_id: None,
+            metadata: None, reasoning: None, provider: None,
+            response_format: None,
+        };
+        let s_none = serde_json::to_string(&wire_none).unwrap();
+        assert!(!s_none.contains("response_format"), "absent ⇒ omitted: {s_none}");
+    }
+
+    #[test]
     fn wire_request_omits_provider_when_no_ignore_list() {
         let wire = WireRequest {
             model: "x/y",
@@ -1631,6 +1669,7 @@ data: [DONE]\n\n";
             metadata: None,
             reasoning: None,
             provider: None,
+            response_format: None,
         };
         let body = serde_json::to_value(&wire).unwrap();
         assert!(
@@ -1656,6 +1695,7 @@ data: [DONE]\n\n";
             metadata: None,
             reasoning: None,
             provider: Some(ProviderPrefs { ignore: &ignore }),
+            response_format: None,
         };
         let body = serde_json::to_value(&wire).unwrap();
         assert_eq!(body["provider"]["ignore"][0], "BadHost");
@@ -1983,6 +2023,7 @@ data: [DONE]\n\n";
             metadata: None,
             reasoning: None,
             provider: None,
+            response_format: None,
         };
         let s = serde_json::to_string(&wire).unwrap();
         assert!(s.contains("\"top_p\":0.9"), "{s}");
@@ -2010,6 +2051,7 @@ data: [DONE]\n\n";
             metadata: None,
             reasoning: None,
             provider: None,
+            response_format: None,
         };
         let s = serde_json::to_string(&wire).unwrap();
         assert!(!s.contains("top_p"), "unset top_p must be omitted: {s}");

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -1633,24 +1633,48 @@ data: [DONE]\n\n";
         let messages: Vec<ChatMessage> = vec![];
         let rf = serde_json::json!({"type": "json_schema"});
         let wire = WireRequest {
-            model: "m", messages: &messages, temperature: 0.0,
-            top_p: None, frequency_penalty: None, presence_penalty: None,
-            max_tokens: 16, stream: false, user: None, session_id: None,
-            metadata: None, reasoning: None, provider: None,
+            model: "m",
+            messages: &messages,
+            temperature: 0.0,
+            top_p: None,
+            frequency_penalty: None,
+            presence_penalty: None,
+            max_tokens: 16,
+            stream: false,
+            user: None,
+            session_id: None,
+            metadata: None,
+            reasoning: None,
+            provider: None,
             response_format: Some(&rf),
         };
         let s = serde_json::to_string(&wire).unwrap();
-        assert!(s.contains("\"response_format\":{\"type\":\"json_schema\"}"), "{s}");
+        assert!(
+            s.contains("\"response_format\":{\"type\":\"json_schema\"}"),
+            "{s}"
+        );
 
         let wire_none = WireRequest {
-            model: "m", messages: &messages, temperature: 0.0,
-            top_p: None, frequency_penalty: None, presence_penalty: None,
-            max_tokens: 16, stream: false, user: None, session_id: None,
-            metadata: None, reasoning: None, provider: None,
+            model: "m",
+            messages: &messages,
+            temperature: 0.0,
+            top_p: None,
+            frequency_penalty: None,
+            presence_penalty: None,
+            max_tokens: 16,
+            stream: false,
+            user: None,
+            session_id: None,
+            metadata: None,
+            reasoning: None,
+            provider: None,
             response_format: None,
         };
         let s_none = serde_json::to_string(&wire_none).unwrap();
-        assert!(!s_none.contains("response_format"), "absent ⇒ omitted: {s_none}");
+        assert!(
+            !s_none.contains("response_format"),
+            "absent ⇒ omitted: {s_none}"
+        );
     }
 
     #[test]

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -215,6 +215,7 @@ fn assemble_chat_request(
         session_id: audit_session,
         metadata: audit_metadata,
         reasoning: resolved.reasoning,
+        ..Default::default()
     }
 }
 

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -1122,6 +1122,56 @@ fn apply_ghosting_killswitch(
     }
 }
 
+/// Build a compact persona disposition block for the PDE judge from EXISTING
+/// genome fields. Blank fields are omitted; an all-empty persona yields "".
+/// Deliberately excludes `system_prompt` (long; would re-import the chat prompt's
+/// framing into the judge) and `topics` (irrelevant to disposition).
+fn build_persona_brief(persona: &eros_engine_core::persona::CompanionPersona) -> String {
+    use crate::prompt::{meta_i32, meta_str, meta_string_array_joined};
+    let name = persona.genome.name.trim();
+
+    let mut bits: Vec<String> = Vec::new();
+    if let Some(g) = meta_str(persona, "gender").map(str::trim).filter(|s| !s.is_empty()) {
+        bits.push(g.to_string());
+    }
+    if let Some(a) = meta_i32(persona, "age") {
+        bits.push(format!("{a}岁"));
+    }
+    if let Some(m) = meta_str(persona, "mbti").map(str::trim).filter(|s| !s.is_empty()) {
+        bits.push(m.to_string());
+    }
+
+    let mut lines: Vec<String> = Vec::new();
+    let head = match (name.is_empty(), bits.is_empty()) {
+        (true, true) => String::new(),
+        (true, false) => format!("[角色人格] {}", bits.join("，")),
+        (false, true) => format!("[角色人格] {name}"),
+        (false, false) => format!("[角色人格] {name}，{}", bits.join("，")),
+    };
+    if !head.is_empty() {
+        lines.push(head);
+    }
+    if let Some(ss) = meta_str(persona, "speech_style").map(str::trim).filter(|s| !s.is_empty()) {
+        lines.push(format!("说话风格：{ss}"));
+    }
+    if let Some(q) = meta_string_array_joined(persona, "quirks")
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+    {
+        lines.push(format!("口癖：{q}"));
+    }
+    if let Some(tp) = persona
+        .genome
+        .tip_personality
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        lines.push(format!("打赏人格：{tp}"));
+    }
+    lines.join("\n")
+}
+
 /// Build the judge's user payload from the shared transcript + the decision input.
 fn build_pde_ctx(transcript: &str, input: &eros_engine_core::types::DecisionInput) -> String {
     let a = &input.affinity;
@@ -1135,8 +1185,14 @@ fn build_pde_ctx(transcript: &str, input: &eros_engine_core::types::DecisionInpu
     } else {
         transcript
     };
+    let brief = build_persona_brief(&input.persona);
+    let persona_block = if brief.is_empty() {
+        String::new()
+    } else {
+        format!("{brief}\n\n")
+    };
     format!(
-        "[最近对话]\n{transcript}\n\n\
+        "{persona_block}[最近对话]\n{transcript}\n\n\
          [关系状态] warmth={:.2} trust={:.2} intrigue={:.2} intimacy={:.2} patience={:.2} tension={:.2}\n\
          [信号] message_count={} hours_since_last_message={:.1} ghost_streak={} hours_since_last_ghost={}\n\n\
          [用户最新消息]\n{latest}",
@@ -5815,5 +5871,111 @@ data: [DONE]\n\n";
             produced[0].full_text, "Hi there\nbye",
             "the retained primary garble must be repaired and salvaged despite the failed fallback",
         );
+    }
+
+    // ── Task-1: compact persona brief in PDE ctx ───────────────────────────
+
+    fn test_persona() -> eros_engine_core::persona::CompanionPersona {
+        pde_test_persona()
+    }
+
+    fn test_affinity() -> eros_engine_core::affinity::Affinity {
+        pde_test_affinity()
+    }
+
+    fn test_signals() -> eros_engine_core::types::ConversationSignals {
+        eros_engine_core::types::ConversationSignals {
+            message_count: 10,
+            hours_since_last_message: 1.0,
+            ghost_streak: 0,
+            hours_since_last_ghost: None,
+        }
+    }
+
+    #[test]
+    fn persona_brief_renders_all_fields() {
+        let mut p = test_persona(); // name = "Mia"
+        p.genome.art_metadata = serde_json::json!({
+            "gender": "女", "age": 22, "mbti": "INFP",
+            "speech_style": "软糯爱撒娇", "quirks": ["摸头杀", "突然沉默"]
+        });
+        p.genome.tip_personality = Some("傲娇".into());
+        let b = build_persona_brief(&p);
+        assert!(b.starts_with("[角色人格] Mia，女，22岁，INFP"), "{b}");
+        assert!(b.contains("说话风格：软糯爱撒娇"), "{b}");
+        assert!(b.contains("口癖：摸头杀、突然沉默"), "{b}");
+        assert!(b.contains("打赏人格：傲娇"), "{b}");
+    }
+
+    #[test]
+    fn persona_brief_omits_blank_fields() {
+        let mut p = test_persona(); // name = "Mia"
+        p.genome.art_metadata = serde_json::json!({}); // no gender/age/mbti/...
+        p.genome.tip_personality = None;
+        let b = build_persona_brief(&p);
+        assert_eq!(b, "[角色人格] Mia", "only name renders: {b}");
+    }
+
+    #[test]
+    fn persona_brief_empty_when_no_signal() {
+        let mut p = test_persona();
+        p.genome.name = "".into();
+        p.genome.art_metadata = serde_json::json!({});
+        p.genome.tip_personality = None;
+        assert_eq!(build_persona_brief(&p), "");
+    }
+
+    #[test]
+    fn pde_ctx_renders_persona_block_at_top() {
+        use eros_engine_core::types::{DecisionInput, Event};
+        let mut p = test_persona();
+        p.genome.art_metadata = serde_json::json!({"mbti": "INFP"});
+        let input = DecisionInput {
+            event: Event::UserMessage {
+                content: "在吗".into(),
+                message_id: Uuid::new_v4(),
+                prompt_traits: vec![],
+                audit: None,
+                tier: None,
+                memory_scope: Default::default(),
+                affinity_scope: Default::default(),
+                tips_amount_usd: None,
+            },
+            affinity: test_affinity(),
+            persona: p,
+            signals: test_signals(),
+        };
+        let ctx = build_pde_ctx("用户：hi\nMia：hey", &input);
+        let persona_at = ctx.find("[角色人格]").expect("persona block present");
+        let rel_at = ctx.find("[关系状态]").expect("relationship block present");
+        assert!(persona_at < rel_at, "persona must precede relationship: {ctx}");
+        assert!(ctx.starts_with("[角色人格]"), "persona block at top: {ctx}");
+    }
+
+    #[test]
+    fn pde_ctx_omits_persona_block_when_empty() {
+        use eros_engine_core::types::{DecisionInput, Event};
+        let mut p = test_persona();
+        p.genome.name = "".into();
+        p.genome.art_metadata = serde_json::json!({});
+        p.genome.tip_personality = None;
+        let input = DecisionInput {
+            event: Event::UserMessage {
+                content: "x".into(),
+                message_id: Uuid::new_v4(),
+                prompt_traits: vec![],
+                audit: None,
+                tier: None,
+                memory_scope: Default::default(),
+                affinity_scope: Default::default(),
+                tips_amount_usd: None,
+            },
+            affinity: test_affinity(),
+            persona: p,
+            signals: test_signals(),
+        };
+        let ctx = build_pde_ctx("", &input);
+        assert!(!ctx.contains("[角色人格]"), "no persona block: {ctx}");
+        assert!(ctx.starts_with("[最近对话]"), "ctx starts with transcript block: {ctx}");
     }
 }

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -991,13 +991,38 @@ pub(crate) struct PdeDecisionRun {
     pub(crate) generation_id: Option<String>,
 }
 
+/// OpenRouter `response_format` for the PDE verdict (json_schema, strict). The
+/// optional verdict fields are nullable so a strict provider returns `null`,
+/// which deserializes to `PdeVerdict`'s `Option` fields as `None`.
+fn pde_response_format() -> serde_json::Value {
+    serde_json::json!({
+        "type": "json_schema",
+        "json_schema": {
+            "name": "pde_verdict",
+            "strict": true,
+            "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["action", "inner_state", "image_prompt", "reason"],
+                "properties": {
+                    "action": { "type": "string",
+                        "enum": ["reply_text", "ghost", "reply_image", "reply_text_image"] },
+                    "inner_state": { "type": "string" },
+                    "image_prompt": { "type": ["string", "null"] },
+                    "reason": { "type": ["string", "null"] }
+                }
+            }
+        }
+    })
+}
+
 /// Run the PDE judge over the assembled context. Walks `[model] + fallback`
-/// trying the next model on a transport failure (error/timeout/empty); a
-/// content-level reply that won't parse is a definitive `ParseError` (no further
-/// walk), mirroring `run_input_filter`. Fail-open: any non-`Ok` status → the
-/// caller uses the rule fallback. NEVER returns an error — always a run record.
+/// trying the next model on a transport failure (error/timeout/empty) or a
+/// parse error; a chain-exhausted ParseError preserves the last attempt's raw
+/// text + audit trio. Fail-open: any non-`Ok` status → the caller uses the
+/// rule fallback. NEVER returns an error — always a run record.
 async fn run_pde_decision(
-    state: &AppState,
+    client: &eros_engine_llm::openrouter::OpenRouterClient,
     p: &eros_engine_llm::model_config::ResolvedPde,
     ctx: &str,
 ) -> PdeDecisionRun {
@@ -1006,6 +1031,10 @@ async fn run_pde_decision(
         .chain(p.fallback_model.iter().cloned())
         .collect();
     let mut last = PdeStatus::Error; // chain-exhausted default
+    // On a content-level reply that won't parse, keep the LAST attempt's text +
+    // audit trio so the chain-exhausted ParseError return stays faithful.
+    let mut last_parse: Option<(String, Option<String>, Option<serde_json::Value>, Option<String>)> = None;
+    let response_format = p.structured_output.then(pde_response_format);
     for model_id in &chain {
         let req = ChatRequest {
             model: model_id.clone(),
@@ -1023,9 +1052,10 @@ async fn run_pde_decision(
             temperature: p.temperature as f32,
             max_tokens: p.max_tokens,
             reasoning: p.reasoning.clone(),
+            response_format: response_format.clone(),
             ..Default::default()
         };
-        let resp = match tokio::time::timeout(FILTER_TIMEOUT, state.openrouter.execute(req)).await {
+        let resp = match tokio::time::timeout(FILTER_TIMEOUT, client.execute(req)).await {
             Ok(Ok(r)) => r,
             Ok(Err(e)) => {
                 tracing::warn!(model = %model_id, error = %e, "pde: model error; next");
@@ -1045,37 +1075,52 @@ async fn run_pde_decision(
             last = PdeStatus::Empty;
             continue;
         }
-        // Content-level reply — definitive, no further chain walk.
-        return match parse_pde_verdict(&text) {
-            Some(verdict) => PdeDecisionRun {
-                status: PdeStatus::Ok,
-                verdict: Some(verdict),
-                raw: None,
-                model: resp.model.or_else(|| Some(model_id.clone())),
-                usage: resp.usage,
-                generation_id: resp.generation_id,
-            },
-            None => {
-                tracing::warn!(model = %model_id, "pde: unparseable verdict; fallback to rule");
-                PdeDecisionRun {
-                    status: PdeStatus::ParseError,
-                    verdict: None,
-                    raw: Some(text),
+        match parse_pde_verdict(&text) {
+            Some(verdict) => {
+                return PdeDecisionRun {
+                    status: PdeStatus::Ok,
+                    verdict: Some(verdict),
+                    raw: None,
                     model: resp.model.or_else(|| Some(model_id.clone())),
                     usage: resp.usage,
                     generation_id: resp.generation_id,
-                }
+                };
             }
-        };
+            None => {
+                tracing::warn!(model = %model_id, "pde: unparseable verdict; trying next model");
+                last = PdeStatus::ParseError;
+                last_parse = Some((
+                    text,
+                    resp.model.or_else(|| Some(model_id.clone())),
+                    resp.usage,
+                    resp.generation_id,
+                ));
+                continue;
+            }
+        }
     }
-    // chain exhausted on transport failures
-    PdeDecisionRun {
-        status: last,
-        verdict: None,
-        raw: None,
-        model: None,
-        usage: None,
-        generation_id: None,
+    // chain exhausted
+    match last {
+        PdeStatus::ParseError => {
+            let (raw, model, usage, generation_id) =
+                last_parse.expect("ParseError ⇒ last_parse is set");
+            PdeDecisionRun {
+                status: PdeStatus::ParseError,
+                verdict: None,
+                raw: Some(raw),
+                model,
+                usage,
+                generation_id,
+            }
+        }
+        other => PdeDecisionRun {
+            status: other,
+            verdict: None,
+            raw: None,
+            model: None,
+            usage: None,
+            generation_id: None,
+        },
     }
 }
 
@@ -1848,7 +1893,7 @@ pub fn run_stream(
             match (is_tip, resolved_pde.as_ref()) {
                 (false, Some(p)) => {
                     let ctx = build_pde_ctx(&pde_transcript, &input);
-                    let run = run_pde_decision(&state, p, &ctx).await;
+                    let run = run_pde_decision(&state.openrouter, p, &ctx).await;
                     let plan = match (&run.status, &run.verdict) {
                         (PdeStatus::Ok, Some(v)) => {
                             let action = guard_action(v.action, &input.affinity, &input.signals);
@@ -5977,5 +6022,96 @@ data: [DONE]\n\n";
         let ctx = build_pde_ctx("", &input);
         assert!(!ctx.contains("[角色人格]"), "no persona block: {ctx}");
         assert!(ctx.starts_with("[最近对话]"), "ctx starts with transcript block: {ctx}");
+    }
+
+    // ── Task-4 PDE schema + chain-walk tests ─────────────────────────────────
+
+    #[test]
+    fn pde_response_format_schema_shape() {
+        let v = pde_response_format();
+        assert_eq!(v["type"], "json_schema");
+        assert_eq!(v["json_schema"]["name"], "pde_verdict");
+        assert_eq!(v["json_schema"]["strict"], true);
+        let req = v["json_schema"]["schema"]["required"].as_array().unwrap();
+        assert_eq!(req.len(), 4, "all four properties required: {v}");
+        let actions = v["json_schema"]["schema"]["properties"]["action"]["enum"]
+            .as_array().unwrap();
+        assert_eq!(actions.len(), 4, "four actions: {v}");
+    }
+
+    fn test_resolved_pde(models: Vec<String>) -> eros_engine_llm::model_config::ResolvedPde {
+        let (model, fallback_model) = {
+            let mut it = models.into_iter();
+            (it.next().unwrap(), it.collect::<Vec<_>>())
+        };
+        eros_engine_llm::model_config::ResolvedPde {
+            model,
+            fallback_model,
+            temperature: 0.2,
+            max_tokens: 180,
+            decision_prompt: "decide".into(),
+            retry_depth: 2,
+            reasoning: None,
+            structured_output: true,
+        }
+    }
+
+    #[tokio::test]
+    async fn pde_parse_error_walks_to_next_model() {
+        use wiremock::matchers::{body_string_contains, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        // primary "model-a" → unparseable text
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("model-a"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "choices": [{"message": {"content": "totally not json"}}],
+                "id": "gen-a", "model": "model-a"
+            })))
+            .mount(&mock).await;
+        // fallback "model-b" → valid verdict
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("model-b"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "choices": [{"message": {"content": "{\"action\":\"reply_text\",\"inner_state\":\"想接话\"}"}}],
+                "id": "gen-b", "model": "model-b"
+            })))
+            .mount(&mock).await;
+
+        let client = eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+            "k".into(),
+            eros_engine_llm::openrouter::AppAttribution::default(),
+            format!("{}/api/v1/chat/completions", mock.uri()),
+        );
+        let p = test_resolved_pde(vec!["model-a".into(), "model-b".into()]);
+        let run = run_pde_decision(&client, &p, "ctx").await;
+        assert_eq!(run.status, PdeStatus::Ok);
+        assert_eq!(run.verdict.unwrap().action, PdeAction::ReplyText);
+        assert_eq!(run.model.as_deref(), Some("model-b"));
+    }
+
+    #[tokio::test]
+    async fn pde_whole_chain_parse_error_preserves_last_raw() {
+        use wiremock::matchers::path as wm_path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "choices": [{"message": {"content": "nope"}}], "id": "g", "model": "m"
+            })))
+            .mount(&mock).await;
+
+        let client = eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+            "k".into(),
+            eros_engine_llm::openrouter::AppAttribution::default(),
+            format!("{}/api/v1/chat/completions", mock.uri()),
+        );
+        let p = test_resolved_pde(vec!["model-a".into(), "model-b".into()]);
+        let run = run_pde_decision(&client, &p, "ctx").await;
+        assert_eq!(run.status, PdeStatus::ParseError);
+        assert_eq!(run.raw.as_deref(), Some("nope"));
+        assert!(run.verdict.is_none());
     }
 }

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -1030,6 +1030,9 @@ struct LastParseAttempt {
 /// parse error; a chain-exhausted ParseError preserves the last attempt's raw
 /// text + audit trio. Fail-open: any non-`Ok` status → the caller uses the
 /// rule fallback. NEVER returns an error — always a run record.
+///
+/// Unlike `run_input_filter`, a content-level reply that won't parse here walks
+/// the rest of the chain before the caller falls back to the rule engine.
 async fn run_pde_decision(
     client: &eros_engine_llm::openrouter::OpenRouterClient,
     p: &eros_engine_llm::model_config::ResolvedPde,
@@ -6139,5 +6142,9 @@ data: [DONE]\n\n";
         assert_eq!(run.status, PdeStatus::ParseError);
         assert_eq!(run.raw.as_deref(), Some("nope"));
         assert!(run.verdict.is_none());
+        assert!(
+            run.model.is_some(),
+            "chain-exhausted ParseError must preserve the last attempt's model"
+        );
     }
 }

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -1016,6 +1016,15 @@ fn pde_response_format() -> serde_json::Value {
     })
 }
 
+/// The last parse-error attempt's text + audit echo, kept so a chain-exhausted
+/// ParseError return preserves the raw model text and audit trio.
+struct LastParseAttempt {
+    raw: String,
+    model: Option<String>,
+    usage: Option<serde_json::Value>,
+    generation_id: Option<String>,
+}
+
 /// Run the PDE judge over the assembled context. Walks `[model] + fallback`
 /// trying the next model on a transport failure (error/timeout/empty) or a
 /// parse error; a chain-exhausted ParseError preserves the last attempt's raw
@@ -1031,9 +1040,9 @@ async fn run_pde_decision(
         .chain(p.fallback_model.iter().cloned())
         .collect();
     let mut last = PdeStatus::Error; // chain-exhausted default
-    // On a content-level reply that won't parse, keep the LAST attempt's text +
-    // audit trio so the chain-exhausted ParseError return stays faithful.
-    let mut last_parse: Option<(String, Option<String>, Option<serde_json::Value>, Option<String>)> = None;
+                                     // On a content-level reply that won't parse, keep the LAST attempt's text +
+                                     // audit trio so the chain-exhausted ParseError return stays faithful.
+    let mut last_parse: Option<LastParseAttempt> = None;
     let response_format = p.structured_output.then(pde_response_format);
     for model_id in &chain {
         let req = ChatRequest {
@@ -1089,12 +1098,12 @@ async fn run_pde_decision(
             None => {
                 tracing::warn!(model = %model_id, "pde: unparseable verdict; trying next model");
                 last = PdeStatus::ParseError;
-                last_parse = Some((
-                    text,
-                    resp.model.or_else(|| Some(model_id.clone())),
-                    resp.usage,
-                    resp.generation_id,
-                ));
+                last_parse = Some(LastParseAttempt {
+                    raw: text,
+                    model: resp.model.or_else(|| Some(model_id.clone())),
+                    usage: resp.usage,
+                    generation_id: resp.generation_id,
+                });
                 continue;
             }
         }
@@ -1102,15 +1111,14 @@ async fn run_pde_decision(
     // chain exhausted
     match last {
         PdeStatus::ParseError => {
-            let (raw, model, usage, generation_id) =
-                last_parse.expect("ParseError ⇒ last_parse is set");
+            let lp = last_parse.expect("ParseError ⇒ last_parse is set");
             PdeDecisionRun {
                 status: PdeStatus::ParseError,
                 verdict: None,
-                raw: Some(raw),
-                model,
-                usage,
-                generation_id,
+                raw: Some(lp.raw),
+                model: lp.model,
+                usage: lp.usage,
+                generation_id: lp.generation_id,
             }
         }
         other => PdeDecisionRun {
@@ -1176,13 +1184,19 @@ fn build_persona_brief(persona: &eros_engine_core::persona::CompanionPersona) ->
     let name = persona.genome.name.trim();
 
     let mut bits: Vec<String> = Vec::new();
-    if let Some(g) = meta_str(persona, "gender").map(str::trim).filter(|s| !s.is_empty()) {
+    if let Some(g) = meta_str(persona, "gender")
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
         bits.push(g.to_string());
     }
     if let Some(a) = meta_i32(persona, "age") {
         bits.push(format!("{a}岁"));
     }
-    if let Some(m) = meta_str(persona, "mbti").map(str::trim).filter(|s| !s.is_empty()) {
+    if let Some(m) = meta_str(persona, "mbti")
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
         bits.push(m.to_string());
     }
 
@@ -1196,7 +1210,10 @@ fn build_persona_brief(persona: &eros_engine_core::persona::CompanionPersona) ->
     if !head.is_empty() {
         lines.push(head);
     }
-    if let Some(ss) = meta_str(persona, "speech_style").map(str::trim).filter(|s| !s.is_empty()) {
+    if let Some(ss) = meta_str(persona, "speech_style")
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
         lines.push(format!("说话风格：{ss}"));
     }
     if let Some(q) = meta_string_array_joined(persona, "quirks")
@@ -5993,7 +6010,10 @@ data: [DONE]\n\n";
         let ctx = build_pde_ctx("用户：hi\nMia：hey", &input);
         let persona_at = ctx.find("[角色人格]").expect("persona block present");
         let rel_at = ctx.find("[关系状态]").expect("relationship block present");
-        assert!(persona_at < rel_at, "persona must precede relationship: {ctx}");
+        assert!(
+            persona_at < rel_at,
+            "persona must precede relationship: {ctx}"
+        );
         assert!(ctx.starts_with("[角色人格]"), "persona block at top: {ctx}");
     }
 
@@ -6021,7 +6041,10 @@ data: [DONE]\n\n";
         };
         let ctx = build_pde_ctx("", &input);
         assert!(!ctx.contains("[角色人格]"), "no persona block: {ctx}");
-        assert!(ctx.starts_with("[最近对话]"), "ctx starts with transcript block: {ctx}");
+        assert!(
+            ctx.starts_with("[最近对话]"),
+            "ctx starts with transcript block: {ctx}"
+        );
     }
 
     // ── Task-4 PDE schema + chain-walk tests ─────────────────────────────────
@@ -6035,7 +6058,8 @@ data: [DONE]\n\n";
         let req = v["json_schema"]["schema"]["required"].as_array().unwrap();
         assert_eq!(req.len(), 4, "all four properties required: {v}");
         let actions = v["json_schema"]["schema"]["properties"]["action"]["enum"]
-            .as_array().unwrap();
+            .as_array()
+            .unwrap();
         assert_eq!(actions.len(), 4, "four actions: {v}");
     }
 
@@ -6069,7 +6093,8 @@ data: [DONE]\n\n";
                 "choices": [{"message": {"content": "totally not json"}}],
                 "id": "gen-a", "model": "model-a"
             })))
-            .mount(&mock).await;
+            .mount(&mock)
+            .await;
         // fallback "model-b" → valid verdict
         Mock::given(wm_path("/api/v1/chat/completions"))
             .and(body_string_contains("model-b"))
@@ -6101,7 +6126,8 @@ data: [DONE]\n\n";
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "choices": [{"message": {"content": "nope"}}], "id": "g", "model": "m"
             })))
-            .mount(&mock).await;
+            .mount(&mock)
+            .await;
 
         let client = eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
             "k".into(),

--- a/crates/eros-engine-server/src/prompt.rs
+++ b/crates/eros-engine-server/src/prompt.rs
@@ -270,7 +270,7 @@ pub fn tips_reaction_context(amount_usd: f64, tip_personality: Option<&str>) -> 
 }
 
 /// Pluck a string field out of `art_metadata`.
-fn meta_str<'a>(persona: &'a CompanionPersona, key: &str) -> Option<&'a str> {
+pub(crate) fn meta_str<'a>(persona: &'a CompanionPersona, key: &str) -> Option<&'a str> {
     persona
         .genome
         .art_metadata
@@ -279,7 +279,7 @@ fn meta_str<'a>(persona: &'a CompanionPersona, key: &str) -> Option<&'a str> {
 }
 
 /// Pluck an i32 field out of `art_metadata`.
-fn meta_i32(persona: &CompanionPersona, key: &str) -> Option<i32> {
+pub(crate) fn meta_i32(persona: &CompanionPersona, key: &str) -> Option<i32> {
     persona
         .genome
         .art_metadata
@@ -289,7 +289,7 @@ fn meta_i32(persona: &CompanionPersona, key: &str) -> Option<i32> {
 }
 
 /// Pluck a string-array field out of `art_metadata`, joined with `、`.
-fn meta_string_array_joined(persona: &CompanionPersona, key: &str) -> Option<String> {
+pub(crate) fn meta_string_array_joined(persona: &CompanionPersona, key: &str) -> Option<String> {
     persona
         .genome
         .art_metadata

--- a/docs/superpowers/specs/2026-06-23-pde-persona-and-structured-output-design.md
+++ b/docs/superpowers/specs/2026-06-23-pde-persona-and-structured-output-design.md
@@ -1,0 +1,273 @@
+# eros-engine — PDE persona injection + structured output (adopt audit 22 §6)
+
+**Status**: design, pending implementation plan
+**Target release**: `0.6.x` dev track. **No schema migration.**
+**Scope**: adopt the two code recommendations from `eros-audit` report 22 (PDE
+conservatism). The PDE judge currently makes character-blind, JSON-fragile
+decisions; this spec gives it (1) a **compact persona brief** so judgments
+differentiate by character, and (2) **`response_format: json_schema`** on the
+PDE request plus a one-line **parse-error chain-walk** so a malformed verdict
+tries the rest of the fallback chain before dropping to the rule engine.
+
+Out of scope (deployment-owned config, already applied live per audit 22 §4/§5):
+the「互动导演」`filter_prompt` rewrite and the Hermes/Mistral/Llama model chain.
+Those live in a deployment's `MODEL_CONFIG_PATH`; the OSS `examples/model_config.toml`
+still ships `pde_decision` **off** (no `filter_prompt`).
+
+---
+
+## 0. Background
+
+### 0.1 What audit 22 found
+
+Across 11 live `companion_decision_events` (early PDE rollout), the judge
+de-escalated **7/7** charged turns. Three root causes; this spec addresses the
+two that are code (not model/prompt config):
+
+- **Root cause C — no persona in the PDE input.** `build_pde_ctx`
+  (`stream.rs:1126`) feeds only transcript + 6 affinity axes + signals + latest
+  message. With no character to reason from, every persona gets the same generic
+  "理性、温和、尊重边界" disposition. The audit's fix: inject a compact persona.
+- **JSON fragility.** The PDE request is free-text parsed
+  (`parse_pde_verdict`, `stream.rs:925`: `from_str` → `find_json_block`). The
+  audit's fix: add `response_format: json_schema` to raise adherence; optionally
+  also let a parse-error try the next model.
+
+### 0.2 What is already in place (shrinks the work)
+
+- **`DecisionInput` already carries the full persona.** `DecisionInput.persona:
+  CompanionPersona` (`types.rs:146`) is already threaded into `build_pde_ctx`'s
+  caller — `build_pde_ctx` simply ignores it. So **no DecisionInput threading is
+  needed** (contra the audit's wording); only rendering.
+- **`parse_pde_verdict` is already belt-and-suspenders.** It tries
+  `serde_json::from_str` then `find_json_block`. So `response_format` is **purely
+  additive**: a provider that honors it → cleaner JSON; a provider that ignores
+  it → free text still parses → no regression.
+- **The `art_metadata` pluck helpers exist** in the same crate
+  (`prompt.rs:273/282/292`: `meta_str` / `meta_i32` / `meta_string_array_joined`),
+  currently private. `build_pde_ctx` is in the same server crate → reuse via
+  `pub(crate)`.
+
+### 0.3 The genome fields that actually exist
+
+`PersonaGenome` (`persona.rs`): `name`, `system_prompt`, `tip_personality:
+Option<String>`, `art_metadata: Value` (JSONB carrying `gender/age/mbti/
+backstory/speech_style/quirks/topics/model`). The audit's illustrative columns
+`personality / initiative_style / conflict_style / image_habit` **do not exist**
+and are **not** added — the brief is built from existing fields only.
+
+---
+
+## 1. Change A — compact persona brief in the PDE ctx
+
+### 1.1 New pure helper
+
+Add a pure, unit-testable function (in `stream.rs`, beside `build_pde_ctx`):
+
+```rust
+/// Build a compact persona disposition block for the PDE judge from EXISTING
+/// genome fields. Empty fields are omitted; an all-empty persona yields "".
+fn build_persona_brief(persona: &CompanionPersona) -> String;
+```
+
+Rendered shape (fields omitted when blank):
+
+```
+[角色人格] {name}，{gender} {age}岁，{mbti}
+说话风格：{speech_style}
+口癖：{quirks}
+打赏人格：{tip_personality}
+```
+
+- **Sources**: `genome.name`; `art_metadata` → `gender` / `age` / `mbti` /
+  `speech_style` / `quirks`; `genome.tip_personality` (only when `Some` and
+  non-blank). Reuse `crate::prompt::{meta_str, meta_i32, meta_string_array_joined}`
+  (changed to `pub(crate)`).
+- **Deliberately NOT injected**: `system_prompt` (long; may re-import the chat
+  prompt's customer-service / boundary framing into the judge — the exact
+  conservatism this spec fights) and `topics` (irrelevant to disposition).
+- The audit's `initiative_style / conflict_style / image_habit` have no backing
+  data → **not invented**. `name + gender/age + mbti + speech_style + quirks +
+  tip_personality` is enough disposition for the judge to differentiate a bold
+  vs. a shy character. The「互动导演」prompt (deployment config) already asks for
+  character-driven judgment; this brief is the character it drives from.
+
+### 1.2 Wiring into `build_pde_ctx`
+
+`build_pde_ctx` renders the brief at the **top** of the ctx (before
+`[最近对话]` / `[关系状态] / [信号] / [用户最新消息]`), so the judge reads
+"who am I" before "what's happening". When the brief is empty, the block is
+omitted and the ctx is byte-identical to today (a deployment with bare-bones
+personas is unaffected). No new function parameters — `build_pde_ctx` already
+receives `&DecisionInput`.
+
+The ctx is the per-turn **user** message (rebuilt every turn), so there is no
+prompt-cache interaction. The brief is not persisted (the audit table stores the
+verdict, not the ctx).
+
+---
+
+## 2. Change B — `response_format: json_schema` + parse-error chain-walk
+
+### 2.1 Wire layer (`openrouter.rs`) — sync path only
+
+- `ChatRequest` gains `pub response_format: Option<serde_json::Value>` — an
+  opaque passthrough, mirroring the existing `metadata` field. `None` ⇒ omitted.
+- `WireRequest<'a>` gains `#[serde(skip_serializing_if = "Option::is_none")]
+  response_format: Option<&'a serde_json::Value>`, threaded through the
+  `execute` / `call_once` WireRequest construction.
+- **Sync path only.** The PDE uses `state.openrouter.execute(req)` (non-stream);
+  `execute_stream` is **not** touched. A deployment that sets nothing produces a
+  byte-identical body to today.
+
+### 2.2 The schema (`run_pde_decision`)
+
+Pure helper `fn pde_response_format() -> serde_json::Value` builds the verdict
+schema (OpenAI/OpenRouter `json_schema` form):
+
+```json
+{
+  "type": "json_schema",
+  "json_schema": {
+    "name": "pde_verdict",
+    "strict": true,
+    "schema": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["action", "inner_state", "image_prompt", "reason"],
+      "properties": {
+        "action": { "type": "string",
+          "enum": ["reply_text", "ghost", "reply_image", "reply_text_image"] },
+        "inner_state": { "type": "string" },
+        "image_prompt": { "type": ["string", "null"] },
+        "reason": { "type": ["string", "null"] }
+      }
+    }
+  }
+}
+```
+
+- `strict: true` requires every property in `required`; the optional
+  `image_prompt` / `reason` are made **nullable** so the model returns `null`,
+  which deserializes to `PdeVerdict`'s `Option` fields as `None`. `action` /
+  `inner_state` stay effectively required.
+- A provider that doesn't support `strict` falls back to free text →
+  `parse_pde_verdict` still parses (§0.2). So the schema is a best-effort
+  adherence lever, never a hard dependency.
+
+`run_pde_decision` sets `response_format: Some(pde_response_format())` on the
+`ChatRequest` **only when `structured_output` is enabled** (§3).
+
+### 2.3 Parse-error chain-walk (the second change)
+
+Today (`stream.rs:1058`) a `ParseError` **returns immediately** — it skips the
+rest of the model chain and the caller drops to the rule engine. Change: a
+parse-error **records and continues** to the next model, exactly like
+`Empty` / `Error` / `Timeout`:
+
+- Replace the immediate `return PdeDecisionRun{ status: ParseError, .. }` with
+  setting `last = PdeStatus::ParseError` and **retaining the attempt's `raw` /
+  `model` / `usage` / `generation_id`** in locals, then `continue`.
+- A later model that parses `Ok` short-circuits and returns `Ok` (unchanged).
+- If the **whole chain** fails to parse, the chain-exhausted return at the
+  bottom (`stream.rs:1072`) must now carry the **last** parse-error's `raw` +
+  audit trio (not all-`None`), so the audit row stays faithful (`status =
+  parse_error`, `payload = raw`, `proposed_action = NULL`). This is the one
+  non-trivial part of the otherwise one-line change: thread the last
+  parse-error's data to the bottom return.
+- Net semantic change: the「内容级回复即终结」rule (mirrored from
+  `run_input_filter`) is relaxed **for parse-errors only** — a malformed verdict
+  now tries the diverse fallback chain (Hermes→Mistral→Llama) before the rule
+  engine. `Empty` / `Error` / `Timeout` behavior is unchanged.
+
+Fail-open is preserved throughout: any terminal non-`Ok` status → rule engine.
+
+---
+
+## 3. Config — `structured_output` knob (config-gated, default on)
+
+`[tasks.pde_decision]` gains `structured_output: Option<bool>` on the shared
+`TaskConfig` (other tasks ignore it, like `ghosting`). Resolver:
+
+```rust
+// ResolvedPde gains:
+pub structured_output: bool,   // resolved value
+// resolve_pde():
+structured_output: self.tasks.get("pde_decision")
+    .and_then(|t| t.structured_output).unwrap_or(true),
+```
+
+- **Default `true`** (absent ⇒ on) — the audit's recommendation is the default.
+- **`false`** — `run_pde_decision` leaves `response_format = None` (byte-identical
+  body to pre-this-spec). The escape hatch for a deployment whose provider
+  *errors* on an unknown `response_format` param, matching the OSS-deployment-
+  safety style of the `ghosting` kill-switch and `ignore_providers`.
+- Task-level only (no per-tier override), consistent with `resolve_pde`.
+- **Schema lock**: add `structured_output` to `pde_decision` in `COMPAT_FIXTURE`
+  (additive — does not break the lock) and assert `resolve_pde` surfaces it.
+- **OSS template** (`examples/model_config.toml`): a comment under
+  `[tasks.pde_decision]` documenting `structured_output` (default `true`). No
+  behavior change to the shipped default (pde stays off without a `filter_prompt`).
+
+---
+
+## 4. Error handling
+
+- Persona brief: pure, infallible; empty string on no data → block omitted.
+- `response_format`: additive; ignored-by-provider is harmless (parser fallback);
+  errored-by-provider walks the chain (and the `structured_output=false` knob
+  disables it entirely). No new error path.
+- Parse-error chain-walk: stays within the existing fail-open contract — a fully
+  failed chain resolves to the rule engine, never blocks a turn.
+- No new logs beyond the existing per-attempt `tracing::warn!`; no migration.
+
+---
+
+## 5. Testing
+
+- **core/server `build_persona_brief`**: all-fields render; missing fields
+  omitted (no stray separators); `tip_personality = None` omitted; all-empty
+  persona → `""`; does not panic on absent `art_metadata` keys.
+- **`build_pde_ctx`**: persona block renders at the top (before `[关系状态]`);
+  empty brief ⇒ ctx byte-identical to today.
+- **`openrouter`**: `response_format = Some(..)` ⇒ present in serialized
+  `WireRequest`; `None` ⇒ key omitted (body byte-identical to today); threaded
+  through the sync `execute`/`call_once` path, not `execute_stream`.
+- **`pde_response_format`**: schema shape — `action` enum has the four actions,
+  `required` lists all four, `image_prompt`/`reason` nullable, `strict = true`.
+- **`run_pde_decision`** (the behavior change):
+  - parse-error on model #1 → tries model #2; model #2 `Ok` ⇒ overall `Ok`.
+  - parse-error on the **whole** chain ⇒ `status = ParseError` **with the last
+    attempt's `raw` + model/usage/generation_id** preserved (not all-`None`).
+  - model #1 `Ok` still short-circuits (no extra calls).
+  - `Empty`/`Error`/`Timeout` chain behavior unchanged.
+  - `structured_output = false` ⇒ request carries no `response_format`.
+- **`model_config`**: `resolve_pde` surfaces `structured_output` (absent → true;
+  `false` → false); `COMPAT_FIXTURE` asserts the new field.
+- **Pre-PR gate**: `fmt` / `clippy` / `test` / `openapi` (no API surface change
+  expected; run `openapi` to confirm).
+
+---
+
+## 6. File-by-file change list
+
+| File | Change |
+| --- | --- |
+| `crates/eros-engine-server/src/pipeline/stream.rs` | `build_persona_brief` (new pure fn); `build_pde_ctx` renders it at the top; `pde_response_format` (new pure fn); `run_pde_decision` sets `response_format` when `structured_output`; **parse-error → `continue` + carry last raw/audit-trio to the chain-exhausted return**. |
+| `crates/eros-engine-server/src/prompt.rs` | `meta_str` / `meta_i32` / `meta_string_array_joined` → `pub(crate)`. |
+| `crates/eros-engine-llm/src/openrouter.rs` | `ChatRequest.response_format: Option<serde_json::Value>`; `WireRequest.response_format` (skip-if-none); threaded through the sync `execute`/`call_once` path only. |
+| `crates/eros-engine-llm/src/model_config.rs` | `TaskConfig.structured_output: Option<bool>`; `ResolvedPde.structured_output: bool` + `resolve_pde` (default true); `COMPAT_FIXTURE` + tests. |
+| `examples/model_config.toml` | `[tasks.pde_decision]`: comment documenting `structured_output` (default `true`). |
+
+---
+
+## 7. Out of scope / future
+
+- The「互动导演」`filter_prompt` and the Hermes/Mistral/Llama model chain
+  (audit 22 §4/§5) — deployment config, already live; not OSS code.
+- Real structured persona columns (`initiative_style` etc.) — only worth it if a
+  future need shows the existing-field brief is insufficient (YAGNI for now).
+- Making `Empty`/`Error`/`Timeout` (already chain-walking) or `ghost`-action
+  audit semantics change — untouched.
+- The audit's watch-items (re-pull `companion_decision_events`; confirm Hermes
+  JSON adherence + gate latency) — operational follow-up, not code.

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -298,6 +298,7 @@ temperature = 0.3
 max_tokens  = 400
 #reasoning   = { enabled = false }
 #ghosting    = false   # uncomment to hard-disable ghosting for this deployment
+#structured_output = true   # send response_format=json_schema on the judge (default true); set false if your provider 400s on it
 # Uncomment filter_prompt to enable the LLM judge. inner_state MUST be a short
 # mood description — NEVER instructions or formatting (it is sanitized, but keep
 # the model honest). Output JSON only, no code fences.


### PR DESCRIPTION
采纳 eros-audit 报告 22（PDE 保守度审计）的两条**代码**建议。范围外（部署侧 config，已上线）：「互动导演」`filter_prompt` 与 Hermes/Mistral/Llama 模型链。

Spec: `docs/superpowers/specs/2026-06-23-pde-persona-and-structured-output-design.md`

## 改了什么

**① 紧凑人格注入（根因 C）** — `DecisionInput` 本就带 `persona`，`build_pde_ctx` 此前忽略它。新增纯函数 `build_persona_brief`，从**现有 genome 字段**（name / art_metadata 的 gender·age·mbti·speech_style·quirks / tip_personality）拼一段 disposition，渲染在 PDE 判官 ctx 顶部。不注入 `system_prompt`/`topics`；**无迁移**；空 brief ⇒ ctx 与改前逐字节相同。

**② 结构化输出 + parse-error 链走完** —
- PDE sync 请求加 `response_format: json_schema`（strict + 可空 optional），由新配置 `[tasks.pde_decision].structured_output`（默认 `true`）开关；`parse_pde_verdict` 已 belt-and-suspenders，provider 忽略也无损。**只走 sync `execute` 路径**，streaming 与未设部署逐字节不变。
- `run_pde_decision` 的 `ParseError` 从「立即回规则引擎」改成**走完 LLMs 链**（并把最后一次 parse-error 的 raw + audit 三件套带到链尾返回，审计忠实）；`Empty`/`Error`/`Timeout` 不变。fail-open 全程保留。
- 顺带：runner 第一参数 `&AppState`→`&OpenRouterClient`，使链走完逻辑可 wiremock 单测、**不需要数据库**。

## 提交
`docs(spec)` + `feat(pde)` 人格注入 + `feat(llm)` wire response_format + `feat(llm)` structured_output 配置 + `feat(pde)` schema/gating/chain-walk + `chore` fmt/struct + `docs(pde)` 复审打磨。全部 GPG 签名。

## 验证（pre-PR gate）
`cargo fmt --check` clean · `cargo clippy --workspace --all-targets -D warnings` clean · `cargo test --workspace --all-features` = **565 passing / 0 failed**（Postgres@17）· openapi 无 drift。每个 task 经 spec+quality 复审；whole-branch 复审（Opus）= **Ready to merge: Yes**。

## ⚠️ Release notes
默认开的 `structured_output` 会改变 PDE 请求 body —— **仅对设了非空 `pde_decision.filter_prompt`（即已启用 LLM 判官）的部署**生效；OSS 默认该 prompt 注释掉，不受影响。escape hatch：`structured_output = false`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)