### PR TITLE
fix(llm): support image-only OpenRouter output models (#101)

### DIFF
--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -171,7 +171,11 @@ fn build_image_body(req: &ImageGenRequest, model: &str) -> serde_json::Value {
     }
     serde_json::json!({
         "model": model,
-        "modalities": ["image", "text"],
+        // #101: image-only output. Image-only models reject ["image","text"]
+        // with 404; text-capable models still return the image for ["image"].
+        // The engine never consumes the image model's text (reply_image writes
+        // empty content; reply_text_image's caption comes from chat_companion).
+        "modalities": ["image"],
         "messages": [ { "role": "user", "content": content } ],
         "max_tokens": req.max_tokens,
         "stream": false,
@@ -2261,7 +2265,10 @@ data: [DONE]\n\n";
             max_tokens: 4096,
         };
         let body = build_image_body(&req, "m");
-        assert_eq!(body["modalities"], serde_json::json!(["image", "text"]));
+        // #101: image-gen requests image-only output so image-only OpenRouter
+        // models (e.g. bytedance-seed/seedream-4.5) don't 404. The engine never
+        // uses the image model's text, so we never ask for the text modality.
+        assert_eq!(body["modalities"], serde_json::json!(["image"]));
         let content = &body["messages"][0]["content"];
         // text-only content block when no face ref
         assert_eq!(content.as_array().unwrap().len(), 1);

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -129,8 +129,6 @@ pub struct ImageGenRequest {
 pub struct ImageGenResponse {
     /// Base64 data-URLs extracted from `message.images[]`.
     pub images: Vec<String>,
-    /// Optional text accompanying the images (from `message.content`).
-    pub text: Option<String>,
     /// OpenRouter response `id` — opaque generation handle.
     pub generation_id: Option<String>,
     /// Model actually served (may differ from request when fallback hit).
@@ -743,11 +741,9 @@ impl OpenRouterClient {
                 continue;
             }
             let first = parsed.choices.into_iter().next();
-            let text = first.as_ref().and_then(|c| c.message.content.clone());
             let finish_reason = first.and_then(|c| c.finish_reason);
             return Ok(ImageGenResponse {
                 images,
-                text,
                 generation_id: parsed.id,
                 model: parsed.model,
                 usage: parsed.usage,

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -1983,18 +1983,24 @@ pub fn run_stream(
         let is_tip = user_msg.tips_amount_usd.is_some();
         // Per-turn image executor resolution. The executor counts as available
         // only when the caller opted in (an `image` block is present) AND a model
-        // resolves this turn (`effective_image_chain` is Some). Omitting `image`
-        // turns image generation OFF for the turn even when a config `fallback`
-        // model exists — mirroring chat_vision, which runs only when `image_url`
-        // is present. With no executor, image actions degrade to text
-        // (guard_action) and a forced image request is ignored.
+        // resolves this turn. Omitting `image` turns image generation OFF for the
+        // turn even when a config `fallback` model exists — mirroring chat_vision,
+        // which runs only when `image_url` is present. With no executor, image
+        // actions degrade to text (guard_action) and a forced request is ignored.
+        //
+        // Resolve the chain ONLY when opted in: `effective_image_chain` advances
+        // the image ModelSpec round-robin cursor (`ModelSpec::select`), so calling
+        // it on opted-out / text turns would consume image-model slots and skew
+        // the sequencing of later opted-in image turns.
         let resolved_image_gen = state.model_config.resolve_image_gen();
         let req_image = user_msg.image.as_ref();
-        let image_chain = eros_engine_llm::model_config::effective_image_chain(
-            req_image.and_then(|i| i.model.as_deref()),
-            resolved_image_gen.as_ref(),
-        );
-        let image_executor_available = req_image.is_some() && image_chain.is_some();
+        let image_chain = req_image.and_then(|i| {
+            eros_engine_llm::model_config::effective_image_chain(
+                i.model.as_deref(),
+                resolved_image_gen.as_ref(),
+            )
+        });
+        let image_executor_available = image_chain.is_some();
         // Forced image: the client asked for it, an executor chain exists this
         // turn, and it is not a tip turn (tips skip the judge / image path).
         let force_image = req_image.is_some_and(|i| i.force) && image_executor_available && !is_tip;

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -1981,16 +1981,20 @@ pub fn run_stream(
         // short-circuits all of them. Tip turns and feature-off skip the judge
         // (rule engine). Fail-open: any non-Ok status falls back to pde::decide.
         let is_tip = user_msg.tips_amount_usd.is_some();
-        // Per-turn image executor resolution. `effective_image_chain` is None ⇒
-        // no model anywhere ⇒ the turn cannot generate, so image actions degrade
-        // to text (guard_action) and a forced image request is ignored.
+        // Per-turn image executor resolution. The executor counts as available
+        // only when the caller opted in (an `image` block is present) AND a model
+        // resolves this turn (`effective_image_chain` is Some). Omitting `image`
+        // turns image generation OFF for the turn even when a config `fallback`
+        // model exists — mirroring chat_vision, which runs only when `image_url`
+        // is present. With no executor, image actions degrade to text
+        // (guard_action) and a forced image request is ignored.
         let resolved_image_gen = state.model_config.resolve_image_gen();
         let req_image = user_msg.image.as_ref();
         let image_chain = eros_engine_llm::model_config::effective_image_chain(
             req_image.and_then(|i| i.model.as_deref()),
             resolved_image_gen.as_ref(),
         );
-        let image_executor_available = image_chain.is_some();
+        let image_executor_available = req_image.is_some() && image_chain.is_some();
         // Forced image: the client asked for it, an executor chain exists this
         // turn, and it is not a tip turn (tips skip the judge / image path).
         let force_image = req_image.is_some_and(|i| i.force) && image_executor_available && !is_tip;

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -254,7 +254,11 @@ curl -N -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/js
 **Optional: companion image reply.** The body may include an `image` object —
 `ImageReplyParams` — to request or force a companion-generated image this turn.
 Requires `[tasks.chat_image_generation]` to be configured (see
-[model-config.md](model-config.md)); the executor is off by default.
+[model-config.md](model-config.md)); the executor is off by default. The `image`
+block is also the per-turn opt-in: **omit it to suppress image generation for the
+turn** (the PDE may then only `reply_text` / `ghost`), or send `image: {}` to
+enable it with the config model. This lets a caller's own per-turn policy gate
+images independently of the PDE's content decision.
 
 ```bash
 curl -N -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json" \

--- a/docs/api-reference.zh.md
+++ b/docs/api-reference.zh.md
@@ -236,7 +236,7 @@ curl -N -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/js
   http://localhost:8080/comp/chat/<session_id>/message/stream
 ```
 
-**可选：伴侣图片回复。** 请求体可附加 `image` 对象（`ImageReplyParams`），请求或强制本轮生成一张伴侣发送的图片。需要配置 `[tasks.chat_image_generation]`（见 [model-config.zh.md](model-config.zh.md)）；执行器默认关闭。
+**可选：伴侣图片回复。** 请求体可附加 `image` 对象（`ImageReplyParams`），请求或强制本轮生成一张伴侣发送的图片。需要配置 `[tasks.chat_image_generation]`（见 [model-config.zh.md](model-config.zh.md)）；执行器默认关闭。`image` 块同时是本轮的 opt-in 开关：**省略它即可关闭本轮的图片生成**（此时 PDE 只能 `reply_text` / `ghost`），或发送 `image: {}` 用配置里的模型启用。这样调用方可以用自己的 per-turn 策略独立于 PDE 的内容决策来控制是否出图。
 
 ```bash
 curl -N -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json" \

--- a/docs/model-config.md
+++ b/docs/model-config.md
@@ -268,6 +268,8 @@ block exists in the config. When active, the engine executes `reply_image` and
 to `reply_text` still occurs when the block is absent or when no model is
 resolvable for a given turn.
 
+Any OpenRouter image model works here, including **image-only** models (e.g. `bytedance-seed/seedream-4.5`): the engine requests `modalities: ["image"]` and never asks the image model for text. The caption on a `reply_text_image` turn always comes from `chat_companion`, never the image model.
+
 ```toml
 [tasks.chat_image_generation]
 # `model` is OPTIONAL. Omit to defer model selection to the per-turn frontend

--- a/docs/model-config.md
+++ b/docs/model-config.md
@@ -251,7 +251,7 @@ A `[tasks.<name>]` entry is only meaningful if the engine actually calls `model_
 By default the engine uses the built-in rule engine (`eros-engine-core/src/pde.rs`) to decide the per-turn action (reply / ghost / proactive). Setting `filter_prompt` in this block switches on an LLM judge:
 
 - The LLM receives the recent conversation, relationship state, and conversation signals, and returns a JSON verdict with:
-  - `action`: `"reply_text"` | `"ghost"` | `"reply_image"` | `"reply_text_image"` (image variants execute when `[tasks.chat_image_generation]` is configured and a model is resolvable; they degrade to `reply_text` only when the task block is absent or no model is resolvable for the turn)
+  - `action`: `"reply_text"` | `"ghost"` | `"reply_image"` | `"reply_text_image"` (image variants execute when `[tasks.chat_image_generation]` is configured, a model is resolvable, **and the request includes an `image` block**; otherwise they degrade to `reply_text` — task block absent, no model resolvable, or no `image` block on the request)
   - `inner_state`: a short mood/tone description folded into the reply prompt
   - `image_prompt`, `reason`: optional
 - **Fail-open:** any LLM timeout or error falls back to the rule engine — the LLM judge never blocks a chat response.
@@ -263,10 +263,12 @@ By default the engine uses the built-in rule engine (`eros-engine-core/src/pde.r
 ### `[tasks.chat_image_generation]` — companion image replies (opt-in)
 
 The companion image executor is **off by default**. It activates when this task
-block exists in the config. When active, the engine executes `reply_image` and
-`reply_text_image` actions instead of degrading them to `reply_text`. Degradation
-to `reply_text` still occurs when the block is absent or when no model is
-resolvable for a given turn.
+block exists in the config **and** the per-turn request carries an `image` block
+(omitting `image` turns generation off for that turn, mirroring how `chat_vision`
+runs only when `image_url` is present). When active, the engine executes
+`reply_image` and `reply_text_image` actions instead of degrading them to
+`reply_text`. Degradation to `reply_text` still occurs when the block is absent,
+no model is resolvable for the turn, or the request omits `image`.
 
 Any OpenRouter image model works here, including **image-only** models (e.g. `bytedance-seed/seedream-4.5`): the engine requests `modalities: ["image"]` and never asks the image model for text. The caption on a `reply_text_image` turn always comes from `chat_companion`, never the image model.
 

--- a/docs/model-config.zh.md
+++ b/docs/model-config.zh.md
@@ -234,6 +234,8 @@ chat SSE stream 结束时发出的 `final` event 包含几个新字段。无论 
 
 Companion 图片执行器**默认关闭**。配置中存在此任务块时，它会激活。激活后，引擎会执行 `reply_image` 和 `reply_text_image` 动作，而不是将其降级为 `reply_text`。任务块缺失或某一轮次无法解析出模型时，仍会降级为 `reply_text`。
 
+这里可以用任意 OpenRouter 图片模型，包括**只输出图片**的模型（如 `bytedance-seed/seedream-4.5`）：引擎只请求 `modalities: ["image"]`，从不向图片模型要文本。`reply_text_image` 轮次的文字始终来自 `chat_companion`，而非图片模型。
+
 ```toml
 [tasks.chat_image_generation]
 # `model` is OPTIONAL. Omit to defer model selection to the per-turn frontend

--- a/docs/model-config.zh.md
+++ b/docs/model-config.zh.md
@@ -221,7 +221,7 @@ chat SSE stream 结束时发出的 `final` event 包含几个新字段。无论 
 默认情况下，引擎使用内置规则引擎（`eros-engine-core/src/pde.rs`）决定每轮动作（reply / ghost / proactive）。在此块中设置 `filter_prompt` 会启用 LLM 判断器：
 
 - LLM 接收最近的对话、关系状态和对话信号，并返回 JSON verdict，其中包含：
-  - `action`：`"reply_text"` \| `"ghost"` \| `"reply_image"` \| `"reply_text_image"`（配置 `[tasks.chat_image_generation]` 且当前轮次可解析出模型时执行图片变体；仅当任务块缺失或当前轮次无法解析出模型时，才降级为 `reply_text`）
+  - `action`：`"reply_text"` \| `"ghost"` \| `"reply_image"` \| `"reply_text_image"`（配置 `[tasks.chat_image_generation]`、当前轮次可解析出模型、**且请求包含 `image` 块**时才执行图片变体；否则降级为 `reply_text`——任务块缺失、无法解析出模型、或请求未带 `image` 块）
   - `inner_state`：融入 reply prompt 的简短情绪/语气描述
   - `image_prompt`、`reason`：可选
 - **Fail-open：**任何 LLM 超时或错误都会回退到规则引擎——LLM 判断器绝不会阻塞 chat 响应。
@@ -232,7 +232,7 @@ chat SSE stream 结束时发出的 `final` event 包含几个新字段。无论 
 
 ### `[tasks.chat_image_generation]` — companion 图片回复（opt-in）
 
-Companion 图片执行器**默认关闭**。配置中存在此任务块时，它会激活。激活后，引擎会执行 `reply_image` 和 `reply_text_image` 动作，而不是将其降级为 `reply_text`。任务块缺失或某一轮次无法解析出模型时，仍会降级为 `reply_text`。
+Companion 图片执行器**默认关闭**。当配置中存在此任务块**且**当前轮次的请求带有 `image` 块时才会激活（省略 `image` 即可关闭该轮的图片生成，类似 `chat_vision` 仅在带 `image_url` 时运行）。激活后，引擎会执行 `reply_image` 和 `reply_text_image` 动作，而不是将其降级为 `reply_text`。任务块缺失、当前轮次无法解析出模型、或请求未带 `image` 块时，仍会降级为 `reply_text`。
 
 这里可以用任意 OpenRouter 图片模型，包括**只输出图片**的模型（如 `bytedance-seed/seedream-4.5`）：引擎只请求 `modalities: ["image"]`，从不向图片模型要文本。`reply_text_image` 轮次的文字始终来自 `chat_companion`，而非图片模型。
 

--- a/docs/superpowers/specs/2026-06-24-image-only-output-models-design.md
+++ b/docs/superpowers/specs/2026-06-24-image-only-output-models-design.md
@@ -70,6 +70,32 @@ The fix therefore collapses to: **stop asking the image model for text.**
 - Removing the `pub text` field is a minor pre-1.0 API trim to `eros-engine-llm`
   (the field had zero readers).
 
+## Follow-on: per-turn image opt-in (issue #101 comment)
+
+Bundled into the same PR. Once a `fallback` is configured under
+`[tasks.chat_image_generation]`, the executor was **always** available, so a
+caller had no way to turn image generation off for a specific turn — the PDE
+could return `reply_image` / `reply_text_image` on any turn and it executed.
+
+**Fix (one line):** make the per-request `image` block the opt-in. At
+`crates/eros-engine-server/src/pipeline/stream.rs`:
+
+```rust
+let image_executor_available = req_image.is_some() && image_chain.is_some();
+```
+
+- Omit `image` → executor unavailable → image actions degrade to `reply_text`
+  (via `guard_action`); a forced request is ignored. Send `image: {}` → enabled
+  with the config model; `image.model` overrides per request.
+- Mirrors `chat_vision`, which runs only when `image_url` is present.
+- `force_image` and `guard_action` already consume this bool, so nothing else
+  moves. The "unavailable ⇒ degrade" path is already covered by
+  `guard_action_degrades_and_honours`; the new clause is a plain boolean AND.
+- Docs updated alongside: the PDE action contract and the
+  `[tasks.chat_image_generation]` activation prose in `docs/model-config.md` +
+  `docs/model-config.zh.md`, and the `image`-field opt-in semantics in
+  `docs/api-reference.md` + `docs/api-reference.zh.md`.
+
 ## Out of scope (YAGNI)
 
 - No per-model `modalities` configuration.

--- a/docs/superpowers/specs/2026-06-24-image-only-output-models-design.md
+++ b/docs/superpowers/specs/2026-06-24-image-only-output-models-design.md
@@ -1,0 +1,85 @@
+# Support image-only OpenRouter output models (issue #101)
+
+- **Date:** 2026-06-24
+- **Issue:** [#101](https://github.com/etherfunlab/eros-engine/issues/101)
+- **Scope:** one crate (`eros-engine-llm`); no DB migration, no SSE/route change, no version bump (rides `dev` at `0.6.3-dev`).
+
+## Problem
+
+`build_image_body()` (`crates/eros-engine-llm/src/openrouter.rs`) unconditionally
+requests `"modalities": ["image", "text"]`. Many routable OpenRouter image models
+output **image only** (e.g. `bytedance-seed/seedream-4.5`,
+`x-ai/grok-imagine-image-quality`) and reject a request that also asks for text
+with `404 (no endpoints support image,text)`. Only models that *also* emit text
+(e.g. `google/gemini-3-pro-image`) work today, so a web client letting users pick
+the image model per request (`image.model`) is limited to text-emitting models.
+
+## Key finding — text/image generation is already decoupled
+
+The issue's suggested fix has two parts; **only the first is an actual change.**
+Part 2 ("`reply_text_image` → compose, don't conflate") is already how the engine
+works:
+
+- **`reply_image`** (`pipeline/stream.rs`, generate-first arm): calls
+  `execute_image`, persists the assistant row with `content: ""`, and emits an
+  image-only turn. The image model's text output is **never read**.
+- **`reply_text_image`** (`pipeline/stream.rs`, text-then-image arm): the caption
+  text comes from the **normal chat path** (`drive_chat_burst` → `chat_companion`),
+  streamed as `meta → delta* → done`; the image is then produced by a **separate**
+  `execute_image` call and appended as one `Image` frame before `final`.
+
+So text (via `chat_companion`) and image (via the `chat_*` image task) are already
+two independent OpenRouter calls; the image model is never asked for the caption.
+`ImageGenResponse.text` is confirmed dead — no reader anywhere in the workspace.
+`ImageGenResponse` is constructed in exactly one place (`execute_image`).
+
+The fix therefore collapses to: **stop asking the image model for text.**
+
+## Decision
+
+1. **`build_image_body()` → `"modalities": ["image"]`.** Per the issue and
+   OpenRouter's documented behavior, a text-capable model asked for `["image"]`
+   still returns the image, so this is backward-compatible for the existing
+   text-emitting models.
+2. **Remove the now-provably-dead text capture** (chosen over keeping it as audit
+   data): drop `pub text: Option<String>` from `ImageGenResponse` and the
+   `let text = … message.content` extraction + `text,` initializer in
+   `execute_image`. Keep the `first` binding and `finish_reason` (still used for
+   content-filter detection). `WireMessage.content` stays — the chat / vision /
+   filter paths still read it.
+3. **Docs:** one additive line in `docs/model-config.md`'s chat-image section
+   noting that **any** OpenRouter image model works, including image-only ones;
+   mirror to `docs/model-config.zh.md` per the doc-language convention.
+
+## Changes (file by file)
+
+- `crates/eros-engine-llm/src/openrouter.rs`
+  - `build_image_body`: `"modalities": ["image"]`.
+  - `ImageGenResponse`: remove `text` field + its doc comment.
+  - `execute_image`: remove the `text` extraction line and the `text,` field in
+    the returned literal.
+  - Test `image_body_has_modalities_and_optional_face_ref`: assert `["image"]`,
+    with a comment anchoring it to #101 as the regression guard.
+- `docs/model-config.md` + `docs/model-config.zh.md`: one-line image-only note.
+
+## Compatibility / non-impact
+
+- No SSE protocol change, no route change, no DB migration.
+- `reply_image` / `reply_text_image` behavior unchanged for text-capable models;
+  image-only models now work for both.
+- Removing the `pub text` field is a minor pre-1.0 API trim to `eros-engine-llm`
+  (the field had zero readers).
+
+## Out of scope (YAGNI)
+
+- No per-model `modalities` configuration.
+- No change to `reply_text_image` composition (already composed) or `chat_vision`.
+
+## Testing / gate
+
+- Updated unit test asserts `["image"]`; existing
+  `image_response_parses_data_url_from_images_array` stays green (does not touch
+  `text`).
+- Pre-PR gate: `cargo fmt --check`, `cargo clippy --workspace --all-targets -D
+  warnings`, `cargo test --workspace`, openapi snapshot (expected no drift —
+  purely internal).


### PR DESCRIPTION
Closes #101.

## Problem

`build_image_body()` hardcoded `"modalities": ["image", "text"]`. Many routable OpenRouter image models output **image only** (`bytedance-seed/seedream-4.5`, `x-ai/grok-imagine-image-quality`, …) and reject a request that also asks for text with `404 (no endpoints support image,text)`. Only models that also emit text (e.g. `google/gemini-3-pro-image`) worked — so a client letting users pick the image model per request was limited to text-emitting models.

## Fix

Text and image generation are **already two separate OpenRouter calls** — `reply_image` writes empty `content`, and `reply_text_image`'s caption comes from the chat path (`chat_companion`). The image model's text was never consumed. So:

1. `build_image_body()` → `"modalities": ["image"]`. Backward-compatible: a text-capable image model asked for `["image"]` still returns the image.
2. Removed the now-provably-dead `ImageGenResponse.text` field + its capture in `execute_image` (zero readers anywhere; `finish_reason` and usage logging unchanged).
3. Docs note (en + zh) in the `[tasks.chat_image_generation]` section that any image model works, including image-only.

Design spec: `docs/superpowers/specs/2026-06-24-image-only-output-models-design.md`.

## Scope / non-impact
- `eros-engine-llm` crate + 2 doc files only. No DB migration, no SSE/route change, no version bump (rides `dev` at `0.6.3-dev`).
- No per-model modality branching (YAGNI).
- Removing `pub text` is a minor pre-1.0 API trim (no in-tree consumers).

## Gate
- `cargo fmt --check` clean
- `cargo clippy --workspace --all-targets -D warnings` clean
- `cargo test --workspace` → 608 passed / 0 failed (updated pinning test asserts `["image"]`)
- OpenAPI snapshot: no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)