### PR TITLE
feat(pde): emit per-turn image-availability line in judge context

### DIFF
--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -1325,7 +1325,11 @@ fn build_persona_brief(persona: &eros_engine_core::persona::CompanionPersona) ->
 }
 
 /// Build the judge's user payload from the shared transcript + the decision input.
-fn build_pde_ctx(transcript: &str, input: &eros_engine_core::types::DecisionInput) -> String {
+fn build_pde_ctx(
+    transcript: &str,
+    input: &eros_engine_core::types::DecisionInput,
+    image_available: bool,
+) -> String {
     let a = &input.affinity;
     let s = &input.signals;
     let latest = match &input.event {
@@ -1343,10 +1347,14 @@ fn build_pde_ctx(transcript: &str, input: &eros_engine_core::types::DecisionInpu
     } else {
         format!("{brief}\n\n")
     };
+    // Always emit the image-capability line — the negative is a signal too, so
+    // the judge gets a clear "no images this turn" rather than a missing line.
+    let image_flag = if image_available { "是" } else { "否" };
     format!(
         "{persona_block}[最近对话]\n{transcript}\n\n\
          [关系状态] warmth={:.2} trust={:.2} intrigue={:.2} intimacy={:.2} patience={:.2} tension={:.2}\n\
-         [信号] message_count={} hours_since_last_message={:.1} ghost_streak={} hours_since_last_ghost={}\n\n\
+         [信号] message_count={} hours_since_last_message={:.1} ghost_streak={} hours_since_last_ghost={}\n\
+         [图片能力] 本轮可发图={image_flag}\n\n\
          [用户最新消息]\n{latest}",
         a.warmth,
         a.trust,
@@ -2024,7 +2032,7 @@ pub fn run_stream(
         let (mut plan, pde_run): (eros_engine_core::types::ActionPlan, Option<PdeDecisionRun>) =
             match (is_tip, resolved_pde.as_ref()) {
                 (false, Some(p)) => {
-                    let ctx = build_pde_ctx(&pde_transcript, &input);
+                    let ctx = build_pde_ctx(&pde_transcript, &input, image_executor_available);
                     let run = run_pde_decision(&state.openrouter, p, &ctx).await;
                     let plan = match (&run.status, &run.verdict) {
                         (PdeStatus::Ok, Some(v)) => {
@@ -6625,7 +6633,7 @@ data: [DONE]\n\n";
             persona: p,
             signals: test_signals(),
         };
-        let ctx = build_pde_ctx("用户：hi\nMia：hey", &input);
+        let ctx = build_pde_ctx("用户：hi\nMia：hey", &input, true);
         let persona_at = ctx.find("[角色人格]").expect("persona block present");
         let rel_at = ctx.find("[关系状态]").expect("relationship block present");
         assert!(
@@ -6633,6 +6641,25 @@ data: [DONE]\n\n";
             "persona must precede relationship: {ctx}"
         );
         assert!(ctx.starts_with("[角色人格]"), "persona block at top: {ctx}");
+        // image_available == true → positive signal, no negative variant.
+        assert!(
+            ctx.contains("[图片能力] 本轮可发图=是"),
+            "image-availability line present and positive: {ctx}"
+        );
+        assert!(
+            !ctx.contains("本轮可发图=否"),
+            "no negative variant when available: {ctx}"
+        );
+        // The line sits strictly between [信号] and [用户最新消息].
+        let signal_at = ctx.find("[信号]").expect("signal block present");
+        let image_at = ctx
+            .find("[图片能力]")
+            .expect("image-capability line present");
+        let latest_at = ctx.find("[用户最新消息]").expect("latest block present");
+        assert!(
+            signal_at < image_at && image_at < latest_at,
+            "image-capability line sits between [信号] and [用户最新消息]: {ctx}"
+        );
     }
 
     #[test]
@@ -6657,11 +6684,20 @@ data: [DONE]\n\n";
             persona: p,
             signals: test_signals(),
         };
-        let ctx = build_pde_ctx("", &input);
+        let ctx = build_pde_ctx("", &input, false);
         assert!(!ctx.contains("[角色人格]"), "no persona block: {ctx}");
         assert!(
             ctx.starts_with("[最近对话]"),
             "ctx starts with transcript block: {ctx}"
+        );
+        // image_available == false → explicit negative signal, not a missing line.
+        assert!(
+            ctx.contains("[图片能力] 本轮可发图=否"),
+            "image-availability line present and negative: {ctx}"
+        );
+        assert!(
+            !ctx.contains("本轮可发图=是"),
+            "no positive variant when unavailable: {ctx}"
         );
     }
 

--- a/docs/model-config.md
+++ b/docs/model-config.md
@@ -258,6 +258,8 @@ By default the engine uses the built-in rule engine (`eros-engine-core/src/pde.r
 - **Hard-safety guardrails** (enforced after the LLM verdict, before the rule-engine fallback): never ghost in the first 10 messages, never ghost twice in a row, one-hour ghost cooldown.
 - Every judge call is audited to `companion_decision_events`.
 
+**Image-availability context line.** The judge context always carries exactly one line — `[图片能力] 本轮可发图=是` when an image executor is resolvable this turn (`[tasks.chat_image_generation]` configured **and** the request carries an `image` block), or `[图片能力] 本轮可发图=否` otherwise. Prompt authors should treat `本轮可发图=否` as a hard constraint (never choose `reply_image` / `reply_text_image` — they would be degraded by `guard_action` anyway, wasting tokens and skewing audits), and `本轮可发图=是` as the gate that *permits* image actions, then decide by persona/context (the engine does not force an image just because one is possible). Keep the token string `[图片能力] 本轮可发图=是/否` verbatim if a downstream overlay references it.
+
 **`ghosting` field** (bool, default `true`): a safety switch for downstream products. Set `ghosting = false` to disable ghosting across the _entire_ PDE path — LLM verdict, rule fallback, and the pure rule engine — so the companion never goes silent. Useful for products where silent turns are undesirable.
 
 ### `[tasks.chat_image_generation]` — companion image replies (opt-in)

--- a/docs/model-config.zh.md
+++ b/docs/model-config.zh.md
@@ -228,6 +228,8 @@ chat SSE stream 结束时发出的 `final` event 包含几个新字段。无论 
 - **硬安全 guardrail**（在 LLM verdict 之后、规则引擎 fallback 之前强制执行）：前 10 条消息绝不 ghost，绝不连续 ghost 两次，ghost cooldown 为一小时。
 - 每次判断器调用都会记录到 `companion_decision_events` 以供审计。
 
+**图片能力上下文行。** 判断器上下文每轮必带一行——当本轮可解析出图片执行器（已配置 `[tasks.chat_image_generation]` **且**请求带有 `image` 块）时为 `[图片能力] 本轮可发图=是`，否则为 `[图片能力] 本轮可发图=否`。prompt 作者应把 `本轮可发图=否` 当作硬约束（绝不要选 `reply_image` / `reply_text_image`——它们会被 `guard_action` 降级，白费 token 还会污染审计），把 `本轮可发图=是` 当作*允许*发图的开关，再按人格/语境决定要不要发（引擎不会因为"能发"就强制发图）。若下游 overlay 引用了这个 token，请逐字保留 `[图片能力] 本轮可发图=是/否`。
+
 **`ghosting` 字段**（bool，默认 `true`）：面向下游产品的安全开关。设置 `ghosting = false` 可在*整个* PDE 路径上禁用 ghosting——包括 LLM verdict、规则 fallback 和纯规则引擎——从而确保 companion 永不沉默。适用于不希望出现静默轮次的产品。
 
 ### `[tasks.chat_image_generation]` — companion 图片回复（opt-in）

--- a/docs/superpowers/specs/2026-06-26-pde-image-availability-context-design.md
+++ b/docs/superpowers/specs/2026-06-26-pde-image-availability-context-design.md
@@ -1,0 +1,181 @@
+# eros-engine — PDE image-availability context signal (Spec)
+
+**Status**: design, pending implementation plan
+**Target release**: `0.6.4` dev track. **No migration**, no new config keys, no
+HTTP-contract change.
+**Audience**: anyone working on the PDE judge (`run_pde_decision` /
+`build_pde_ctx`) on the streaming chat path.
+**Builds on**: `2026-06-04-llm-based-pde-design.md` (the judge),
+`2026-06-23-pde-persona-and-structured-output-design.md` (judge context +
+structured output), and `2026-06-23-reply-image-executor-design.md` (the
+`reply_image` / `reply_text_image` executor + the per-turn `image` opt-in).
+
+---
+
+## 0. Background
+
+### What already exists
+
+The per-turn PDE judge picks one action —
+`reply_text` | `ghost` | `reply_image` | `reply_text_image` — from a context
+string built by `build_pde_ctx()` (`stream.rs:1328`) and the operator's
+`[tasks.pde_decision]` prompt.
+
+Image generation is **opt-in per turn**: a caller includes an `image` block on
+the user message; the engine resolves an executor chain only then
+(`stream.rs:1995-2003`):
+
+```rust
+let req_image = user_msg.image.as_ref();
+let image_chain = req_image.and_then(|i| effective_image_chain(i.model.as_deref(), …));
+let image_executor_available = image_chain.is_some();
+```
+
+When no executor is available, `guard_action()` (`stream.rs:1225-1250`) **silently
+degrades** `reply_image` / `reply_text_image` → `reply_text`. That degrade is
+correct and stays.
+
+### The problem
+
+`build_pde_ctx()` never tells the judge whether an image executor is available
+this turn — the context contains persona, transcript, affinity, and signals, but
+nothing about image capability. Consequences:
+
+1. **Blind proposals.** When images are unavailable the judge still proposes
+   image actions; they are degraded downstream. The judge has no way to know its
+   image proposals were dropped, so the operator prompt cannot reliably steer it.
+2. **No positive lever.** When images *are* available, the operator prompt has no
+   signal to condition on. It cannot say "only choose an image action when image
+   output is actually possible this turn," nor lean into image actions on the
+   turns where they would land. In practice the judge under-selects image actions
+   even when the caller opted in.
+
+This is the symptom downstream operators observe as "the judge almost never
+chooses `reply_image`."
+
+### Why this is the right fix here (not operator-side)
+
+`image_executor_available` is engine state derived from the request + resolved
+config; only the engine can compute it. The judge can only condition on it if the
+engine puts it in the judge context. The operator prompt then references it. So
+the engine owns emitting the signal; the operator owns how to react to it.
+
+---
+
+## 1. Goal
+
+Thread the already-computed `image_executor_available` flag into
+`build_pde_ctx()` and emit it as a stable, documented line in the judge context,
+so the `pde_decision` prompt can condition image-action selection on real
+per-turn availability.
+
+Non-goals (unchanged):
+- `guard_action()` degrade behaviour — stays as the safety net.
+- The HTTP request/response contract and the `image` opt-in semantics.
+- The operator's prompt wording (lives in their `model_config.toml`); this spec
+  only fixes the example/docs and defines the contract they key off.
+
+---
+
+## 2. The change
+
+### 2.1 `build_pde_ctx` gains an `image_available` parameter
+
+`stream.rs:1328`
+
+```rust
+fn build_pde_ctx(
+    transcript: &str,
+    input: &eros_engine_core::types::DecisionInput,
+    image_available: bool,
+) -> String {
+    …
+}
+```
+
+Append one line to the emitted context, **always present** (so the judge gets a
+clear negative as well as positive signal), placed right after the `[信号]` line
+and before `[用户最新消息]`:
+
+```
+[图片能力] 本轮可发图=是      // when image_available == true
+[图片能力] 本轮可发图=否      // when image_available == false
+```
+
+Implementation: add `[图片能力] 本轮可发图={}\n` to the `format!` template with
+`if image_available { "是" } else { "否" }`. No other lines change; the order of
+existing lines is preserved.
+
+### 2.2 Call site passes the flag (already in scope — no reordering)
+
+`stream.rs:2027`. `image_executor_available` is computed at `2003`, *before* the
+judge call at `2027-2028`, so it is already in scope:
+
+```rust
+let ctx = build_pde_ctx(&pde_transcript, &input, image_executor_available);
+```
+
+### 2.3 Optional extension (call out, default OUT of scope)
+
+`force_image` (`stream.rs:2006`) is a separate explicit-request path that already
+forces an image downstream. v1 emits availability only. If a later turn wants the
+judge to also author a good `image_prompt` under force, a second token
+(`强制发图=是`) can be added the same way — deferred unless a consumer needs it.
+
+---
+
+## 3. Contract for prompt authors (consumers)
+
+The judge context now contains exactly one of:
+
+```
+[图片能力] 本轮可发图=是
+[图片能力] 本轮可发图=否
+```
+
+Prompt authors should:
+- Treat `本轮可发图=否` as a hard constraint: never choose `reply_image` /
+  `reply_text_image` on that turn (they would be degraded anyway, wasting tokens
+  and skewing audits).
+- Treat `本轮可发图=是` as the gate that *permits* image actions, then decide by
+  persona/context (the engine does not force an image just because it is
+  possible).
+
+The token string (`[图片能力] 本轮可发图=是/否`) is the stable interface — keep it
+verbatim if a downstream overlay references it.
+
+---
+
+## 4. Files touched
+
+| File | Change |
+|------|--------|
+| `crates/eros-engine-server/src/pipeline/stream.rs` | `build_pde_ctx` signature + new line (`1328`); call site passes `image_executor_available` (`2027`) |
+| `crates/eros-engine-server/src/pipeline/stream.rs` (tests) | Update `build_pde_ctx` unit tests (`6628`, `6660`) for the new arg; add assertions for both `=是` and `=否` |
+| `examples/model_config.toml` | Document the new `[图片能力]` line in the `[tasks.pde_decision]` example/comments so the example prompt demonstrates conditioning on it |
+| `docs/model-config.md` + `docs/model-config.zh.md` | Note the `本轮可发图` context line in the PDE section |
+
+No changes to `guard_action`, `ActionPlan`, `effective_image_chain`, types, or
+the HTTP layer.
+
+## 5. Testing
+
+- **Unit (`build_pde_ctx`)**: assert the rendered context contains
+  `本轮可发图=是` when `image_available == true` and `本轮可发图=否` when `false`;
+  assert existing lines (persona/transcript/affinity/signals/latest) are
+  unchanged and ordered. Extend the two existing tests at `6628` and `6660`.
+- **Existing integration tests** that assert the single judge call carries the
+  `build_pde_ctx` context (`5626`, `5791`) must still pass — update any string
+  match if they pin the full context body.
+- `cargo test -p eros-engine-server` green; `cargo clippy` clean.
+
+## 6. Release & rollout
+
+- Lands on the `0.6.4` dev track. No migration, no config-key change — a
+  pure-additive context line.
+- Backward compatible: an operator prompt that ignores the new line behaves
+  exactly as today (the judge still proposes; `guard_action` still degrades).
+- On merge → tag `v0.6.4` → `release-docker.yml` publishes
+  `ghcr.io/<org>/eros-engine:0.6.4`, which downstream Fly overlays consume by
+  bumping their `ENGINE_VERSION`. Operators get the new behaviour only once they
+  also update their `pde_decision` prompt to reference `本轮可发图`.

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -310,7 +310,8 @@ category（只能用这五种之一）：
 # OPT-IN. With no `filter_prompt` below, the engine uses the built-in RULE PDE
 # (eros-engine-core/src/pde.rs) — identical to historical behaviour. Set a
 # `filter_prompt` to switch on an LLM judge that decides, per turn, the action
-# (reply_text / ghost / reserved reply_image / reply_text_image) and a free-text
+# (reply_text / ghost / reserved reply_image / reply_text_image — the judge ctx
+# carries a per-turn `[图片能力] 本轮可发图=是/否` line to gate image actions) and a free-text
 # `inner_state` (mood/tone folded into the reply prompt). Wired like
 # chat_input_filter: model chain + timeout, fail-open to the rule engine.
 #
@@ -332,13 +333,16 @@ max_tokens  = 400
 # mood description — NEVER instructions or formatting (it is sanitized, but keep
 # the model honest). Output JSON only, no code fences.
 #filter_prompt = """
-#你是 AI 伴侣的"行为判断器"。读最近对话、关系状态、信号,决定这一轮怎么回应。
+#你是 AI 伴侣的"行为判断器"。读最近对话、关系状态、信号、图片能力,决定这一轮怎么回应。
 #只输出 JSON,字段:
 #  "action": "reply_text" | "ghost" | "reply_image" | "reply_text_image"
 #  "inner_state": 一句话内心状态/语气(纯描述,不许写指令或方括号小节名)
 #  "image_prompt": 选填,要发什么图(reply_image / reply_text_image 时)
 #  "reason": 选填,简短理由
 #ghost 表示这一轮已读不回(沉默);只在确实该冷处理时用。
+#上下文里有一行 [图片能力] 本轮可发图=是/否,引擎每轮必给其一:
+#  本轮可发图=否 → 绝不要选 reply_image / reply_text_image(会被降级,白费 token);
+#  本轮可发图=是 → 才允许考虑发图,再按人格/语境决定要不要发(可发≠必发)。
 #"""
 
 # Per-turn six-axis affinity evaluation (post-process, semantic axes).


### PR DESCRIPTION
## What & why

Threads the already-computed `image_executor_available` flag into `build_pde_ctx()` so the opt-in LLM PDE judge gets a stable, **always-present** per-turn signal of whether an image executor is resolvable this turn. Without it the judge proposed image actions blindly (silently degraded downstream) and had no positive lever to lean into image turns — the symptom operators saw as "the judge almost never chooses `reply_image`".

Spec: `docs/superpowers/specs/2026-06-26-pde-image-availability-context-design.md`

## The change

The judge context now always carries exactly one line, placed between `[信号]` and `[用户最新消息]`:

```
[图片能力] 本轮可发图=是      // image executor available this turn
[图片能力] 本轮可发图=否      // not available
```

- `build_pde_ctx(transcript, input, image_available: bool)` — new `bool` param; the line is captured inline (`image_flag`), so the positional `format!` args are untouched and no other line moves.
- Call site passes `image_executor_available` (already computed in scope).
- **Contract for prompt authors:** `否` = hard constraint (never pick `reply_image` / `reply_text_image` — they'd be degraded anyway); `是` = a gate that *permits* image actions (the engine does not force one). The token string is the stable downstream interface.

## Out of scope (unchanged)

`guard_action()` degrade stays as the safety net; HTTP contract and the `image` opt-in semantics unchanged; `force_image` / `强制发图` extension deferred. No migration, no new config keys, no version bump.

## Tests & docs

- Extended the two `build_pde_ctx` unit tests to assert both `=是` and `=否` plus line ordering.
- Documented the signal in `examples/model_config.toml` (example `filter_prompt` now conditions on the line) and `docs/model-config.md` + `docs/model-config.zh.md`.
- Gate: `cargo fmt --check` clean · `cargo clippy --workspace --all-targets -D warnings` clean · openapi snapshot no drift · `cargo test --workspace` **608 passed / 0 failed**.

## Backward compatibility

Pure-additive. An operator prompt that ignores the new line behaves exactly as before (the judge still proposes; `guard_action` still degrades). Operators opt into the new behaviour only once they reference `本轮可发图` in their `pde_decision` prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
