### PR TITLE
fix(server): empty SUPABASE_JWT_SECRET fails fast instead of all-reject boot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,7 +37,9 @@ SUPABASE_URL=https://<project-ref>.supabase.co
 
 # Optional. Legacy HS256 shared secret, for projects that haven't migrated
 # to JWT signing keys. If set alongside SUPABASE_URL, both validators are
-# wired and the engine dispatches by the token's `alg` header.
+# wired and the engine dispatches by the token's `alg` header. An empty value
+# (as shipped here) counts as unset: the server refuses to boot unless at least
+# one usable source — a JWKS URL or a non-empty secret — is configured.
 SUPABASE_JWT_SECRET=
 
 # Voyage embeddings (voyage-3-lite, 512-dim).

--- a/crates/eros-engine-server/src/main.rs
+++ b/crates/eros-engine-server/src/main.rs
@@ -232,29 +232,29 @@ async fn run_server() -> Result<()> {
     // - SUPABASE_JWKS_URL: explicit override.
     // - SUPABASE_URL: derive `${SUPABASE_URL}/auth/v1/.well-known/jwks.json`.
     // - SUPABASE_JWT_SECRET: legacy HS256 shared secret (optional).
-    let mut validator = SupabaseJwtValidator::new();
     let jwks_url = std::env::var("SUPABASE_JWKS_URL").ok().or_else(|| {
         std::env::var("SUPABASE_URL")
             .ok()
             .map(|u| format!("{}/auth/v1/.well-known/jwks.json", u.trim_end_matches('/')))
     });
+    // Resolve+validate the sources before wiring anything: an empty
+    // SUPABASE_JWT_SECRET counts as absent, so `SUPABASE_JWT_SECRET=""` with no
+    // JWKS source fails fast here instead of booting a validator that silently
+    // rejects every request.
+    let legacy_secret = resolve_legacy_secret(
+        jwks_url.is_some(),
+        std::env::var("SUPABASE_JWT_SECRET").ok(),
+    )?;
+
+    let mut validator = SupabaseJwtValidator::new();
     if let Some(url) = jwks_url.as_deref() {
         validator = validator
             .with_jwks_url(url)
             .await
             .with_context(|| format!("failed to load Supabase JWKS from {url}"))?;
     }
-    if let Ok(secret) = std::env::var("SUPABASE_JWT_SECRET") {
-        if !secret.is_empty() {
-            validator = validator.with_legacy_secret(secret);
-        }
-    }
-    if jwks_url.is_none() && std::env::var("SUPABASE_JWT_SECRET").ok().is_none() {
-        anyhow::bail!(
-            "no JWT validation source configured: set SUPABASE_URL (preferred) \
-             or SUPABASE_JWKS_URL for asymmetric JWT validation, and/or \
-             SUPABASE_JWT_SECRET for the legacy HS256 path"
-        );
+    if let Some(secret) = legacy_secret {
+        validator = validator.with_legacy_secret(secret);
     }
     let auth: Arc<dyn AuthValidator> = Arc::new(validator);
 
@@ -332,8 +332,27 @@ async fn run_server() -> Result<()> {
     Ok(())
 }
 
+/// Validates the configured JWT sources and returns the legacy HS256 secret to
+/// wire, if any. A *non-empty* `SUPABASE_JWT_SECRET` is the only thing that
+/// counts as the legacy source — an empty one is treated as absent, so the boot
+/// guard agrees with what actually gets wired. Returns an error (fail-fast at
+/// boot) when neither a JWKS source nor a non-empty legacy secret is present;
+/// otherwise the server would boot a validator that rejects every token.
+fn resolve_legacy_secret(has_jwks: bool, jwt_secret: Option<String>) -> Result<Option<String>> {
+    let legacy_secret = jwt_secret.filter(|s| !s.is_empty());
+    if !has_jwks && legacy_secret.is_none() {
+        anyhow::bail!(
+            "no JWT validation source configured: set SUPABASE_URL (preferred) \
+             or SUPABASE_JWKS_URL for asymmetric JWT validation, and/or \
+             SUPABASE_JWT_SECRET for the legacy HS256 path"
+        );
+    }
+    Ok(legacy_secret)
+}
+
 #[cfg(test)]
 mod tests {
+    use super::resolve_legacy_secret;
     use eros_engine_llm::model_config::ModelConfig;
 
     /// The committed example config is the dev/prod boot default; it MUST pass the
@@ -348,5 +367,40 @@ mod tests {
             "shipped config must pass the extraction boot gate: {:?}",
             cfg.validate_extraction_prompts()
         );
+    }
+
+    #[test]
+    fn no_source_bails() {
+        assert!(resolve_legacy_secret(false, None).is_err());
+    }
+
+    #[test]
+    fn empty_secret_without_jwks_bails() {
+        // The regression: a present-but-empty SUPABASE_JWT_SECRET with no JWKS
+        // source must fail fast, not boot an all-reject validator.
+        assert!(resolve_legacy_secret(false, Some(String::new())).is_err());
+    }
+
+    #[test]
+    fn jwks_alone_is_enough_and_wires_no_legacy_secret() {
+        let secret = resolve_legacy_secret(true, None).expect("jwks source is sufficient");
+        assert_eq!(secret, None);
+    }
+
+    #[test]
+    fn empty_secret_with_jwks_is_ok_but_not_wired() {
+        let secret =
+            resolve_legacy_secret(true, Some(String::new())).expect("jwks source is sufficient");
+        assert_eq!(
+            secret, None,
+            "empty secret must not be wired as legacy source"
+        );
+    }
+
+    #[test]
+    fn nonempty_secret_alone_is_enough_and_is_returned() {
+        let secret = resolve_legacy_secret(false, Some("shh".to_string()))
+            .expect("a non-empty legacy secret is a valid source");
+        assert_eq!(secret.as_deref(), Some("shh"));
     }
 }

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -61,6 +61,8 @@ volumes:
 
 Run with `docker compose -f docker/docker-compose.yml up`. The first boot will run migrations via the `migrate` subcommand entry; subsequent reboots skip already-applied migrations.
 
+This compose file wires only the legacy `SUPABASE_JWT_SECRET`, so export a non-empty value before `up`. An empty or unset secret with no JWKS source makes the engine refuse to boot — by design, so a misconfigured deploy fails loudly instead of silently rejecting every request. For asymmetric JWKS validation instead, add `SUPABASE_URL` (or `SUPABASE_JWKS_URL`) to the `environment:` block.
+
 Place a real Caddy / Traefik / Cloudflare in front for HTTPS termination.
 
 ## Path 2: Embed as a library

--- a/docs/deploying.zh.md
+++ b/docs/deploying.zh.md
@@ -61,6 +61,8 @@ volumes:
 
 `docker compose -f docker/docker-compose.yml up` 跑起來。第一次 boot 會走 `migrate` 子命令入口跑遷移；之後重啟跳過已應用的遷移。
 
+这份 compose 只接了旧版的 `SUPABASE_JWT_SECRET`，所以 `up` 之前要先导出一个非空值。空或未设置、又没有 JWKS 来源时，引擎会拒绝启动——这是刻意设计，让配错的部署直接报错，而不是默默拒掉每一个请求。若想改用非对称 JWKS 校验，在 `environment:` 块里加上 `SUPABASE_URL`（或 `SUPABASE_JWKS_URL`）。
+
 前面放個真正的 Caddy / Traefik / Cloudflare 做 HTTPS 終止。
 
 ## 路徑 2：作為庫嵌入


### PR DESCRIPTION
## What

`run_server`'s boot guard tested whether `SUPABASE_JWT_SECRET` was **set**, but the legacy HS256 source is only wired when it is **non-empty**. So `SUPABASE_JWT_SECRET=""` with no JWKS source (`SUPABASE_URL` / `SUPABASE_JWKS_URL`) slipped past the guard and booted a `SupabaseJwtValidator` with **no sources** — fail-closed (rejects every request) but:

- contradicting the documented *"The server refuses to boot if no auth source is set"* contract, and
- forcing operators to debug blanket `401`s instead of getting a clear boot error.

## Fix

Extract the decision into a pure `resolve_legacy_secret(has_jwks, jwt_secret) -> Result<Option<String>>` helper that empty-filters the secret in **one** place, so the boot guard agrees with what actually gets wired. An empty `SUPABASE_JWT_SECRET` now counts as absent → fails fast at boot when no JWKS source is present.

No behaviour change for valid configs: JWKS-only, secret-only, and JWKS+secret all wire exactly as before.

## Tests

5 pure unit tests (no DB) covering the boundary:
- `no_source_bails`
- `empty_secret_without_jwks_bails` ← the regression
- `jwks_alone_is_enough_and_wires_no_legacy_secret`
- `empty_secret_with_jwks_is_ok_but_not_wired`
- `nonempty_secret_alone_is_enough_and_is_returned`

## Gate
- `cargo fmt --check` clean
- `cargo clippy --workspace --all-targets -D warnings` clean
- `cargo test --workspace` → 608 passed / 0 failed
- OpenAPI snapshot: no drift

Server-only; no migration; no version bump (`dev` stays `0.6.3-dev`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)