### PR TITLE
docs(readme): drop sync /message removal note (en/zh/ja)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -130,7 +130,7 @@ cargo run -p eros-engine-server -- serve
 - `GET /comp/chat/{session_id}/history` · `GET /comp/chat/{user_id}/sessions` · `GET /comp/user/{user_id}/profile` — 履歴、セッション一覧、構造化されたインサイトプロフィールを取得します。
 - `GET /comp/affinity/{session_id}` — debug 専用のリアルタイム親密度ベクトル（`EXPOSE_AFFINITY_DEBUG=true`）。
 
-ブロッキング型の同期 `/message` endpoint は 0.3 で削除され、SSE が唯一のチャット経路になりました。完全なリクエスト schema、SSE frame layout（`delta`、`image`、ghost、error frame を含む）、各フィールドの意味については、[API reference](docs/api-reference.md) を参照してください。
+完全なリクエスト schema、SSE frame layout（`delta`、`image`、ghost、error frame を含む）、各フィールドの意味については、[API reference](docs/api-reference.md) を参照してください。
 
 ## 設定
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ All `/comp/*` routes require `Authorization: Bearer <Supabase JWT>` by default (
 - `GET /comp/chat/{session_id}/history` · `GET /comp/chat/{user_id}/sessions` · `GET /comp/user/{user_id}/profile` — history, session list, and the structured insight profile.
 - `GET /comp/affinity/{session_id}` — debug-only live affinity vector (`EXPOSE_AFFINITY_DEBUG=true`).
 
-The blocking synchronous `/message` endpoint was removed in 0.3 — SSE is the only chat path. For the full request schema, SSE frame layout (including `delta`, `image`, ghost, and error frames), and per-field semantics, see the [API reference](docs/api-reference.md).
+For the full request schema, SSE frame layout (including `delta`, `image`, ghost, and error frames), and per-field semantics, see the [API reference](docs/api-reference.md).
 
 ## Configuration
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -130,7 +130,7 @@ cargo run -p eros-engine-server -- serve
 - `GET /comp/chat/{session_id}/history` · `GET /comp/chat/{user_id}/sessions` · `GET /comp/user/{user_id}/profile`——历史、会话列表、结构化画像。
 - `GET /comp/affinity/{session_id}`——仅调试用的实时亲密度向量（`EXPOSE_AFFINITY_DEBUG=true`）。
 
-阻塞式同步 `/message` 端点已在 0.3 移除——SSE 是唯一的聊天路径。有关完整的请求 schema、SSE 帧布局（包括 `delta`、`image`、ghost 和 error 帧）以及各字段语义，请参阅 [API 参考](docs/api-reference.zh.md)。
+有关完整的请求 schema、SSE 帧布局（包括 `delta`、`image`、ghost 和 error 帧）以及各字段语义，请参阅 [API 参考](docs/api-reference.zh.md)。
 
 ## 配置
 


### PR DESCRIPTION
Removes the historical "blocking synchronous \`/message\` endpoint was removed in 0.3 — SSE is the only chat path" sentence from the README (en/zh/ja). It's changelog material, not standing README content; the endpoint list already presents the streaming route as **the** chat path, and the API reference covers the details. The pointer to the API reference is kept.

Docs-only. Targets `main` directly per request; back-merge to `dev` follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)