### PR TITLE
feat(prompt-log): raw prompt disk log for main reply (PROMPT_LOG_DIR)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,3 +54,8 @@ EMA_INERTIA=0.5
 DEMO_EMA_INERTIA=0.3
 MODEL_CONFIG_PATH=examples/model_config.toml
 RUST_LOG=info
+# Optional. When set, the engine writes the fully-assembled MAIN-REPLY prompt
+# for each turn to one human-readable file in this directory (debug aid for
+# prompt assembly). Unset/empty = disabled (default). Files contain raw chat
+# content — operator-only; point this at a volume you control (see docs/deploying.md).
+# PROMPT_LOG_DIR=/data/prompt-logs

--- a/crates/eros-engine-server/src/main.rs
+++ b/crates/eros-engine-server/src/main.rs
@@ -196,6 +196,15 @@ async fn run_migrations() -> Result<()> {
 async fn run_server() -> Result<()> {
     let cfg = ServerConfig::from_env();
 
+    if let Some(dir) = cfg.prompt_log_dir.as_ref() {
+        if let Err(e) = std::fs::create_dir_all(dir) {
+            tracing::warn!(error = %e, dir = %dir.display(),
+                "prompt logging: could not create PROMPT_LOG_DIR; writes may fail");
+        }
+        tracing::info!(dir = %dir.display(),
+            "prompt logging ENABLED — writing raw assembled chat prompts to disk (operator-only)");
+    }
+
     let database_url = std::env::var("DATABASE_URL").context("DATABASE_URL is required")?;
     let pool = eros_engine_store::pool::build(&database_url)
         .await

--- a/crates/eros-engine-server/src/main.rs
+++ b/crates/eros-engine-server/src/main.rs
@@ -5,6 +5,7 @@ mod middleware;
 mod openapi;
 mod pipeline;
 mod prompt;
+mod prompt_log;
 mod repetition;
 mod routes;
 mod state;

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -2475,6 +2475,17 @@ pub fn run_stream(
                         return;
                     }
                 };
+                // Optional fire-and-forget raw-prompt disk log (PROMPT_LOG_DIR).
+                // Logged once here — before the fallback-model send loop — so a
+                // turn that retries across models still produces exactly one file.
+                if let Some(dir) = state.config.prompt_log_dir.as_ref() {
+                    crate::prompt_log::spawn_write(
+                        dir.clone(),
+                        &req,
+                        user_msg.session_id,
+                        user_msg.user_message_id,
+                    );
+                }
                 // The filter trigger's `traits` predicate AND `prompt_injected`
                 // both use the KEPT tags (post tier `allow_traits` gating), so a
                 // tier that drops a requested trait can't trigger filtering on it.

--- a/crates/eros-engine-server/src/prompt_log.rs
+++ b/crates/eros-engine-server/src/prompt_log.rs
@@ -1,0 +1,175 @@
+//! Optional raw-prompt disk log for the main chat reply. Gated by
+//! `ServerConfig.prompt_log_dir` (env `PROMPT_LOG_DIR`). Fire-and-forget:
+//! the capture happens before the network send and never blocks or fails
+//! the reply path. Files contain raw chat content — operator-only.
+
+use std::path::Path;
+
+use chrono::{DateTime, SecondsFormat, Utc};
+use eros_engine_llm::openrouter::ChatRequest;
+use uuid::Uuid;
+
+/// Owned snapshot of everything a single reply prompt log needs, decoupled
+/// from the borrowed `ChatRequest` so the writer task can own it.
+struct PromptLogSnapshot {
+    ts: DateTime<Utc>,
+    session_id: Uuid,
+    user_message_id: Uuid,
+    task: &'static str,
+    model: String,
+    fallback_model: Vec<String>,
+    temperature: f32,
+    top_p: Option<f32>,
+    max_tokens: u32,
+    /// (role, content) pairs cloned from `req.messages`, in order.
+    messages: Vec<(String, String)>,
+}
+
+/// Build a snapshot from a borrowed request. `ts` is injected so the pure
+/// core stays deterministic for tests; `spawn_write` passes `Utc::now()`.
+fn snapshot(
+    req: &ChatRequest,
+    session_id: Uuid,
+    user_message_id: Uuid,
+    ts: DateTime<Utc>,
+) -> PromptLogSnapshot {
+    PromptLogSnapshot {
+        ts,
+        session_id,
+        user_message_id,
+        task: "reply",
+        model: req.model.clone(),
+        fallback_model: req.fallback_model.clone(),
+        temperature: req.temperature,
+        top_p: req.top_p,
+        max_tokens: req.max_tokens,
+        messages: req
+            .messages
+            .iter()
+            .map(|m| (m.role.clone(), m.content.clone()))
+            .collect(),
+    }
+}
+
+/// Human-readable rendering: metadata header + one verbatim block per message.
+fn render(snap: &PromptLogSnapshot) -> String {
+    let mut out = String::new();
+    out.push_str("# eros-engine prompt log\n");
+    out.push_str(&format!(
+        "# ts:       {}\n",
+        snap.ts.to_rfc3339_opts(SecondsFormat::Millis, true)
+    ));
+    out.push_str(&format!("# session:  {}\n", snap.session_id));
+    out.push_str(&format!("# user_msg: {}\n", snap.user_message_id));
+    out.push_str(&format!("# task:     {}\n", snap.task));
+    let fallbacks = if snap.fallback_model.is_empty() {
+        String::new()
+    } else {
+        format!("   fallbacks: {}", snap.fallback_model.join(", "))
+    };
+    out.push_str(&format!("# model:    {}{}\n", snap.model, fallbacks));
+    let top_p = snap
+        .top_p
+        .map(|v| format!("{v:.2}"))
+        .unwrap_or_else(|| "none".to_string());
+    out.push_str(&format!(
+        "# params:   temperature={:.2} top_p={} max_tokens={}\n",
+        snap.temperature, top_p, snap.max_tokens
+    ));
+    out.push_str(&format!("# messages: {}\n\n", snap.messages.len()));
+    for (i, (role, content)) in snap.messages.iter().enumerate() {
+        out.push_str(&format!("================= [{i:02}] {role} =================\n"));
+        out.push_str(content);
+        out.push_str("\n\n");
+    }
+    out
+}
+
+/// `{compactUtc}__{session}__{user_message_id}.prompt.txt` — all components
+/// are colon-free and path-safe.
+fn file_name(snap: &PromptLogSnapshot) -> String {
+    let ts = snap.ts.format("%Y%m%dT%H%M%S%3fZ");
+    format!(
+        "{ts}__{}__{}.prompt.txt",
+        snap.session_id, snap.user_message_id
+    )
+}
+
+/// Synchronous write core: ensure the directory exists, then write the file.
+fn write_file(dir: &Path, snap: &PromptLogSnapshot) -> std::io::Result<()> {
+    std::fs::create_dir_all(dir)?;
+    std::fs::write(dir.join(file_name(snap)), render(snap))
+}
+
+/// Fire-and-forget. Builds the snapshot on the caller thread (the only place
+/// `req` is borrowed), then writes on a blocking pool thread. Never blocks the
+/// reply path; an IO error is logged once and swallowed.
+pub(crate) fn spawn_write(
+    dir: std::path::PathBuf,
+    req: &ChatRequest,
+    session_id: Uuid,
+    user_message_id: Uuid,
+) {
+    let snap = snapshot(req, session_id, user_message_id, Utc::now());
+    tokio::task::spawn_blocking(move || {
+        if let Err(e) = write_file(&dir, &snap) {
+            tracing::warn!(error = %e, dir = %dir.display(), "prompt_log: write failed");
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture() -> PromptLogSnapshot {
+        PromptLogSnapshot {
+            ts: DateTime::parse_from_rfc3339("2026-06-27T12:34:56.789Z")
+                .unwrap()
+                .with_timezone(&Utc),
+            session_id: Uuid::nil(),
+            user_message_id: Uuid::from_u128(1),
+            task: "reply",
+            model: "vendor/model-a".into(),
+            fallback_model: vec!["vendor/model-b".into()],
+            temperature: 0.9,
+            top_p: Some(0.95),
+            max_tokens: 1024,
+            messages: vec![
+                ("system".into(), "You are Aria.\nBe warm.".into()),
+                ("user".into(), "hi".into()),
+            ],
+        }
+    }
+
+    #[test]
+    fn render_includes_header_and_verbatim_messages() {
+        let out = render(&fixture());
+        assert!(out.contains("# task:     reply"));
+        assert!(out.contains("# model:    vendor/model-a   fallbacks: vendor/model-b"));
+        assert!(out.contains("# messages: 2"));
+        assert!(out.contains("================= [00] system ================="));
+        assert!(out.contains("You are Aria.\nBe warm.")); // verbatim newline preserved
+        assert!(out.contains("================= [01] user ================="));
+    }
+
+    #[test]
+    fn file_name_is_path_safe_and_suffixed() {
+        let name = file_name(&fixture());
+        assert!(name.ends_with(".prompt.txt"));
+        assert!(!name.contains(':')); // colon-free timestamp
+        assert!(name.starts_with("20260627T123456789Z__"));
+        assert!(name.contains(&Uuid::from_u128(1).to_string()));
+    }
+
+    #[test]
+    fn write_file_creates_readable_file() {
+        let snap = fixture();
+        let dir = std::env::temp_dir().join(format!("eros-promptlog-test-{}", Uuid::new_v4()));
+        write_file(&dir, &snap).expect("write");
+        let path = dir.join(file_name(&snap));
+        let contents = std::fs::read_to_string(&path).expect("read back");
+        assert_eq!(contents, render(&snap));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/crates/eros-engine-server/src/prompt_log.rs
+++ b/crates/eros-engine-server/src/prompt_log.rs
@@ -78,7 +78,9 @@ fn render(snap: &PromptLogSnapshot) -> String {
     ));
     out.push_str(&format!("# messages: {}\n\n", snap.messages.len()));
     for (i, (role, content)) in snap.messages.iter().enumerate() {
-        out.push_str(&format!("================= [{i:02}] {role} =================\n"));
+        out.push_str(&format!(
+            "================= [{i:02}] {role} =================\n"
+        ));
         out.push_str(content);
         out.push_str("\n\n");
     }

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -696,6 +696,7 @@ pub(crate) fn test_state(pool: sqlx::PgPool) -> AppState {
                 cron: "0 0 23 * * *".into(),
                 tz: chrono_tz::Asia::Singapore,
             },
+            prompt_log_dir: None,
         },
         openrouter: Arc::new(eros_engine_llm::openrouter::OpenRouterClient::new(
             "stub".into(),

--- a/crates/eros-engine-server/src/state.rs
+++ b/crates/eros-engine-server/src/state.rs
@@ -63,6 +63,12 @@ pub(crate) fn parse_snapshot_config(
     SnapshotConfig { disabled, cron, tz }
 }
 
+/// Parse `PROMPT_LOG_DIR`. Empty or unset ⇒ `None` (logging disabled).
+/// Any non-empty value is the destination directory for raw prompt logs.
+pub(crate) fn parse_prompt_log_dir(raw: Option<&str>) -> Option<std::path::PathBuf> {
+    raw.filter(|s| !s.is_empty()).map(std::path::PathBuf::from)
+}
+
 /// Per-user in-flight SSE stream counter. Used by the
 /// `send_message_stream` handler to enforce spec §1.9 (≤3 concurrent
 /// active streams per user, returning HTTP 429 over the cap).
@@ -150,6 +156,11 @@ pub struct ServerConfig {
     /// Cron-scheduled companion_insights_snapshot sweeper config. See
     /// `pipeline::snapshot` for the sweep loop.
     pub snapshot: SnapshotConfig,
+    /// Destination directory for raw assembled main-reply prompts. `None`
+    /// (env `PROMPT_LOG_DIR` unset or empty) disables prompt logging. When
+    /// `Some`, each reply turn writes one human-readable file here. Contains
+    /// raw chat content — operator-only; point it at a volume you control.
+    pub prompt_log_dir: Option<std::path::PathBuf>,
 }
 
 impl ServerConfig {
@@ -207,6 +218,9 @@ impl ServerConfig {
                     .as_deref(),
             ),
             snapshot,
+            prompt_log_dir: parse_prompt_log_dir(
+                std::env::var("PROMPT_LOG_DIR").ok().as_deref(),
+            ),
         }
     }
 }
@@ -296,5 +310,19 @@ mod tests {
         // Misspelled tz → default + (caller will warn-log; we just verify fallback)
         let cfg = parse_snapshot_config(None, None, Some("Not/A_Real_Zone"));
         assert_eq!(cfg.tz, chrono_tz::Asia::Singapore);
+    }
+
+    #[test]
+    fn prompt_log_dir_unset_or_empty_is_none() {
+        assert_eq!(parse_prompt_log_dir(None), None);
+        assert_eq!(parse_prompt_log_dir(Some("")), None);
+    }
+
+    #[test]
+    fn prompt_log_dir_set_is_some_path() {
+        assert_eq!(
+            parse_prompt_log_dir(Some("/data/prompt-logs")),
+            Some(std::path::PathBuf::from("/data/prompt-logs")),
+        );
     }
 }

--- a/crates/eros-engine-server/src/state.rs
+++ b/crates/eros-engine-server/src/state.rs
@@ -218,9 +218,7 @@ impl ServerConfig {
                     .as_deref(),
             ),
             snapshot,
-            prompt_log_dir: parse_prompt_log_dir(
-                std::env::var("PROMPT_LOG_DIR").ok().as_deref(),
-            ),
+            prompt_log_dir: parse_prompt_log_dir(std::env::var("PROMPT_LOG_DIR").ok().as_deref()),
         }
     }
 }

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -166,6 +166,36 @@ Both queries should return zero rows after the migration applies.
 
 ## Operational notes
 
