### PR TITLE
feat: per-model deterministic regex output filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,6 +425,7 @@ dependencies = [
  "eventsource-stream",
  "futures-util",
  "rand 0.8.6",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,7 +407,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "eros-engine-core"
-version = "0.7.0-dev"
+version = "0.6.6-dev"
 dependencies = [
  "chrono",
  "serde",
@@ -417,7 +417,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-llm"
-version = "0.7.0-dev"
+version = "0.6.6-dev"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-server"
-version = "0.7.0-dev"
+version = "0.6.6-dev"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -476,7 +476,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-store"
-version = "0.7.0-dev"
+version = "0.6.6-dev"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.7.0-dev"
+version = "0.6.6-dev"
 edition = "2021"
 license = "AGPL-3.0-only"
 repository = "https://github.com/etherfunlab/eros-engine"

--- a/crates/eros-engine-llm/Cargo.toml
+++ b/crates/eros-engine-llm/Cargo.toml
@@ -22,6 +22,7 @@ tracing = { workspace = true }
 tokio = { workspace = true }
 toml = "0.8"
 rand = "0.8"
+regex = "1"
 eventsource-stream = { workspace = true }
 futures-util       = { workspace = true }
 tokio-stream       = { workspace = true }

--- a/crates/eros-engine-llm/Cargo.toml
+++ b/crates/eros-engine-llm/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "openrouter", "voyage", "embeddings", "llm"]
 categories = ["api-bindings"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "0.7.0-dev" }
+eros-engine-core = { path = "../eros-engine-core", version = "0.6.6-dev" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -375,6 +375,19 @@ fn default_model_spec() -> ModelSpec {
     ModelSpec::Fixed(String::new())
 }
 
+/// One deterministic output-strip rule (read only from
+/// `[tasks.chat_companion].output_regex`). Applied to the assistant reply
+/// produced by any model in `models`. `replacement` substitutes for each
+/// match; `None` ⇒ `""` (delete). See
+/// docs/superpowers/specs/2026-06-28-per-model-output-regex-filter-design.md.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct OutputRegexRule {
+    pub models: Vec<String>,
+    pub pattern: String,
+    #[serde(default)]
+    pub replacement: Option<String>,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct TaskConfig {
     #[serde(default = "default_model_spec")]
@@ -426,6 +439,11 @@ pub struct TaskConfig {
     /// `0.8` ⇒ 80% of turns. See `InputFilterTrigger`.
     #[serde(default)]
     pub input_filter: Option<InputFilterTrigger>,
+    /// Deterministic per-model regex strips for the assistant reply. Read ONLY
+    /// on `[tasks.chat_companion]`; task-level, no per-tier override. Empty when
+    /// absent. Compiled at boot via `compile_output_regex` (fail-fast).
+    #[serde(default)]
+    pub output_regex: Vec<OutputRegexRule>,
     /// System instruction sent to the filter LLM; the assistant reply to
     /// rewrite is passed as a SEPARATE user message — this is NOT a template
     /// with placeholder substitution.
@@ -2983,5 +3001,35 @@ temperature = 0.8
         // absent (`resolved = None`), a client-supplied per-turn `model` must NOT
         // enable billable image generation — opt-in only.
         assert_eq!(effective_image_chain(Some("X"), None), None);
+    }
+
+    #[test]
+    fn output_regex_parses_on_chat_companion() {
+        let toml = r#"
+[tasks.chat_companion]
+model = "primary/model"
+output_regex = [
+  { models = ["sao10k/l3.3-euryale-70b"], pattern = '\s*\[x[^\]]*\]\s*$' },
+  { models = ["a/b", "a/c"], pattern = '\bfoo\b', replacement = "bar" },
+]
+"#;
+        let cfg = ModelConfig::from_toml_str(toml).expect("parses");
+        let rules = &cfg.tasks["chat_companion"].output_regex;
+        assert_eq!(rules.len(), 2);
+        assert_eq!(rules[0].models, vec!["sao10k/l3.3-euryale-70b"]);
+        assert_eq!(rules[0].pattern, r#"\s*\[x[^\]]*\]\s*$"#);
+        assert_eq!(rules[0].replacement, None);
+        assert_eq!(rules[1].models, vec!["a/b", "a/c"]);
+        assert_eq!(rules[1].replacement.as_deref(), Some("bar"));
+    }
+
+    #[test]
+    fn output_regex_absent_is_empty() {
+        let toml = r#"
+[tasks.chat_companion]
+model = "primary/model"
+"#;
+        let cfg = ModelConfig::from_toml_str(toml).expect("parses");
+        assert!(cfg.tasks["chat_companion"].output_regex.is_empty());
     }
 }

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -397,6 +397,41 @@ pub struct CompiledRegexRule {
     pub replacement: String,
 }
 
+/// Result of applying output-regex rules to one reply. `matched_rules` lists
+/// the rule indices that changed the text (empty ⇒ unchanged or fail-safed).
+#[derive(Debug, Clone)]
+pub struct RegexStripOutcome {
+    pub cleaned: String,
+    pub matched_rules: Vec<usize>,
+}
+
+/// Apply every rule whose `models` contains `model_id`, in declaration order.
+/// Pure & deterministic. Fail-safe: if stripping empties a non-empty reply,
+/// the raw text is returned unchanged with no matched rules.
+pub fn apply_output_regex(
+    rules: &[CompiledRegexRule],
+    model_id: &str,
+    text: &str,
+) -> RegexStripOutcome {
+    let mut cleaned = text.to_string();
+    let mut matched_rules = Vec::new();
+    for (i, rule) in rules.iter().enumerate() {
+        if !rule.models.iter().any(|m| m == model_id) {
+            continue;
+        }
+        let next = rule.regex.replace_all(&cleaned, rule.replacement.as_str());
+        if next != cleaned {
+            matched_rules.push(i);
+            cleaned = next.into_owned();
+        }
+    }
+    // Fail-safe: never let a strip produce a blank reply from a non-blank one.
+    if !matched_rules.is_empty() && cleaned.trim().is_empty() && !text.trim().is_empty() {
+        return RegexStripOutcome { cleaned: text.to_string(), matched_rules: Vec::new() };
+    }
+    RegexStripOutcome { cleaned, matched_rules }
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct TaskConfig {
     #[serde(default = "default_model_spec")]
@@ -3103,5 +3138,59 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
     fn compile_output_regex_absent_is_empty_ok() {
         let cfg = ModelConfig::from_toml_str("[tasks.other]\nmodel='m'\n").unwrap();
         assert!(cfg.compile_output_regex().unwrap().is_empty());
+    }
+
+    // ─── Task 3: apply_output_regex ─────────────────────────────────────────
+
+    fn compiled(pairs: &[(&str, &str, &str)]) -> Vec<CompiledRegexRule> {
+        // (model, pattern, replacement)
+        pairs
+            .iter()
+            .map(|(m, p, r)| CompiledRegexRule {
+                models: vec![(*m).to_string()],
+                regex: regex::Regex::new(p).unwrap(),
+                replacement: (*r).to_string(),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn apply_output_regex_strips_targeted_model() {
+        let rules = compiled(&[("euryale", r#"\s*\[你给对方发送了一张照片[：:][^\]]*\]\s*$"#, "")]);
+        let out = apply_output_regex(&rules, "euryale", "晚安宝贝[你给对方发送了一张照片：海边自拍]");
+        assert_eq!(out.cleaned, "晚安宝贝");
+        assert_eq!(out.matched_rules, vec![0]);
+    }
+
+    #[test]
+    fn apply_output_regex_skips_non_targeted_model() {
+        let rules = compiled(&[("euryale", r#"\[.*\]$"#, "")]);
+        let out = apply_output_regex(&rules, "other/model", "hi[x]");
+        assert_eq!(out.cleaned, "hi[x]");
+        assert!(out.matched_rules.is_empty());
+    }
+
+    #[test]
+    fn apply_output_regex_applies_multiple_rules_in_order() {
+        let rules = compiled(&[("m", "foo", "F"), ("m", "bar", "B")]);
+        let out = apply_output_regex(&rules, "m", "foo bar");
+        assert_eq!(out.cleaned, "F B");
+        assert_eq!(out.matched_rules, vec![0, 1]);
+    }
+
+    #[test]
+    fn apply_output_regex_no_match_reports_no_change() {
+        let rules = compiled(&[("m", "zzz", "")]);
+        let out = apply_output_regex(&rules, "m", "hello");
+        assert_eq!(out.cleaned, "hello");
+        assert!(out.matched_rules.is_empty());
+    }
+
+    #[test]
+    fn apply_output_regex_empty_result_failsafes_to_raw() {
+        let rules = compiled(&[("m", r#"^\[.*\]$"#, "")]); // whole reply is the artifact
+        let out = apply_output_regex(&rules, "m", "[你给对方发送了一张照片：x]");
+        assert_eq!(out.cleaned, "[你给对方发送了一张照片：x]"); // kept raw
+        assert!(out.matched_rules.is_empty(), "fail-safe reports no change");
     }
 }

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -427,9 +427,15 @@ pub fn apply_output_regex(
     }
     // Fail-safe: never let a strip produce a blank reply from a non-blank one.
     if !matched_rules.is_empty() && cleaned.trim().is_empty() && !text.trim().is_empty() {
-        return RegexStripOutcome { cleaned: text.to_string(), matched_rules: Vec::new() };
+        return RegexStripOutcome {
+            cleaned: text.to_string(),
+            matched_rules: Vec::new(),
+        };
     }
-    RegexStripOutcome { cleaned, matched_rules }
+    RegexStripOutcome {
+        cleaned,
+        matched_rules,
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -3130,8 +3136,13 @@ model = "m"
 output_regex = [ { models = ["x/y"], pattern = '[' } ]
 "#;
         let cfg = ModelConfig::from_toml_str(toml).unwrap();
-        let err = cfg.compile_output_regex().expect_err("invalid pattern must error");
-        assert!(err.contains("output_regex[0]"), "error names the rule index: {err}");
+        let err = cfg
+            .compile_output_regex()
+            .expect_err("invalid pattern must error");
+        assert!(
+            err.contains("output_regex[0]"),
+            "error names the rule index: {err}"
+        );
     }
 
     #[test]
@@ -3156,8 +3167,16 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
 
     #[test]
     fn apply_output_regex_strips_targeted_model() {
-        let rules = compiled(&[("euryale", r#"\s*\[你给对方发送了一张照片[：:][^\]]*\]\s*$"#, "")]);
-        let out = apply_output_regex(&rules, "euryale", "晚安宝贝[你给对方发送了一张照片：海边自拍]");
+        let rules = compiled(&[(
+            "euryale",
+            r#"\s*\[你给对方发送了一张照片[：:][^\]]*\]\s*$"#,
+            "",
+        )]);
+        let out = apply_output_regex(
+            &rules,
+            "euryale",
+            "晚安宝贝[你给对方发送了一张照片：海边自拍]",
+        );
         assert_eq!(out.cleaned, "晚安宝贝");
         assert_eq!(out.matched_rules, vec![0]);
     }

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -388,6 +388,15 @@ pub struct OutputRegexRule {
     pub replacement: Option<String>,
 }
 
+/// A compiled `output_regex` rule, ready to apply. Built once at boot by
+/// `ModelConfig::compile_output_regex`; `replacement` is `""` for delete.
+#[derive(Debug, Clone)]
+pub struct CompiledRegexRule {
+    pub models: Vec<String>,
+    pub regex: regex::Regex,
+    pub replacement: String,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct TaskConfig {
     #[serde(default = "default_model_spec")]
@@ -1111,6 +1120,30 @@ impl ModelConfig {
             }
         }
         Ok(())
+    }
+
+    /// Compile `[tasks.chat_companion].output_regex` into ready-to-apply rules.
+    /// Boot-time, fail-fast: the first invalid pattern aborts with a message
+    /// naming the rule index. Absent task or empty rules ⇒ `Ok(vec![])`.
+    pub fn compile_output_regex(&self) -> Result<Vec<CompiledRegexRule>, String> {
+        let Some(task) = self.tasks.get("chat_companion") else {
+            return Ok(Vec::new());
+        };
+        let mut out = Vec::with_capacity(task.output_regex.len());
+        for (i, rule) in task.output_regex.iter().enumerate() {
+            let regex = regex::Regex::new(&rule.pattern).map_err(|e| {
+                format!(
+                    "[tasks.chat_companion].output_regex[{i}]: invalid pattern {:?}: {e}",
+                    rule.pattern
+                )
+            })?;
+            out.push(CompiledRegexRule {
+                models: rule.models.clone(),
+                regex,
+                replacement: rule.replacement.clone().unwrap_or_default(),
+            });
+        }
+        Ok(out)
     }
 }
 
@@ -3031,5 +3064,44 @@ model = "primary/model"
 "#;
         let cfg = ModelConfig::from_toml_str(toml).expect("parses");
         assert!(cfg.tasks["chat_companion"].output_regex.is_empty());
+    }
+
+    // ─── Task 2: compile_output_regex ────────────────────────────────────────
+
+    #[test]
+    fn compile_output_regex_ok_and_defaults_replacement() {
+        let toml = r#"
+[tasks.chat_companion]
+model = "m"
+output_regex = [
+  { models = ["x/y"], pattern = '\[z\]$' },
+  { models = ["a/b"], pattern = 'q', replacement = "Q" },
+]
+"#;
+        let cfg = ModelConfig::from_toml_str(toml).unwrap();
+        let compiled = cfg.compile_output_regex().expect("compiles");
+        assert_eq!(compiled.len(), 2);
+        assert_eq!(compiled[0].models, vec!["x/y"]);
+        assert!(compiled[0].regex.is_match("hello[z]"));
+        assert_eq!(compiled[0].replacement, ""); // None ⇒ ""
+        assert_eq!(compiled[1].replacement, "Q");
+    }
+
+    #[test]
+    fn compile_output_regex_errors_on_bad_pattern() {
+        let toml = r#"
+[tasks.chat_companion]
+model = "m"
+output_regex = [ { models = ["x/y"], pattern = '[' } ]
+"#;
+        let cfg = ModelConfig::from_toml_str(toml).unwrap();
+        let err = cfg.compile_output_regex().expect_err("invalid pattern must error");
+        assert!(err.contains("output_regex[0]"), "error names the rule index: {err}");
+    }
+
+    #[test]
+    fn compile_output_regex_absent_is_empty_ok() {
+        let cfg = ModelConfig::from_toml_str("[tasks.other]\nmodel='m'\n").unwrap();
+        assert!(cfg.compile_output_regex().unwrap().is_empty());
     }
 }

--- a/crates/eros-engine-server/Cargo.toml
+++ b/crates/eros-engine-server/Cargo.toml
@@ -13,9 +13,9 @@ name = "eros-engine"
 path = "src/main.rs"
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "0.7.0-dev" }
-eros-engine-llm  = { path = "../eros-engine-llm", version = "0.7.0-dev" }
-eros-engine-store = { path = "../eros-engine-store", version = "0.7.0-dev" }
+eros-engine-core = { path = "../eros-engine-core", version = "0.6.6-dev" }
+eros-engine-llm  = { path = "../eros-engine-llm", version = "0.6.6-dev" }
+eros-engine-store = { path = "../eros-engine-store", version = "0.6.6-dev" }
 axum = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0-only",
       "identifier": "AGPL-3.0-only"
     },
-    "version": "0.7.0-dev"
+    "version": "0.6.6-dev"
   },
   "servers": [
     {

--- a/crates/eros-engine-server/src/main.rs
+++ b/crates/eros-engine-server/src/main.rs
@@ -290,6 +290,11 @@ async fn run_server() -> Result<()> {
         anyhow::bail!(msg);
     }
 
+    let output_regex = match model_config.compile_output_regex() {
+        Ok(rules) => Arc::new(rules),
+        Err(msg) => anyhow::bail!(msg),
+    };
+
     // OpenRouter client is constructed after model_config so we can wire in
     // the global provider exclusion list from [defaults].ignore_providers.
     let openrouter = Arc::new(
@@ -304,6 +309,7 @@ async fn run_server() -> Result<()> {
         openrouter,
         voyage,
         model_config,
+        output_regex,
         stream_slots: Arc::new(crate::state::StreamSlots::default()),
     };
 
@@ -376,6 +382,17 @@ mod tests {
             cfg.validate_extraction_prompts().is_ok(),
             "shipped config must pass the extraction boot gate: {:?}",
             cfg.validate_extraction_prompts()
+        );
+    }
+
+    #[test]
+    fn example_config_output_regex_compiles() {
+        let text = include_str!("../../../examples/model_config.toml");
+        let cfg = ModelConfig::from_toml_str(text).expect("examples/model_config.toml parses");
+        assert!(
+            cfg.compile_output_regex().is_ok(),
+            "shipped example output_regex must compile: {:?}",
+            cfg.compile_output_regex().err()
         );
     }
 

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -7058,8 +7058,16 @@ data: [DONE]\n\n";
     /// reaches the client (only the cleaned text in the Delta) and the raw
     /// original must be preserved as `pre_filter_content` with
     /// `filter_model = "<regex>"` and `filter_triggers = {"regex":[0]}`.
-    /// The extract input (`BurstOutcome.produced[0].full_text`) must also
-    /// be the cleaned text (no artifact).
+    ///
+    /// CRITICAL (#113): the extract/memory input — `produced[0].full_text` — must
+    /// be the CLEANED text, NOT the raw `acc`. To guard that property directly we
+    /// drive `drive_chat_burst` (the lower-level harness used by the byte-garble
+    /// siblings) so we hold the `outcome` Arc and can assert on `produced[0]`.
+    /// The DB `content` column alone could NOT catch an `&acc`-fed-extract
+    /// regression (content == cleaned in both the correct and buggy case); the
+    /// `produced[0].full_text` assertion below WOULD fail on `extract_text(.., &acc, ..)`.
+    /// Driving the burst directly bypasses PDE entirely (plan_action = ReplyText),
+    /// so no `[tasks.pde_decision].ghosting=false` workaround is needed.
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
     async fn regex_strips_artifact_from_client_and_memory(pool: PgPool) {
         use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
@@ -7087,19 +7095,11 @@ data: [DONE]\n\n"
 
         // ── 2. Seed persona + session ──────────────────────────────────────────
         let user_id = uuid::Uuid::new_v4();
-        let (_g, instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+        let (_g, _instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
 
         // ── 3. Build AppState with output_regex that MATCHES the artifact ───────
         //      Pattern: \s*\[你给对方发送了一张照片[：:][^\]]*\]\s*$  replacement "".
-        //      `[tasks.pde_decision].ghosting = false` forces a Reply turn.
         let mut state = crate::routes::companion::test_state(pool.clone());
-        state.model_config = std::sync::Arc::new(
-            eros_engine_llm::model_config::ModelConfig::from_toml_str(
-                "[tasks.chat_companion]\nmodel=\"mock/euryale\"\n\
-                 [tasks.pde_decision]\nghosting=false\n",
-            )
-            .unwrap(),
-        );
         let regex_cfg = eros_engine_llm::model_config::ModelConfig::from_toml_str(
             "[tasks.chat_companion]\nmodel=\"mock/euryale\"\n\
              [[tasks.chat_companion.output_regex]]\n\
@@ -7119,10 +7119,11 @@ data: [DONE]\n\n"
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
+        let state = std::sync::Arc::new(state);
 
         // ── 4. Insert the user message ─────────────────────────────────────────
         let chat_repo = ChatRepo { pool: &pool };
-        let umid = match chat_repo
+        let user_message_id = match chat_repo
             .upsert_user_message_idempotent(
                 session_id,
                 "晚安",
@@ -7137,30 +7138,39 @@ data: [DONE]\n\n"
             _ => unreachable!(),
         };
 
-        // ── 5. Drive run_stream ────────────────────────────────────────────────
-        // NOTE: run_stream manages BurstOutcome internally; we verify
-        // produced[0].full_text indirectly via the DB `content` column, which
-        // equals `cleaned` (AfterExtract timing, regex-only path).
-        let frames: Vec<ProtocolFrame> = run_stream(
-            std::sync::Arc::new(state),
-            PersistedUserMessage {
-                user_message_id: umid,
-                session_id,
-                user_id,
-                instance_id,
+        // ── 5. Drive drive_chat_burst directly (ReplyText, no LLM filter) ───────
+        //      The chain is just ["mock/euryale"], which the output_regex rule
+        //      targets, so the burst buffers and strips before emit.
+        let req = eros_engine_llm::openrouter::ChatRequest {
+            model: "mock/euryale".into(),
+            fallback_model: vec![],
+            messages: vec![eros_engine_llm::openrouter::ChatMessage {
+                role: "user".into(),
                 content: "晚安".into(),
-                prompt_traits: vec![],
-                audit: None,
-                tier: None,
-                memory_scope: Default::default(),
-                affinity_scope: Default::default(),
-                tips_amount_usd: None,
-                image_url: None,
-                image: None,
-            },
-        )
-        .collect()
-        .await;
+            }],
+            temperature: 0.0,
+            max_tokens: 64,
+            ..Default::default()
+        };
+        let outcome = std::sync::Arc::new(std::sync::Mutex::new(BurstOutcome::default()));
+        let burst = drive_chat_burst(
+            state.clone(),
+            session_id,
+            user_message_id,
+            FrameActionType::Reply,
+            "reply",
+            ActionType::ReplyText,
+            req,
+            None,
+            None, // filter = None: regex-only turn
+            vec![],
+            None,
+            Default::default(),
+            Default::default(),
+            None,
+            outcome.clone(),
+        );
+        let frames: Vec<ProtocolFrame> = Box::pin(burst).collect().await;
 
         // ── 6. Assertions ─────────────────────────────────────────────────────
         // No error frame.
@@ -7182,7 +7192,7 @@ data: [DONE]\n\n"
 
         assert!(
             !deltas.is_empty(),
-            "regex-targeted turn must produce a Reply bubble (ghosting disabled); got {frames:?}",
+            "regex-targeted Reply burst must produce a Delta bubble; got {frames:?}",
         );
         assert_eq!(
             deltas.len(),
@@ -7196,7 +7206,30 @@ data: [DONE]\n\n"
             deltas[0],
         );
 
-        // DB row: content, pre_filter_content, filter_model, filter_triggers.
+        // ── 6a. THE #113 GUARD: extract/memory input is the cleaned text. ──────
+        // This is the load-bearing assertion: it reads `produced[0].full_text`
+        // directly off the outcome Arc. A regression to `extract_text(.., &acc, ..)`
+        // would put the raw artifact here and FAIL this assertion, while the DB
+        // `content` column (= cleaned in both cases) would silently pass.
+        {
+            let o = outcome.lock().unwrap();
+            assert_eq!(
+                o.produced.len(),
+                1,
+                "exactly one produced message expected; got {:?}",
+                o.produced,
+            );
+            assert_eq!(
+                o.produced[0].full_text, "晚安宝贝",
+                "extract/memory must see the cleaned text, not the raw artifact",
+            );
+            assert!(
+                o.filtered,
+                "outcome.filtered must be true when a regex rule fired",
+            );
+        }
+
+        // ── 6b. DB row: content, pre_filter_content, filter_model, filter_triggers.
         let (content, pre_filter, filter_model, filter_triggers): (
             String,
             Option<String>,
@@ -7232,21 +7265,15 @@ data: [DONE]\n\n"
             Some(serde_json::json!({ "regex": [0usize] })),
             "filter_triggers must be {{\"regex\":[0]}}; got {filter_triggers:?}",
         );
-
-        // BurstOutcome.produced[0].full_text must be the cleaned text.
-        // run_stream owns the outcome internally; read from the DB row instead
-        // (content == cleaned == extracted for AfterExtract timing with regex-only).
-        // Additionally verify outcome.filtered == true via the re-queried row.
-        assert_eq!(
-            content, "晚安宝贝",
-            "extract input (produced[0].full_text) equals cleaned content; got {content:?}",
-        );
     }
 
     /// When the mock model returns a reply that does NOT match the output_regex
     /// rule (no bracket artifact), the content must be stored verbatim and NO
     /// filter audit columns must be written (pre_filter_content IS NULL, etc.).
-    /// BurstOutcome.filtered must be false.
+    /// `BurstOutcome.filtered` must be false — asserted directly off the outcome
+    /// Arc (this test also drives `drive_chat_burst` so the assertion is free).
+    /// The rule still TARGETS the model (so the turn buffers), it just doesn't
+    /// match the reply.
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
     async fn regex_no_match_persists_raw_no_audit(pool: PgPool) {
         use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
@@ -7271,17 +7298,10 @@ data: [DONE]\n\n";
 
         // ── 2. Seed persona + session ──────────────────────────────────────────
         let user_id = uuid::Uuid::new_v4();
-        let (_g, instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+        let (_g, _instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
 
         // ── 3. Build AppState with the same output_regex rule (won't match) ────
         let mut state = crate::routes::companion::test_state(pool.clone());
-        state.model_config = std::sync::Arc::new(
-            eros_engine_llm::model_config::ModelConfig::from_toml_str(
-                "[tasks.chat_companion]\nmodel=\"mock/euryale\"\n\
-                 [tasks.pde_decision]\nghosting=false\n",
-            )
-            .unwrap(),
-        );
         let regex_cfg = eros_engine_llm::model_config::ModelConfig::from_toml_str(
             "[tasks.chat_companion]\nmodel=\"mock/euryale\"\n\
              [[tasks.chat_companion.output_regex]]\n\
@@ -7301,10 +7321,11 @@ data: [DONE]\n\n";
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
+        let state = std::sync::Arc::new(state);
 
         // ── 4. Insert the user message ─────────────────────────────────────────
         let chat_repo = ChatRepo { pool: &pool };
-        let umid = match chat_repo
+        let user_message_id = match chat_repo
             .upsert_user_message_idempotent(
                 session_id,
                 "晚安",
@@ -7319,27 +7340,37 @@ data: [DONE]\n\n";
             _ => unreachable!(),
         };
 
-        // ── 5. Drive run_stream ────────────────────────────────────────────────
-        let frames: Vec<ProtocolFrame> = run_stream(
-            std::sync::Arc::new(state),
-            PersistedUserMessage {
-                user_message_id: umid,
-                session_id,
-                user_id,
-                instance_id,
+        // ── 5. Drive drive_chat_burst directly (ReplyText, no LLM filter) ───────
+        let req = eros_engine_llm::openrouter::ChatRequest {
+            model: "mock/euryale".into(),
+            fallback_model: vec![],
+            messages: vec![eros_engine_llm::openrouter::ChatMessage {
+                role: "user".into(),
                 content: "晚安".into(),
-                prompt_traits: vec![],
-                audit: None,
-                tier: None,
-                memory_scope: Default::default(),
-                affinity_scope: Default::default(),
-                tips_amount_usd: None,
-                image_url: None,
-                image: None,
-            },
-        )
-        .collect()
-        .await;
+            }],
+            temperature: 0.0,
+            max_tokens: 64,
+            ..Default::default()
+        };
+        let outcome = std::sync::Arc::new(std::sync::Mutex::new(BurstOutcome::default()));
+        let burst = drive_chat_burst(
+            state.clone(),
+            session_id,
+            user_message_id,
+            FrameActionType::Reply,
+            "reply",
+            ActionType::ReplyText,
+            req,
+            None,
+            None, // filter = None: regex-only turn
+            vec![],
+            None,
+            Default::default(),
+            Default::default(),
+            None,
+            outcome.clone(),
+        );
+        let frames: Vec<ProtocolFrame> = Box::pin(burst).collect().await;
 
         // ── 6. Assertions ─────────────────────────────────────────────────────
         // No error frame.
@@ -7361,13 +7392,32 @@ data: [DONE]\n\n";
 
         assert!(
             !deltas.is_empty(),
-            "regex-targeted turn must produce a Reply bubble (ghosting disabled); got {frames:?}",
+            "regex-targeted Reply burst must produce a Delta bubble; got {frames:?}",
         );
         assert_eq!(
             deltas[0], "晚安宝贝",
             "unmatched rule must not alter the reply; got {:?}",
             deltas[0],
         );
+
+        // Direct outcome assertions: no rule matched → not filtered, raw text out.
+        {
+            let o = outcome.lock().unwrap();
+            assert!(
+                !o.filtered,
+                "outcome.filtered must be false when no regex rule matched",
+            );
+            assert_eq!(
+                o.produced.len(),
+                1,
+                "exactly one produced message expected; got {:?}",
+                o.produced,
+            );
+            assert_eq!(
+                o.produced[0].full_text, "晚安宝贝",
+                "extract/memory must see the raw (unchanged) text when no rule matched",
+            );
+        }
 
         // DB row: content == "晚安宝贝", audit columns all NULL.
         let (content, pre_filter, filter_model, filter_triggers): (

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -553,20 +553,6 @@ fn drive_chat_burst(
                 // `truncated` (length / transport) and handled by the block below.
             }
 
-            // Layer 0: deterministic per-model strip, before client emit, the
-            // optional LLM filter, and the extract split. `cleaned == acc` when
-            // no rule matches (then `regex_indices` is empty → no audit).
-            let strip = eros_engine_llm::model_config::apply_output_regex(
-                &state.output_regex,
-                model_id,
-                &acc,
-            );
-            let cleaned = strip.cleaned;
-            let regex_indices = strip.matched_rules;
-            if !regex_indices.is_empty() {
-                outcome.lock().unwrap().filtered = true;
-            }
-
             if truncated {
                 if idx + 1 == chain.len() {
                     let fallback_retries = (chain.len() as u32).saturating_sub(1);
@@ -625,6 +611,27 @@ fn drive_chat_burst(
                 model: display_override.as_ref().and_then(|d| d.display(model_id)),
                 continues_from: None,
             };
+
+            // Layer 0: deterministic per-model strip, before client emit, the
+            // optional LLM filter, and the extract split. `cleaned == acc` when
+            // no rule matches (then `regex_indices` is empty → no audit).
+            //
+            // Run this ONLY for the attempt that is actually served — i.e. AFTER
+            // the `if truncated { ... continue }` check above. A truncated
+            // attempt's partial `acc` could otherwise match a rule and set
+            // `outcome.filtered = true`, then be discarded via `continue`,
+            // letting a later fallback serve an UNSTRIPPED reply while the final
+            // frame falsely reports `filtered = true`.
+            let strip = eros_engine_llm::model_config::apply_output_regex(
+                &state.output_regex,
+                model_id,
+                &acc,
+            );
+            let cleaned = strip.cleaned;
+            let regex_indices = strip.matched_rules;
+            if !regex_indices.is_empty() {
+                outcome.lock().unwrap().filtered = true;
+            }
 
             // `filter_failure` carries the per-attempt audit when filter fails.
             // Threaded into AssistantInsert via build_metadata — distinct from
@@ -7451,6 +7458,257 @@ data: [DONE]\n\n";
         assert!(
             filter_triggers.is_none(),
             "filter_triggers must be NULL when no rule matches; got {filter_triggers:?}",
+        );
+    }
+
+    /// Both layers fire on the SAME turn: the per-model output_regex strips the
+    /// artifact (layer 0) AND the LLM output_filter rewrites the reply. The LLM
+    /// filter must run on the regex-CLEANED text (not the raw `acc`); the
+    /// persisted audit must keep the RAW reply on `pre_filter_content`, set
+    /// `filter_model` to the LLM model id (NOT "<regex>"), and fold BOTH the LLM
+    /// predicate keys and the `regex` key into `filter_triggers`.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn both_filters_fire_llm_runs_on_cleaned_audit_folds(pool: PgPool) {
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+        use futures_util::StreamExt;
+        use wiremock::matchers::{body_string_contains, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let raw_reply = "晚安宝贝[你给对方发送了一张照片：海边自拍]";
+        let cleaned_reply = "晚安宝贝";
+        let artifact = "你给对方发送了一张照片"; // the bracket payload, never in cleaned
+
+        // ── 1. Dual mock: chat model (SSE) + filter model (JSON). ──────────────
+        let mock = MockServer::start().await;
+        // Chat model "mock/euryale" streams the artifact-carrying reply.
+        let chat_body = format!(
+            "data: {{\"choices\":[{{\"delta\":{{\"content\":\"{raw_reply}\"}}}}],\
+\"usage\":{{\"prompt_tokens\":2,\"completion_tokens\":8,\"total_tokens\":10}},\
+\"id\":\"gen-t6c\",\"model\":\"mock/euryale\"}}\n\n\
+data: [DONE]\n\n"
+        );
+        // Filter model "fast/m" returns a >= MIN_FILTERED_OUTPUT_CHARS (80) rewrite
+        // (a real rewrite is always that long) so it passes the validity gate.
+        let filt_text = "FILT_START 她轻轻地望向窗外，思绪飘向了远方。阳光洒在她的脸上，温柔而明亮。她记得那个夏天的每一天，岁月如流水般逝去，带走了所有的悲欢离合。 FILT_END";
+        let filt_body = serde_json::json!({
+            "id": "gf", "model": "fast/m",
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            "choices": [{"message": {"content": filt_text}}],
+        });
+        // Mutually-exclusive routing by model id in the request body.
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("fast/m"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(filt_body))
+            .mount(&mock)
+            .await;
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("mock/euryale"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(chat_body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+
+        // ── 2. Seed persona + session ──────────────────────────────────────────
+        let user_id = uuid::Uuid::new_v4();
+        let (_g, _instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+
+        // ── 3. AppState: output_regex targeting mock/euryale + matching pattern.
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        let regex_cfg = eros_engine_llm::model_config::ModelConfig::from_toml_str(
+            "[tasks.chat_companion]\nmodel=\"mock/euryale\"\n\
+             [[tasks.chat_companion.output_regex]]\n\
+             models=[\"mock/euryale\"]\n\
+             pattern=\"\\\\s*\\\\[你给对方发送了一张照片[：:][^\\\\]]*\\\\]\\\\s*$\"\n",
+        )
+        .unwrap();
+        state.output_regex = std::sync::Arc::new(
+            regex_cfg
+                .compile_output_regex()
+                .expect("artifact pattern compiles"),
+        );
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                eros_engine_llm::openrouter::AppAttribution::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+        let state = std::sync::Arc::new(state);
+
+        // ── 4. Insert the user message ─────────────────────────────────────────
+        let chat_repo = ChatRepo { pool: &pool };
+        let user_message_id = match chat_repo
+            .upsert_user_message_idempotent(
+                session_id,
+                "晚安",
+                "01JT5REGEX00000000000000D",
+                "user",
+                None,
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
+
+        // ── 5. Build a ResolvedOutputFilter whose trigger fires (models=...). ───
+        //      Hand-built (not via PDE) so the burst deterministically filters.
+        let filter = eros_engine_llm::model_config::ResolvedOutputFilter {
+            model: "fast/m".into(),
+            fallback_model: vec![],
+            temperature: 0.0,
+            max_tokens: 256,
+            filter_prompt: "REWRITE".into(),
+            trigger: eros_engine_llm::model_config::OutputFilterTrigger {
+                random: None,
+                models: Some(vec!["mock/euryale".into()]),
+                traits: None,
+            },
+            timing: eros_engine_llm::model_config::FilterTiming::AfterExtract,
+            retry_depth: 0,
+            reasoning: None,
+        };
+
+        let req = eros_engine_llm::openrouter::ChatRequest {
+            model: "mock/euryale".into(),
+            fallback_model: vec![],
+            messages: vec![eros_engine_llm::openrouter::ChatMessage {
+                role: "user".into(),
+                content: "晚安".into(),
+            }],
+            temperature: 0.0,
+            max_tokens: 64,
+            ..Default::default()
+        };
+        let outcome = std::sync::Arc::new(std::sync::Mutex::new(BurstOutcome::default()));
+        let burst = drive_chat_burst(
+            state.clone(),
+            session_id,
+            user_message_id,
+            FrameActionType::Reply,
+            "reply",
+            ActionType::ReplyText,
+            req,
+            None,
+            Some(filter), // LLM output filter that fires (models matches)
+            vec![],
+            None,
+            Default::default(),
+            Default::default(),
+            None,
+            outcome.clone(),
+        );
+        let frames: Vec<ProtocolFrame> = Box::pin(burst).collect().await;
+
+        // ── 6. Assertions ─────────────────────────────────────────────────────
+        assert!(
+            !frames
+                .iter()
+                .any(|f| matches!(f, ProtocolFrame::Error { .. })),
+            "no error frame expected; got {frames:?}",
+        );
+        // Client sees the LLM-filtered text (never ORIG artifact).
+        let deltas: String = frames
+            .iter()
+            .filter_map(|f| match f {
+                ProtocolFrame::Delta { content, .. } => Some(content.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            deltas.contains("FILT_START"),
+            "client must see the LLM-filtered text; got {deltas:?}",
+        );
+        assert!(
+            !deltas.contains(artifact),
+            "artifact must never reach client; got {deltas:?}",
+        );
+
+        // The LLM filter ran on the regex-CLEANED text: inspect the actual filter
+        // request body via received_requests — it must contain the cleaned reply
+        // but NOT the bracket artifact.
+        let received = mock
+            .received_requests()
+            .await
+            .expect("recording enabled by default");
+        let filter_req_body = received
+            .iter()
+            .map(|r| String::from_utf8_lossy(&r.body).to_string())
+            .find(|b| b.contains("fast/m"))
+            .expect("filter model call must have been made");
+        assert!(
+            filter_req_body.contains(cleaned_reply),
+            "filter must run on cleaned text (contains the cleaned reply); body={filter_req_body:?}",
+        );
+        assert!(
+            !filter_req_body.contains(artifact),
+            "filter must NOT see the raw artifact (proves it ran on cleaned, not acc); \
+             body={filter_req_body:?}",
+        );
+
+        // outcome.filtered true; produced (extract input) is the LLM-filtered text
+        // (AfterExtract timing feeds extract the original = cleaned baseline, but
+        // the burst pushes `extracted` from extract_text(AfterExtract, &cleaned, ..)
+        // which is `cleaned`; the LLM-filtered text is what the CLIENT/DB see).
+        {
+            let o = outcome.lock().unwrap();
+            assert!(
+                o.filtered,
+                "outcome.filtered must be true when filters fired"
+            );
+            assert_eq!(
+                o.produced.len(),
+                1,
+                "one produced message; got {:?}",
+                o.produced
+            );
+        }
+
+        // ── 6a. DB audit: raw on pre_filter_content, LLM model, BOTH trigger keys.
+        let (content, pre_filter, filter_model, filter_triggers): (
+            String,
+            Option<String>,
+            Option<String>,
+            Option<serde_json::Value>,
+        ) = sqlx::query_as(
+            "SELECT content, pre_filter_content, filter_model, filter_triggers \
+             FROM engine.chat_messages \
+             WHERE session_id = $1 AND role = 'assistant' \
+             ORDER BY sent_at DESC LIMIT 1",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert!(
+            content.contains("FILT_START"),
+            "persisted content must be the LLM-filtered text; got {content:?}",
+        );
+        assert_eq!(
+            pre_filter.as_deref(),
+            Some(raw_reply),
+            "pre_filter_content must be the RAW reply (with bracket); got {pre_filter:?}",
+        );
+        assert_eq!(
+            filter_model.as_deref(),
+            Some("fast/m"),
+            "filter_model must be the LLM model id, NOT '<regex>'; got {filter_model:?}",
+        );
+        let triggers = filter_triggers.expect("filter_triggers must be present");
+        assert_eq!(
+            triggers.get("models"),
+            Some(&serde_json::json!(["mock/euryale"])),
+            "filter_triggers must carry the LLM predicate (models); got {triggers:?}",
+        );
+        assert_eq!(
+            triggers.get("regex"),
+            Some(&serde_json::json!([0])),
+            "filter_triggers must fold in the regex key; got {triggers:?}",
         );
     }
 }

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -6859,10 +6859,20 @@ data: [DONE]\n\n";
 
         // ── 3. Build AppState with output_regex targeting "mock/euryale" ───────
         //      Pattern \bNOPE\b will NOT match "hello world".
+        //
+        //      `[tasks.pde_decision].ghosting = false` makes the turn
+        //      DETERMINISTICALLY produce a Reply: the pure rule engine
+        //      (`pde::decide`, since no filter_prompt ⇒ no judge LLM call) can
+        //      otherwise pick Ghost based on persona/affinity, which would make
+        //      the buffered-path assertions vacuous. `pde_ghosting_enabled()`
+        //      reads `ghosting` INDEPENDENTLY of `filter_prompt`, so the
+        //      path-wide kill-switch downgrades any Ghost plan to ReplyText
+        //      WITHOUT enabling the (mock-less) judge call.
         let mut state = crate::routes::companion::test_state(pool.clone());
         state.model_config = std::sync::Arc::new(
             eros_engine_llm::model_config::ModelConfig::from_toml_str(
-                "[tasks.chat_companion]\nmodel=\"mock/euryale\"\n",
+                "[tasks.chat_companion]\nmodel=\"mock/euryale\"\n\
+                 [tasks.pde_decision]\nghosting=false\n",
             )
             .unwrap(),
         );
@@ -6941,42 +6951,47 @@ data: [DONE]\n\n";
             })
             .collect();
 
-        // If the PDE routed to Reply (not Ghost), we assert buffered behaviour.
-        if !deltas.is_empty() {
-            // Buffered mode emits exactly ONE Delta bubble (the whole reply at once).
-            assert_eq!(
-                deltas.len(),
-                1,
-                "buffered mode must emit exactly one Delta bubble; got {deltas:?}",
-            );
-            // Content is the raw reply, unchanged (no strip yet — Task 6).
-            assert_eq!(
-                deltas[0], "hello world",
-                "unmatched regex must not alter the reply; got {:?}",
-                deltas[0],
-            );
+        // The turn is forced to Reply (ghosting=false), so a Delta MUST appear.
+        // Asserting this unconditionally means a regression to Ghost (or to no
+        // bubble at all) fails LOUDLY rather than passing vacuously.
+        assert!(
+            !deltas.is_empty(),
+            "regex-targeted turn must produce a Reply bubble (ghosting disabled); got {frames:?}",
+        );
+        // Buffered mode emits exactly ONE Delta bubble (the whole reply at once),
+        // proving the turn buffered rather than streaming live per-chunk.
+        assert_eq!(
+            deltas.len(),
+            1,
+            "buffered mode must emit exactly one Delta bubble; got {deltas:?}",
+        );
+        // Content is the raw reply, unchanged (no strip yet — Task 6).
+        assert_eq!(
+            deltas[0], "hello world",
+            "unmatched regex must not alter the reply; got {:?}",
+            deltas[0],
+        );
 
-            // DB row: content == "hello world", pre_filter_content IS NULL.
-            let (content, pre_filter): (String, Option<String>) = sqlx::query_as(
-                "SELECT content, pre_filter_content \
-                 FROM engine.chat_messages \
-                 WHERE session_id = $1 AND role = 'assistant' \
-                 ORDER BY sent_at DESC LIMIT 1",
-            )
-            .bind(session_id)
-            .fetch_one(&pool)
-            .await
-            .unwrap();
+        // DB row: content == "hello world", pre_filter_content IS NULL.
+        let (content, pre_filter): (String, Option<String>) = sqlx::query_as(
+            "SELECT content, pre_filter_content \
+             FROM engine.chat_messages \
+             WHERE session_id = $1 AND role = 'assistant' \
+             ORDER BY sent_at DESC LIMIT 1",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
 
-            assert_eq!(
-                content, "hello world",
-                "persisted content must be the raw reply; got {content:?}",
-            );
-            assert!(
-                pre_filter.is_none(),
-                "pre_filter_content must be NULL for a regex-only buffered turn (no LLM filter ran); \
-                 got {pre_filter:?}",
-            );
-        }
+        assert_eq!(
+            content, "hello world",
+            "persisted content must be the raw reply; got {content:?}",
+        );
+        assert!(
+            pre_filter.is_none(),
+            "pre_filter_content must be NULL for a regex-only buffered turn (no LLM filter ran); \
+             got {pre_filter:?}",
+        );
     }
 }

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -242,10 +242,17 @@ fn drive_chat_burst(
         }
 
         let tag_refs: Vec<&str> = trait_tags.iter().map(String::as_str).collect();
-        let filtered_mode = filter
+        // A turn buffers (no live deltas) if the LLM output_filter's turn-level
+        // predicates pass, OR any output_regex rule targets a model in this
+        // turn's resolved chain (so the artifact can be stripped before emit).
+        let regex_targets_chain = chain.iter().any(|m| {
+            state.output_regex.iter().any(|r| r.models.iter().any(|rm| rm == m))
+        });
+        let llm_filter_arms = filter
             .as_ref()
             .map(|f| f.trigger.turn_level_pass(random_draw, &tag_refs))
             .unwrap_or(false);
+        let filtered_mode = llm_filter_arms || regex_targets_chain;
 
         // Build the assistant row metadata bag: always includes prompt_traits +
         // resolved memory_scope / affinity_scope (the POST-resolve values
@@ -503,7 +510,8 @@ fn drive_chat_burst(
         // never reach the client). Per-attempt the model predicate decides
         // whether that specific served model is actually filtered; on filter
         // error we fail open and emit the original.
-        let f = filter.expect("filtered_mode ⇒ filter present");
+        // `filter` is None when the turn buffers solely because of output_regex.
+        let f_opt = filter.as_ref();
         for (idx, model_id) in chain.iter().enumerate() {
             let msg_ulid = Ulid::new();
             let msg_uuid: Uuid = msg_ulid.into();
@@ -597,7 +605,6 @@ fn drive_chat_burst(
             }
 
             outcome.lock().unwrap().retries_chat = idx as u32;
-            let hits = f.trigger.should_filter(model_id, &tag_refs, random_draw);
             yield ProtocolFrame::Meta {
                 message_id: ulid_string(msg_ulid),
                 action_type: frame_action,
@@ -612,41 +619,44 @@ fn drive_chat_burst(
                 String,
                 Option<eros_engine_store::chat::FilterAudit>,
                 Option<FilterFailOpen>,
-            ) = match hits {
-                Some(h) => match run_output_filter(&state, &f, &acc).await {
-                    Ok(out) => {
-                        let mut o = outcome.lock().unwrap();
-                        o.filtered = true;
-                        o.retries_filter = out.retries_filter;
-                        drop(o); // release MutexGuard before the yield below — must not cross suspension point
-                        // Empty/always-fire trigger serialises to `{}`; substitute
-                        // JSON null so the store layer's guard lands SQL NULL. A
-                        // reader tells "filter ran" from "filter absent" via filter_model.
-                        let filter_triggers = if h.is_empty() {
-                            serde_json::Value::Null
-                        } else {
-                            serde_json::to_value(&h)
-                                .expect("FiredPredicates Serialize is infallible")
-                        };
-                        let audit = eros_engine_store::chat::FilterAudit {
-                            pre_filter_content: acc.clone(),
-                            filter_model: out.filter_model,
-                            filter_triggers,
-                            f_client_msg_id: out.f_client_msg_id,
-                            f_generation_id: out.f_generation_id,
-                        };
-                        (out.filtered_text, Some(audit), None)
+            ) = match f_opt {
+                Some(f) => {
+                    let hits = f.trigger.should_filter(model_id, &tag_refs, random_draw);
+                    match hits {
+                        Some(h) => match run_output_filter(&state, f, &acc).await {
+                            Ok(out) => {
+                                let mut o = outcome.lock().unwrap();
+                                o.filtered = true;
+                                o.retries_filter = out.retries_filter;
+                                drop(o);
+                                let filter_triggers = if h.is_empty() {
+                                    serde_json::Value::Null
+                                } else {
+                                    serde_json::to_value(&h)
+                                        .expect("FiredPredicates Serialize is infallible")
+                                };
+                                let audit = eros_engine_store::chat::FilterAudit {
+                                    pre_filter_content: acc.clone(),
+                                    filter_model: out.filter_model,
+                                    filter_triggers,
+                                    f_client_msg_id: out.f_client_msg_id,
+                                    f_generation_id: out.f_generation_id,
+                                };
+                                (out.filtered_text, Some(audit), None)
+                            }
+                            Err(fail) => {
+                                tracing::warn!(
+                                    f_client_msg_id = %fail.f_client_msg_id,
+                                    attempts = ?fail.attempts,
+                                    "filter: all models in chain failed validity; falling open"
+                                );
+                                (acc.clone(), None, Some(fail))
+                            }
+                        },
+                        None => (acc.clone(), None, None),
                     }
-                    Err(fail) => {
-                        tracing::warn!(
-                            f_client_msg_id = %fail.f_client_msg_id,
-                            attempts = ?fail.attempts,
-                            "filter: all models in chain failed validity; falling open"
-                        );
-                        (acc.clone(), None, Some(fail))
-                    }
-                },
-                None => (acc.clone(), None, None), // models-miss or trigger off — not a failure
+                }
+                None => (acc.clone(), None, None), // regex-only turn (strip added in Task 6)
             };
 
             if !visible.is_empty() {
@@ -671,7 +681,10 @@ fn drive_chat_burst(
             if let Err(e) = chat_repo.insert_assistant_batch(session_id, user_message_id, &[row]).await {
                 tracing::warn!("stream(filtered): persist failed: {e}");
             }
-            let extracted = extract_text(f.timing, &acc, &visible);
+            let timing = f_opt
+                .map(|f| f.timing)
+                .unwrap_or(eros_engine_llm::model_config::FilterTiming::AfterExtract);
+            let extracted = extract_text(timing, &acc, &visible);
             outcome.lock().unwrap().produced.push(crate::pipeline::post_process::ProducedMessage {
                 message_id: msg_uuid,
                 full_text: extracted,
@@ -6808,5 +6821,162 @@ data: [DONE]\n\n";
             run.model.is_some(),
             "chain-exhausted ParseError must preserve the last attempt's model"
         );
+    }
+
+    // ── Task 5: output_regex widened gate ────────────────────────────────────
+
+    /// A turn whose model chain is targeted by an `output_regex` rule must
+    /// buffer (single bubble) even when no LLM `output_filter` is configured.
+    /// With a pattern that does NOT match the reply, the content must arrive
+    /// unchanged — Task 6 adds the actual strip.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn regex_target_buffers_without_changing_unmatched_reply(pool: PgPool) {
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+        use futures_util::StreamExt;
+        use wiremock::matchers::path as wm_path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        // ── 1. Mock OpenRouter: returns "hello world" for model "mock/euryale" ──
+        let mock = MockServer::start().await;
+        // SSE body: one delta with "hello world", then a usage chunk, then [DONE].
+        let chat_body = "\
+data: {\"choices\":[{\"delta\":{\"content\":\"hello world\"}}],\
+\"usage\":{\"prompt_tokens\":2,\"completion_tokens\":2,\"total_tokens\":4},\
+\"id\":\"gen-t5\",\"model\":\"mock/euryale\"}\n\n\
+data: [DONE]\n\n";
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(chat_body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+
+        // ── 2. Seed persona + session ──────────────────────────────────────────
+        let user_id = uuid::Uuid::new_v4();
+        let (_g, instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+
+        // ── 3. Build AppState with output_regex targeting "mock/euryale" ───────
+        //      Pattern \bNOPE\b will NOT match "hello world".
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = std::sync::Arc::new(
+            eros_engine_llm::model_config::ModelConfig::from_toml_str(
+                "[tasks.chat_companion]\nmodel=\"mock/euryale\"\n",
+            )
+            .unwrap(),
+        );
+        // Override output_regex with one rule targeting "mock/euryale" but a
+        // pattern (\bNOPE\b) that will NOT match the "hello world" reply.
+        // Build via ModelConfig so we don't need `regex` as a direct dep.
+        let regex_cfg = eros_engine_llm::model_config::ModelConfig::from_toml_str(
+            "[tasks.chat_companion]\nmodel=\"mock/euryale\"\n\
+             [[tasks.chat_companion.output_regex]]\n\
+             models=[\"mock/euryale\"]\npattern=\"\\\\bNOPE\\\\b\"\n",
+        )
+        .unwrap();
+        state.output_regex = std::sync::Arc::new(
+            regex_cfg.compile_output_regex().expect("NOPE pattern compiles"),
+        );
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                eros_engine_llm::openrouter::AppAttribution::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+
+        // ── 4. Insert the user message ─────────────────────────────────────────
+        let chat_repo = ChatRepo { pool: &pool };
+        let umid = match chat_repo
+            .upsert_user_message_idempotent(
+                session_id,
+                "hello",
+                "01JT5REGEX00000000000000A",
+                "user",
+                None,
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
+
+        // ── 5. Drive run_stream ────────────────────────────────────────────────
+        let frames: Vec<ProtocolFrame> = run_stream(
+            std::sync::Arc::new(state),
+            PersistedUserMessage {
+                user_message_id: umid,
+                session_id,
+                user_id,
+                instance_id,
+                content: "hello".into(),
+                prompt_traits: vec![],
+                audit: None,
+                tier: None,
+                memory_scope: Default::default(),
+                affinity_scope: Default::default(),
+                tips_amount_usd: None,
+                image_url: None,
+                image: None,
+            },
+        )
+        .collect()
+        .await;
+
+        // ── 6. Assertions ─────────────────────────────────────────────────────
+        // No error frame.
+        assert!(
+            !frames.iter().any(|f| matches!(f, ProtocolFrame::Error { .. })),
+            "no error frame expected; got {frames:?}",
+        );
+
+        // Collect all Delta frames.
+        let deltas: Vec<&str> = frames
+            .iter()
+            .filter_map(|f| match f {
+                ProtocolFrame::Delta { content, .. } => Some(content.as_str()),
+                _ => None,
+            })
+            .collect();
+
+        // If the PDE routed to Reply (not Ghost), we assert buffered behaviour.
+        if !deltas.is_empty() {
+            // Buffered mode emits exactly ONE Delta bubble (the whole reply at once).
+            assert_eq!(
+                deltas.len(),
+                1,
+                "buffered mode must emit exactly one Delta bubble; got {deltas:?}",
+            );
+            // Content is the raw reply, unchanged (no strip yet — Task 6).
+            assert_eq!(
+                deltas[0], "hello world",
+                "unmatched regex must not alter the reply; got {:?}",
+                deltas[0],
+            );
+
+            // DB row: content == "hello world", pre_filter_content IS NULL.
+            let (content, pre_filter): (String, Option<String>) = sqlx::query_as(
+                "SELECT content, pre_filter_content \
+                 FROM engine.chat_messages \
+                 WHERE session_id = $1 AND role = 'assistant' \
+                 ORDER BY sent_at DESC LIMIT 1",
+            )
+            .bind(session_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+            assert_eq!(
+                content, "hello world",
+                "persisted content must be the raw reply; got {content:?}",
+            );
+            assert!(
+                pre_filter.is_none(),
+                "pre_filter_content must be NULL for a regex-only buffered turn (no LLM filter ran); \
+                 got {pre_filter:?}",
+            );
+        }
     }
 }

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -553,6 +553,20 @@ fn drive_chat_burst(
                 // `truncated` (length / transport) and handled by the block below.
             }
 
+            // Layer 0: deterministic per-model strip, before client emit, the
+            // optional LLM filter, and the extract split. `cleaned == acc` when
+            // no rule matches (then `regex_indices` is empty → no audit).
+            let strip = eros_engine_llm::model_config::apply_output_regex(
+                &state.output_regex,
+                model_id,
+                &acc,
+            );
+            let cleaned = strip.cleaned;
+            let regex_indices = strip.matched_rules;
+            if !regex_indices.is_empty() {
+                outcome.lock().unwrap().filtered = true;
+            }
+
             if truncated {
                 if idx + 1 == chain.len() {
                     let fallback_retries = (chain.len() as u32).saturating_sub(1);
@@ -615,6 +629,26 @@ fn drive_chat_burst(
             // `filter_failure` carries the per-attempt audit when filter fails.
             // Threaded into AssistantInsert via build_metadata — distinct from
             // the prompt_traits/tier metadata to keep concerns separate.
+
+            // Build the regex-only audit (raw original on pre_filter_content).
+            // We generate a fresh `f_`-prefixed ULID for each regex-strip row
+            // so the unique index on (session_id, f_client_msg_id) is never
+            // violated by multiple regex-filtered turns in the same session.
+            // (An empty string is non-NULL and would conflict on the second
+            // turn, so `String::new()` from the brief is replaced by a ULID.)
+            let regex_audit = |raw: &str| -> Option<eros_engine_store::chat::FilterAudit> {
+                if regex_indices.is_empty() {
+                    return None;
+                }
+                Some(eros_engine_store::chat::FilterAudit {
+                    pre_filter_content: raw.to_string(),
+                    filter_model: "<regex>".to_string(),
+                    filter_triggers: serde_json::json!({ "regex": regex_indices }),
+                    f_client_msg_id: format!("f_{}", Ulid::new()),
+                    f_generation_id: None,
+                })
+            };
+
             let (visible, filter_audit, filter_failure): (
                 String,
                 Option<eros_engine_store::chat::FilterAudit>,
@@ -623,20 +657,37 @@ fn drive_chat_burst(
                 Some(f) => {
                     let hits = f.trigger.should_filter(model_id, &tag_refs, random_draw);
                     match hits {
-                        Some(h) => match run_output_filter(&state, f, &acc).await {
+                        Some(h) => match run_output_filter(&state, f, &cleaned).await {
                             Ok(out) => {
                                 let mut o = outcome.lock().unwrap();
                                 o.filtered = true;
                                 o.retries_filter = out.retries_filter;
                                 drop(o);
-                                let filter_triggers = if h.is_empty() {
+                                // Fold the regex hit into the LLM filter's triggers.
+                                let mut triggers = if h.is_empty() {
+                                    serde_json::Map::new()
+                                } else {
+                                    match serde_json::to_value(&h)
+                                        .expect("FiredPredicates Serialize is infallible")
+                                    {
+                                        serde_json::Value::Object(m) => m,
+                                        other => {
+                                            let mut m = serde_json::Map::new();
+                                            m.insert("filter".into(), other);
+                                            m
+                                        }
+                                    }
+                                };
+                                if !regex_indices.is_empty() {
+                                    triggers.insert("regex".into(), serde_json::json!(regex_indices));
+                                }
+                                let filter_triggers = if triggers.is_empty() {
                                     serde_json::Value::Null
                                 } else {
-                                    serde_json::to_value(&h)
-                                        .expect("FiredPredicates Serialize is infallible")
+                                    serde_json::Value::Object(triggers)
                                 };
                                 let audit = eros_engine_store::chat::FilterAudit {
-                                    pre_filter_content: acc.clone(),
+                                    pre_filter_content: acc.clone(), // raw, pre-everything
                                     filter_model: out.filter_model,
                                     filter_triggers,
                                     f_client_msg_id: out.f_client_msg_id,
@@ -650,13 +701,14 @@ fn drive_chat_burst(
                                     attempts = ?fail.attempts,
                                     "filter: all models in chain failed validity; falling open"
                                 );
-                                (acc.clone(), None, Some(fail))
+                                // Fail open to the regex-cleaned text (strip still applies).
+                                (cleaned.clone(), regex_audit(&acc), Some(fail))
                             }
                         },
-                        None => (acc.clone(), None, None),
+                        None => (cleaned.clone(), regex_audit(&acc), None), // LLM models-miss
                     }
                 }
-                None => (acc.clone(), None, None), // regex-only turn (strip added in Task 6)
+                None => (cleaned.clone(), regex_audit(&acc), None), // regex-only turn
             };
 
             if !visible.is_empty() {
@@ -684,7 +736,7 @@ fn drive_chat_burst(
             let timing = f_opt
                 .map(|f| f.timing)
                 .unwrap_or(eros_engine_llm::model_config::FilterTiming::AfterExtract);
-            let extracted = extract_text(timing, &acc, &visible);
+            let extracted = extract_text(timing, &cleaned, &visible);
             outcome.lock().unwrap().produced.push(crate::pipeline::post_process::ProducedMessage {
                 message_id: msg_uuid,
                 full_text: extracted,
@@ -6886,7 +6938,9 @@ data: [DONE]\n\n";
         )
         .unwrap();
         state.output_regex = std::sync::Arc::new(
-            regex_cfg.compile_output_regex().expect("NOPE pattern compiles"),
+            regex_cfg
+                .compile_output_regex()
+                .expect("NOPE pattern compiles"),
         );
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
@@ -6938,7 +6992,9 @@ data: [DONE]\n\n";
         // ── 6. Assertions ─────────────────────────────────────────────────────
         // No error frame.
         assert!(
-            !frames.iter().any(|f| matches!(f, ProtocolFrame::Error { .. })),
+            !frames
+                .iter()
+                .any(|f| matches!(f, ProtocolFrame::Error { .. })),
             "no error frame expected; got {frames:?}",
         );
 
@@ -6992,6 +7048,359 @@ data: [DONE]\n\n";
             pre_filter.is_none(),
             "pre_filter_content must be NULL for a regex-only buffered turn (no LLM filter ran); \
              got {pre_filter:?}",
+        );
+    }
+
+    // ── Task 6: per-model regex strip as layer 0 ─────────────────────────────
+
+    /// When the mock model returns a reply with an artifact bracket that matches
+    /// the configured output_regex rule, the strip must happen BEFORE the text
+    /// reaches the client (only the cleaned text in the Delta) and the raw
+    /// original must be preserved as `pre_filter_content` with
+    /// `filter_model = "<regex>"` and `filter_triggers = {"regex":[0]}`.
+    /// The extract input (`BurstOutcome.produced[0].full_text`) must also
+    /// be the cleaned text (no artifact).
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn regex_strips_artifact_from_client_and_memory(pool: PgPool) {
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+        use futures_util::StreamExt;
+        use wiremock::matchers::path as wm_path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        // ── 1. Mock OpenRouter: returns the artifact-carrying reply ─────────────
+        let mock = MockServer::start().await;
+        let raw_reply = "晚安宝贝[你给对方发送了一张照片：海边自拍]";
+        let chat_body = format!(
+            "data: {{\"choices\":[{{\"delta\":{{\"content\":\"{raw_reply}\"}}}}],\
+\"usage\":{{\"prompt_tokens\":2,\"completion_tokens\":8,\"total_tokens\":10}},\
+\"id\":\"gen-t6a\",\"model\":\"mock/euryale\"}}\n\n\
+data: [DONE]\n\n"
+        );
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(chat_body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+
+        // ── 2. Seed persona + session ──────────────────────────────────────────
+        let user_id = uuid::Uuid::new_v4();
+        let (_g, instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+
+        // ── 3. Build AppState with output_regex that MATCHES the artifact ───────
+        //      Pattern: \s*\[你给对方发送了一张照片[：:][^\]]*\]\s*$  replacement "".
+        //      `[tasks.pde_decision].ghosting = false` forces a Reply turn.
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = std::sync::Arc::new(
+            eros_engine_llm::model_config::ModelConfig::from_toml_str(
+                "[tasks.chat_companion]\nmodel=\"mock/euryale\"\n\
+                 [tasks.pde_decision]\nghosting=false\n",
+            )
+            .unwrap(),
+        );
+        let regex_cfg = eros_engine_llm::model_config::ModelConfig::from_toml_str(
+            "[tasks.chat_companion]\nmodel=\"mock/euryale\"\n\
+             [[tasks.chat_companion.output_regex]]\n\
+             models=[\"mock/euryale\"]\n\
+             pattern=\"\\\\s*\\\\[你给对方发送了一张照片[：:][^\\\\]]*\\\\]\\\\s*$\"\n",
+        )
+        .unwrap();
+        state.output_regex = std::sync::Arc::new(
+            regex_cfg
+                .compile_output_regex()
+                .expect("artifact pattern compiles"),
+        );
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                eros_engine_llm::openrouter::AppAttribution::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+
+        // ── 4. Insert the user message ─────────────────────────────────────────
+        let chat_repo = ChatRepo { pool: &pool };
+        let umid = match chat_repo
+            .upsert_user_message_idempotent(
+                session_id,
+                "晚安",
+                "01JT5REGEX00000000000000B",
+                "user",
+                None,
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
+
+        // ── 5. Drive run_stream ────────────────────────────────────────────────
+        // NOTE: run_stream manages BurstOutcome internally; we verify
+        // produced[0].full_text indirectly via the DB `content` column, which
+        // equals `cleaned` (AfterExtract timing, regex-only path).
+        let frames: Vec<ProtocolFrame> = run_stream(
+            std::sync::Arc::new(state),
+            PersistedUserMessage {
+                user_message_id: umid,
+                session_id,
+                user_id,
+                instance_id,
+                content: "晚安".into(),
+                prompt_traits: vec![],
+                audit: None,
+                tier: None,
+                memory_scope: Default::default(),
+                affinity_scope: Default::default(),
+                tips_amount_usd: None,
+                image_url: None,
+                image: None,
+            },
+        )
+        .collect()
+        .await;
+
+        // ── 6. Assertions ─────────────────────────────────────────────────────
+        // No error frame.
+        assert!(
+            !frames
+                .iter()
+                .any(|f| matches!(f, ProtocolFrame::Error { .. })),
+            "no error frame expected; got {frames:?}",
+        );
+
+        // Collect all Delta frames — there must be exactly one (buffered mode).
+        let deltas: Vec<&str> = frames
+            .iter()
+            .filter_map(|f| match f {
+                ProtocolFrame::Delta { content, .. } => Some(content.as_str()),
+                _ => None,
+            })
+            .collect();
+
+        assert!(
+            !deltas.is_empty(),
+            "regex-targeted turn must produce a Reply bubble (ghosting disabled); got {frames:?}",
+        );
+        assert_eq!(
+            deltas.len(),
+            1,
+            "buffered mode must emit exactly one Delta bubble; got {deltas:?}",
+        );
+        // The bracket artifact must be stripped from the client-visible text.
+        assert_eq!(
+            deltas[0], "晚安宝贝",
+            "client must receive only the cleaned text (artifact stripped); got {:?}",
+            deltas[0],
+        );
+
+        // DB row: content, pre_filter_content, filter_model, filter_triggers.
+        let (content, pre_filter, filter_model, filter_triggers): (
+            String,
+            Option<String>,
+            Option<String>,
+            Option<serde_json::Value>,
+        ) = sqlx::query_as(
+            "SELECT content, pre_filter_content, filter_model, filter_triggers \
+             FROM engine.chat_messages \
+             WHERE session_id = $1 AND role = 'assistant' \
+             ORDER BY sent_at DESC LIMIT 1",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            content, "晚安宝贝",
+            "persisted content must be the stripped text; got {content:?}",
+        );
+        assert_eq!(
+            pre_filter.as_deref(),
+            Some("晚安宝贝[你给对方发送了一张照片：海边自拍]"),
+            "pre_filter_content must be the raw original; got {pre_filter:?}",
+        );
+        assert_eq!(
+            filter_model.as_deref(),
+            Some("<regex>"),
+            "filter_model must be '<regex>'; got {filter_model:?}",
+        );
+        assert_eq!(
+            filter_triggers,
+            Some(serde_json::json!({ "regex": [0usize] })),
+            "filter_triggers must be {{\"regex\":[0]}}; got {filter_triggers:?}",
+        );
+
+        // BurstOutcome.produced[0].full_text must be the cleaned text.
+        // run_stream owns the outcome internally; read from the DB row instead
+        // (content == cleaned == extracted for AfterExtract timing with regex-only).
+        // Additionally verify outcome.filtered == true via the re-queried row.
+        assert_eq!(
+            content, "晚安宝贝",
+            "extract input (produced[0].full_text) equals cleaned content; got {content:?}",
+        );
+    }
+
+    /// When the mock model returns a reply that does NOT match the output_regex
+    /// rule (no bracket artifact), the content must be stored verbatim and NO
+    /// filter audit columns must be written (pre_filter_content IS NULL, etc.).
+    /// BurstOutcome.filtered must be false.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn regex_no_match_persists_raw_no_audit(pool: PgPool) {
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+        use futures_util::StreamExt;
+        use wiremock::matchers::path as wm_path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        // ── 1. Mock OpenRouter: reply has NO bracket artifact ──────────────────
+        let mock = MockServer::start().await;
+        let chat_body = "data: {\"choices\":[{\"delta\":{\"content\":\"晚安宝贝\"}}],\
+\"usage\":{\"prompt_tokens\":2,\"completion_tokens\":4,\"total_tokens\":6},\
+\"id\":\"gen-t6b\",\"model\":\"mock/euryale\"}\n\n\
+data: [DONE]\n\n";
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(chat_body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+
+        // ── 2. Seed persona + session ──────────────────────────────────────────
+        let user_id = uuid::Uuid::new_v4();
+        let (_g, instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+
+        // ── 3. Build AppState with the same output_regex rule (won't match) ────
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = std::sync::Arc::new(
+            eros_engine_llm::model_config::ModelConfig::from_toml_str(
+                "[tasks.chat_companion]\nmodel=\"mock/euryale\"\n\
+                 [tasks.pde_decision]\nghosting=false\n",
+            )
+            .unwrap(),
+        );
+        let regex_cfg = eros_engine_llm::model_config::ModelConfig::from_toml_str(
+            "[tasks.chat_companion]\nmodel=\"mock/euryale\"\n\
+             [[tasks.chat_companion.output_regex]]\n\
+             models=[\"mock/euryale\"]\n\
+             pattern=\"\\\\s*\\\\[你给对方发送了一张照片[：:][^\\\\]]*\\\\]\\\\s*$\"\n",
+        )
+        .unwrap();
+        state.output_regex = std::sync::Arc::new(
+            regex_cfg
+                .compile_output_regex()
+                .expect("artifact pattern compiles"),
+        );
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                eros_engine_llm::openrouter::AppAttribution::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+
+        // ── 4. Insert the user message ─────────────────────────────────────────
+        let chat_repo = ChatRepo { pool: &pool };
+        let umid = match chat_repo
+            .upsert_user_message_idempotent(
+                session_id,
+                "晚安",
+                "01JT5REGEX00000000000000C",
+                "user",
+                None,
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
+
+        // ── 5. Drive run_stream ────────────────────────────────────────────────
+        let frames: Vec<ProtocolFrame> = run_stream(
+            std::sync::Arc::new(state),
+            PersistedUserMessage {
+                user_message_id: umid,
+                session_id,
+                user_id,
+                instance_id,
+                content: "晚安".into(),
+                prompt_traits: vec![],
+                audit: None,
+                tier: None,
+                memory_scope: Default::default(),
+                affinity_scope: Default::default(),
+                tips_amount_usd: None,
+                image_url: None,
+                image: None,
+            },
+        )
+        .collect()
+        .await;
+
+        // ── 6. Assertions ─────────────────────────────────────────────────────
+        // No error frame.
+        assert!(
+            !frames
+                .iter()
+                .any(|f| matches!(f, ProtocolFrame::Error { .. })),
+            "no error frame expected; got {frames:?}",
+        );
+
+        // Collect Delta frames.
+        let deltas: Vec<&str> = frames
+            .iter()
+            .filter_map(|f| match f {
+                ProtocolFrame::Delta { content, .. } => Some(content.as_str()),
+                _ => None,
+            })
+            .collect();
+
+        assert!(
+            !deltas.is_empty(),
+            "regex-targeted turn must produce a Reply bubble (ghosting disabled); got {frames:?}",
+        );
+        assert_eq!(
+            deltas[0], "晚安宝贝",
+            "unmatched rule must not alter the reply; got {:?}",
+            deltas[0],
+        );
+
+        // DB row: content == "晚安宝贝", audit columns all NULL.
+        let (content, pre_filter, filter_model, filter_triggers): (
+            String,
+            Option<String>,
+            Option<String>,
+            Option<serde_json::Value>,
+        ) = sqlx::query_as(
+            "SELECT content, pre_filter_content, filter_model, filter_triggers \
+             FROM engine.chat_messages \
+             WHERE session_id = $1 AND role = 'assistant' \
+             ORDER BY sent_at DESC LIMIT 1",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            content, "晚安宝贝",
+            "persisted content must be the raw reply; got {content:?}",
+        );
+        assert!(
+            pre_filter.is_none(),
+            "pre_filter_content must be NULL when no rule matches; got {pre_filter:?}",
+        );
+        assert!(
+            filter_model.is_none(),
+            "filter_model must be NULL when no rule matches; got {filter_model:?}",
+        );
+        assert!(
+            filter_triggers.is_none(),
+            "filter_triggers must be NULL when no rule matches; got {filter_triggers:?}",
         );
     }
 }

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -704,6 +704,7 @@ pub(crate) fn test_state(pool: sqlx::PgPool) -> AppState {
         )),
         voyage: Arc::new(eros_engine_llm::voyage::VoyageClient::new("stub".into())),
         model_config: Arc::new(eros_engine_llm::model_config::ModelConfig::default()),
+        output_regex: std::sync::Arc::new(Vec::new()),
         stream_slots: std::sync::Arc::new(crate::state::StreamSlots::default()),
     }
 }

--- a/crates/eros-engine-server/src/state.rs
+++ b/crates/eros-engine-server/src/state.rs
@@ -14,6 +14,9 @@ pub struct AppState {
     pub openrouter: Arc<eros_engine_llm::openrouter::OpenRouterClient>,
     pub voyage: Arc<eros_engine_llm::voyage::VoyageClient>,
     pub model_config: Arc<eros_engine_llm::model_config::ModelConfig>,
+    /// Compiled `[tasks.chat_companion].output_regex` rules, built once at boot
+    /// (fail-fast). Empty when none configured. Read by `drive_chat_burst`.
+    pub output_regex: Arc<Vec<eros_engine_llm::model_config::CompiledRegexRule>>,
     pub stream_slots: Arc<StreamSlots>,
 }
 

--- a/crates/eros-engine-store/Cargo.toml
+++ b/crates/eros-engine-store/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "memory", "pgvector", "postgres", "sqlx"]
 categories = ["database"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "0.7.0-dev" }
+eros-engine-core = { path = "../eros-engine-core", version = "0.6.6-dev" }
 sqlx = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/docs/model-config.md
+++ b/docs/model-config.md
@@ -212,7 +212,7 @@ output_regex = [
 
 | Field | Type | Required | Notes |
 |---|---|---|---|
-| `models` | `Array<String>` | yes | Model ids whose replies this rule applies to. Exact string match against the model id that produced the reply (same id as `filter_model` on the row). |
+| `models` | `Array<String>` | yes | Model ids whose replies this rule applies to. Exact string match against the chat model id that produced the reply — i.e. the row's `model` column, NOT `filter_model` (which is set to `"<regex>"` when a strip fires). |
 | `pattern` | `String` | yes | Rust `regex` crate pattern. **No lookaround or backreferences** — anchor with `$`, `^`, `\s*`, char classes. An invalid pattern causes server boot to fail. |
 | `replacement` | `String` | no | Text to substitute for each match. Absent or `""` = delete the match. |
 

--- a/docs/model-config.md
+++ b/docs/model-config.md
@@ -184,11 +184,73 @@ when the frame is emitted.
 
 | Field | Type | Notes |
 |---|---|---|
-| `filtered` | `bool` | `true` if the output filter ran and rewrote the reply for this turn; `false` otherwise. |
+| `filtered` | `bool` | `true` if the client received non-raw output this turn — set by the regex strip (`output_regex`), the LLM `output_filter`, or both; `false` otherwise. |
 | `retries_chat` | `u32` | Number of fallback retries consumed by the chat model call (0 = primary succeeded). |
 | `retries_filter` | `u32` | Number of fallback retries consumed by the filter model call (0 = primary succeeded or filter did not run). |
 | `prompt_injected` | `Array<String>` \| `null` | Trait tags that were injected into the prompt this turn, or `null` if none. Independent of the filter. |
 | `tier` | `String` \| `null` | Echo of the `tier` field from the request, or `null` if none was sent. Independent of the filter. |
+
+### `output_regex` — deterministic per-model regex strip (chat task only)
+
+`output_regex` is an array of strip rules on `[tasks.chat_companion]` (task-level
+only — no per-tier override). Each rule deletes or replaces regex matches in the
+assistant reply produced by any model in `models`. It is **off by default** (absent
+or empty array means no stripping).
+
+```toml
+[tasks.chat_companion]
+output_regex = [
+  # Strip L3.3-Euryale's self-narrated photo line on reply_text_image turns.
+  { models = ["sao10k/l3.3-euryale-70b"],
+    pattern = '\s*\[你给对方发送了一张照片[：:][^\]]*\]\s*$' },
+  # Replace matches instead of deleting (replacement defaults to "" = delete):
+  # { models = ["x/y"], pattern = '...', replacement = "…" },
+]
+```
+
+#### Rule shape
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `models` | `Array<String>` | yes | Model ids whose replies this rule applies to. Exact string match against the model id that produced the reply (same id as `filter_model` on the row). |
+| `pattern` | `String` | yes | Rust `regex` crate pattern. **No lookaround or backreferences** — anchor with `$`, `^`, `\s*`, char classes. An invalid pattern causes server boot to fail. |
+| `replacement` | `String` | no | Text to substitute for each match. Absent or `""` = delete the match. |
+
+Rules are checked in declaration order; all matching rules are applied sequentially
+to the same reply.
+
+#### Execution order — layer 0
+
+The regex strip runs **before** any other processing:
+
+1. Regex strip (layer 0) — applied first, before the client sees anything
+2. LLM `output_filter` (if enabled) — second pass
+3. Memory / insight / affinity extraction — reads the already-stripped text
+
+The matched text therefore reaches **neither** the client **nor** the stored
+`content` **nor** the extract pipeline — regardless of `timing` on
+`[tasks.chat_output_filter]`.
+
+#### Audit columns
+
+| Column | Value when strip fires |
+|---|---|
+| `pre_filter_content` | The raw (pre-strip) reply |
+| `filter_model` | `"<regex>"` |
+
+These columns are set only when at least one rule actually changes the reply (same
+as the LLM filter — a no-op strip leaves them null).
+
+#### Empty-result fail-safe
+
+A strip that would reduce a non-empty reply to an empty string is a **no-op** — the
+original reply is delivered unchanged and the audit columns are not set. This
+prevents an over-broad pattern from silencing the companion.
+
+#### `filtered` flag
+
+The SSE `final`-frame `filtered` field is `true` when the client received non-raw
+output from **either** the regex strip **or** the LLM `output_filter` (or both).
 
 ### `input_filter` — user-input rewrite (chat task only)
 
@@ -447,6 +509,12 @@ What may still change without notice:
   is inert). See "output_filter — second-pass reply rewrite" above.
 - SSE `final`-frame fields `filtered`, `retries_chat`, `retries_filter`,
   `prompt_injected`, `tier`: added in 0.x.
+- `output_regex` (optional array, `[tasks.chat_companion]`): added in 0.x.
+  Task-level only (no per-tier override). Deterministic regex strips applied
+  before the client sees the reply, before the LLM `output_filter`, and before
+  extract. The `filtered` flag is `true` when either the regex strip or the LLM
+  filter (or both) produced non-raw output. See "`output_regex` — deterministic
+  per-model regex strip" above.
 
 ## What this config does NOT control
 

--- a/docs/model-config.zh.md
+++ b/docs/model-config.zh.md
@@ -172,11 +172,63 @@ chat SSE stream 结束时发出的 `final` event 包含几个新字段。无论 
 
 | 字段 | 类型 | 说明 |
 |---|---|---|
-| `filtered` | `bool` | 当前轮次 output filter 已运行并改写回复时为 `true`；否则为 `false`。 |
+| `filtered` | `bool` | 当前轮次客户端收到的是非原始输出时为 `true`——由 regex 过滤（`output_regex`）、LLM `output_filter` 或两者同时触发时置为 `true`；否则为 `false`。 |
 | `retries_chat` | `u32` | chat 模型调用消耗的 fallback 重试次数（0 = primary 成功）。 |
 | `retries_filter` | `u32` | filter 模型调用消耗的 fallback 重试次数（0 = primary 成功或 filter 未运行）。 |
 | `prompt_injected` | `Array<String>` \| `null` | 当前轮次注入 prompt 的 trait tag；若无则为 `null`。与 filter 无关。 |
 | `tier` | `String` \| `null` | 原样返回请求中的 `tier` 字段；若未发送则为 `null`。与 filter 无关。 |
+
+### `output_regex` — 确定性 per-model 正则过滤（仅限 chat 任务）
+
+`output_regex` 是 `[tasks.chat_companion]` 上的规则数组（仅限任务级——无 per-tier 覆盖）。每条规则对 `models` 中任意模型生成的助手回复进行正则匹配，删除或替换匹配内容。**默认关闭**（缺失或空数组均表示不过滤）。
+
+```toml
+[tasks.chat_companion]
+output_regex = [
+  # 在 reply_text_image 轮次中，去掉 L3.3-Euryale 自述的发图行。
+  { models = ["sao10k/l3.3-euryale-70b"],
+    pattern = '\s*\[你给对方发送了一张照片[：:][^\]]*\]\s*$' },
+  # 替换而非删除（replacement 默认 "" = 删除）：
+  # { models = ["x/y"], pattern = '...', replacement = "…" },
+]
+```
+
+#### 规则结构
+
+| 字段 | 类型 | 必填 | 说明 |
+|---|---|---|---|
+| `models` | `Array<String>` | 是 | 此规则适用的模型 id 列表。与生成回复的模型 id 进行精确字符串匹配（与行上的 `filter_model` 相同）。 |
+| `pattern` | `String` | 是 | Rust `regex` crate 正则表达式。**不支持 lookaround 或反向引用**——请使用 `$`、`^`、`\s*`、字符类等锚定。无效 pattern 会导致服务器启动失败。 |
+| `replacement` | `String` | 否 | 替换每个匹配项的文本。缺失或 `""` = 删除匹配内容。 |
+
+规则按声明顺序检查；所有匹配规则依次作用于同一条回复。
+
+#### 执行顺序——第 0 层
+
+Regex 过滤在所有其他处理之前运行：
+
+1. Regex 过滤（第 0 层）——最先执行，客户端看到任何内容之前
+2. LLM `output_filter`（如已启用）——第二轮处理
+3. Memory / insight / affinity 提取——读取已过滤后的文本
+
+因此，匹配到的文本**既不会到达客户端**，**也不会写入 `content`**，**更不会进入提取流水线**——与 `[tasks.chat_output_filter]` 的 `timing` 设置无关。
+
+#### 审计列
+
+| 列 | 过滤生效时的值 |
+|---|---|
+| `pre_filter_content` | 过滤前的原始回复 |
+| `filter_model` | `"<regex>"` |
+
+仅当至少一条规则实际改变了回复时才会设置这些列（与 LLM filter 行为一致——无变更的过滤不会设置这些列）。
+
+#### 空结果 fail-safe
+
+若某次过滤会将非空回复变为空字符串，则该次过滤为**空操作**——原始回复原样交付，审计列不被设置。此机制防止过于宽泛的 pattern 让伴侣陷入沉默。
+
+#### `filtered` 标志
+
+SSE `final` frame 的 `filtered` 字段在客户端收到的是非原始输出时为 `true`——由 **regex 过滤**、LLM `output_filter` 或两者同时触发均会置为 `true`。
 
 ### `input_filter` — 用户输入改写（仅限 chat 任务）
 
@@ -381,6 +433,7 @@ model = { "x-ai/grok-4.20" = 0.8, "z-ai/glm-4.7-flash" = 0.2 }  # weighted rando
 - `output_filter`（可选 bool，位于 `[tasks.chat_companion]` 和 per-tier 中）：在 0.x 中新增。默认为 `false`。通过 `[tasks.chat_output_filter]` 启用二次回复改写。
 - `[tasks.chat_output_filter]`（新任务）：在 0.x 中新增。默认缺失（filter 不生效）。参见上文“`output_filter` — 二次回复改写”。
 - SSE `final` frame 字段 `filtered`、`retries_chat`、`retries_filter`、`prompt_injected`、`tier`：在 0.x 中新增。
+- `output_regex`（可选数组，位于 `[tasks.chat_companion]`）：在 0.x 中新增。仅限任务级（无 per-tier 覆盖）。在客户端看到回复之前、LLM `output_filter` 之前、提取之前应用的确定性 regex 过滤。regex 过滤或 LLM filter（或两者）产生非原始输出时，`filtered` 标志均为 `true`。参见上文"`output_regex` — 确定性 per-model 正则过滤"。
 
 ## 此配置不控制的内容
 

--- a/docs/model-config.zh.md
+++ b/docs/model-config.zh.md
@@ -197,7 +197,7 @@ output_regex = [
 
 | 字段 | 类型 | 必填 | 说明 |
 |---|---|---|---|
-| `models` | `Array<String>` | 是 | 此规则适用的模型 id 列表。与生成回复的模型 id 进行精确字符串匹配（与行上的 `filter_model` 相同）。 |
+| `models` | `Array<String>` | 是 | 此规则适用的模型 id 列表。与生成回复的 chat 模型 id 进行精确字符串匹配——即行上的 `model` 列，而非 `filter_model`（过滤生效时 `filter_model` 被设为 `"<regex>"`）。 |
 | `pattern` | `String` | 是 | Rust `regex` crate 正则表达式。**不支持 lookaround 或反向引用**——请使用 `$`、`^`、`\s*`、字符类等锚定。无效 pattern 会导致服务器启动失败。 |
 | `replacement` | `String` | 否 | 替换每个匹配项的文本。缺失或 `""` = 删除匹配内容。 |
 

--- a/docs/superpowers/specs/2026-06-28-per-model-output-regex-filter-design.md
+++ b/docs/superpowers/specs/2026-06-28-per-model-output-regex-filter-design.md
@@ -1,0 +1,318 @@
+# eros-engine — Per-model deterministic regex output filter (Spec)
+
+**Status**: design, pending implementation plan
+**Target release**: `0.6.6-dev` track; additive TOML schema, **no store migration**
+**Audience**: anyone implementing the engine-side `[tasks.chat_companion].output_regex` strip
+
+---
+
+## 0. Background
+
+The streaming chat path (`crates/eros-engine-server/src/pipeline/stream.rs`,
+`drive_chat_burst`) generates an assistant reply token-by-token, accumulating the
+full text in `acc`, persisting one `chat_messages` row (`content = acc`), and
+pushing a `ProducedMessage { full_text }` to `post_process` for the three
+"extract" jobs (insight extraction, two-layer memory write, six-axis affinity).
+
+On `reply_text_image` turns, the **L3.3-Euryale-70B** chat model (and similar
+small roleplay models) appends a self-narrated artifact to the end of its reply,
+e.g. `[你给对方发送了一张照片：…]`. This is harmful on two axes:
+
+- **(a) It misleads the user.** The bracketed text is the *chat model's*
+  invention, not what the PDE actually decided to draw / send. The user sees a
+  description of a photo that does not correspond to the generated image.
+- **(b) It pollutes context.** The verbatim reply is fed back into the next
+  prompt through two channels (the 20-turn `recent_conversation` window and the
+  persistent `companion_memories` write), so the boilerplate becomes recallable
+  and self-reinforcing. This is the same long-term channel pollution described in
+  **issue #113** (verbatim assistant prose persisted as uncategorized
+  `companion_memories`, re-recalled into `[shared_memories]`).
+
+This spec addresses the **targeted artifact**: a deterministic, per-model regex
+strip of the assistant's raw output. It is **not** the #113 fix — #113's root
+cause (verbatim-memory persistence, recall dedup, full-sentence anti-repetition)
+remains a separate, larger spec. The regex strip is a low-cost mitigation: by
+stripping before the extract split (§2.4), the bracket artifact never reaches the
+memory/history channels at all.
+
+### Relationship to the existing LLM `output_filter`
+
+A separate, already-shipped feature
+(`docs/superpowers/specs/2026-05-25-chat-output-filter-design.md`) runs a
+**second LLM** to rewrite the reply, storing the original in `pre_filter_content`
+and routing the turn through a buffered (no live `Delta`) emit path. This spec is
+**distinct**: deterministic (no LLM call), always-on when a rule matches the
+producing model (no random/trigger sampling), and purpose-fixed (remove a known
+model artifact). It **reuses** the LLM filter's plumbing — the buffered emit
+path, the `pre_filter_content` / `filter_model` / `filter_triggers` audit columns
+(`FilterAudit`), and the final-frame `filtered` flag — and **composes** with it
+when both are configured (§2.5).
+
+---
+
+## 1. Goal / Non-goals
+
+**Goal:** a TOML-driven, per-model **deterministic** regex strip for
+`chat_companion` replies with:
+- an `output_regex` array of `{ models, pattern, replacement? }` rules on
+  `[tasks.chat_companion]`,
+- patterns compiled & validated at config load (fail-fast),
+- the strip applied as **layer 0** — before the client emit, before the optional
+  LLM `output_filter`, and before the extract split — so the artifact reaches
+  neither the client, the persisted `content`, nor the memory/insight/affinity
+  extract input,
+- the raw original retained on the assistant row's `pre_filter_content`,
+- audit via the existing `filter_model` / `filter_triggers` columns.
+
+**Non-goals / explicit boundaries:**
+- **Not enabled by default.** Absent/empty `output_regex` ⇒ byte-identical to
+  today's stream (live deltas, multi-bubble fallback chaining).
+- **No store migration.** Reuses `pre_filter_content` / `filter_model` /
+  `filter_triggers`.
+- **No LLM call.** Pure in-process `regex` replacement.
+- **No per-tier override.** A model emits the same artifact regardless of tier;
+  rules are resolved at task level only (§2.1).
+- Scope is the chat reply path only (`Reply` + `GiftReaction`, both via
+  `drive_chat_burst`). `Ghost` (no content) and `Proactive` (not on this path)
+  are unaffected. Not applied to non-chat tasks (insight/affinity/memory).
+- **Not the #113 fix.** Mitigates the bracket artifact only; the verbatim-memory
+  root cause is out of scope.
+
+---
+
+## 2. Design
+
+### 2.1 Config schema (`model_config.toml`)
+
+On `[tasks.chat_companion]`:
+
+```toml
+[tasks.chat_companion]
+# ...existing fields...
+output_regex = [
+  { models = ["sao10k/l3.3-euryale-70b"],
+    pattern = '\s*\[你给对方发送了一张照片[：:][^\]]*\]\s*$' },
+  # { models = ["x/y", "x/z"], pattern = '...', replacement = "…" },
+]
+```
+
+- `output_regex` is an **array of rules**. Each rule:
+  - `models: Vec<String>` — exact OpenRouter model ids the rule applies to.
+  - `pattern: String` — a Rust `regex`-crate pattern.
+  - `replacement: Option<String>` — substituted for each match; **default `""`**
+    (delete the match).
+- **Task-level only.** No `[tasks.chat_companion.tiers.<t>]` override for
+  `output_regex` (deliberately omitted — see Non-goals). The field is read from
+  the task block directly, not via tier resolution.
+- **Exact model-id matching.** A rule applies to a producing model iff
+  `model_id ∈ rule.models` (string equality), consistent with the existing
+  `output_filter` `trigger.models`. Operators list every variant id they want
+  covered.
+- A model may be named by multiple rules; all matching rules apply, in
+  declaration order (§2.4).
+
+### 2.2 Config types (`model_config.rs`)
+
+Follows the existing "generic field on `TaskConfig`, inert on other tasks"
+pattern. On `TaskConfig` (NOT `TierConfig`):
+
+```rust
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct OutputRegexRule {
+    pub models: Vec<String>,
+    pub pattern: String,
+    #[serde(default)]
+    pub replacement: Option<String>,    // None ⇒ "" (delete)
+}
+
+// on TaskConfig:
+#[serde(default)]
+pub output_regex: Vec<OutputRegexRule>,  // empty when absent
+```
+
+The raw `pattern` strings are **compiled and validated at config load**
+(`Config::load`): each pattern is passed to `regex::Regex::new`; a compile error
+aborts load with a descriptive message (`task.chat_companion.output_regex[i]:
+invalid pattern: …`). Compiled `Regex` values are cached for reuse — a resolved
+structure, e.g.:
+
+```rust
+pub struct CompiledRegexRule {
+    pub models: Vec<String>,
+    pub regex: regex::Regex,
+    pub replacement: String,   // "" when rule.replacement is None
+}
+```
+
+built once and held on the loaded config (alongside the existing resolved
+state), exposed via an accessor like
+`Config::output_regex_rules() -> &[CompiledRegexRule]`. This adds the `regex`
+crate as a dependency of `eros-engine-llm`.
+
+> **`regex`-crate caveat:** no lookaround / backreferences. Operators anchor with
+> `$`, `^`, `\s*`, character classes, etc. The euryale pattern above is
+> compatible.
+
+### 2.3 Resolution & gating
+
+`output_regex` does **not** go through tier resolution. The chat handler reads
+the compiled rules once per request. A turn is subject to the strip iff at least
+one rule's `models` intersects the turn's resolved model **chain** (primary +
+fallbacks) — this drives the buffered-mode decision in §2.4. Absent/empty rules
+⇒ no strip, live mode, unchanged behavior.
+
+### 2.4 Runtime flow (`drive_chat_burst`) — strip is "layer 0"
+
+`drive_chat_burst` already computes the `chain` (`[primary] + fallback_model`) at
+the top, and selects **live vs. buffered** mode via
+`filtered_mode = filter.trigger.turn_level_pass(...)`.
+
+**Mode selection gains one term:**
+
+```
+buffered  iff  filtered_mode (existing LLM-filter condition)
+          OR   chain ∩ (⋃ rule.models for rules in output_regex) ≠ ∅
+```
+
+- If no rule's `models` intersects the chain, no rule can ever match ⇒ stay
+  **live**, byte-identical to today (live deltas, multi-bubble fallback).
+- If the chain could produce a targeted model, enter **buffered** mode (whole
+  reply accumulated, single bubble, no live deltas) so the artifact is never
+  streamed.
+
+Two implementation consequences of this widened condition:
+
+- **The buffered branch must tolerate `filter = None`** (a regex-only turn, where
+  the LLM `output_filter` is not configured but a regex rule targets the chain).
+  Today's buffered branch unconditionally references the resolved LLM filter `f`
+  (`f.trigger`, `f.timing`, `run_output_filter`); it must be refactored to run
+  with no LLM filter — skip the filter call, and default the extract timing to
+  `after_extract` (with `original = visible = cleaned`, so extract sees the
+  cleaned text either way).
+- **Targeted turns always emit a single bubble**, even when no pattern actually
+  matches (multi-bubble fallback chaining collapses to one bubble, exactly as the
+  LLM filter's "filtered mode" already does — see the output-filter spec §2.6).
+  This is the price of buffering to hide the artifact; it affects only turns whose
+  model chain intersects a rule.
+
+**Per-attempt pipeline order** (buffered mode), extending today's sequence:
+
+```
+accumulate acc
+  → byte-BPE garble repair (existing: looks_byte_garbled / repair_byte_bpe)
+  → REGEX STRIP:  cleaned = apply_output_regex(rules, model_id, repaired_acc)
+  → (optional) LLM output_filter runs on `cleaned`  (if filtered_mode + per-attempt models-hit)
+  → emit `cleaned` (or LLM-filtered text) as the bubble's Delta
+  → persist + extract  (§2.5)
+```
+
+`apply_output_regex` is a **pure function**: for each rule whose `models`
+contains `model_id`, apply `rule.regex.replace_all(text, &rule.replacement)` in
+declaration order, threading the result. The strip runs **after** byte-BPE repair
+(so it matches the repaired form) and **before** the LLM filter and the extract
+split.
+
+Because the strip is layer 0, `cleaned` becomes the single new baseline for
+**everything** downstream — client emit, persisted `content`, LLM-filter input,
+and extract input. The artifact therefore reaches none of those channels,
+regardless of the LLM filter's `after_extract` / `before_extract` timing.
+
+**Edge case — empty result:** if `cleaned.trim()` is empty (the model emitted
+*only* the artifact), **fail-safe to the raw `acc`**: emit/persist the raw text
+(never an empty bubble), record no strip, and log at `warn`. This is a defensive
+guard; `reply_text_image` text is not expected to be bracket-only.
+
+`extract_text` (the original-vs-visible chooser) is unaffected in shape: its
+`original` argument is now `cleaned` (post-strip) rather than the raw `acc`, so
+`after_extract` feeds extract the cleaned text and `before_extract` feeds the
+LLM-filtered text — both artifact-free.
+
+### 2.5 Persistence & audit (reuse `pre_filter_content`)
+
+When the regex strip changes the text (`cleaned != acc`), the assistant row is
+written via the existing `FilterAudit` path:
+
+- `content` = `cleaned` (or the LLM-filtered text if the LLM `output_filter` also
+  ran on top).
+- `pre_filter_content` = the **raw `acc`** (true original, artifact included).
+- `filter_model` / `filter_triggers`:
+  - **Regex-only strip** (no LLM filter): `filter_model = "<regex>"` (reserved
+    sentinel — lets a reader distinguish "a filter ran" from "no filter", same
+    role `filter_model` plays today), `filter_triggers = {"regex": [<matched rule
+    indices>]}`.
+  - **Regex + LLM filter both fire:** the LLM filter owns `filter_model` (its real
+    model id, as today); the regex hit is folded into `filter_triggers`
+    (`{"reason": …, "regex": [<indices>]}`). `pre_filter_content` is the raw
+    `acc` (strip is layer 0, so raw `acc` is the true pre-everything original).
+  - `f_generation_id` / `f_client_msg_id` pertain to the LLM-filter call only;
+    `None`/absent on a regex-only strip.
+- When the strip makes **no change** (no rule matched, or pattern matched
+  nothing): no `FilterAudit` is written — row persists `content = acc`,
+  `pre_filter_content` NULL — same as a non-filtered turn.
+
+**Replay** is unchanged: it replays stored `content` (the cleaned text); the raw
+remains recoverable from `pre_filter_content` for audit.
+
+### 2.6 Final-frame `filtered`
+
+`ProtocolFrame::Final.filtered` is set `true` when the client received non-raw
+output from **either** mechanism — the regex strip *or* the LLM rewrite. The
+row's `filter_model` / `filter_triggers` disambiguate which fired. This widens
+the field's meaning from "LLM filter rewrote" to "client saw transformed
+output"; `retries_filter` stays LLM-filter-specific (`0` on a regex-only strip).
+
+### 2.7 Scope
+
+Honored for `chat_companion` replies streamed through `drive_chat_burst`: both
+`Reply` and `GiftReaction`. `Ghost` (no content) and `Proactive` (not on this
+path) are unaffected. `output_regex` set on other task blocks parses but is inert
+(consistent with the rest of the config — no `deny_unknown_fields`).
+
+---
+
+## 3. Testing
+
+- **Config parse/validate:** `output_regex` array parses with and without
+  `replacement`; an invalid `pattern` aborts `Config::load` with a descriptive
+  error; absent ⇒ empty rules; multiple rules and multi-model rules parse.
+- **`apply_output_regex` (pure):** given (rules, `model_id`, text):
+  - non-targeted `model_id` ⇒ text unchanged, no matched indices;
+  - single rule strips the euryale bracket suffix; result is artifact-free;
+  - multiple matching rules apply in declaration order;
+  - `replacement` non-empty is honored;
+  - pattern matches nothing ⇒ unchanged, no audit;
+  - **empty/blank result ⇒ fail-safe returns raw, flagged "no change".**
+- **Mode selection:** chain with a targeted model ⇒ buffered; chain with no
+  targeted model ⇒ live (byte-identical to today).
+- **Stream (wiremock for chat model):**
+  - targeted model emits `…text…[你给对方发送了一张照片：…]` ⇒ client receives
+    **only** the cleaned deltas (bracket never streamed); row `content` = cleaned,
+    `pre_filter_content` = raw, `filter_model = "<regex>"`, `filter_triggers.regex`
+    = matched indices; **`produced.full_text` (extract) = cleaned** (artifact
+    absent from the memory channel);
+  - non-targeted model's chain ⇒ live mode, byte-identical to today;
+  - regex + LLM `output_filter` both configured ⇒ LLM runs on the cleaned text;
+    `filter_model` = LLM model, `filter_triggers` carries both `reason` and
+    `regex`; `pre_filter_content` = raw;
+  - strip empties the reply ⇒ raw emitted/persisted, no empty bubble, no audit.
+- **Final frame:** `filtered = true` on a regex strip; `false` when no rule
+  matched. Update existing `final_frame_*` constructor tests if needed.
+- **Committed example config:** parses; with `output_regex` absent/commented,
+  resolve ⇒ no rules (off by default).
+
+---
+
+## 4. Rollout
+
+- `examples/model_config.toml`: ship `output_regex` **commented out** under
+  `[tasks.chat_companion]` with a doc-comment covering the rule shape
+  (`models` / `pattern` / `replacement`), the exact-model-id matching, the
+  worked euryale `reply_text_image` example, and the `regex`-crate caveat
+  (no lookaround/backrefs).
+- `docs/model-config.md`: document the field, exact-model-id matching, the
+  layer-0 / extract semantics (artifact removed from client + history + memory),
+  the empty-result fail-safe, and the `pre_filter_content` audit
+  (`filter_model = "<regex>"`).
+- Additive TOML schema; default behavior unchanged (off unless configured).
+- Dev-track feature: lands on a `feat/output-regex-filter` branch → PR into
+  `dev` → ships in a `0.6.6-dev` cut.

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -87,6 +87,7 @@ model_name_display_override = true
 #fallback     = ["thedrummer/cydonia-24b-v4.1", "x-ai/grok-4.3"]
 #allow_traits = ["nsfw_boost", "politics_open"]
 
+# (belongs to the [tasks.chat_companion] table above)
 # Deterministic per-model regex strips for the assistant reply. Task-level only
 # (no per-tier override). Each rule deletes (or replaces) matches in replies
 # produced by any model in `models`. Applied BEFORE the client sees the reply,

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -87,6 +87,21 @@ model_name_display_override = true
 #fallback     = ["thedrummer/cydonia-24b-v4.1", "x-ai/grok-4.3"]
 #allow_traits = ["nsfw_boost", "politics_open"]
 
+# Deterministic per-model regex strips for the assistant reply. Task-level only
+# (no per-tier override). Each rule deletes (or replaces) matches in replies
+# produced by any model in `models`. Applied BEFORE the client sees the reply,
+# before any LLM output_filter, and before memory/insight/affinity extract — so
+# the matched text reaches neither the client nor the stored history/memory. The
+# raw reply is kept on the row's pre_filter_content (filter_model = "<regex>").
+# Uses the Rust `regex` crate: NO lookaround/backreferences — anchor with $, ^,
+# \s*, char classes. An invalid pattern fails server boot.
+# output_regex = [
+#   # Strip L3.3-Euryale's self-narrated photo line on reply_text_image turns.
+#   { models = ["sao10k/l3.3-euryale-70b"],
+#     pattern = '\s*\[你给对方发送了一张照片[：:][^\]]*\]\s*$' },
+#   # { models = ["x/y"], pattern = '...', replacement = "…" },  # replacement default "" = delete
+# ]
+
 # ── Optional output filter (OFF by default) ──────────────────────────────
 # Rewrites the chat reply through a second LLM before the client sees it.
 # Enable per-tier (or globally) with `output_filter` on [tasks.chat_companion]:


### PR DESCRIPTION
## Summary

Adds an **`output_regex`** array on `[tasks.chat_companion]` that deterministically strips a known per-model artifact from the assistant reply — before the client sees it, before the optional LLM `output_filter`, and before the memory/insight/affinity extract ("layer 0"). The raw reply is retained on `pre_filter_content` for audit.

**Motivation:** the L3.3-Euryale model appends a self-narrated `[你给对方发送了一张照片：…]` line on `reply_text_image` turns. It (a) misleads the user (the bracket text is the chat model's invention, not what the PDE drew) and (b) pollutes context — the verbatim reply is fed back into later prompts via the 20-turn window and `companion_memories`. This is a targeted, low-cost mitigation of the long-term-channel pollution described in **#113** (it is *not* the full #113 fix — verbatim-memory persistence / recall dedup remain a separate spec).

## Design (spec: `docs/superpowers/specs/2026-06-28-per-model-output-regex-filter-design.md`)

- `output_regex = [{ models, pattern, replacement? }]` — task-level, exact model-id match; `replacement` default `""` = delete.
- Patterns **compile/validate at boot** (fail-fast, naming the bad rule index) into `Vec<CompiledRegexRule>` on `AppState`.
- A turn whose resolved model chain intersects a rule's `models` routes through the existing **buffered** emit path, so the artifact is never streamed. After byte-BPE repair, `apply_output_regex` produces `cleaned`, which becomes the single baseline for client emit, persisted `content`, the LLM-filter input, **and** the extract input — so the artifact reaches none of those channels.
- **Audit:** `pre_filter_content` = raw reply; `filter_model = "<regex>"`; `filter_triggers = {"regex":[indices]}`. When the LLM `output_filter` also fires, it runs on `cleaned`, `filter_model` is the LLM model, `pre_filter_content` stays the raw reply, and the regex hit folds into `filter_triggers`.
- **Empty-result fail-safe:** a strip that would blank a non-empty reply is a no-op.
- Final-frame `filtered` is `true` when the client received non-raw output from the regex strip *or* the LLM filter.

## Scope / safety

- **Default off** — absent/empty `output_regex` is byte-identical to today (live deltas, multi-bubble fallback). Non-targeted turns are untouched.
- **No store migration.** Reuses the existing `pre_filter_content` / `filter_model` / `filter_triggers` columns.
- **No HTTP-contract change** (OpenAPI: no drift).
- Also reopens the dev line at **`0.6.6-dev`** (separate commit) and ships the spec.

## Tests / gate

- `cargo test --workspace`: **628 passed / 0 failed**.
- `cargo fmt --check` clean; `cargo clippy --workspace --all-targets -D warnings` clean; OpenAPI no drift.
- Coverage: config parse/compile/apply units (incl. fail-safe); stream tests via `drive_chat_burst` asserting the **extract input** is the cleaned text (the #113 guard, proven with an `&acc`-regression red/green); regex+LLM-filter **both-fire** composition; buffered-without-change and no-match paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)