### PR TITLE
docs: slim README (en/zh/ja) + audit-driven docs/examples fixes

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,172 @@
+# eros-engine
+
+> **本物の人間のように感じられる AI コンパニオンのための、オープンソース Rust エンジン。永続記憶、進展する関係モデル、そして数千ターンにわたってペルソナを一貫させる意思決定エンジンを備えています。**
+>
+> `eros-engine` は、[Eros Chat](https://chat.etherfun.xyz) のコンパニオンチャット中核を独立したサービスとして切り出したものです。会話を、構造化されたユーザープロフィール、2 層の長期記憶、6 次元の親密度モデルという永続的な状態へ変換します。これにより、ユーザーが戻るたびに、ペルソナはいつも同じ人物として振る舞います。
+
+[![CI](https://github.com/etherfunlab/eros-engine/actions/workflows/ci.yml/badge.svg)](https://github.com/etherfunlab/eros-engine/actions/workflows/ci.yml)
+[![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
+[![Crates.io: core](https://img.shields.io/crates/v/eros-engine-core.svg?label=eros-engine-core)](https://crates.io/crates/eros-engine-core)
+[![Crates.io: store](https://img.shields.io/crates/v/eros-engine-store.svg?label=eros-engine-store)](https://crates.io/crates/eros-engine-store)
+[![Crates.io: llm](https://img.shields.io/crates/v/eros-engine-llm.svg?label=eros-engine-llm)](https://crates.io/crates/eros-engine-llm)
+[![GHCR: eros-engine](https://img.shields.io/badge/ghcr.io-etherfunlab%2Feros--engine-blue)](https://github.com/etherfunlab/eros-engine/pkgs/container/eros-engine)
+
+[English](README.md) · [中文](README.zh.md) · **日本語**
+
+## このエンジンが存在する理由
+
+多くの AI キャラクターアプリでは、記憶をプロンプトに追加するテキストとして扱い、関係性を一段落の指示で表現しています。デモでは機能しても、長いセッションでは振る舞いが徐々にずれ、キャラクター性が崩れ、デバッグも困難になります。`eros-engine` はこれらを明示的で検査可能な状態へ移すことで、コンパニオンを**本物の人間のように**感じさせます。コンパニオンはあなたを覚え、現在の関係性に応じて反応します。また、振る舞いは即興ではなく*決定*されるため、何ターン重ねても**キャラクター性を維持**します。
+
+これを支えるのが、次の 5 つの柱です。
+
+- **2 層の記憶** — プロフィール記憶（安定したユーザー情報）と関係記憶（共有した出来事、過去の話題への言及、未完了の話題）を Postgres + pgvector に保存し、セッションやペルソナをまたいでコンパニオンがあなたを記憶できるようにします。→ [Memory layers](docs/memory-layers.md)
+- **6 軸の親密度 + ghost mechanics** — 数値化された関係ベクトル（warmth、trust、intimacy、intrigue、patience、tension）を EMA による平滑化とリアルタイム減衰で更新します。時間とともに口調、会話の深さ、振る舞いを変化させ、*返信しない*という判断さえ可能にします。→ [Affinity model](docs/affinity-model.md) · [Ghost mechanics](docs/ghost-mechanics.md)
+- **Persona Decision Engine (PDE)** — 各ターンの行動（返信、ghost、写真送信）と内的状態を選択します。デフォルトではルールベースで、任意に LLM judge を有効化できます。汎用アシスタントのような口調ではなく、人間らしくキャラクターに沿った返信を維持する仕組みです。judge の呼び出しは `companion_decision_events` に監査記録されます。→ [Model config](docs/model-config.md)
+- **構造化されたユーザーインサイト** — 都市、職業、興味、MBTI signals、感情的ニーズ、生活リズム、マッチング設定を JSONB プロフィールとして保持し、重み付きの `training_level` を付与します。下流プロダクトからクエリし、マッチメイキング、オンボーディング、分析、gating に利用できます。→ [API reference](docs/api-reference.md)
+- **流暢なコンパニオンチャットのための設計** — トークン単位の SSE ストリーミング、画像理解（ユーザーからの写真送信）、コンパニオンによる画像生成（`reply_image` / `reply_text_image`）、リクエスト単位の `prompt_traits` と tier、OpenRouter ベースのルーティングを備えています。タスクごとのモデル選択（固定 / ラウンドロビン / 加重とフォールバックチェーン）と、すべての呼び出しに対する監査にも対応します。→ [API reference](docs/api-reference.md) · [Model config](docs/model-config.md)
+
+これは汎用エージェントフレームワークではありません。同じペルソナが同じユーザーと複数のセッションにわたって会話するプロダクトに特化したエンジンです。AI コンパニオン、ジャーナリングコンパニオン、コーチングエージェント、語学チューター、キャラクターチャットなどに適しています。
+
+## アーキテクチャ
+
+```txt
+┌─────────────────────────────────────────────────────────┐
+│ /comp/* HTTP routes  ←  Supabase JWT middleware          │
+│         │                                                │
+│         ▼                                                │
+│ pipeline orchestrator: load → PDE → handler → chat → post│
+│                                          │              │
+│  ┌───────────────────────────────────────┴────────┐     │
+│  │ post-process, spawned after reply              │     │
+│  │   • affinity: persist 6D delta + EMA           │     │
+│  │   • memory:   Voyage embed → pgvector upsert   │     │
+│  │   • insight:  extract facts → JSONB merge      │     │
+│  └────────────────────────────────────────────────┘     │
+└─────────────────────────────────────────────────────────┘
+```
+
+ワークスペースは 4 つの crate に分かれています。
+
+| Crate | 役割 |
+|---|---|
+| `eros-engine-core` | 純粋なドメインロジック：親密度の計算、ghost の判定、PDE、ペルソナ型。I/O はありません。 |
+| `eros-engine-llm` | OpenRouter チャットクライアント、Voyage embedding クライアント、TOML モデル設定ローダー。 |
+| `eros-engine-store` | Postgres + pgvector による永続化。すべてのテーブルは `engine` schema 配下に置かれます。 |
+| `eros-engine-server` | Axum HTTP サービス、Supabase JWT ミドルウェア、OpenAPI ドキュメント、pipeline の接続処理。 |
+
+`eros-engine-server` を HTTP API として実行することも、`core + llm + store` を独自の Rust サービスへ直接組み込むこともできます。crate の境界、pipeline の各フェーズ、データフローについては、[Architecture](docs/architecture.md) を参照してください。
+
+## ライブラリとして使う
+
+3 つのライブラリ crate は crates.io で公開されています（[core](https://crates.io/crates/eros-engine-core) · [store](https://crates.io/crates/eros-engine-store) · [llm](https://crates.io/crates/eros-engine-llm)）。
+
+```bash
+cargo add eros-engine-core eros-engine-store eros-engine-llm
+```
+
+```toml
+[dependencies]
+eros-engine-core  = "0.6"
+eros-engine-store = "0.6"   # only if you want the Postgres + pgvector layer
+eros-engine-llm   = "0.6"   # only if you want the OpenRouter + Voyage clients
+```
+
+`eros-engine-server` は意図的に crates.io では公開していません。Docker イメージとして実行してください（下記参照）。
+
+## Docker イメージとして実行する
+
+`eros-engine-server` の `linux/amd64` イメージは、`v*` タグごとに GitHub Container Registry へ公開されます（arm64 が必要な場合は、`docker/Dockerfile` からビルドしてください）。
+
+```bash
+docker pull ghcr.io/etherfunlab/eros-engine:0.6.2
+# or track the latest tagged release
+docker pull ghcr.io/etherfunlab/eros-engine:latest
+```
+
+最小構成での実行例です（Postgres と独自の `.env` が必要です）。
+
+```bash
+docker run --rm -p 8080:8080 --env-file .env \
+  ghcr.io/etherfunlab/eros-engine:0.6.2 serve
+```
+
+このイメージのビルドには、同じ `docker/Dockerfile` が使われています。任意のコンテナホストにデプロイできます。詳細は [Deploying](docs/deploying.md) を参照してください。
+
+## ドキュメント
+
+- [Architecture](docs/architecture.md) — crate の境界、pipeline の各フェーズ、データフロー。
+- [Affinity model](docs/affinity-model.md) — 6 つの次元、EMA、時間減衰、関係ラベル。
+- [Ghost mechanics](docs/ghost-mechanics.md) — スコア式、保護ルール、例。
+- [Memory layers](docs/memory-layers.md) — プロフィール記憶と関係記憶、Voyage、pgvector による検索。
+- [Model config](docs/model-config.md) — `model_config.toml` schema、すべてのタスク（chat、vision、image generation、PDE、filters、extraction）、モデル選択、0.x の安定性に関する方針。
+- [Prompt traits](docs/prompt-traits.md) — リクエスト単位の system prompt 注入と tier の許可リスト。
+- [LLM / OpenRouter audit](docs/llm-audit.md) — ユーザー単位 / セッション単位の attribution の受け渡し。
+- [Deploying](docs/deploying.md) — Docker、独自の Postgres / IdP、運用向け環境変数。
+- [API reference](docs/api-reference.md) — すべての `/comp/*` endpoint、リクエストフィールド、SSE frame layout。
+
+## クイックスタート
+
+前提条件：Rust ツールチェーン（`rust-toolchain.toml`）、`pgvector` を導入した Postgres 16+、OpenRouter API key、Voyage API key、そして認証元を 1 つ（Supabase JWKS（`SUPABASE_URL`）または旧来の `SUPABASE_JWT_SECRET`）、あるいは独自の `AuthValidator`。
+
+```bash
+git clone https://github.com/etherfunlab/eros-engine
+cd eros-engine
+cp .env.example .env   # fill in DATABASE_URL, OPENROUTER_API_KEY, VOYAGE_API_KEY, and one auth source
+
+cargo run -p eros-engine-server -- migrate
+cargo run -p eros-engine-server -- seed-personas examples/personas
+cargo run -p eros-engine-server -- serve
+```
+
+サーバーはデフォルトで `0.0.0.0:8080` で待ち受けます。Scalar API ドキュメントは `/docs`、OpenAPI JSON は `/api-docs/openapi.json` にあります。公式の Eros Chat Web クライアントはクローズドソースです。独自の UI を用意するか、crate を別のサービスへ組み込んでください。
+
+## API 概要
+
+デフォルトでは、すべての `/comp/*` ルートに `Authorization: Bearer <Supabase JWT>` が必要です（他の identity provider には、差し替え可能な `AuthValidator` trait で対応できます）。主な endpoint は次のとおりです。
+
+- `POST /comp/chat/start` — ペルソナとのチャットセッションを開始します。
+- `POST /comp/chat/{session_id}/message/stream` — **中心となる**チャットターンの endpoint です。トークン単位の Server-Sent Events を返します。ターンごとの任意フィールドには、`tier`、`prompt_traits`、`audit`、`tips_amount_usd`（コンパニオンへの tip）、`image_url`（コンパニオンへ写真を送信）、`image`（コンパニオンによる画像生成を要求。style / model / aspect ratio / face reference を指定）があります。
+- `POST /comp/chat/{session_id}/message/{message_id}/image` — コンパニオンが生成した画像のストレージ URL を書き戻します。
+- `GET /comp/chat/{session_id}/history` · `GET /comp/chat/{user_id}/sessions` · `GET /comp/user/{user_id}/profile` — 履歴、セッション一覧、構造化されたインサイトプロフィールを取得します。
+- `GET /comp/affinity/{session_id}` — debug 専用のリアルタイム親密度ベクトル（`EXPOSE_AFFINITY_DEBUG=true`）。
+
+ブロッキング型の同期 `/message` endpoint は 0.3 で削除され、SSE が唯一のチャット経路になりました。完全なリクエスト schema、SSE frame layout（`delta`、`image`、ghost、error frame を含む）、各フィールドの意味については、[API reference](docs/api-reference.md) を参照してください。
+
+## 設定
+
+必須の環境変数は `DATABASE_URL`、`OPENROUTER_API_KEY`、`VOYAGE_API_KEY` と、**いずれか 1 つ**の認証元です。`SUPABASE_URL` / `SUPABASE_JWKS_URL`（JWKS、2025 年以降の Supabase のデフォルト）、**または** `SUPABASE_JWT_SECRET`（旧来の HS256）を設定してください。認証元が未設定の場合、サーバーは起動しません。
+
+その他の項目には適切なデフォルト値があります。モデルルーティング（`MODEL_CONFIG_PATH` → `model_config.toml`）、OpenRouter attribution headers、dreaming-lite / snapshot sweepers、関係性の難易度を調整する `EMA_INERTIA`、debug toggles などです。注釈付きの全項目は [`.env.example`](.env.example)、運用ガイドは [Deploying](docs/deploying.md)、モデルルーティングは [Model config](docs/model-config.md) を参照してください。
+
+## Roadmap
+
+現時点ではエンジンに含まれていませんが、今後の候補となっている項目です。
+
+- **Agents playground** — 複数の AI ペルソナが 1 つのセッションで互いに、そしてユーザーと対話します。
+- **Voice messages** — コンパニオンとユーザーの双方が送信できる音声ターン。
+- **Real-time voice conversation** — 低レイテンシーの音声によるリアルタイムなやり取り。
+- **Video generation** — image executor を拡張し、コンパニオンが短い動画クリップを送信します。
+
+## 意図的に対象外としているもの
+
+このリポジトリは、会話、記憶、関係状態の中核です。次の機能は含まれません。
+
+- **Matchmaking** — 多段階 filtering、soft scoring、agent-to-agent matching simulation は、引き続きクローズドソースのプロダクトに含まれます。
+- **完全な social UX** — onboarding、video、voice、billing、photos、moderation UI、mobile clients。
+- **ペルソナの provenance / marketplace logic** — 商用プロダクトのコードであり、このエンジンには含まれません。
+
+別のプロダクトを構築する場合、再利用できるのは親密度 + 記憶 + インサイトの pipeline です。
+
+## コンテンツに関する注意
+
+`examples/personas/` のサンプルペルソナは、成人向けキャラクターチャットの例として記述されています。関係状態がその段階に達すると、相手を誘惑したり欲求を表現したりする一方で、敬意を欠く行為や境界を越える行為は拒否します。プロダクトで SFW をデフォルトにする必要がある場合は、デプロイ前にこれらのペルソナファイルを置き換えてください。
+
+リクエストごとの振る舞いは、メッセージ route の [`prompt_traits`](docs/prompt-traits.md) フィールドでさらに調整できます。エンジンは渡されたテキストを不透明なデータとして扱うため、`prompt_traits` がどのようなポリシーを表すかは、frontend / middleware 側で完全に定義します。
+
+## コントリビューション
+
+[`CONTRIBUTING.md`](CONTRIBUTING.md) をお読みください。すべての contributor は、最初の PR で cla-assistant.io を通じて [`CLA`](CLA.md) に同意する必要があります。
+
+## ライセンス
+
+`eros-engine` は AGPL-3.0-only でライセンスされています。AGPL が配布モデルに適さない場合は、商用ライセンスをご利用いただけます：`henrylin@etherfun.xyz`。

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # eros-engine
 
-> **An open-source Rust engine for AI companions with memory, relationship state, and structured user insight.**
+> **An open-source Rust engine for AI companions that feel real: persistent memory, an evolving relationship model, and a decision engine that keeps a persona in character across thousands of turns.**
 >
-> `eros-engine` is the companion-chat core behind [Eros Chat](https://chat.etherfun.xyz), extracted into a standalone service. It turns conversation into three durable signals: a structured user profile, two-layer long-term memory, and a six-dimensional affinity model that changes how a persona behaves over time.
+> `eros-engine` is the companion-chat core behind [Eros Chat](https://chat.etherfun.xyz), extracted into a standalone service. It turns conversation into durable state — a structured user profile, two-layer long-term memory, and a six-dimensional affinity model — so a persona behaves like the same person each time a user comes back.
 
 [![CI](https://github.com/etherfunlab/eros-engine/actions/workflows/ci.yml/badge.svg)](https://github.com/etherfunlab/eros-engine/actions/workflows/ci.yml)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
@@ -15,72 +15,17 @@ English · [中文](README.zh.md)
 
 ## Why this exists
 
-Most AI character apps treat memory as a prompt append and relationship as a paragraph of instructions. That works for a demo, but it drifts in long sessions and is hard to debug.
+Most AI character apps treat memory as a prompt append and relationship as a paragraph of instructions. That works for a demo, but it drifts over long sessions, breaks character, and is hard to debug. `eros-engine` moves those concerns into explicit, inspectable state, so a companion feels like **a real person** — it remembers you and reacts to where the relationship is — and **stays in character** turn after turn, because behavior is *decided*, not improvised.
 
-`eros-engine` moves those concerns into explicit state:
+Five pillars carry that:
 
-- **Memory** lives in Postgres + pgvector, split into profile memory and relationship memory.
-- **Affinity** is a numeric vector updated with EMA smoothing and real-time decay.
-- **User insight** is a structured JSONB profile that downstream products can query.
-- **Persona behavior** is planned through a Persona Decision Engine (PDE) — rules-based by default, with an opt-in LLM judge layer configurable via `[tasks.pde_decision].filter_prompt` — then rendered by an LLM. Per-turn judge calls are audited to `companion_decision_events`.
+- **Two-layer memory** — profile memory (stable user facts) and relationship memory (shared moments, callbacks, open threads) in Postgres + pgvector, so the companion remembers you across sessions and personas. → [Memory layers](docs/memory-layers.md)
+- **Six-axis affinity + ghost mechanics** — a numeric relationship vector (warmth, trust, intimacy, intrigue, patience, tension) updated with EMA smoothing and real-time decay; it reshapes tone, depth, and behavior over time, and can even decide *not* to reply. → [Affinity model](docs/affinity-model.md) · [Ghost mechanics](docs/ghost-mechanics.md)
+- **Persona Decision Engine (PDE)** — picks each turn's action (reply, ghost, or send a photo) and inner state — rules-based by default, with an opt-in LLM judge. This is what keeps replies human and in-character instead of a generic assistant voice; judge calls are audited to `companion_decision_events`. → [Model config](docs/model-config.md)
+- **Structured user insight** — a JSONB profile (city, occupation, interests, MBTI signals, emotional needs, life rhythm, matching preferences) with a weighted `training_level`, queryable by downstream products for matchmaking, onboarding, analytics, or gating. → [API reference](docs/api-reference.md)
+- **Built for fluent companion chat** — token-by-token SSE streaming; image understanding (the user can send a photo) and companion-sent image generation (`reply_image` / `reply_text_image`); per-request prompt traits and tiers; OpenRouter-backed routing with per-task model selection (fixed / round-robin / weighted, plus a fallback chain) and full call auditing. → [API reference](docs/api-reference.md) · [Model config](docs/model-config.md)
 
-The result is not a generic agent framework. It is a focused engine for products where a persona talks to the same user across many sessions: AI companions, journaling companions, coaching agents, language tutors, and character chat.
-
-## Key features
-
-### Two-layer memory
-
-`eros-engine` stores memory in two semantic scopes:
-
-| Layer | Scope | Purpose |
-|---|---|---|
-| Profile memory | `user_id`, with `instance_id IS NULL` | Stable user facts shared across sessions and personas. |
-| Relationship memory | `user_id + persona instance` | Callbacks, shared moments, unresolved threads, and relationship-specific context. |
-
-Embeddings use Voyage `voyage-3-lite` with 512-dimensional vectors. Retrieval runs through pgvector IVFFlat cosine search.
-
-### Six-dimensional affinity
-
-Each chat session carries a six-dimensional relationship vector. The six axes — the dimensions of the vector — are:
-
-| Axis | Range | Controls |
-|---|---:|---|
-| `warmth` | -1.0 to 1.0 | Tone and address, from distant to affectionate. |
-| `trust` | 0.0 to 1.0 | Topic depth and willingness to disclose. |
-| `intimacy` | 0.0 to 1.0 | Nicknames, inside jokes, and callbacks. |
-| `intrigue` | 0.0 to 1.0 | Curiosity and follow-up behavior. |
-| `patience` | 0.0 to 1.0 | Tolerance for low-effort or repeated messages. |
-| `tension` | 0.0 to 1.0 | Push-pull, friction, and playful resistance. |
-
-Two **composite scores** summarize this vector for prompt-shaping — each is the mean of a disjoint triplet of axes (`warmth` is rescaled to 0-1 first):
-
-- **bond** (how close it feels) = mean(`warmth`, `intimacy`, `tension`)
-- **chemistry** (how charged it feels) = mean(`trust`, `intrigue`, `patience`)
-
-Updates are smoothed with exponential moving average (EMA), so the persona does not jump between emotional states. `intrigue`, `patience`, and `tension` also decay or recover with real time. The smoothing strength is set by `EMA_INERTIA` (default `0.8`): each turn applies only `1 − inertia` of the evaluated delta, so a higher value makes the relationship build (and cool) more slowly — in effect a difficulty dial — while `0` applies every delta in full.
-
-A per-request `affinity_scope` flag selects which composite shapes the prompt: `bond` (default), `chemistry`, `bond_and_chemistry` (≡ `full`, all six axes), `none`, or an explicit axis subset like `["warmth", "trust"]`. It gates prompt injection only — all six axes are always persisted and updated regardless.
-
-Relationship labels such as `stranger`, `slow_burn`, `friend`, `frenemy`, and `romantic` emerge from threshold rules. They are internal state, not user-facing badges.
-
-### Deterministic ghost mechanics
-
-The same affinity vector drives a deterministic ghost decision. When patience and intrigue drop far enough, the persona can choose not to reply.
-
-Four protection rules keep this from feeling arbitrary:
-
-- no ghosting before message 10;
-- no two ghosts in a row;
-- one-hour cooldown after a ghost;
-- a higher threshold after a recent ghost.
-
-This is implemented as domain logic in Rust, not as a prompt suggestion.
-
-### Structured user insight
-
-The `companion_insights` table stores a JSONB profile per user: city, occupation, interests, MBTI signals, relationship values, emotional needs, life rhythm, personality traits, and matching preferences.
-
-Each field contributes to a weighted `training_level`. That makes the profile useful outside the chat loop: matchmaking, onboarding completion, coaching logic, analytics, and product gating can all query structured fields instead of parsing free text.
+This is not a generic agent framework. It is a focused engine for products where one persona talks to the same user across many sessions: AI companions, journaling companions, coaching agents, language tutors, and character chat.
 
 ## Architecture
 
@@ -109,7 +54,7 @@ The workspace is split into four crates:
 | `eros-engine-store` | Postgres + pgvector persistence, with all tables under the `engine` schema. |
 | `eros-engine-server` | Axum HTTP service, Supabase JWT middleware, OpenAPI docs, and pipeline wiring. |
 
-You can run `eros-engine-server` as an HTTP API, or embed `core + llm + store` directly in your own Rust service.
+You can run `eros-engine-server` as an HTTP API, or embed `core + llm + store` directly in your own Rust service. See [Architecture](docs/architecture.md) for crate boundaries, pipeline phases, and data flow.
 
 ## Use as a library
 
@@ -121,12 +66,12 @@ cargo add eros-engine-core eros-engine-store eros-engine-llm
 
 ```toml
 [dependencies]
-eros-engine-core  = "0.4"
-eros-engine-store = "0.4"   # only if you want the Postgres + pgvector layer
-eros-engine-llm   = "0.4"   # only if you want the OpenRouter + Voyage clients
+eros-engine-core  = "0.6"
+eros-engine-store = "0.6"   # only if you want the Postgres + pgvector layer
+eros-engine-llm   = "0.6"   # only if you want the OpenRouter + Voyage clients
 ```
 
-`eros-engine-server` is intentionally not published to crates.io. See the next section to run it as a Docker image.
+`eros-engine-server` is intentionally not published to crates.io — run it as a Docker image (below).
 
 ## Run as a Docker image
 
@@ -145,7 +90,7 @@ docker run --rm -p 8080:8080 --env-file .env \
   ghcr.io/etherfunlab/eros-engine:0.6.2 serve
 ```
 
-The `docker/Dockerfile` is the same artifact used to build this image. Deploy it on any container host.
+The `docker/Dockerfile` is the same artifact used to build this image. Deploy it on any container host. See [Deploying](docs/deploying.md).
 
 ## Documentation
 
@@ -153,107 +98,54 @@ The `docker/Dockerfile` is the same artifact used to build this image. Deploy it
 - [Affinity model](docs/affinity-model.md) — six dimensions, EMA, time decay, relationship labels.
 - [Ghost mechanics](docs/ghost-mechanics.md) — score formula, protection rules, examples.
 - [Memory layers](docs/memory-layers.md) — profile vs relationship memory, Voyage, pgvector retrieval.
-- [Model config](docs/model-config.md) — `model_config.toml` schema, task names, resolution rules, 0.x stability commitments.
-- [Deploying](docs/deploying.md) — Docker, bring-your-own Postgres / IdP.
-- [API reference](docs/api-reference.md) — every `/comp/*` endpoint.
+- [Model config](docs/model-config.md) — `model_config.toml` schema, every task (chat, vision, image generation, PDE, filters, extraction), model selection, 0.x stability commitments.
+- [Prompt traits](docs/prompt-traits.md) — per-request system-prompt injection and tier allow-lists.
+- [LLM / OpenRouter audit](docs/llm-audit.md) — per-user / per-session attribution passthrough.
+- [Deploying](docs/deploying.md) — Docker, bring-your-own Postgres / IdP, operational env vars.
+- [API reference](docs/api-reference.md) — every `/comp/*` endpoint, request fields, and SSE frame layout.
 
 ## Quickstart
 
-Prerequisites:
-
-- Rust toolchain from `rust-toolchain.toml`.
-- Postgres 16+ with the `pgvector` extension.
-- OpenRouter API key.
-- Voyage API key.
-- Supabase JWT secret, or your own `AuthValidator` implementation.
+Prerequisites: a Rust toolchain (`rust-toolchain.toml`), Postgres 16+ with `pgvector`, an OpenRouter API key, a Voyage API key, and a Supabase JWT secret (or your own `AuthValidator`).
 
 ```bash
 git clone https://github.com/etherfunlab/eros-engine
 cd eros-engine
-cp .env.example .env
-```
+cp .env.example .env   # fill in DATABASE_URL, OPENROUTER_API_KEY, VOYAGE_API_KEY, and one auth source
 
-Fill in `DATABASE_URL`, `OPENROUTER_API_KEY`, `VOYAGE_API_KEY`, and `SUPABASE_JWT_SECRET`, then run:
-
-```bash
 cargo run -p eros-engine-server -- migrate
 cargo run -p eros-engine-server -- seed-personas examples/personas
 cargo run -p eros-engine-server -- serve
 ```
 
-The server listens on `0.0.0.0:8080` by default. Scalar API docs are available at `/docs`, and the OpenAPI JSON is available at `/api-docs/openapi.json`.
-
-The official Eros Chat web client is closed-source. `eros-engine` is designed to run standalone; bring your own UI or embed the crates in another service.
+The server listens on `0.0.0.0:8080` by default. Scalar API docs are at `/docs`; the OpenAPI JSON is at `/api-docs/openapi.json`. The official Eros Chat web client is closed-source — bring your own UI or embed the crates in another service.
 
 ## API surface
 
-All `/comp/*` routes require `Authorization: Bearer <Supabase JWT>` by default.
-
-Highlights:
+All `/comp/*` routes require `Authorization: Bearer <Supabase JWT>` by default (the `AuthValidator` trait is pluggable for other identity providers). Key endpoints:
 
 - `POST /comp/chat/start` — open a chat session against a persona.
-- `POST /comp/chat/{session_id}/message/stream` — **the** chat turn endpoint: token-by-token Server-Sent Events (SSE) streaming. (The old blocking synchronous `/message` endpoint was removed in 0.3 — SSE is now the only chat path.)
-- `GET  /comp/chat/{session_id}/history` — paginated chat history.
-- `GET  /comp/chat/{user_id}/sessions` — list a user's sessions.
-- `GET  /comp/user/{user_id}/profile` — current `companion_insights` and `training_level`.
-- `POST /comp/chat/{session_id}/event/gift` — apply an out-of-band gift event and affinity delta.
-- `GET  /comp/chat/{session_id}/gifts` — list gift events for a session.
-- `/message/stream` accepts several optional caller-supplied fields:
-  - `tier` — selects a per-tier chat model and `prompt_traits` allow-list
-    from `model_config.toml`; unknown/absent falls back to the task default.
-    See [docs/model-config.md](docs/model-config.md).
-  - `prompt_traits` — per-request system-prompt injection, gated by the
-    resolved tier's allow-list, see [docs/prompt-traits.md](docs/prompt-traits.md).
-  - `audit` — opaque OpenRouter passthrough (`user` / `session_id` /
-    `metadata`) for per-user / per-session attribution on OpenRouter
-    dashboards. See [docs/llm-audit.md](docs/llm-audit.md).
-- `GET  /comp/affinity/{session_id}` — debug-only live affinity vector, enabled by `EXPOSE_AFFINITY_DEBUG=true`.
+- `POST /comp/chat/{session_id}/message/stream` — **the** chat turn endpoint: token-by-token Server-Sent Events. Optional per-turn fields include `tier`, `prompt_traits`, `audit`, `tips_amount_usd` (tip the companion), `image_url` (send the companion a photo), and `image` (request a companion-generated image — style / model / aspect ratio / face reference).
+- `POST /comp/chat/{session_id}/message/{message_id}/image` — write back the storage URL of a companion-generated image.
+- `GET /comp/chat/{session_id}/history` · `GET /comp/chat/{user_id}/sessions` · `GET /comp/user/{user_id}/profile` — history, session list, and the structured insight profile.
+- `GET /comp/affinity/{session_id}` — debug-only live affinity vector (`EXPOSE_AFFINITY_DEBUG=true`).
 
-The `AuthValidator` trait is pluggable if you use a different identity provider.
-
-### Streaming chat
-
-Chat is streaming-only: replies arrive token-by-token over SSE so clients can render as the model generates, instead of blocking on a full synchronous response. (The legacy blocking `/message` endpoint was removed in 0.3.)
-
-```bash
-curl -N -X POST \
-  -H "Authorization: Bearer $JWT" \
-  -H "Content-Type: application/json" \
-  -H "Accept: text/event-stream" \
-  -d '{"content":"hi","client_msg_id":"01J3333333333333333333333A"}' \
-  http://localhost:8080/comp/chat/<session_id>/message/stream
-```
-
-See [docs/api-reference.md](docs/api-reference.md#post-compchatsession_idmessagestream)
-for frame layout and error semantics.
+The blocking synchronous `/message` endpoint was removed in 0.3 — SSE is the only chat path. For the full request schema, SSE frame layout (incl. `delta`, `image`, ghost, and error frames), and per-field semantics, see the [API reference](docs/api-reference.md).
 
 ## Configuration
 
-| Env var | Required | Notes |
-|---|---|---|
-| `DATABASE_URL` | yes | Postgres with `pgvector`; tables are created under `engine.*`. |
-| `OPENROUTER_API_KEY` | yes | Chat completions, routed by `examples/model_config.toml` unless overridden. |
-| `OPENROUTER_APP_REFERER` | no | When set, sent as `HTTP-Referer` on every outbound OpenRouter call. Shows up on OpenRouter's app analytics dashboard. |
-| `OPENROUTER_APP_TITLE` | no | When set, sent as `X-OpenRouter-Title`. Display name in OpenRouter app analytics. Pairs with `OPENROUTER_APP_REFERER`; both optional. |
-| `OPENROUTER_APP_CATEGORIES` | no | When set, sent as `X-OpenRouter-Categories` — comma-separated OpenRouter marketplace categories (e.g. `roleplay,general-chat`). Passed through verbatim; OpenRouter ignores unrecognised values and only honours it alongside `OPENROUTER_APP_REFERER`. |
-| `OPENROUTER_USAGE_HIDDEN_KEYS` | no | Comma-separated list of top-level keys to strip from the `usage` object on the SSE streaming `done` frame. Useful for hiding wholesale `cost` / `cost_details` from downstream customers. The full usage is still persisted and traced server-side. |
-| `VOYAGE_API_KEY` | yes | Embeddings. Empty keys fail server boot. |
-| `SUPABASE_URL` | no | Supabase project URL. When set, the server derives the JWKS endpoint (`<url>/auth/v1/.well-known/jwks.json`) for asymmetric (RS256/ES256) JWT validation — the post-2025 Supabase default. |
-| `SUPABASE_JWKS_URL` | no | Explicit JWKS endpoint; takes precedence over deriving it from `SUPABASE_URL`. |
-| `SUPABASE_JWT_SECRET` | no | Legacy HS256 shared secret. At least one auth source — `SUPABASE_URL` / `SUPABASE_JWKS_URL` (JWKS) or `SUPABASE_JWT_SECRET` (HS256) — must be set, or the server refuses to boot (fail-closed). |
-| `BIND_ADDR` | no | Defaults to `0.0.0.0:8080`. |
-| `EXPOSE_AFFINITY_DEBUG` | no | Set `true` to enable `/comp/affinity/{session_id}`. |
-| `EMA_INERTIA` | no | EMA smoothing for affinity updates, in `[0, 1]`; defaults to `0.8`. Each turn applies `1 − inertia` of the evaluated delta, so a higher value moves the affinity vector less per turn (slower to build or lose) — a relationship-difficulty dial; `0` applies every delta in full. |
-| `DEMO_EMA_INERTIA` | no | EMA inertia applied only to sessions opened with `is_demo: true`; defaults to `0.3` so meters move visibly across a short demo. Falls back to `EMA_INERTIA` semantics otherwise. |
-| `DREAMING_DISABLED` | no | Set `1` to skip spawning the dreaming-lite sweeper (session-end memory extraction). |
-| `DREAMING_TICK_SECS` | no | How often the dreaming-lite sweeper wakes; defaults to `300`. |
-| `DREAMING_IDLE_SECS` | no | Minimum idle time before a session is eligible for classification; defaults to `1800`. |
-| `DREAMING_CLAIM_STALE_SECS` | no | How long a classification claim stays fresh before a crashed worker's row is re-claimed; defaults to `600`. |
-| `SNAPSHOT_DISABLED` | no | Set `1` to skip spawning the `companion_insights_snapshot` sweeper. |
-| `SNAPSHOT_CRON` | no | 6-field cron (`sec min hr dom mon dow`) for the snapshot sweeper; defaults to `0 0 23 * * *` (daily 23:00). |
-| `SNAPSHOT_TZ` | no | IANA timezone the snapshot cron is evaluated in; defaults to `Asia/Singapore`. |
-| `MODEL_CONFIG_PATH` | no | Defaults to `examples/model_config.toml`. |
-| `RUST_LOG` | no | Defaults to `info`. |
+Required env vars: `DATABASE_URL`, `OPENROUTER_API_KEY`, `VOYAGE_API_KEY`, and **one** auth source — `SUPABASE_URL` / `SUPABASE_JWKS_URL` (JWKS, the post-2025 Supabase default) **or** `SUPABASE_JWT_SECRET` (legacy HS256). The server fails closed to boot if no auth source is set.
+
+Everything else has sane defaults: model routing (`MODEL_CONFIG_PATH` → `model_config.toml`), OpenRouter attribution headers, the dreaming-lite / snapshot sweepers, the `EMA_INERTIA` relationship-difficulty dial, and debug toggles. The full annotated list lives in [`.env.example`](.env.example); operational guidance is in [Deploying](docs/deploying.md), and model routing in [Model config](docs/model-config.md).
+
+## Roadmap
+
+Not part of the engine today, but on the radar:
+
+- **Agents playground** — multiple AI personas interacting with each other (and the user) in one session.
+- **Voice messages** — companion-sent and user-sent audio turns.
+- **Real-time voice conversation** — low-latency spoken back-and-forth.
+- **Video generation** — short companion-sent video clips, extending the image executor.
 
 ## What is deliberately out of scope
 
@@ -267,16 +159,9 @@ If you are building a different product, the reusable part is the affinity + mem
 
 ## Content note
 
-The example personas under `examples/personas/` are written as adult
-character-chat examples. They can flirt and express desire when the
-relationship state reaches that point, while still refusing disrespectful or
-boundary-crossing behavior. If your product needs a SFW default, replace
-those persona files before deploying.
+The example personas under `examples/personas/` are written as adult character-chat examples. They can flirt and express desire when the relationship state reaches that point, while still refusing disrespectful or boundary-crossing behavior. If your product needs a SFW default, replace those persona files before deploying.
 
-Per-request behaviour can be further modulated via the
-[`prompt_traits`](docs/prompt-traits.md) field on the message routes —
-the engine treats the supplied text as opaque, so the policy of what
-those traits encode lives entirely in your frontend / middleware.
+Per-request behaviour can be further modulated via the [`prompt_traits`](docs/prompt-traits.md) field on the message routes — the engine treats the supplied text as opaque, so the policy of what those traits encode lives entirely in your frontend / middleware.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -11,17 +11,17 @@
 [![Crates.io: llm](https://img.shields.io/crates/v/eros-engine-llm.svg?label=eros-engine-llm)](https://crates.io/crates/eros-engine-llm)
 [![GHCR: eros-engine](https://img.shields.io/badge/ghcr.io-etherfunlab%2Feros--engine-blue)](https://github.com/etherfunlab/eros-engine/pkgs/container/eros-engine)
 
-English · [中文](README.zh.md)
+**English** · [中文](README.zh.md) · [日本語](README.ja.md)
 
 ## Why this exists
 
-Most AI character apps treat memory as a prompt append and relationship as a paragraph of instructions. That works for a demo, but it drifts over long sessions, breaks character, and is hard to debug. `eros-engine` moves those concerns into explicit, inspectable state, so a companion feels like **a real person** — it remembers you and reacts to where the relationship is — and **stays in character** turn after turn, because behavior is *decided*, not improvised.
+Most AI character apps treat memory as text appended to a prompt and relationship as a paragraph of instructions. That can work in a demo, but behavior drifts over long sessions, breaks character, and becomes hard to debug. `eros-engine` moves those concerns into explicit, inspectable state, so a companion feels like **a real person** — remembering you and responding to the state of the relationship — and **stays in character** turn after turn, because behavior is *decided*, not improvised.
 
-Five pillars carry that:
+Five pillars support this:
 
 - **Two-layer memory** — profile memory (stable user facts) and relationship memory (shared moments, callbacks, open threads) in Postgres + pgvector, so the companion remembers you across sessions and personas. → [Memory layers](docs/memory-layers.md)
 - **Six-axis affinity + ghost mechanics** — a numeric relationship vector (warmth, trust, intimacy, intrigue, patience, tension) updated with EMA smoothing and real-time decay; it reshapes tone, depth, and behavior over time, and can even decide *not* to reply. → [Affinity model](docs/affinity-model.md) · [Ghost mechanics](docs/ghost-mechanics.md)
-- **Persona Decision Engine (PDE)** — picks each turn's action (reply, ghost, or send a photo) and inner state — rules-based by default, with an opt-in LLM judge. This is what keeps replies human and in-character instead of a generic assistant voice; judge calls are audited to `companion_decision_events`. → [Model config](docs/model-config.md)
+- **Persona Decision Engine (PDE)** — selects each turn's action (reply, ghost, or send a photo) and inner state — rules-based by default, with an opt-in LLM judge. This keeps replies human and in character instead of sounding like a generic assistant; judge calls are audited to `companion_decision_events`. → [Model config](docs/model-config.md)
 - **Structured user insight** — a JSONB profile (city, occupation, interests, MBTI signals, emotional needs, life rhythm, matching preferences) with a weighted `training_level`, queryable by downstream products for matchmaking, onboarding, analytics, or gating. → [API reference](docs/api-reference.md)
 - **Built for fluent companion chat** — token-by-token SSE streaming; image understanding (the user can send a photo) and companion-sent image generation (`reply_image` / `reply_text_image`); per-request prompt traits and tiers; OpenRouter-backed routing with per-task model selection (fixed / round-robin / weighted, plus a fallback chain) and full call auditing. → [API reference](docs/api-reference.md) · [Model config](docs/model-config.md)
 
@@ -75,7 +75,7 @@ eros-engine-llm   = "0.6"   # only if you want the OpenRouter + Voyage clients
 
 ## Run as a Docker image
 
-`linux/amd64` images for `eros-engine-server` are published to GitHub Container Registry on every `v*` tag (need arm64? build it yourself from `docker/Dockerfile`):
+`linux/amd64` images for `eros-engine-server` are published to GitHub Container Registry for every `v*` tag (need arm64? Build it yourself from `docker/Dockerfile`):
 
 ```bash
 docker pull ghcr.io/etherfunlab/eros-engine:0.6.2
@@ -106,7 +106,7 @@ The `docker/Dockerfile` is the same artifact used to build this image. Deploy it
 
 ## Quickstart
 
-Prerequisites: a Rust toolchain (`rust-toolchain.toml`), Postgres 16+ with `pgvector`, an OpenRouter API key, a Voyage API key, and a Supabase JWT secret (or your own `AuthValidator`).
+Prerequisites: a Rust toolchain (`rust-toolchain.toml`), Postgres 16+ with `pgvector`, an OpenRouter API key, a Voyage API key, and one auth source — Supabase JWKS (`SUPABASE_URL`) or a legacy `SUPABASE_JWT_SECRET` (or your own `AuthValidator`).
 
 ```bash
 git clone https://github.com/etherfunlab/eros-engine
@@ -118,7 +118,7 @@ cargo run -p eros-engine-server -- seed-personas examples/personas
 cargo run -p eros-engine-server -- serve
 ```
 
-The server listens on `0.0.0.0:8080` by default. Scalar API docs are at `/docs`; the OpenAPI JSON is at `/api-docs/openapi.json`. The official Eros Chat web client is closed-source — bring your own UI or embed the crates in another service.
+The server listens on `0.0.0.0:8080` by default. Scalar API docs are available at `/docs`; the OpenAPI JSON is at `/api-docs/openapi.json`. The official Eros Chat web client is closed-source — bring your own UI or embed the crates in another service.
 
 ## API surface
 
@@ -130,11 +130,11 @@ All `/comp/*` routes require `Authorization: Bearer <Supabase JWT>` by default (
 - `GET /comp/chat/{session_id}/history` · `GET /comp/chat/{user_id}/sessions` · `GET /comp/user/{user_id}/profile` — history, session list, and the structured insight profile.
 - `GET /comp/affinity/{session_id}` — debug-only live affinity vector (`EXPOSE_AFFINITY_DEBUG=true`).
 
-The blocking synchronous `/message` endpoint was removed in 0.3 — SSE is the only chat path. For the full request schema, SSE frame layout (incl. `delta`, `image`, ghost, and error frames), and per-field semantics, see the [API reference](docs/api-reference.md).
+The blocking synchronous `/message` endpoint was removed in 0.3 — SSE is the only chat path. For the full request schema, SSE frame layout (including `delta`, `image`, ghost, and error frames), and per-field semantics, see the [API reference](docs/api-reference.md).
 
 ## Configuration
 
-Required env vars: `DATABASE_URL`, `OPENROUTER_API_KEY`, `VOYAGE_API_KEY`, and **one** auth source — `SUPABASE_URL` / `SUPABASE_JWKS_URL` (JWKS, the post-2025 Supabase default) **or** `SUPABASE_JWT_SECRET` (legacy HS256). The server fails closed to boot if no auth source is set.
+Required env vars: `DATABASE_URL`, `OPENROUTER_API_KEY`, `VOYAGE_API_KEY`, and **one** auth source — `SUPABASE_URL` / `SUPABASE_JWKS_URL` (JWKS, the post-2025 Supabase default) **or** `SUPABASE_JWT_SECRET` (legacy HS256). The server refuses to boot if no auth source is set.
 
 Everything else has sane defaults: model routing (`MODEL_CONFIG_PATH` → `model_config.toml`), OpenRouter attribution headers, the dreaming-lite / snapshot sweepers, the `EMA_INERTIA` relationship-difficulty dial, and debug toggles. The full annotated list lives in [`.env.example`](.env.example); operational guidance is in [Deploying](docs/deploying.md), and model routing in [Model config](docs/model-config.md).
 
@@ -161,7 +161,7 @@ If you are building a different product, the reusable part is the affinity + mem
 
 The example personas under `examples/personas/` are written as adult character-chat examples. They can flirt and express desire when the relationship state reaches that point, while still refusing disrespectful or boundary-crossing behavior. If your product needs a SFW default, replace those persona files before deploying.
 
-Per-request behaviour can be further modulated via the [`prompt_traits`](docs/prompt-traits.md) field on the message routes — the engine treats the supplied text as opaque, so the policy of what those traits encode lives entirely in your frontend / middleware.
+Per-request behavior can be further adjusted via the [`prompt_traits`](docs/prompt-traits.md) field on the message routes — the engine treats the supplied text as opaque, so the policy defining what those traits encode lives entirely in your frontend / middleware.
 
 ## Contributing
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,218 +1,172 @@
 # eros-engine
 
-> **一個用 Rust 寫的開源 AI 伴侶引擎：記憶、關係狀態、結構化用戶洞察。**
+> **一个开源的 Rust AI 伴侣引擎：让角色"像真人"——持久记忆、会演变的关系模型，以及一个让人设在成千上万轮对话里保持稳定的决策引擎。**
 >
-> `eros-engine` 是 [Eros Chat](https://chat.etherfun.xyz) 背後的 companion-chat 核心，現在抽成可獨立部署的服務。它把每輪對話轉成三種可持久化的信號：結構化用戶畫像、雙層長期記憶，以及會持續影響 persona 行為的六維好感度模型。
+> `eros-engine` 是 [Eros Chat](https://chat.etherfun.xyz) 背后的伴侣对话核心，抽取成了独立服务。它把对话沉淀为可持久的状态——结构化用户画像、双层长期记忆、六维亲密度模型——让角色在用户每次回来时都表现得像同一个人。
 
 [![CI](https://github.com/etherfunlab/eros-engine/actions/workflows/ci.yml/badge.svg)](https://github.com/etherfunlab/eros-engine/actions/workflows/ci.yml)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
+[![Crates.io: core](https://img.shields.io/crates/v/eros-engine-core.svg?label=eros-engine-core)](https://crates.io/crates/eros-engine-core)
+[![Crates.io: store](https://img.shields.io/crates/v/eros-engine-store.svg?label=eros-engine-store)](https://crates.io/crates/eros-engine-store)
+[![Crates.io: llm](https://img.shields.io/crates/v/eros-engine-llm.svg?label=eros-engine-llm)](https://crates.io/crates/eros-engine-llm)
+[![GHCR: eros-engine](https://img.shields.io/badge/ghcr.io-etherfunlab%2Feros--engine-blue)](https://github.com/etherfunlab/eros-engine/pkgs/container/eros-engine)
 
 [English](README.md) · 中文
 
-## 為甚麼需要它
+## 为什么做这个
 
-很多 AI character app 把記憶當成 prompt append，把關係當成一段 system prompt 描述。Demo 階段可以運作，但長 session 很容易漂移，也很難調試。
+大多数 AI 角色应用把记忆当成往 prompt 里追加文本，把关系写成一段指令。这能撑起一个 demo，但在长会话里会漂移、会崩人设，也很难调试。`eros-engine` 把这些都搬进显式、可检视的状态里——所以角色会"像真人"（记得你、并对关系所处的位置作出反应），并且"人设稳定"（行为是被*决策*出来的，而不是即兴发挥）。
 
-`eros-engine` 把這些能力變成明確狀態：
+五大支柱支撑这一点：
 
-- **Memory** 放在 Postgres + pgvector，拆成 profile memory 和 relationship memory。
-- **Affinity** 是數值向量，透過 EMA 平滑與真實時間衰退更新。
-- **User insight** 是可查詢的 JSONB 用戶畫像。
-- **Persona behavior** 先由 Persona Decision Engine（PDE）规划，再交给 LLM 生成。PDE 默认为规则型；可通过 `[tasks.pde_decision].filter_prompt` 启用可选 LLM 判断器层，每轮判断结果记录到 `companion_decision_events`。
+- **双层记忆**——画像记忆（稳定的用户事实）与关系记忆（共同时刻、回扣、未了的话头），都存在 Postgres + pgvector 里，让角色跨会话、跨人设地记得你。→ [记忆分层](docs/memory-layers.zh.md)
+- **六维亲密度 + ghost 机制**——一个数值化的关系向量（warmth、trust、intimacy、intrigue、patience、tension），用 EMA 平滑、随真实时间衰减；它会随时间重塑语气、深度与行为，甚至可以决定*不回复*。→ [亲密度模型](docs/affinity-model.zh.md) · [ghost 机制](docs/ghost-mechanics.zh.md)
+- **人设决策引擎（PDE）**——为每一轮挑选行为（回复 / ghost / 发一张照片）和内在状态——默认基于规则，可选开启 LLM 裁判层。这正是让回复"像真人"且不崩人设、而不是变成通用助手腔的关键；裁判调用会审计到 `companion_decision_events`。→ [模型配置](docs/model-config.zh.md)
+- **结构化用户画像**——每个用户一份 JSONB 画像（城市、职业、兴趣、MBTI 信号、情感需求、生活节奏、匹配偏好），带一个加权的 `training_level`，下游产品可直接查询用于匹配、引导、分析或灰度。→ [API 参考](docs/api-reference.zh.md)
+- **为流畅的伴侣对话而生**——逐 token 的 SSE 流式输出；图像理解（用户可以发照片）与角色主动生成图片（`reply_image` / `reply_text_image`）；按请求注入的 prompt traits 与 tier；OpenRouter 路由，按任务选模型（固定 / 轮询 / 加权，外加 fallback 链）并全程审计调用。→ [API 参考](docs/api-reference.zh.md) · [模型配置](docs/model-config.zh.md)
 
-這不是通用 agent framework，而是為「同一個 persona 長期跟同一個用戶互動」設計的引擎：AI 伴侶、日記式陪伴、coaching agent、language tutor、character chat 都屬於這類場景。
+这不是一个通用 agent 框架。它是一个聚焦的引擎，专为"同一个角色跨多次会话与同一个用户对话"的产品而做：AI 伴侣、日记陪伴、教练 agent、语言陪练、角色聊天。
 
-## 核心特性
-
-### 雙層記憶
-
-`eros-engine` 用兩種語義 scope 存記憶：
-
-| 層級 | Scope | 用途 |
-|---|---|---|
-| Profile memory | `user_id`，且 `instance_id IS NULL` | 跨 session、跨 persona 共享的穩定用戶事實。 |
-| Relationship memory | `user_id + persona instance` | 共同經歷、回頭呼應、未解決話題，以及只屬於這段關係的上下文。 |
-
-Embedding 使用 Voyage `voyage-3-lite`，512 維向量。檢索走 pgvector IVFFlat cosine search。
-
-### 六維好感度
-
-每個 chat session 都有一條六維關係向量。六個維度（向量的各軸）如下：
-
-| 維度 | 範圍 | 控制 |
-|---|---:|---|
-| `warmth` | -1.0 到 1.0 | 語氣與稱呼，從疏離到親近。 |
-| `trust` | 0.0 到 1.0 | 話題深度，以及 persona 是否願意透露自己。 |
-| `intimacy` | 0.0 到 1.0 | 暱稱、內部梗、對過往細節的呼應。 |
-| `intrigue` | 0.0 到 1.0 | 好奇心與追問傾向。 |
-| `patience` | 0.0 到 1.0 | 對低 effort 或重複消息的容忍度。 |
-| `tension` | 0.0 到 1.0 | 推拉、摩擦、玩鬧式抵抗。 |
-
-兩個**复合指标**把這條向量壓成便於 prompt 塑形的摘要——各是一組互斥三維的平均（`warmth` 先線性縮放到 0–1）：
-
-- **bond**（朋友感，關係有多近）= mean(`warmth`、`intimacy`、`tension`)
-- **chemistry**（来电感，張力有多強）= mean(`trust`、`intrigue`、`patience`)
-
-更新使用指數移動平均（EMA），避免 persona 在情緒狀態間突然跳變。`intrigue`、`patience`、`tension` 也會隨真實時間自然衰退或恢復。平滑强度由 `EMA_INERTIA`（默认 `0.8`）控制：每轮只施加 `1 − inertia` 比例的评估增量，所以值越高、关系升温（与降温）越慢——相当于一个难度旋钮；设为 `0` 则每次增量全额生效。
-
-每個 request 可帶 `affinity_scope` flag，決定哪一個复合指标參與 prompt 注入：`bond`（默認）、`chemistry`、`bond_and_chemistry`（≡ `full`，全部六維）、`none`，或像 `["warmth", "trust"]` 這樣的顯式維度子集。它只 gate prompt 注入——六個維度始終照常持久化與更新。
-
-`stranger`、`slow_burn`、`friend`、`frenemy`、`romantic` 這些關係標籤由閾值規則從向量中推導出來。它們是內部狀態，不是展示給用戶看的 badge。
-
-### 確定性的 ghost 機制
-
-同一條 affinity vector 也驅動 ghost decision。當 patience 和 intrigue 下降到一定程度，persona 可以選擇不回覆。
-
-四條保護規則避免它變得隨機：
-
-- 前 10 條消息不 ghost；
-- 不連續 ghost 兩次；
-- ghost 後有 1 小時 cooldown；
-- 最近 ghost 過時提高下一次 ghost 閾值。
-
-這是 Rust 裡的 domain logic，不是 prompt 裡的一句建議。
-
-### 結構化用戶洞察
-
-`companion_insights` 表為每個用戶保存一份 JSONB profile：城市、職業、興趣、MBTI 信號、感情價值觀、情緒需求、生活節奏、性格特質、配對偏好。
-
-每個字段會貢獻一部分加權 `training_level`。因此這份 profile 不只服務聊天，也能被 matchmaking、onboarding、coaching logic、analytics 或產品 gating 直接查詢。
-
-## 架構
+## 架构
 
 ```txt
 ┌─────────────────────────────────────────────────────────┐
-│ /comp/* HTTP routes  ←  Supabase JWT middleware          │
+│ /comp/* HTTP 路由  ←  Supabase JWT 中间件                │
 │         │                                                │
 │         ▼                                                │
-│ pipeline orchestrator: load → PDE → handler → chat → post│
+│ pipeline 编排：load → PDE → handler → chat → post        │
 │                                          │              │
 │  ┌───────────────────────────────────────┴────────┐     │
-│  │ post-process，在回覆後背景執行                 │     │
-│  │   • affinity: 寫入 6D delta + EMA              │     │
-│  │   • memory:   Voyage embed → pgvector upsert   │     │
-│  │   • insight:  抽取 facts → JSONB merge         │     │
+│  │ post-process，回复后异步 spawn                  │     │
+│  │   • 亲密度：持久化 6 维 delta + EMA            │     │
+│  │   • 记忆：  Voyage embed → pgvector upsert     │     │
+│  │   • 画像：  抽取事实 → JSONB 合并              │     │
 │  └────────────────────────────────────────────────┘     │
 └─────────────────────────────────────────────────────────┘
 ```
 
-Workspace 拆成四個 crate：
+工作区拆成四个 crate：
 
-| Crate | 職責 |
+| Crate | 职责 |
 |---|---|
-| `eros-engine-core` | 純 domain logic：affinity math、ghost decision、PDE、persona types。零 I/O。 |
-| `eros-engine-llm` | OpenRouter chat client、Voyage embedding client、TOML model-config loader。 |
-| `eros-engine-store` | Postgres + pgvector 持久層，所有表都在 `engine` schema 下。 |
-| `eros-engine-server` | Axum HTTP service、Supabase JWT middleware、OpenAPI docs、pipeline wiring。 |
+| `eros-engine-core` | 纯领域逻辑：亲密度计算、ghost 决策、PDE、人设类型。零 I/O。 |
+| `eros-engine-llm` | OpenRouter 聊天客户端、Voyage 向量客户端、TOML 模型配置加载。 |
+| `eros-engine-store` | Postgres + pgvector 持久层，所有表都在 `engine` schema 下。 |
+| `eros-engine-server` | Axum HTTP 服务、Supabase JWT 中间件、OpenAPI 文档、pipeline 接线。 |
 
-你可以直接跑 `eros-engine-server` 當 HTTP API，也可以把 `core + llm + store` 嵌入自己的 Rust service。
+你可以把 `eros-engine-server` 当 HTTP API 跑，也可以把 `core + llm + store` 直接嵌进你自己的 Rust 服务。crate 边界、pipeline 阶段、数据流见 [架构](docs/architecture.zh.md)。
 
-## 文檔
+## 作为库使用
 
-- [架構](docs/architecture.zh.md)——crate 邊界、pipeline 階段、data flow。
-- [好感度模型](docs/affinity-model.zh.md)——六個維度、EMA、時間衰退、關係標籤。
-- [Ghost 機制](docs/ghost-mechanics.zh.md)——score formula、保護規則、示例。
-- [記憶層](docs/memory-layers.zh.md)——profile vs relationship memory、Voyage、pgvector retrieval。
-- [模型配置](docs/model-config.zh.md)——`model_config.toml` schema、任務名、解析優先級、0.x 穩定性承諾。
-- [部署](docs/deploying.zh.md)——Docker、自帶 Postgres / IdP。
-- [API 參考](docs/api-reference.zh.md)——每個 `/comp/*` endpoint。
+三个库 crate 已发布到 crates.io（[core](https://crates.io/crates/eros-engine-core) · [store](https://crates.io/crates/eros-engine-store) · [llm](https://crates.io/crates/eros-engine-llm)）：
 
-## 快速開始
+```bash
+cargo add eros-engine-core eros-engine-store eros-engine-llm
+```
 
-前置需求：
+```toml
+[dependencies]
+eros-engine-core  = "0.6"
+eros-engine-store = "0.6"   # 需要 Postgres + pgvector 层时
+eros-engine-llm   = "0.6"   # 需要 OpenRouter + Voyage 客户端时
+```
 
-- `rust-toolchain.toml` 指定的 Rust toolchain。
-- Postgres 16+，並啟用 `pgvector` extension。
-- OpenRouter API key。
-- Voyage API key。
-- Supabase JWT secret，或你自己的 `AuthValidator` 實現。
+`eros-engine-server` 刻意不发布到 crates.io——它以 Docker 镜像方式运行（见下）。
+
+## 作为 Docker 镜像运行
+
+每个 `v*` tag 都会把 `eros-engine-server` 的 `linux/amd64` 镜像发布到 GitHub Container Registry（需要 arm64？用 `docker/Dockerfile` 自己构建）：
+
+```bash
+docker pull ghcr.io/etherfunlab/eros-engine:0.6.2
+# 或跟踪最新 release
+docker pull ghcr.io/etherfunlab/eros-engine:latest
+```
+
+最小运行（自带 Postgres 与 `.env`）：
+
+```bash
+docker run --rm -p 8080:8080 --env-file .env \
+  ghcr.io/etherfunlab/eros-engine:0.6.2 serve
+```
+
+`docker/Dockerfile` 就是构建该镜像的同一份产物，可部署到任意容器平台。见 [部署](docs/deploying.zh.md)。
+
+## 文档
+
+- [架构](docs/architecture.zh.md)——crate 边界、pipeline 阶段、数据流。
+- [亲密度模型](docs/affinity-model.zh.md)——六个维度、EMA、时间衰减、关系标签。
+- [ghost 机制](docs/ghost-mechanics.zh.md)——评分公式、保护规则、示例。
+- [记忆分层](docs/memory-layers.zh.md)——画像记忆 vs 关系记忆、Voyage、pgvector 检索。
+- [模型配置](docs/model-config.zh.md)——`model_config.toml` schema、各任务（chat、vision、图像生成、PDE、过滤器、抽取）、选模型规则、0.x 稳定性承诺。
+- [Prompt traits](docs/prompt-traits.zh.md)——按请求注入系统 prompt 与 tier 白名单。
+- [LLM / OpenRouter 审计](docs/llm-audit.zh.md)——按用户 / 按会话的归因透传。
+- [部署](docs/deploying.zh.md)——Docker、自带 Postgres / IdP、运行期环境变量。
+- [API 参考](docs/api-reference.zh.md)——每个 `/comp/*` 端点、请求字段、SSE 帧布局。
+
+## 快速开始
+
+前置：`rust-toolchain.toml` 指定的 Rust 工具链、带 `pgvector` 的 Postgres 16+、一个 OpenRouter API key、一个 Voyage API key，以及一个 Supabase JWT secret（或你自己的 `AuthValidator`）。
 
 ```bash
 git clone https://github.com/etherfunlab/eros-engine
 cd eros-engine
-cp .env.example .env
-```
+cp .env.example .env   # 填入 DATABASE_URL、OPENROUTER_API_KEY、VOYAGE_API_KEY，以及一个鉴权来源
 
-填好 `DATABASE_URL`、`OPENROUTER_API_KEY`、`VOYAGE_API_KEY`、`SUPABASE_JWT_SECRET` 之後執行：
-
-```bash
 cargo run -p eros-engine-server -- migrate
 cargo run -p eros-engine-server -- seed-personas examples/personas
 cargo run -p eros-engine-server -- serve
 ```
 
-Server 默認監聽 `0.0.0.0:8080`。Scalar API docs 在 `/docs`，OpenAPI JSON 在 `/api-docs/openapi.json`。
+服务默认监听 `0.0.0.0:8080`。Scalar API 文档在 `/docs`，OpenAPI JSON 在 `/api-docs/openapi.json`。官方 Eros Chat 网页客户端是闭源的——自带 UI，或把这些 crate 嵌进别的服务。
 
-官方 Eros Chat web client 是閉源產品。`eros-engine` 本身可以獨立運行；你可以自帶 UI，也可以把 crates 嵌進另一個 service。
+## API 一览
 
-## API 表面
+默认所有 `/comp/*` 路由都需要 `Authorization: Bearer <Supabase JWT>`（`AuthValidator` trait 可替换成其他身份提供方）。核心端点：
 
-默認情況下，所有 `/comp/*` route 都需要 `Authorization: Bearer <Supabase JWT>`。
+- `POST /comp/chat/start`——对某个人设开一个会话。
+- `POST /comp/chat/{session_id}/message/stream`——**核心**对话端点：逐 token 的 Server-Sent Events。每轮可选字段：`tier`、`prompt_traits`、`audit`、`tips_amount_usd`（给角色打赏）、`image_url`（给角色发一张照片）、`image`（请求角色生成一张图片——风格 / 模型 / 画幅 / 脸部参考）。
+- `POST /comp/chat/{session_id}/message/{message_id}/image`——回写角色所生成图片在你存储里的 URL。
+- `GET /comp/chat/{session_id}/history` · `GET /comp/chat/{user_id}/sessions` · `GET /comp/user/{user_id}/profile`——历史、会话列表、结构化画像。
+- `GET /comp/affinity/{session_id}`——仅调试用的实时亲密度向量（`EXPOSE_AFFINITY_DEBUG=true`）。
 
-重點 endpoint：
-
-- `POST /comp/chat/start`——對指定 persona 開啟 chat session。
-- `POST /comp/chat/{session_id}/message/stream`——**唯一**的聊天輪 endpoint：逐 token 的 Server-Sent Events (SSE) 串流。（舊的阻塞式同步 `/message` endpoint 已在 0.3 移除——SSE 現在是唯一的聊天路徑。）
-- `GET  /comp/chat/{session_id}/history`——分頁讀聊天歷史。
-- `GET  /comp/chat/{user_id}/sessions`——列出用戶 sessions。
-- `GET  /comp/user/{user_id}/profile`——讀取目前的 `companion_insights` 和 `training_level`。
-- `POST /comp/chat/{session_id}/event/gift`——套用外部 gift event 與 affinity delta。
-- `GET  /comp/chat/{session_id}/gifts`——列出某個 session 的 gift events。
-- `/message/stream` 接受幾個可選的 caller-supplied 欄位：
-  - `tier` —— 從 `model_config.toml` 選出該 tier 的 chat model 和
-    `prompt_traits` allow-list；未知或缺省會 fallback 到 task 默認 block。
-    詳見 [docs/model-config.zh.md](docs/model-config.zh.md)。
-  - `prompt_traits` —— per-request system-prompt 注入，會被解析出的 tier
-    allow-list gating，詳見 [docs/prompt-traits.md](docs/prompt-traits.md)。
-  - `audit` —— 不透明的 OpenRouter passthrough（`user` / `session_id` /
-    `metadata`），用於在 OpenRouter dashboard 上做 per-user / per-session
-    attribution。詳見 [docs/llm-audit.zh.md](docs/llm-audit.zh.md)。
-- `GET  /comp/affinity/{session_id}`——debug-only 即時 affinity vector，由 `EXPOSE_AFFINITY_DEBUG=true` 開啟。
-
-如果你不用 Supabase，可以實現 `AuthValidator` trait 接自己的 identity provider。
+阻塞式同步 `/message` 端点已在 0.3 移除——SSE 是唯一的对话路径。完整请求 schema、SSE 帧布局（含 `delta`、`image`、ghost、error 帧）与逐字段语义见 [API 参考](docs/api-reference.zh.md)。
 
 ## 配置
 
-| 環境變量 | 必要 | 說明 |
-|---|---|---|
-| `DATABASE_URL` | 是 | 帶 `pgvector` 的 Postgres；表建在 `engine.*`。 |
-| `OPENROUTER_API_KEY` | 是 | Chat completions；默認由 `examples/model_config.toml` 路由。 |
-| `OPENROUTER_APP_REFERER` | 否 | 設了之後每次出站 OpenRouter 調用都帶 `HTTP-Referer`。會出現在 OpenRouter 的 app 分析面板上。 |
-| `OPENROUTER_APP_TITLE` | 否 | 設了之後帶 `X-OpenRouter-Title`。OpenRouter app analytics 顯示名稱。和 `OPENROUTER_APP_REFERER` 一對；兩個都可選。 |
-| `OPENROUTER_APP_CATEGORIES` | 否 | 设了之后带 `X-OpenRouter-Categories` —— 逗号分隔的 OpenRouter marketplace 分类（如 `roleplay,general-chat`）。原样透传；OpenRouter 对无法识别的值静默忽略，且只有在同时设了 `OPENROUTER_APP_REFERER` 时才生效。 |
-| `OPENROUTER_USAGE_HIDDEN_KEYS` | 否 | 逗号分隔的顶层 key 列表，从 `usage` 对象里剔除 —— 在 SSE 流式 `done` 帧上生效。常用于把批发 `cost` / `cost_details` 隐藏起来不外泄给下游客户。完整 usage 仍会落库并写入服务器端 tracing。 |
-| `VOYAGE_API_KEY` | 是 | Embeddings。空 key 會拒絕啟動。 |
-| `SUPABASE_URL` | 否 | Supabase project URL。保留在 `.env.example` 裡方便 client / deploy 約定；目前 server 不讀取它。 |
-| `SUPABASE_JWT_SECRET` | 是 | 默認 auth 使用的 JWT signing secret。 |
-| `BIND_ADDR` | 否 | 默認 `0.0.0.0:8080`。 |
-| `EXPOSE_AFFINITY_DEBUG` | 否 | 設為 `true` 會開啟 `/comp/affinity/{session_id}`。 |
-| `EMA_INERTIA` | 否 | affinity 更新的 EMA 平滑系数，范围 `[0, 1]`，默认 `0.8`。每轮只施加 `1 − inertia` 比例的增量，值越高则关系向量每轮移动越小（升温/降温都更慢）——相当于关系难度旋钮；`0` 表示每次增量全额生效。 |
-| `MODEL_CONFIG_PATH` | 否 | 默認 `examples/model_config.toml`。 |
-| `RUST_LOG` | 否 | 默認 `info`。 |
+必填环境变量：`DATABASE_URL`、`OPENROUTER_API_KEY`、`VOYAGE_API_KEY`，以及**一个**鉴权来源——`SUPABASE_URL` / `SUPABASE_JWKS_URL`（JWKS，2025 年后 Supabase 默认）**或** `SUPABASE_JWT_SECRET`（旧版 HS256）。一个都不设，服务会 fail-closed 拒绝启动。
 
-## 刻意不包含的東西
+其余都有合理默认值：模型路由（`MODEL_CONFIG_PATH` → `model_config.toml`）、OpenRouter 归因头、dreaming-lite / snapshot 后台任务、`EMA_INERTIA`（关系难度旋钮）、调试开关等。完整带注释的清单见 [`.env.example`](.env.example)；运行期指引见 [部署](docs/deploying.zh.md)，模型路由见 [模型配置](docs/model-config.zh.md)。
 
-這個 repo 是 conversation、memory、relationship-state core。它不包含：
+## Roadmap
 
-- **Matchmaking**——多階段 filter、soft scoring、agent-to-agent matching simulation 留在閉源產品裡。
-- **完整社交產品 UX**——onboarding、video、voice、billing、photos、moderation UI、mobile clients。
-- **Persona provenance / marketplace logic**——這是商業產品代碼，不屬於 engine。
+目前不在引擎里，但在计划中：
 
-如果你要做另一個產品，最值得重用的是 affinity + memory + insight pipeline。
+- **Agents playground**——多个 AI 人设在同一会话里互相（以及与用户）互动。
+- **语音消息**——角色发出与用户发出的音频轮次。
+- **实时语音对话**——低延迟的语音来回。
+- **视频生成**——角色主动发送的短视频片段，延续图像执行器。
 
-## 內容說明
+## 明确不在范围内
 
-`examples/personas/` 裡的人格是成人 character-chat 示例。當 relationship state 走到相應位置，它們可以調情、表達慾望；同時仍會拒絕不尊重或越界的要求。如果你的產品需要 SFW default，部署前請替換這些 persona files。
+本仓库是对话、记忆、关系状态的核心，不包含：
 
-每一輪的行為還可以透過 message routes 上的
-[`prompt_traits`](docs/prompt-traits.md) 欄位再調整——engine 把傳入的文字
-當成 opaque string 處理，這些 traits 實際代表什麼策略，完全交給你的
-frontend / middleware 決定。
+- **匹配**——多阶段过滤、软打分、agent 对 agent 的匹配模拟，仍在闭源产品里。
+- **完整社交 UX**——引导、视频、语音、计费、相册、审核 UI、移动端。
+- **人设来源 / 市场逻辑**——属于商业产品代码，不是引擎的一部分。
 
-## 貢獻
+如果你在做不同的产品，可复用的部分是亲密度 + 记忆 + 画像这条 pipeline。
 
-請先閱讀 [`CONTRIBUTING.md`](CONTRIBUTING.md)。所有貢獻者首次提 PR 時都需要透過 cla-assistant.io 接受 [`CLA`](CLA.md)。
+## 内容提示
 
-## 授權
+`examples/personas/` 下的示例人设是面向成人的角色聊天示例。当关系状态到位时，它们可以调情、表达欲望，同时仍会拒绝不尊重或越界的行为。如果你的产品需要默认 SFW，请在部署前替换这些人设文件。
 
-`eros-engine` 使用 AGPL-3.0-only 授權。如果 AGPL 不符合你的分發方式，可以洽談商業授權：`henrylin@etherfun.xyz`。
+每轮行为还可以通过消息路由上的 [`prompt_traits`](docs/prompt-traits.zh.md) 字段进一步调节——引擎把传入文本当作不透明内容，所以"这些 trait 编码了什么策略"完全由你的前端 / 中间层决定。
+
+## 贡献
+
+阅读 [`CONTRIBUTING.md`](CONTRIBUTING.md)。所有贡献者在首次 PR 时须通过 cla-assistant.io 接受 [`CLA`](CLA.md)。
+
+## 许可
+
+`eros-engine` 以 AGPL-3.0-only 授权。如果 AGPL 不适合你的分发模式，可提供商业授权：`henrylin@etherfun.xyz`。

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,8 +1,8 @@
 # eros-engine
 
-> **一个开源的 Rust AI 伴侣引擎：让角色"像真人"——持久记忆、会演变的关系模型，以及一个让人设在成千上万轮对话里保持稳定的决策引擎。**
+> **一个让 AI 伴侣如真人般鲜活的开源 Rust 引擎：具备持久记忆、持续演变的关系模型，以及让人设历经数千轮对话仍保持一致的决策引擎。**
 >
-> `eros-engine` 是 [Eros Chat](https://chat.etherfun.xyz) 背后的伴侣对话核心，抽取成了独立服务。它把对话沉淀为可持久的状态——结构化用户画像、双层长期记忆、六维亲密度模型——让角色在用户每次回来时都表现得像同一个人。
+> `eros-engine` 是 [Eros Chat](https://chat.etherfun.xyz) 背后的伴侣对话核心，现已抽离为独立服务。它将对话转化为持久状态——结构化用户画像、双层长期记忆和六维亲密度模型——让用户每次回来时，角色都像始终如一的同一个人。
 
 [![CI](https://github.com/etherfunlab/eros-engine/actions/workflows/ci.yml/badge.svg)](https://github.com/etherfunlab/eros-engine/actions/workflows/ci.yml)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
@@ -11,50 +11,50 @@
 [![Crates.io: llm](https://img.shields.io/crates/v/eros-engine-llm.svg?label=eros-engine-llm)](https://crates.io/crates/eros-engine-llm)
 [![GHCR: eros-engine](https://img.shields.io/badge/ghcr.io-etherfunlab%2Feros--engine-blue)](https://github.com/etherfunlab/eros-engine/pkgs/container/eros-engine)
 
-[English](README.md) · 中文
+[English](README.md) · **中文** · [日本語](README.ja.md)
 
 ## 为什么做这个
 
-大多数 AI 角色应用把记忆当成往 prompt 里追加文本，把关系写成一段指令。这能撑起一个 demo，但在长会话里会漂移、会崩人设，也很难调试。`eros-engine` 把这些都搬进显式、可检视的状态里——所以角色会"像真人"（记得你、并对关系所处的位置作出反应），并且"人设稳定"（行为是被*决策*出来的，而不是即兴发挥）。
+大多数 AI 角色应用只是将记忆作为文本附加到 prompt 中，并用一段指令描述关系。这种做法或许足以演示，但在长会话中，行为会逐渐漂移、偏离人设，而且难以调试。`eros-engine` 将这些要素转化为明确、可检查的状态，使伴侣**如真人一般**——记得你，也会根据当前的关系状态作出反应——并在一轮又一轮对话中**始终符合人设**，因为行为是经过*决策*的，而非临场发挥。
 
-五大支柱支撑这一点：
+这建立在五大支柱之上：
 
-- **双层记忆**——画像记忆（稳定的用户事实）与关系记忆（共同时刻、回扣、未了的话头），都存在 Postgres + pgvector 里，让角色跨会话、跨人设地记得你。→ [记忆分层](docs/memory-layers.zh.md)
-- **六维亲密度 + ghost 机制**——一个数值化的关系向量（warmth、trust、intimacy、intrigue、patience、tension），用 EMA 平滑、随真实时间衰减；它会随时间重塑语气、深度与行为，甚至可以决定*不回复*。→ [亲密度模型](docs/affinity-model.zh.md) · [ghost 机制](docs/ghost-mechanics.zh.md)
-- **人设决策引擎（PDE）**——为每一轮挑选行为（回复 / ghost / 发一张照片）和内在状态——默认基于规则，可选开启 LLM 裁判层。这正是让回复"像真人"且不崩人设、而不是变成通用助手腔的关键；裁判调用会审计到 `companion_decision_events`。→ [模型配置](docs/model-config.zh.md)
-- **结构化用户画像**——每个用户一份 JSONB 画像（城市、职业、兴趣、MBTI 信号、情感需求、生活节奏、匹配偏好），带一个加权的 `training_level`，下游产品可直接查询用于匹配、引导、分析或灰度。→ [API 参考](docs/api-reference.zh.md)
-- **为流畅的伴侣对话而生**——逐 token 的 SSE 流式输出；图像理解（用户可以发照片）与角色主动生成图片（`reply_image` / `reply_text_image`）；按请求注入的 prompt traits 与 tier；OpenRouter 路由，按任务选模型（固定 / 轮询 / 加权，外加 fallback 链）并全程审计调用。→ [API 参考](docs/api-reference.zh.md) · [模型配置](docs/model-config.zh.md)
+- **双层记忆**——画像记忆（稳定的用户事实）与关系记忆（共同经历、前情呼应、未完话题）均存储在 Postgres + pgvector 中，让伴侣能够跨会话、跨人设记住你。→ [记忆分层](docs/memory-layers.zh.md)
+- **六维亲密度 + ghost 机制**——以数值关系向量（warmth、trust、intimacy、intrigue、patience、tension）结合 EMA 平滑与实时衰减；它会逐渐改变语气、深度和行为，甚至可以决定*不回复*。→ [亲密度模型](docs/affinity-model.zh.md) · [ghost 机制](docs/ghost-mechanics.zh.md)
+- **人设决策引擎（PDE）**——为每轮对话选择行为（回复、ghost 或发送照片）与内在状态——默认基于规则，也可选择启用 LLM judge。它让回复自然、符合人设，而非流于通用助手的腔调；judge 调用会审计到 `companion_decision_events`。→ [模型配置](docs/model-config.zh.md)
+- **结构化用户洞察**——以 JSONB 画像记录城市、职业、兴趣、MBTI 信号、情感需求、生活节奏和匹配偏好，并附带加权的 `training_level`；下游产品可查询这些数据，用于匹配、用户引导、分析或 gating。→ [API 参考](docs/api-reference.zh.md)
+- **专为流畅的伴侣对话打造**——逐 token 的 SSE 流式输出；图像理解（用户可发送照片）和伴侣端图像生成（`reply_image` / `reply_text_image`）；按请求指定 `prompt_traits` 与 tier；基于 OpenRouter 的路由，支持按任务选择模型（固定 / 轮询 / 加权，并配有 fallback chain）和完整的调用审计。→ [API 参考](docs/api-reference.zh.md) · [模型配置](docs/model-config.zh.md)
 
-这不是一个通用 agent 框架。它是一个聚焦的引擎，专为"同一个角色跨多次会话与同一个用户对话"的产品而做：AI 伴侣、日记陪伴、教练 agent、语言陪练、角色聊天。
+这不是通用 agent 框架，而是一个专注于同一人设跨多个会话与同一用户持续交流的引擎，适用于 AI 伴侣、日记伴侣、教练 agent、语言导师和角色聊天。
 
 ## 架构
 
 ```txt
 ┌─────────────────────────────────────────────────────────┐
-│ /comp/* HTTP 路由  ←  Supabase JWT 中间件                │
+│ /comp/* HTTP routes  ←  Supabase JWT middleware          │
 │         │                                                │
 │         ▼                                                │
-│ pipeline 编排：load → PDE → handler → chat → post        │
+│ pipeline orchestrator: load → PDE → handler → chat → post│
 │                                          │              │
 │  ┌───────────────────────────────────────┴────────┐     │
-│  │ post-process，回复后异步 spawn                  │     │
-│  │   • 亲密度：持久化 6 维 delta + EMA            │     │
-│  │   • 记忆：  Voyage embed → pgvector upsert     │     │
-│  │   • 画像：  抽取事实 → JSONB 合并              │     │
+│  │ post-process, spawned after reply              │     │
+│  │   • affinity: persist 6D delta + EMA           │     │
+│  │   • memory:   Voyage embed → pgvector upsert   │     │
+│  │   • insight:  extract facts → JSONB merge      │     │
 │  └────────────────────────────────────────────────┘     │
 └─────────────────────────────────────────────────────────┘
 ```
 
-工作区拆成四个 crate：
+工作区分为四个 crate：
 
 | Crate | 职责 |
 |---|---|
-| `eros-engine-core` | 纯领域逻辑：亲密度计算、ghost 决策、PDE、人设类型。零 I/O。 |
-| `eros-engine-llm` | OpenRouter 聊天客户端、Voyage 向量客户端、TOML 模型配置加载。 |
-| `eros-engine-store` | Postgres + pgvector 持久层，所有表都在 `engine` schema 下。 |
-| `eros-engine-server` | Axum HTTP 服务、Supabase JWT 中间件、OpenAPI 文档、pipeline 接线。 |
+| `eros-engine-core` | 纯领域逻辑：亲密度计算、ghost 决策、PDE、人设类型。无 I/O。 |
+| `eros-engine-llm` | OpenRouter 聊天客户端、Voyage embedding 客户端、TOML 模型配置加载器。 |
+| `eros-engine-store` | Postgres + pgvector 持久化，所有表均位于 `engine` schema 下。 |
+| `eros-engine-server` | Axum HTTP 服务、Supabase JWT 中间件、OpenAPI 文档和 pipeline 连接。 |
 
-你可以把 `eros-engine-server` 当 HTTP API 跑，也可以把 `core + llm + store` 直接嵌进你自己的 Rust 服务。crate 边界、pipeline 阶段、数据流见 [架构](docs/architecture.zh.md)。
+你可以将 `eros-engine-server` 作为 HTTP API 运行，也可以把 `core + llm + store` 直接嵌入自己的 Rust 服务。有关 crate 边界、pipeline 阶段和数据流，请参阅[架构](docs/architecture.zh.md)。
 
 ## 作为库使用
 
@@ -67,30 +67,30 @@ cargo add eros-engine-core eros-engine-store eros-engine-llm
 ```toml
 [dependencies]
 eros-engine-core  = "0.6"
-eros-engine-store = "0.6"   # 需要 Postgres + pgvector 层时
-eros-engine-llm   = "0.6"   # 需要 OpenRouter + Voyage 客户端时
+eros-engine-store = "0.6"   # only if you want the Postgres + pgvector layer
+eros-engine-llm   = "0.6"   # only if you want the OpenRouter + Voyage clients
 ```
 
-`eros-engine-server` 刻意不发布到 crates.io——它以 Docker 镜像方式运行（见下）。
+`eros-engine-server` 有意不发布到 crates.io——请使用 Docker 镜像运行（见下文）。
 
 ## 作为 Docker 镜像运行
 
-每个 `v*` tag 都会把 `eros-engine-server` 的 `linux/amd64` 镜像发布到 GitHub Container Registry（需要 arm64？用 `docker/Dockerfile` 自己构建）：
+每个 `v*` tag 都会将 `eros-engine-server` 的 `linux/amd64` 镜像发布到 GitHub Container Registry（需要 arm64？请使用 `docker/Dockerfile` 自行构建）：
 
 ```bash
 docker pull ghcr.io/etherfunlab/eros-engine:0.6.2
-# 或跟踪最新 release
+# or track the latest tagged release
 docker pull ghcr.io/etherfunlab/eros-engine:latest
 ```
 
-最小运行（自带 Postgres 与 `.env`）：
+最简运行方式（需自行提供 Postgres 和 `.env`）：
 
 ```bash
 docker run --rm -p 8080:8080 --env-file .env \
   ghcr.io/etherfunlab/eros-engine:0.6.2 serve
 ```
 
-`docker/Dockerfile` 就是构建该镜像的同一份产物，可部署到任意容器平台。见 [部署](docs/deploying.zh.md)。
+构建此镜像使用的正是 `docker/Dockerfile`，可将其部署到任意容器托管平台。请参阅[部署](docs/deploying.zh.md)。
 
 ## 文档
 
@@ -106,37 +106,37 @@ docker run --rm -p 8080:8080 --env-file .env \
 
 ## 快速开始
 
-前置：`rust-toolchain.toml` 指定的 Rust 工具链、带 `pgvector` 的 Postgres 16+、一个 OpenRouter API key、一个 Voyage API key，以及一个 Supabase JWT secret（或你自己的 `AuthValidator`）。
+前置：`rust-toolchain.toml` 指定的 Rust 工具链、带 `pgvector` 的 Postgres 16+、一个 OpenRouter API key、一个 Voyage API key，以及一个鉴权来源——Supabase JWKS（`SUPABASE_URL`）或旧版 `SUPABASE_JWT_SECRET`（或你自己的 `AuthValidator`）。
 
 ```bash
 git clone https://github.com/etherfunlab/eros-engine
 cd eros-engine
-cp .env.example .env   # 填入 DATABASE_URL、OPENROUTER_API_KEY、VOYAGE_API_KEY，以及一个鉴权来源
+cp .env.example .env   # fill in DATABASE_URL, OPENROUTER_API_KEY, VOYAGE_API_KEY, and one auth source
 
 cargo run -p eros-engine-server -- migrate
 cargo run -p eros-engine-server -- seed-personas examples/personas
 cargo run -p eros-engine-server -- serve
 ```
 
-服务默认监听 `0.0.0.0:8080`。Scalar API 文档在 `/docs`，OpenAPI JSON 在 `/api-docs/openapi.json`。官方 Eros Chat 网页客户端是闭源的——自带 UI，或把这些 crate 嵌进别的服务。
+服务默认监听 `0.0.0.0:8080`。Scalar API 文档位于 `/docs`，OpenAPI JSON 位于 `/api-docs/openapi.json`。官方 Eros Chat Web 客户端并未开源——请自行提供 UI，或将这些 crate 嵌入其他服务。
 
 ## API 一览
 
 默认所有 `/comp/*` 路由都需要 `Authorization: Bearer <Supabase JWT>`（`AuthValidator` trait 可替换成其他身份提供方）。核心端点：
 
-- `POST /comp/chat/start`——对某个人设开一个会话。
+- `POST /comp/chat/start`——与指定人设开启聊天会话。
 - `POST /comp/chat/{session_id}/message/stream`——**核心**对话端点：逐 token 的 Server-Sent Events。每轮可选字段：`tier`、`prompt_traits`、`audit`、`tips_amount_usd`（给角色打赏）、`image_url`（给角色发一张照片）、`image`（请求角色生成一张图片——风格 / 模型 / 画幅 / 脸部参考）。
 - `POST /comp/chat/{session_id}/message/{message_id}/image`——回写角色所生成图片在你存储里的 URL。
 - `GET /comp/chat/{session_id}/history` · `GET /comp/chat/{user_id}/sessions` · `GET /comp/user/{user_id}/profile`——历史、会话列表、结构化画像。
 - `GET /comp/affinity/{session_id}`——仅调试用的实时亲密度向量（`EXPOSE_AFFINITY_DEBUG=true`）。
 
-阻塞式同步 `/message` 端点已在 0.3 移除——SSE 是唯一的对话路径。完整请求 schema、SSE 帧布局（含 `delta`、`image`、ghost、error 帧）与逐字段语义见 [API 参考](docs/api-reference.zh.md)。
+阻塞式同步 `/message` 端点已在 0.3 移除——SSE 是唯一的聊天路径。有关完整的请求 schema、SSE 帧布局（包括 `delta`、`image`、ghost 和 error 帧）以及各字段语义，请参阅 [API 参考](docs/api-reference.zh.md)。
 
 ## 配置
 
-必填环境变量：`DATABASE_URL`、`OPENROUTER_API_KEY`、`VOYAGE_API_KEY`，以及**一个**鉴权来源——`SUPABASE_URL` / `SUPABASE_JWKS_URL`（JWKS，2025 年后 Supabase 默认）**或** `SUPABASE_JWT_SECRET`（旧版 HS256）。一个都不设，服务会 fail-closed 拒绝启动。
+必填环境变量：`DATABASE_URL`、`OPENROUTER_API_KEY`、`VOYAGE_API_KEY`，以及**一个**身份验证来源——`SUPABASE_URL` / `SUPABASE_JWKS_URL`（JWKS，Supabase 在 2025 年之后的默认方式）**或** `SUPABASE_JWT_SECRET`（旧版 HS256）。若未设置身份验证来源，服务将拒绝启动。
 
-其余都有合理默认值：模型路由（`MODEL_CONFIG_PATH` → `model_config.toml`）、OpenRouter 归因头、dreaming-lite / snapshot 后台任务、`EMA_INERTIA`（关系难度旋钮）、调试开关等。完整带注释的清单见 [`.env.example`](.env.example)；运行期指引见 [部署](docs/deploying.zh.md)，模型路由见 [模型配置](docs/model-config.zh.md)。
+其余配置均有合理的默认值：模型路由（`MODEL_CONFIG_PATH` → `model_config.toml`）、OpenRouter 归因标头、dreaming-lite / snapshot sweepers、用于调整关系难度的 `EMA_INERTIA`，以及调试开关。完整注释清单见 [`.env.example`](.env.example)；操作指南见[部署](docs/deploying.zh.md)，模型路由见[模型配置](docs/model-config.zh.md)。
 
 ## Roadmap
 
@@ -149,19 +149,19 @@ cargo run -p eros-engine-server -- serve
 
 ## 明确不在范围内
 
-本仓库是对话、记忆、关系状态的核心，不包含：
+本仓库提供对话、记忆和关系状态的核心能力，不包含：
 
 - **匹配**——多阶段过滤、软打分、agent 对 agent 的匹配模拟，仍在闭源产品里。
 - **完整社交 UX**——引导、视频、语音、计费、相册、审核 UI、移动端。
 - **人设来源 / 市场逻辑**——属于商业产品代码，不是引擎的一部分。
 
-如果你在做不同的产品，可复用的部分是亲密度 + 记忆 + 画像这条 pipeline。
+如果你在构建其他类型的产品，可复用的部分是亲密度 + 记忆 + 洞察 pipeline。
 
 ## 内容提示
 
 `examples/personas/` 下的示例人设是面向成人的角色聊天示例。当关系状态到位时，它们可以调情、表达欲望，同时仍会拒绝不尊重或越界的行为。如果你的产品需要默认 SFW，请在部署前替换这些人设文件。
 
-每轮行为还可以通过消息路由上的 [`prompt_traits`](docs/prompt-traits.zh.md) 字段进一步调节——引擎把传入文本当作不透明内容，所以"这些 trait 编码了什么策略"完全由你的前端 / 中间层决定。
+还可通过消息路由中的 [`prompt_traits`](docs/prompt-traits.zh.md) 字段进一步调整每次请求的行为——引擎将传入文本视为不透明内容，因此 `prompt_traits` 所编码的策略完全由前端 / 中间件定义。
 
 ## 贡献
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -26,7 +26,7 @@ curl http://localhost:8080/healthz
 {
   "status": "ok",
   "service": "eros-engine",
-  "version": "0.6.0",
+  "version": "0.6.x",
   "timestamp": "2026-05-05T19:06:05.309302232+00:00"
 }
 ```
@@ -314,6 +314,7 @@ data: {"type":"image","message_id":"01J...","data_url":"data:image/png;base64,..
 
 - `reply_text_image`: `meta(action_type=reply_text_image) → delta* → done → image → final`
 - `reply_image`: `meta(action_type=reply_image) → image → done → final`
+- `ghost`: `meta(action_type=ghost) → done → final` — no `delta`, no `model` in `meta`, `usage` and `generation_id` are `null` in `done`. The companion stayed silent this turn; no LLM was called.
 
 **Failed-image client contract** — no new error frame is emitted on image failure.
 The `meta` frame's `action_type` declares the intended shape:

--- a/docs/api-reference.zh.md
+++ b/docs/api-reference.zh.md
@@ -26,7 +26,7 @@ curl http://localhost:8080/healthz
 {
   "status": "ok",
   "service": "eros-engine",
-  "version": "0.6.0",
+  "version": "0.6.x",
   "timestamp": "2026-05-05T19:06:05.309302232+00:00"
 }
 ```
@@ -293,6 +293,7 @@ data: {"type":"image","message_id":"01J...","data_url":"data:image/png;base64,..
 
 - `reply_text_image`：`meta(action_type=reply_text_image) → delta* → done → image → final`
 - `reply_image`：`meta(action_type=reply_image) → image → done → final`
+- `ghost`：`meta(action_type=ghost) → done → final` — 无 `delta`，`meta` 中无 `model`，`done` 的 `usage` 和 `generation_id` 均为 `null`。该轮伴侣保持沉默，未调用任何 LLM。
 
 **图片失败客户端约定** — 图片失败时不会发出额外的 error 帧。客户端通过 `meta` 帧的 `action_type` 判断预期形状：
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,7 +25,7 @@ The dependency graph is strictly downward — `core` doesn't know about `llm`, `
 
 ## Pipeline
 
-`pipeline::run(state, session_id, event)` orchestrates a single chat turn:
+`pipeline::stream::run_stream(state: Arc<AppState>, user_msg: PersistedUserMessage)` orchestrates a single chat turn, returning an SSE frame stream:
 
 ```
 load context           load persona via PersonaRepo
@@ -73,7 +73,7 @@ eros-engine-server :8080
     │
     ├─► auth middleware → user_id from JWT claims
     │
-    ├─► pipeline::run(session_id, event)
+    ├─► pipeline::stream::run_stream(state, user_msg)
     │       │
     │       └─► spawn post_process(state.clone(), …)
     │              │
@@ -113,7 +113,7 @@ crates/
 │       ├── voyage.rs         # 512-dim embeddings, fail-loud on empty key
 │       └── model_config.rs   # TOML loader
 ├── eros-engine-store/
-│   ├── migrations/           # 0000_schema → 0005_insights
+│   ├── migrations/           # 0000_schema → 0028_companion_decision_events
 │   └── src/
 │       ├── pool.rs           # PgPoolOptions builder
 │       ├── chat.rs           # ChatRepo
@@ -129,7 +129,7 @@ crates/
         ├── auth/             # AuthValidator trait + Supabase impl + middleware
         ├── pipeline/         # mod (orchestrator) / handlers / post_process
         ├── prompt.rs         # system-prompt builder (affinity → directives)
-        ├── routes/           # health / companion / debug / mod
+        ├── routes/           # health / companion / companion_stream / debug / mod
         └── openapi.rs        # utoipa ApiDoc spec metadata
 ```
 
@@ -138,5 +138,5 @@ crates/
 - [Affinity model](affinity-model.md) — 6 dimensions, EMA, time decay, relationship labels
 - [Ghost mechanics](ghost-mechanics.md) — score formula + protection rules + worked examples
 - [Memory layers](memory-layers.md) — profile vs relationship, Voyage, pgvector retrieval
-- [Deploying](deploying.md) — Docker, Fly.io, bring-your-own-Postgres / IdP
+- [Deploying](deploying.md) — Docker, bring-your-own Postgres / IdP
 - [API reference](api-reference.md) — every `/comp/*` endpoint

--- a/docs/architecture.zh.md
+++ b/docs/architecture.zh.md
@@ -25,7 +25,7 @@
 
 ## Pipeline
 
-`pipeline::run(state, session_id, event)` 編排單輪對話：
+`pipeline::stream::run_stream(state: Arc<AppState>, user_msg: PersistedUserMessage)` 編排單輪對話，返回 SSE 帧流：
 
 ```
 加載上下文              用 PersonaRepo 加載人格
@@ -73,7 +73,7 @@ eros-engine-server :8080
     │
     ├─► auth 中間件 → 從 JWT claims 提取 user_id
     │
-    ├─► pipeline::run(session_id, event)
+    ├─► pipeline::stream::run_stream(state, user_msg)
     │       │
     │       └─► spawn post_process(state.clone(), …)
     │              │
@@ -113,7 +113,7 @@ crates/
 │       ├── voyage.rs         # 512 維 embedding，空 key 直接 fail
 │       └── model_config.rs   # TOML 加載器
 ├── eros-engine-store/
-│   ├── migrations/           # 0000_schema → 0005_insights
+│   ├── migrations/           # 0000_schema → 0028_companion_decision_events
 │   └── src/
 │       ├── pool.rs           # PgPoolOptions 構造
 │       ├── chat.rs           # ChatRepo
@@ -129,7 +129,7 @@ crates/
         ├── auth/             # AuthValidator trait + Supabase 實現 + 中間件
         ├── pipeline/         # mod（編排器）/ handlers / post_process
         ├── prompt.rs         # system prompt 構造（affinity → 行為指令）
-        ├── routes/           # health / companion / debug / mod
+        ├── routes/           # health / companion / companion_stream / debug / mod
         └── openapi.rs        # utoipa ApiDoc 元數據
 ```
 
@@ -138,5 +138,5 @@ crates/
 - [好感度模型](affinity-model.zh.md)——6 個維度、EMA、時間衰退、關係標籤
 - [Ghost 機制](ghost-mechanics.zh.md)——評分公式 + 保護規則 + 實例計算
 - [記憶層](memory-layers.zh.md)——profile vs relationship、Voyage、pgvector 檢索
-- [部署](deploying.zh.md)——Docker、Fly.io、自帶 Postgres / IdP
+- [部署](deploying.zh.md)——Docker、自带 Postgres / IdP
 - [API 參考](api-reference.zh.md)——每個 `/comp/*` 端點

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -168,7 +168,7 @@ Both queries should return zero rows after the migration applies.
 - **OpenAPI / Scalar:** `GET /docs` serves a live Scalar reference. The OpenAPI JSON is at `/api-docs/openapi.json`.
 - **Affinity debug:** `GET /comp/affinity/{session_id}` is gated by `EXPOSE_AFFINITY_DEBUG=true`. Production deploys typically leave it off; turn it on if your frontend renders a live radar of the affinity vector.
 - **Logs:** `RUST_LOG=info` is the default. Set `RUST_LOG=debug,sqlx=warn` to see everything except SQLx query churn.
-- **Cost:** the OSS deployment defaults to grok-4-fast (cheap) for chat and grok-4-mini for insight extraction. A typical chat turn costs ≪ $0.001 in token spend plus a Voyage embedding call (~$0.000003 for a memory-worthy fact). 10k chat turns costs single-digit dollars.
+- **Cost:** the OSS deployment defaults to a fast, cheap model for chat and a capable extraction model for insight extraction (see `examples/model_config.toml` for current defaults). A typical chat turn costs ≪ $0.001 in token spend plus a Voyage embedding call (~$0.000003 for a memory-worthy fact). 10k chat turns costs single-digit dollars.
 
 ## Source
 

--- a/docs/deploying.zh.md
+++ b/docs/deploying.zh.md
@@ -168,7 +168,7 @@ SELECT grantee, table_name, privilege_type
 - **OpenAPI / Scalar：** `GET /docs` 提供實時的 Scalar 參考。OpenAPI JSON 在 `/api-docs/openapi.json`。
 - **Affinity debug：** `GET /comp/affinity/{session_id}` 受 `EXPOSE_AFFINITY_DEBUG=true` 控制。生產部署一般關掉；如果你的前端要實時畫好感度雷達圖，再打開。
 - **日誌：** `RUST_LOG=info` 是默認。`RUST_LOG=debug,sqlx=warn` 看到除 SQLx 查詢噪音以外的一切。
-- **成本：** OSS 部署默認 chat 用 grok-4-fast（便宜）、insight 抽取用 grok-4-mini。一輪典型對話花費 ≪ $0.001 美元 token 成本，加上一個 Voyage embedding 調用（每個值得記住的事實大約 $0.000003）。10000 輪對話花個位數美元。
+- **成本：** OSS 部署默认 chat 使用一个快速廉价的模型、insight 抽取使用一个高质量抽取模型（当前默认值见 `examples/model_config.toml`）。一轮典型对话花费 ≪ $0.001 美元 token 成本，加上一个 Voyage embedding 调用（每个值得记住的事实约 $0.000003）。10000 轮对话花个位数美元。
 
 ## 源碼
 

--- a/docs/ghost-mechanics.md
+++ b/docs/ghost-mechanics.md
@@ -113,7 +113,7 @@ If the persona never ghosts → check that LLM affinity-evaluation is actually m
 
 ## What ghosting is not
 
-- It's **not** an error response. The HTTP route still returns 200. The body has `reply: null` (or the engine's chosen "no reply" shape).
+- It's **not** an error response. The HTTP route still returns 200. Because the engine is SSE-streaming, a ghost turn emits three frames and then closes the stream: `meta(action_type=ghost, model=null)` → `done(usage=null, generation_id=null)` → `final`. No `delta` frame is emitted and no LLM is called.
 - It's **not** an LLM call gone wrong. The decision is pure Rust; the LLM never gets asked.
 - It's **not** silent forever. Time-decay restores `patience` and softens `tension`; eventually the persona will reply again to the next message.
 

--- a/docs/ghost-mechanics.zh.md
+++ b/docs/ghost-mechanics.zh.md
@@ -113,7 +113,7 @@ score = (1−0.05)×0.4 + (1−0.05)×0.4 + 0×0.2
 
 ## Ghost 不是甚麼
 
-- **不是** 錯誤響應。HTTP 路由仍返 200。響應體 `reply: null`（或引擎選定的「無回覆」形狀）。
+- **不是** 错误响应。HTTP 路由仍返 200。由于引擎采用 SSE 流式传输，ghost 轮会发出三帧后关闭流：`meta(action_type=ghost, model=null)` → `done(usage=null, generation_id=null)` → `final`。不会发出 `delta` 帧，也不会调用任何 LLM。
 - **不是** LLM 調用失敗。決策純 Rust，從不問 LLM。
 - **不是** 永遠沉默。時間衰退會恢復 `patience`、軟化 `tension`；最終人格會回應下一條消息。
 

--- a/docs/model-config.md
+++ b/docs/model-config.md
@@ -42,6 +42,7 @@ Field details:
 | `defaults.fallback_model` | `String` | no | Hard fallback if the task config provides no model. If still missing, code uses the compiled-in default `x-ai/grok-4-mini`. |
 | `defaults.fallback_temperature` | `f64` | no | Same precedence; compiled-in default `0.5`. |
 | `defaults.fallback_max_tokens` | `u32` | no | Same precedence; compiled-in default `200`. |
+| `defaults.ignore_providers` | `Array<String>` | no | OpenRouter provider slugs to exclude from routing on **every** task. Sent as `provider.ignore` on each outbound call; `allow_fallbacks` remains `true` so the model is still served by any healthy provider. Use this when a specific provider returns garbled output for a model (e.g. undecoded byte-BPE text — issue #84). Find the offending slug via the OpenRouter generation API. Empty or absent means no exclusion. |
 | `tasks.<name>.model` | `String` \| `Array<String>` \| `Table<String,f64>` | yes | Primary model. String = fixed; array = round-robin; table = weighted random. See "Primary model selection". |
 | `tasks.<name>.fallback` | `String` | no | Secondary model used by `OpenRouterClient` if the primary call fails. |
 | `tasks.<name>.temperature` | `f64` | no | Per-task sampling temperature. No per-tier override. |
@@ -231,13 +232,17 @@ input filter has no triggers, timing, or tiers).
 | `chat_output_filter` | `pipeline::handlers::ReplyHandler` (optional second-pass rewrite of the chat reply before delivery) | live |
 | `pde_decision` | `pipeline::stream` (opt-in LLM judge via `run_pde_decision`, called from `run_stream`; rules engine used when `filter_prompt` is absent or the LLM call fails) | live (opt-in) |
 | `chat_image_generation` | `pipeline::stream` (opt-in image reply executor; activated when this task block is present) | live (opt-in) |
+| `chat_vision` | `pipeline::stream` via `resolve_vision()` (vision pre-stage: describes an `image_url` attachment into JSON before the reply prompt; off when task block absent or `filter_prompt` blank) | live (opt-in) |
+| `affinity_evaluation` | `pipeline::post_process` (per-turn 6-axis affinity delta; runs after each Reply turn, fire-and-forget) | live |
+| `memory_extraction` | dreaming sweeper (session-end memory consolidation; off when task block absent) | live (opt-in) |
+| `chat_input_filter` | `pipeline::stream` (user-input rewrite filter; activated by `input_filter` on `[tasks.chat_companion]` and this task block; off by default) | live (opt-in) |
 | `embedding` | reserved — `VoyageClient` reads its own `VOYAGE_API_KEY` and hard-codes `voyage-3-lite` | reserved |
 
 A `[tasks.<name>]` entry is only meaningful if the engine actually calls `model_config.resolve("<name>", ...)` somewhere. The current call sites are:
 
 - `crates/eros-engine-server/src/pipeline/handlers.rs` → `chat_companion`, `chat_output_filter`
-- `crates/eros-engine-server/src/pipeline/post_process.rs` → `insight_extraction`
-- `crates/eros-engine-server/src/pipeline/stream.rs` → `pde_decision` via `run_pde_decision` inside `run_stream` (only when `filter_prompt` is set); `chat_image_generation` via `resolve_image_gen()` (image executor, opt-in)
+- `crates/eros-engine-server/src/pipeline/post_process.rs` → `insight_extraction`, `affinity_evaluation`
+- `crates/eros-engine-server/src/pipeline/stream.rs` → `pde_decision` via `run_pde_decision` inside `run_stream` (only when `filter_prompt` is set); `chat_image_generation` via `resolve_image_gen()` (image executor, opt-in); `chat_vision` via `resolve_vision()` (vision pre-stage, opt-in); `chat_input_filter` via `resolve_input_filter()` (input rewrite, opt-in); `memory_extraction` via the dreaming sweeper
 
 `embedding` is vestigial — Voyage doesn't go through this path.
 
@@ -316,6 +321,22 @@ unaffected.
 
 Call site: `crates/eros-engine-server/src/pipeline/stream.rs` via
 `resolve_image_gen()` in `model_config.rs`.
+
+### `[tasks.chat_vision]` — image input (vision pre-stage, opt-in)
+
+When a chat turn carries an `image_url`, the engine runs `resolve_vision()` to
+obtain a vision-capable model and `filter_prompt`, calls that model to describe
+the image into a fixed JSON schema (`description`, `ocr_text`, `people`, `scene`),
+and folds the result into the user-facing prompt before the main chat call. The
+main `chat_companion` model stays text-only.
+
+The feature is **off by default** and activates only when this task block exists
+with a non-blank `filter_prompt`. `retry_depth` defaults to `1` (primary +
+first fallback). Pick a vision-capable model; the example uses
+`google/gemini-3.1-flash-lite`.
+
+Call site: `crates/eros-engine-server/src/pipeline/stream.rs` via
+`resolve_vision()` in `model_config.rs`.
 
 ### Enabling / disabling extraction
 

--- a/docs/model-config.zh.md
+++ b/docs/model-config.zh.md
@@ -42,6 +42,7 @@ allow_traits = ["tag_a"]                    # 可选,该 tier 覆盖任务级 al
 | `defaults.fallback_model` | `String` | 否 | 任务没给 model 时的兜底。还是缺,走代码内置的 `x-ai/grok-4-mini`。 |
 | `defaults.fallback_temperature` | `f64` | 否 | 同样优先级链;代码内置默认 `0.5`。 |
 | `defaults.fallback_max_tokens` | `u32` | 否 | 同样;代码内置默认 `200`。 |
+| `defaults.ignore_providers` | `Array<String>` | 否 | 对**所有**任务排除的 OpenRouter provider slug 列表。作为 `provider.ignore` 随每次对外调用发送；`allow_fallbacks` 保持 `true`，模型仍可由其他健康 provider 提供服务。用于某 provider 对特定模型返回乱码时（如未解码的 byte-BPE 文本——issue #84）。可通过 OpenRouter generation API 找到有问题的 slug。空或缺失表示不排除任何 provider。 |
 | `tasks.<name>.model` | `String` \| `Array<String>` \| `Table<String,f64>` | 是 | 主模型。String = 固定；数组 = 轮转（round-robin）；表 = 加权随机。见「主模型选择」。 |
 | `tasks.<name>.fallback` | `String` | 否 | 主模型调用挂掉时,`OpenRouterClient` 用的备选。 |
 | `tasks.<name>.temperature` | `f64` | 否 | 任务级 sampling temperature。无 per-tier 覆盖。 |
@@ -59,7 +60,13 @@ allow_traits = ["tag_a"]                    # 可选,该 tier 覆盖任务级 al
 | `insight_extraction` | `pipeline::post_process::extract_facts` 和 `extract_structured_insights` (抽事实 + JSONB merge) | live |
 | `pde_decision` | `pipeline::stream`（可选 LLM 判断器，通过 `run_pde_decision` 在 `run_stream` 中调用；`filter_prompt` 缺失或 LLM 调用失败时使用规则引擎） | live（opt-in） |
 | `chat_image_generation` | `pipeline::stream`（可选图片回复执行器；任务块存在时激活） | live（opt-in） |
+| `chat_vision` | `pipeline::stream` 经 `resolve_vision()`（视觉预处理阶段：将 `image_url` 附件描述为 JSON 后注入回复 prompt；任务块缺失或 `filter_prompt` 为空时关闭） | live（opt-in） |
+| `affinity_evaluation` | `pipeline::post_process`（逐轮六轴好感度 delta 评估；每次 Reply 轮后 fire-and-forget 运行） | live |
+| `memory_extraction` | dreaming sweeper（会话结束时的记忆整合；任务块缺失时关闭） | live（opt-in） |
+| `chat_input_filter` | `pipeline::stream`（用户输入改写过滤器；由 `[tasks.chat_companion]` 的 `input_filter` 字段及本任务块共同启用；默认关闭） | live（opt-in） |
 | `embedding` | reserved — `VoyageClient` 自己读 `VOYAGE_API_KEY` 并 hard-code `voyage-3-lite`,不走这条路径 | reserved |
+
+<!-- TODO: sync with model-config.md (output_filter/input_filter/chat_vision/ignore_providers sections) -->
 
 `[tasks.<name>]` 只有当代码里真有 `model_config.resolve("<name>", ...)` 调用时才有意义。当前调用点:
 

--- a/examples/personas/kenji.toml
+++ b/examples/personas/kenji.toml
@@ -26,3 +26,4 @@ backstory = "Runs a six-seat ramen counter in Sapporo. Closes at 3am. Lost a bro
 speech_style = "short, dry, almost-jokes; lots of one-word answers; rare smile"
 quirks = ["judges your day by what you ate for lunch", "describes weather in cooking terms", "answers questions with questions"]
 topics = ["broth temperatures", "winter", "old Korean films", "what makes a city feel like 4am"]
+# appearance = "..."  # optional visual seed for image generation (reply_image)

--- a/examples/personas/miel.toml
+++ b/examples/personas/miel.toml
@@ -26,3 +26,4 @@ backstory = "Architecture grad student who moonlights at a vinyl shop. Talks fas
 speech_style = "bouncy, lots of em-dashes, self-edits mid-sentence"
 quirks = ["sends song recommendations", "describes buildings as people", "apologises for being too much, then is too much again"]
 topics = ["albums you should know", "Brutalism", "city walks", "why airports feel sad on Sundays"]
+# appearance = "..."  # optional visual seed for image generation (reply_image)


### PR DESCRIPTION
A full audit of `README.md` / `docs/` / `examples/` for stale/missing content, a slimmed README that points detail into `docs/`, and codex-polished EN + zh + a new Japanese README — codex fact-checked against the codebase.

## README (slimmed — `287 → ~150` EN lines)
- "Why this exists" + "Key features" merged into **5 pillars** (Memory · Affinity+ghost · PDE · User insight · Fluent delivery), framed around *realness* and *persona consistency*. Heavy tables (affinity/memory/ghost deep-dives, full env table, per-field API docs) replaced by summaries + links to `docs/`.
- Added the previously-undocumented capabilities: companion **image generation** (`reply_image`/`reply_text_image`), **image understanding** (`image_url`), **tips**, the **image write-back endpoint**, provider routing/auditing.
- New **Roadmap**: agents playground, voice messages, real-time voice, video generation.
- Fixed stale: removed legacy gift endpoints, library pins `0.4 → 0.6`, doc index now lists prompt-traits + llm-audit.
- **README.zh.md** rewritten in fluent 简体中文; **README.ja.md** added (codex-translated from the authoritative English). 3-way language switcher (English · 中文 · 日本語); zh links → `*.zh.md` docs, ja links → English docs.

## docs/ + examples/ staleness fixes (from the audit)
- `architecture.md(.zh)`: `pipeline::run` → `stream::run_stream`; added `companion_stream` route; dropped Fly.io; migrations range `0005 → 0028`.
- `ghost-mechanics.md(.zh)` + `api-reference.md(.zh)`: replaced the stale `reply: null` claim with the real **ghost SSE contract** (`meta(ghost) → done → final`); healthz `0.6.0 → 0.6.x`.
- `model-config.md`: added task rows for `chat_vision` / `affinity_evaluation` / `memory_extraction` / `chat_input_filter`, a `[tasks.chat_vision]` section, and a `[defaults].ignore_providers` (provider exclusion / garble guard) note.
- `deploying.md(.zh)`: genericized the stale model-name cost note.
- `examples/personas/kenji.toml` + `miel.toml`: added a commented `appearance` stub.

## codex fact-check
codex verified all three READMEs against the repo — endpoints, feature claims, versions, env vars, roadmap-as-future, translation fidelity, and links all **CLEAN**. Two findings surfaced; one fixed here, one flagged below.

## Follow-ups (not in this PR)
- **Code (flagged by fact-check):** a *present-but-empty* `SUPABASE_JWT_SECRET` boots an all-reject validator instead of failing fast (`main.rs:247/252`). The README claim ("no auth source set → refuses to boot") is accurate for the no-var case; the empty-string edge is a small code-robustness gap better fixed on its own.
- **`docs/model-config.zh.md`** is structurally ~170 lines behind the EN (missing `output_filter`/`input_filter`/`model_name_display_override` sections); a `<!-- TODO: sync -->` marker was left. A full zh re-sync is a separate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)