+### Prompt logging (debug, optional)
+
+Set `PROMPT_LOG_DIR` to capture the fully-assembled main-reply prompt for each
+turn as one human-readable file (header + per-message blocks). It is **off by
+default**, **operator-only** (files contain raw chat content), and writes
+fire-and-forget so it never blocks or fails a reply. Point it at a mounted
+volume you control:
+
+```yaml
+# docker-compose: mount a volume and set the env
+services:
+  engine:
+    environment:
+      PROMPT_LOG_DIR: /data/prompt-logs
+    volumes:
+      - ./prompt-logs:/data/prompt-logs
+```
+
+```toml
+# fly.io: declare a mount + the env (illustrative)
+[mounts]
+source = "prompt_logs"
+destination = "/data/prompt-logs"
+
+[env]
+PROMPT_LOG_DIR = "/data/prompt-logs"
+```
+
+There is no built-in rotation or retention — manage the volume yourself.
+
 - **Health probe:** `GET /healthz` returns 200 with `{ status: "ok", service, version, timestamp }`. Wire this into your platform's health check.
 - **OpenAPI / Scalar:** `GET /docs` serves a live Scalar reference. The OpenAPI JSON is at `/api-docs/openapi.json`.
 - **Affinity debug:** `GET /comp/affinity/{session_id}` is gated by `EXPOSE_AFFINITY_DEBUG=true`. Production deploys typically leave it off; turn it on if your frontend renders a live radar of the affinity vector.

--- a/docs/deploying.zh.md
+++ b/docs/deploying.zh.md
@@ -166,6 +166,34 @@ SELECT grantee, table_name, privilege_type
 
 ## 運維注意事項
 
+### Prompt 日志（调试用，可选）
+
+设置 `PROMPT_LOG_DIR` 后，引擎会把每一轮**主回复**组装好的完整 prompt 写成一个
+可读文件（头部元数据 + 按 role 分块）。默认**关闭**，**仅供运营调试**（文件含原始
+聊天内容），写入为后台 fire-and-forget，绝不阻塞或拖垮回复。把它指向你自己挂载的卷：
+
+```yaml
+# docker-compose: 挂载卷并设置 env
+services:
+  engine:
+    environment:
+      PROMPT_LOG_DIR: /data/prompt-logs
+    volumes:
+      - ./prompt-logs:/data/prompt-logs
+```
+
+```toml
+# fly.io: 声明卷和 env（示例）
+[mounts]
+source = "prompt_logs"
+destination = "/data/prompt-logs"
+
+[env]
+PROMPT_LOG_DIR = "/data/prompt-logs"
+```
+
+引擎不内置轮转或保留策略——卷由你自行管理。
+
 - **健康探針：** `GET /healthz` 返 200，響應 `{ status: "ok", service, version, timestamp }`。把這個接到平台的健康檢查上。
 - **OpenAPI / Scalar：** `GET /docs` 提供實時的 Scalar 參考。OpenAPI JSON 在 `/api-docs/openapi.json`。
 - **Affinity debug：** `GET /comp/affinity/{session_id}` 受 `EXPOSE_AFFINITY_DEBUG=true` 控制。生產部署一般關掉；如果你的前端要實時畫好感度雷達圖，再打開。

--- a/docs/superpowers/specs/2026-06-27-prompt-disk-log-design.md
+++ b/docs/superpowers/specs/2026-06-27-prompt-disk-log-design.md
@@ -1,0 +1,334 @@
+# eros-engine — Raw prompt disk log for the main reply (Spec)
+
+**Status**: design, pending implementation plan
+**Target release**: `0.6.5` dev track. **No migration**, no HTTP-contract change.
+One new optional env key (`PROMPT_LOG_DIR`).
+**Audience**: anyone working on the streaming chat reply path
+(`build_reply_request` / `drive_chat_burst`) or operating an eros-engine
+deployment who wants to inspect the fully-assembled prompt on disk.
+
+---
+
+## 0. Background
+
+### What already exists
+
+The main chat reply prompt is assembled by `build_reply_request()`
+(`crates/eros-engine-server/src/pipeline/handlers.rs:558`), which calls
+`build_prompt()` (`crates/eros-engine-server/src/prompt.rs:332`) to produce the
+system prompt string and then assembles a `ChatRequest`:
+
+```rust
+// crates/eros-engine-llm/src/openrouter.rs:29-61
+pub struct ChatRequest {
+    pub model: String,
+    pub fallback_model: Vec<String>,
+    pub messages: Vec<ChatMessage>,   // [system, user, assistant, ...]
+    pub temperature: f32,
+    pub top_p: Option<f32>,
+    pub frequency_penalty: Option<f32>,
+    pub presence_penalty: Option<f32>,
+    pub max_tokens: u32,
+    // user / session_id / metadata / reasoning / response_format ...
+}
+// ChatMessage { role: String, content: String }  (openrouter.rs:23-27)
+```
+
+That `ChatRequest` is returned to the streaming driver and bound as `req` in the
+`Ok(r)` arm at `crates/eros-engine-server/src/pipeline/stream.rs:2466`, *before*
+the per-model fallback send loop inside `drive_chat_burst` (the actual POST is
+`state.openrouter.execute_stream(per_model_req)` at `stream.rs:307` / `:518`).
+
+Configuration is read by `ServerConfig::from_env()`
+(`crates/eros-engine-server/src/state.rs:156`) using plain `std::env::var()` with
+no unified prefix (`BIND_ADDR`, `DREAMING_*`, `OPENROUTER_*`, …). Logging is
+`tracing` → **stdout only**, plain text, `RUST_LOG`-controlled
+(`tracing_subscriber::fmt::init()` at `main.rs:37`). There is **no file-based
+logging** today, and the Docker image (`docker/Dockerfile`) is **fully stateless
+with no volumes**.
+
+### The problem
+
+When debugging persona / prompt-assembly behaviour, there is no way to see the
+*exact* prompt the engine assembled for a given turn. `RUST_LOG` traces usage
+metadata (`log_openrouter_usage`, `pipeline/mod.rs:25`) but never the prompt
+body, and the prompt is too large and newline-heavy to dump to stdout. The
+operator needs the fully-assembled prompt persisted somewhere they can open and
+read, one turn at a time.
+
+### Goal & non-goals
+
+**Goal**: optionally persist the fully-assembled **main-reply** prompt to a
+human-readable file on disk, one file per reply turn, controlled by a single env
+var, designed so the operator can point that env var at a Docker/fly volume.
+
+**Non-goals (v1, explicit YAGNI)** — see §6:
+rotation/retention/size caps, redaction, capturing auxiliary OpenRouter calls
+(affinity / dreaming / snapshot), `generation_id` correlation lines, and
+JSON/JSONL output.
+
+---
+
+## 1. Decision summary
+
+| Decision | Choice | Why |
+|---|---|---|
+| Primary purpose | Debug prompt assembly | Eyeball "did my assembly produce the right prompt"; precise OpenRouter correlation not required |
+| Capture scope | Main reply generation only | Smallest change, single hook point |
+| On-disk shape | One human-readable file per request | Prompt is newline-heavy; per-file transcript reads best |
+| Env control | Single `PROMPT_LOG_DIR` | One var is both the on/off switch and the destination; maps cleanly onto a volume mount |
+| Where it lives | `eros-engine-server` (the binary) only | No change to the published `core`/`llm`/`store` lib crates → zero crates.io surface change |
+| Hot-path cost | Fire-and-forget; never blocks the send | The user reply must never wait on or fail because of disk IO |
+
+**Rejected alternative**: inject a sink at the `WireRequest` boundary in
+`eros-engine-llm` (`openrouter.rs`). It would capture the exact wire bytes and
+uniformly cover *all* call types, but it forces env-reading and file IO into a
+published library crate, muddying its boundary. Since scope is "main reply only,"
+a single server-side hook is cleaner.
+
+---
+
+## 2. Architecture & components
+
+Everything lives in `eros-engine-server`. No new dependency is required
+(`tokio`, `tracing`, `uuid`, `chrono` are already in the crate).
+
+### 2.1 Config: `ServerConfig.prompt_log_dir`
+
+Add to `ServerConfig` (`state.rs`):
+
+```rust
+pub prompt_log_dir: Option<std::path::PathBuf>,
+```
+
+Populated in `from_env()`:
+
+```rust
+prompt_log_dir: std::env::var("PROMPT_LOG_DIR")
+    .ok()
+    .filter(|s| !s.is_empty())
+    .map(std::path::PathBuf::from),
+```
+
+`None` (unset or empty) ⇒ logging disabled.
+
+### 2.2 New module: `crates/eros-engine-server/src/prompt_log.rs`
+
+A small, focused module with three units:
+
+- **`PromptLogSnapshot`** — an owned snapshot built from borrowed call-site data
+  (so the spawned task owns everything it needs):
+  ```rust
+  struct PromptLogSnapshot {
+      ts: chrono::DateTime<chrono::Utc>,
+      session_id: Uuid,
+      user_message_id: Uuid,
+      task: &'static str,        // "reply"
+      model: String,
+      fallback_model: Vec<String>,
+      temperature: f32,
+      top_p: Option<f32>,
+      max_tokens: u32,
+      messages: Vec<(String, String)>,  // (role, content), cloned from req.messages
+  }
+  ```
+
+- **`render(&PromptLogSnapshot) -> String`** — pure, deterministic, unit-tested.
+  Produces the header + per-message blocks (see §4).
+
+- **`file_name(&PromptLogSnapshot) -> String`** — pure; builds a path-safe name
+  (see §4), unit-tested.
+
+- **`write_file(dir: &Path, snap: &PromptLogSnapshot) -> std::io::Result<()>`** —
+  synchronous IO core: `create_dir_all(dir)` defensively, then write
+  `dir/<file_name>`. Unit-tested against a tempdir. Kept synchronous so tests are
+  deterministic (no async sleeps).
+
+- **`spawn_write(dir: PathBuf, req: &ChatRequest, session_id, user_message_id)`** —
+  the only async/`tokio` surface: builds the `PromptLogSnapshot` from the borrows
+  (the single `messages` clone happens here), then
+  `tokio::task::spawn_blocking(move || write_file(&dir, &snap))` and **does not
+  await it**. On `Err`, logs a single `tracing::warn!`. Never panics, never
+  propagates an error to the caller.
+
+  > `spawn_blocking` (not `tokio::fs`) keeps `write_file` a plain sync fn that the
+  > unit tests call directly, and moves the blocking write off the async worker.
+
+### 2.3 Hook point: `stream.rs:2466`
+
+In the `Ok(r)` arm where `req` is bound, after `build_reply_request` succeeds and
+before `drive_chat_burst`:
+
+```rust
+let (req, injected_tags) = match req_res {
+    Ok(r) => r,
+    Err(e) => { /* unchanged */ }
+};
+if let Some(dir) = state.config.prompt_log_dir.as_ref() {
+    crate::prompt_log::spawn_write(
+        dir.clone(), &req, user_msg.session_id, user_msg.user_message_id,
+    );
+}
+```
+
+`req` is still owned by the surrounding scope and continues into
+`drive_chat_burst` unchanged; `spawn_write` only borrows it to build the snapshot.
+
+### 2.4 Startup visibility
+
+In `main.rs` (after the subscriber is installed and `ServerConfig` is built), if
+`prompt_log_dir` is `Some(dir)`:
+
+- `std::fs::create_dir_all(&dir)` once; on error, `tracing::warn!` but **do not
+  fail boot**.
+- Emit one `tracing::info!` line, e.g.:
+  `prompt logging ENABLED → {dir} (writes raw assembled chat prompts to disk; operator-only)`.
+
+This makes the privacy-sensitive mode visible in logs and surfaces a bad path
+early rather than per-request.
+
+---
+
+## 3. Data flow & the non-blocking guarantee
+
+```
+build_reply_request ─► Ok(req) ─┬─► [flag off] one Option check, continue            ─► drive_chat_burst ─► execute_stream (POST)
+                                └─► [flag on]  clone snapshot + spawn_blocking(write) ─► drive_chat_burst ─► execute_stream (POST)
+                                                     (background, not awaited)
+```
+
+Hard requirements:
+
+1. **Flag off (default)**: a single `Option` check. No clone, no spawn, no IO.
+2. **Flag on**: one `messages` clone (a few KB) + a spawned blocking task. The
+   send path proceeds immediately and **never awaits** the write.
+3. The write happens **before** the network send, so the prompt lands on disk even
+   when the OpenRouter call later fails.
+4. A slow or full disk can only make a file **lag or be dropped** (logged via
+   `warn`). It can **never** delay, block, or fail the user's reply.
+
+---
+
+## 4. File format
+
+One file per reply turn.
+
+**File name**: `{ts}__{session}__{user_message_id}.prompt.txt`
+
+- `ts`: compact UTC, no colons (filesystem-safe), e.g. `20260627T123456789Z`.
+- `session` / `user_message_id`: the `Uuid`s, rendered hyphenated (already
+  path-safe). `user_message_id` is unique per user turn, so files do not collide
+  in normal operation and the on-disk prompt ties back to the DB row for free.
+  (Regeneration of the same `user_message_id` is the only collision risk; v1
+  accepts last-writer-wins. If that proves annoying, append a short random suffix
+  later — out of scope for now.)
+
+**Contents**:
+
+```
+# eros-engine prompt log
+# ts:       2026-06-27T12:34:56.789Z
+# session:  6b1c…-uuid
+# user_msg: 9a2f…-uuid
+# task:     reply
+# model:    moonshotai/kimi-k2   fallbacks: anthropic/claude-…, …
+# params:   temperature=0.90 top_p=0.95 max_tokens=1024
+# messages: 7
+
+================= [00] system =================
+<full system prompt, verbatim, original newlines>
+
+================= [01] user =================
+<content>
+
+================= [02] assistant =================
+<content>
+...
+```
+
+The header is metadata for triage; each message is rendered verbatim with its
+original newlines so the system prompt is read exactly as assembled.
+
+---
+
+## 5. Error handling & edge cases
+
+- **Write failure** (permissions, disk full, bad path): `tracing::warn!` once in
+  the spawned task; the turn is unaffected. No retry in v1.
+- **`create_dir_all` at startup fails**: `warn`, continue booting; the writer also
+  calls `create_dir_all` defensively, so a later-available mount still works.
+- **Empty `PROMPT_LOG_DIR`**: treated as unset (filtered in `from_env`).
+- **Concurrency**: per-request unique file names ⇒ no append contention, no lock.
+
+---
+
+## 6. Out of scope (v1, YAGNI)
+
+Documented so operators know what they own:
+
+- **Rotation / retention / size caps** — the operator manages the volume. (A
+  future `PROMPT_LOG_MAX_FILES` could prune oldest.)
+- **Redaction** — files contain raw chat content by design; mitigated by docs +
+  the startup warning, not by scrubbing.
+- **Auxiliary OpenRouter calls** (affinity / dreaming / snapshot) — main reply
+  only. (A future shared sink could generalize this.)
+- **`generation_id` correlation line** — purpose is assembly debugging;
+  `user_message_id` already links to the DB.
+- **JSON / JSONL output** — readability beats machine-parsing for this use case.
+
+---
+
+## 7. Docker / fly volume usage (docs only)
+
+No `fly.toml` is committed (the OSS engine is not responsible for deployment); the
+docs ship example snippets with placeholder paths only.
+
+- **Docker**: mount a volume and point the env at it:
+  ```
+  docker run … \
+    -v "$(pwd)/prompt-logs:/data/prompt-logs" \
+    -e PROMPT_LOG_DIR=/data/prompt-logs \
+    eros-engine serve
+  ```
+- **fly.io**: declare a mount and set the env (illustrative):
+  ```toml
+  [mounts]
+  source = "prompt_logs"
+  destination = "/data/prompt-logs"
+  ```
+  ```toml
+  [env]
+  PROMPT_LOG_DIR = "/data/prompt-logs"
+  ```
+- **`.env.example`**: add a commented, **off-by-default** entry noting it writes
+  raw chat content and should point at a volume the operator controls.
+
+---
+
+## 8. Testing
+
+Unit tests in `prompt_log.rs` (pure / sync, no sleeps):
+
+1. `render` — given a `PromptLogSnapshot`, the output contains the verbatim system
+   content, the correct `# messages:` count, the model line (incl. fallbacks), and
+   one block per message in order.
+2. `file_name` — correct `.prompt.txt` suffix, colon-free timestamp, path-safe
+   components.
+3. `write_file` — writes into a tempdir; assert the expected file exists and its
+   contents round-trip what `render` produced.
+4. `ServerConfig::from_env` — `PROMPT_LOG_DIR` unset ⇒ `None`; empty ⇒ `None`;
+   set ⇒ `Some(path)`.
+
+`spawn_write` itself is a thin spawn wrapper over the tested sync core, so it
+needs no async test.
+
+---
+
+## 9. Release / crate impact
+
+- Lives entirely in `eros-engine-server` (the binary); **no change** to the
+  published `eros-engine-core` / `-llm` / `-store` lib crates → no crates.io
+  surface change, consistent with the release flow (server is never published to
+  crates.io; it ships via GHCR).
+- One new optional env key (`PROMPT_LOG_DIR`); document it in `.env.example` and
+  the Docker/deploy docs. No migration, no OpenAPI change.


### PR DESCRIPTION
## Summary

Optional operator-debug feature: when env `PROMPT_LOG_DIR` is set, the engine writes the **fully-assembled main-reply prompt** for each turn to one human-readable file in that directory. Unset/empty = disabled (default). Intended for debugging prompt assembly; pair it with a Docker/fly volume.

Design spec: `docs/superpowers/specs/2026-06-27-prompt-disk-log-design.md`

## What changed (all inside `eros-engine-server` — no published-crate surface change)

- **Config:** `ServerConfig.prompt_log_dir: Option<PathBuf>` from `PROMPT_LOG_DIR` (pure `parse_prompt_log_dir` helper, tested directly).
- **New module `prompt_log.rs`:** pure `snapshot`/`render`/`file_name`, sync `write_file`, and fire-and-forget `spawn_write` (`tokio::spawn_blocking`, warn-only on IO error).
- **Hook:** one call at the reply-request arm in `stream.rs`, before the fallback-model send loop (logs once per turn). Borrows `req` (no move), captured before the network send — so the prompt lands even if the call later fails.
- **Startup:** `create_dir_all` + a one-time "enabled" info log when the dir is set (warn-only; never fails boot).
- **Docs:** `.env.example`, `docs/deploying.md`, `docs/deploying.zh.md` (docker-compose + fly.io volume snippets; off-by-default / operator-only / raw-chat-content framing; no rotation).

## Guarantees

- **Never blocks or fails the reply path** — fire-and-forget; flag-off is a single `Option` check.
- One file per turn: `{compactUtc}__{session}__{user_message_id}.prompt.txt` (path-safe, colon-free).
- No migration, no OpenAPI change, one new optional env key.

## Testing

- `cargo fmt --all -- --check`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo test --workspace`: **613 passed / 0 failed** (server 309 → 314: +3 prompt_log, +2 config)
- OpenAPI snapshot: no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)