### PR TITLE
feat: image iteration, ref reuse, real aspect ratio, prompt composer

### DIFF
--- a/crates/eros-engine-core/src/pde.rs
+++ b/crates/eros-engine-core/src/pde.rs
@@ -6,7 +6,7 @@
 
 use crate::affinity::AffinityDeltas;
 use crate::ghost::{self, GhostDecision, GhostSignals};
-use crate::types::{ActionPlan, ActionType, DecisionInput, Event, ReplyStyle};
+use crate::types::{ActionPlan, ActionType, DecisionInput, Event, ImageRef, ReplyStyle};
 
 // Decision thresholds — tune here rather than at call sites.
 const LONG_MSG_CHARS: usize = 30;
@@ -50,6 +50,8 @@ pub fn decide(input: &DecisionInput) -> ActionPlan {
             energy_cost: ENERGY_COST_REPLY,
             context_hints: vec![],
             image_prompt: None,
+            image_ref: ImageRef::Face,
+            aspect_ratio: None,
         };
     }
 
@@ -66,6 +68,8 @@ pub fn decide(input: &DecisionInput) -> ActionPlan {
             energy_cost: ENERGY_COST_GHOST,
             context_hints: vec![],
             image_prompt: None,
+            image_ref: ImageRef::Face,
+            aspect_ratio: None,
         };
     }
 
@@ -78,6 +82,8 @@ pub fn decide(input: &DecisionInput) -> ActionPlan {
             energy_cost: ENERGY_COST_PROACTIVE,
             context_hints: vec![],
             image_prompt: None,
+            image_ref: ImageRef::Face,
+            aspect_ratio: None,
         };
     }
 
@@ -91,6 +97,8 @@ pub fn decide(input: &DecisionInput) -> ActionPlan {
             energy_cost: ENERGY_COST_APP_OPEN,
             context_hints: vec![],
             image_prompt: None,
+            image_ref: ImageRef::Face,
+            aspect_ratio: None,
         };
     }
 
@@ -102,6 +110,8 @@ pub fn decide(input: &DecisionInput) -> ActionPlan {
         energy_cost: ENERGY_COST_REPLY,
         context_hints: vec![],
         image_prompt: None,
+        image_ref: ImageRef::Face,
+        aspect_ratio: None,
     }
 }
 
@@ -117,6 +127,8 @@ pub fn plan_for(
     action: ActionType,
     hints: Vec<String>,
     image_prompt: Option<String>,
+    image_ref: ImageRef,
+    aspect_ratio: Option<String>,
 ) -> ActionPlan {
     match action {
         ActionType::ReplyText | ActionType::ReplyImage | ActionType::ReplyTextImage => ActionPlan {
@@ -126,6 +138,8 @@ pub fn plan_for(
             energy_cost: ENERGY_COST_REPLY,
             context_hints: hints,
             image_prompt,
+            image_ref,
+            aspect_ratio,
         },
         ActionType::Ghost => ActionPlan {
             action_type: ActionType::Ghost,
@@ -134,6 +148,8 @@ pub fn plan_for(
             energy_cost: ENERGY_COST_GHOST,
             context_hints: vec![],
             image_prompt: None,
+            image_ref: ImageRef::Face,
+            aspect_ratio: None,
         },
         ActionType::Proactive => {
             unreachable!("plan_for is never called with Proactive; it comes only from pde::decide")
@@ -422,7 +438,14 @@ mod tests {
     #[test]
     fn plan_for_reply_text_is_neutral_with_hints() {
         let input = test_decision_input();
-        let plan = plan_for(&input, ActionType::ReplyText, vec!["有点开心".into()], None);
+        let plan = plan_for(
+            &input,
+            ActionType::ReplyText,
+            vec!["有点开心".into()],
+            None,
+            ImageRef::Face,
+            None,
+        );
         assert_eq!(plan.action_type, ActionType::ReplyText);
         assert_eq!(plan.reply_style, ReplyStyle::Neutral);
         assert_eq!(plan.context_hints, vec!["有点开心".to_string()]);
@@ -432,7 +455,14 @@ mod tests {
     #[test]
     fn plan_for_ghost_is_cold_and_drops_hints() {
         let input = test_decision_input();
-        let plan = plan_for(&input, ActionType::Ghost, vec!["想躲".into()], None);
+        let plan = plan_for(
+            &input,
+            ActionType::Ghost,
+            vec!["想躲".into()],
+            None,
+            ImageRef::Face,
+            None,
+        );
         assert_eq!(plan.action_type, ActionType::Ghost);
         assert_eq!(plan.reply_style, ReplyStyle::Cold);
         assert!(plan.context_hints.is_empty());
@@ -447,11 +477,47 @@ mod tests {
             ActionType::ReplyTextImage,
             vec![],
             Some("a selfie in a cafe".to_string()),
+            ImageRef::Face,
+            None,
         );
         assert_eq!(plan.action_type, ActionType::ReplyTextImage);
         assert_eq!(plan.image_prompt.as_deref(), Some("a selfie in a cafe"));
 
-        let ghost = plan_for(&input, ActionType::Ghost, vec![], Some("ignored".into()));
+        let ghost = plan_for(
+            &input,
+            ActionType::Ghost,
+            vec![],
+            Some("ignored".into()),
+            ImageRef::Face,
+            None,
+        );
         assert_eq!(ghost.image_prompt, None, "ghost carries no image prompt");
+    }
+
+    #[test]
+    fn plan_for_threads_image_ref_and_aspect() {
+        let input = test_decision_input(); // reuse the helper the sibling plan_for tests use
+        let plan = plan_for(
+            &input,
+            ActionType::ReplyImage,
+            vec![],
+            Some("a subject".into()),
+            ImageRef::Previous,
+            Some("9:16".into()),
+        );
+        assert_eq!(plan.image_ref, ImageRef::Previous);
+        assert_eq!(plan.aspect_ratio.as_deref(), Some("9:16"));
+
+        // ghost discards image fields → defaults
+        let ghost = plan_for(
+            &input,
+            ActionType::Ghost,
+            vec![],
+            Some("ignored".into()),
+            ImageRef::Previous,
+            Some("9:16".into()),
+        );
+        assert_eq!(ghost.image_ref, ImageRef::Face);
+        assert_eq!(ghost.aspect_ratio, None);
     }
 }

--- a/crates/eros-engine-core/src/types.rs
+++ b/crates/eros-engine-core/src/types.rs
@@ -73,6 +73,17 @@ pub enum Event {
     AppOpen,
 }
 
+/// Which reference image an image turn should build on. `Face` = the static
+/// avatar / face reference; `Previous` = the previously generated image
+/// (iteration). Defaults to `Face`. Internal-only (mapped from the PDE verdict);
+/// not serialized to any DB/SSE wire path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ImageRef {
+    #[default]
+    Face,
+    Previous,
+}
+
 /// Action decision produced by the PDE. NOT serialized to any DB/SSE wire path
 /// (the persisted action string and `FrameActionType` are separate) — so the
 /// rename is internal-only and the serde derive is intentionally absent.
@@ -118,6 +129,12 @@ pub struct ActionPlan {
     /// Subject for the image executor (`reply_image`/`reply_text_image`); `None`
     /// for text/ghost/proactive. Carried from the PDE verdict or a forced turn.
     pub image_prompt: Option<String>,
+    /// Which reference image an image turn builds on (avatar vs previous gen).
+    /// `Face` for non-image actions.
+    pub image_ref: ImageRef,
+    /// Aspect ratio chosen by the PDE for an image turn; `None` ⇒ caller falls
+    /// back (request → config default). Always `None` for non-image actions.
+    pub aspect_ratio: Option<String>,
 }
 
 /// Conversation signals computed from chat history.

--- a/crates/eros-engine-core/src/types.rs
+++ b/crates/eros-engine-core/src/types.rs
@@ -77,7 +77,8 @@ pub enum Event {
 /// avatar / face reference; `Previous` = the previously generated image
 /// (iteration). Defaults to `Face`. Internal-only (mapped from the PDE verdict);
 /// not serialized to any DB/SSE wire path.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum ImageRef {
     #[default]
     Face,

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -677,6 +677,35 @@ pub struct ResolvedVision {
     pub reasoning: Option<ReasoningConfig>,
 }
 
+/// Generic, product-identity-free default prompt for the image-prompt composer.
+/// Used when the task is enabled but supplies no `filter_prompt`; deployments
+/// override it via `[tasks.chat_image_prompt_compose].filter_prompt`. Keep the
+/// text identity-free — no product name or brand. Its stance is EXPAND-ONLY: it
+/// must not soften, downgrade, or refuse, and must not add its own
+/// content-moderation layer — content policy is enforced by the image provider
+/// and the downstream consumer, not this step. This is the one engine task whose
+/// prompt ships in code.
+const DEFAULT_COMPOSE_PROMPT: &str = "You expand a short image subject into a single, detailed, vivid image-generation prompt. \
+You receive the character's appearance, the recent scene, a seed subject, a visual style, and a target aspect ratio, each as a labeled section. \
+Your only job is to EXPAND: produce one coherent prompt that faithfully preserves the appearance and the full intent and tone of the seed subject, and fits the style and aspect ratio. \
+Do not soften, sanitize, downgrade, omit, censor, or refuse any part of the requested subject, and do not add safety warnings, disclaimers, or moderation of your own — content policy is the responsibility of the image provider and the downstream consumer, not this step. \
+Do not add commentary, options, or headings. Output only the final image prompt.";
+
+/// Resolved image-prompt composer task (`chat_image_prompt_compose`). Mirrors
+/// `ResolvedVision`. Optional: `resolve_image_prompt_compose` returns `None`
+/// (feature off) only when the task is absent; a present task with no
+/// `filter_prompt` resolves with `compose_prompt = DEFAULT_COMPOSE_PROMPT`.
+#[derive(Debug, Clone)]
+pub struct ResolvedImagePromptCompose {
+    pub model: String,
+    pub fallback_model: Vec<String>,
+    pub temperature: f64,
+    pub max_tokens: u32,
+    pub compose_prompt: String,
+    pub retry_depth: u32,
+    pub reasoning: Option<ReasoningConfig>,
+}
+
 /// Resolved PDE decision task (`pde_decision`). Mirrors `ResolvedVision`: the
 /// configured `filter_prompt` is the judge's system instruction; the engine
 /// builds the user payload (transcript + affinity + signals). `fallback_model`
@@ -1061,6 +1090,36 @@ impl ModelConfig {
                 .unwrap_or_else(|| "1:1".to_string()),
             default_resolution: task_cfg.default_resolution.clone(),
             max_tokens: task_cfg.max_tokens.unwrap_or(4096),
+        })
+    }
+
+    /// Resolve the image-prompt composer task. `None` (feature off) only when
+    /// `[tasks.chat_image_prompt_compose]` is absent. When the task is present, a
+    /// non-blank `filter_prompt` overrides the built-in `DEFAULT_COMPOSE_PROMPT`;
+    /// a blank/absent one falls back to it. No probability/trigger gate; the
+    /// caller invokes it only after an image action is decided.
+    pub fn resolve_image_prompt_compose(&self) -> Option<ResolvedImagePromptCompose> {
+        const COMPOSE_TASK: &str = "chat_image_prompt_compose";
+        let task_cfg = self.tasks.get(COMPOSE_TASK)?;
+        let compose_prompt = task_cfg
+            .filter_prompt
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+            .unwrap_or_else(|| DEFAULT_COMPOSE_PROMPT.to_string());
+        let retry_depth = task_cfg.retry_depth.unwrap_or(1);
+        let m = self.resolve(COMPOSE_TASK, None);
+        let mut fallback_model = m.fallback_model;
+        fallback_model.truncate(retry_depth as usize);
+        Some(ResolvedImagePromptCompose {
+            model: m.model,
+            fallback_model,
+            temperature: m.temperature,
+            max_tokens: m.max_tokens,
+            compose_prompt,
+            retry_depth,
+            reasoning: task_cfg.reasoning.clone(),
         })
     }
 }
@@ -3211,5 +3270,55 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
         let out = apply_output_regex(&rules, "m", "[你给对方发送了一张照片：x]");
         assert_eq!(out.cleaned, "[你给对方发送了一张照片：x]"); // kept raw
         assert!(out.matched_rules.is_empty(), "fail-safe reports no change");
+    }
+
+    #[test]
+    fn resolve_image_prompt_compose_none_when_task_absent() {
+        let cfg = ModelConfig::from_toml_str("[tasks.chat_companion]\nmodel = \"m\"\n").unwrap();
+        assert!(cfg.resolve_image_prompt_compose().is_none());
+    }
+
+    #[test]
+    fn resolve_image_prompt_compose_uses_builtin_when_prompt_blank() {
+        // task present but no usable filter_prompt → enabled with the built-in
+        // default (NOT off — this is the deviation from the sibling tasks).
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.chat_image_prompt_compose]\nmodel = \"m\"\nfilter_prompt = \"   \"\n",
+        )
+        .unwrap();
+        let r = cfg.resolve_image_prompt_compose().unwrap();
+        assert_eq!(r.compose_prompt, DEFAULT_COMPOSE_PROMPT);
+
+        // also true when filter_prompt is omitted entirely
+        let cfg2 = ModelConfig::from_toml_str("[tasks.chat_image_prompt_compose]\nmodel = \"m\"\n")
+            .unwrap();
+        assert_eq!(
+            cfg2.resolve_image_prompt_compose().unwrap().compose_prompt,
+            DEFAULT_COMPOSE_PROMPT
+        );
+    }
+
+    #[test]
+    fn resolve_image_prompt_compose_override_when_prompt_present() {
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.chat_image_prompt_compose]\nmodel = \"m\"\nfilter_prompt = \"custom composer\"\n",
+        )
+        .unwrap();
+        assert_eq!(
+            cfg.resolve_image_prompt_compose().unwrap().compose_prompt,
+            "custom composer"
+        );
+    }
+
+    #[test]
+    fn resolve_image_prompt_compose_some_truncates_fallback() {
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.chat_image_prompt_compose]\nmodel = \"m\"\nfilter_prompt = \"compose it\"\nfallback = [\"a\", \"b\", \"c\"]\nretry_depth = 1\n",
+        )
+        .unwrap();
+        let r = cfg.resolve_image_prompt_compose().unwrap();
+        assert_eq!(r.compose_prompt, "compose it");
+        assert_eq!(r.retry_depth, 1);
+        assert_eq!(r.fallback_model.len(), 1);
     }
 }

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -115,11 +115,11 @@ pub struct ImageGenRequest {
     pub prompt: String,
     /// Optional face/style reference image URL (image2image hint).
     pub face_ref_url: Option<String>,
-    /// Model-specific aspect ratio hint (e.g. `"3:4"`). Folded into the
-    /// text instruction when present.
+    /// Model-specific aspect ratio hint (e.g. `"3:4"`). Sent as a real size
+    /// parameter (see `build_image_body`).
     pub aspect_ratio: Option<String>,
-    /// Model-specific resolution hint (e.g. `"1024x1024"`). Folded into
-    /// the text instruction when present.
+    /// Model-specific resolution hint (e.g. `"1024x1024"`). Sent as a real
+    /// size parameter (see `build_image_body`); preferred over `aspect_ratio`.
     pub resolution: Option<String>,
     pub max_tokens: u32,
 }
@@ -149,25 +149,50 @@ fn images_from_wire(parsed: &WireResponse) -> Vec<String> {
         .unwrap_or_default()
 }
 
+/// Map a supported aspect ratio to a concrete `width×height` (pixels). The five
+/// ratios match the engine's validated allow-list. Used to drive a real size
+/// parameter for image models that do not honor a free-form aspect hint. Pure.
+fn aspect_to_resolution(aspect: &str) -> Option<(u32, u32)> {
+    match aspect {
+        "1:1" => Some((1024, 1024)),
+        "3:4" => Some((900, 1200)),
+        "4:3" => Some((1200, 900)),
+        "9:16" => Some((720, 1280)),
+        "16:9" => Some((1280, 720)),
+        _ => None,
+    }
+}
+
+/// Parse an explicit `"WxH"` resolution string into `(width, height)`. Pure.
+fn parse_resolution(res: &str) -> Option<(u32, u32)> {
+    let (w, h) = res.split_once('x')?;
+    Some((w.parse().ok()?, h.parse().ok()?))
+}
+
 /// Build the OpenRouter wire body for one image-gen attempt. Pure (no I/O).
 fn build_image_body(req: &ImageGenRequest, model: &str) -> serde_json::Value {
-    // Aspect ratio / resolution are model-specific; fold them into the text
-    // instruction as a best-effort hint (works across image models).
-    let mut text = req.prompt.clone();
-    if let Some(ar) = req.aspect_ratio.as_deref().filter(|s| !s.is_empty()) {
-        text.push_str(&format!("\n(aspect ratio: {ar})"));
-    }
-    if let Some(res) = req.resolution.as_deref().filter(|s| !s.is_empty()) {
-        text.push_str(&format!("\n(resolution: {res})"));
-    }
-    let mut content = vec![serde_json::json!({ "type": "text", "text": text })];
+    // Size is a real generation parameter: prefer an explicit resolution, else
+    // derive a concrete width×height from the aspect ratio. (The old text-hint
+    // "(aspect ratio: …)" was ignored by image models — removed.)
+    let size = req
+        .resolution
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .and_then(parse_resolution)
+        .or_else(|| {
+            req.aspect_ratio
+                .as_deref()
+                .filter(|s| !s.is_empty())
+                .and_then(aspect_to_resolution)
+        });
+    let mut content = vec![serde_json::json!({ "type": "text", "text": req.prompt })];
     if let Some(face) = req.face_ref_url.as_deref().filter(|s| !s.is_empty()) {
         content.push(serde_json::json!({
             "type": "image_url",
             "image_url": { "url": face }
         }));
     }
-    serde_json::json!({
+    let mut body = serde_json::json!({
         "model": model,
         // #101: image-only output. Image-only models reject ["image","text"]
         // with 404; text-capable models still return the image for ["image"].
@@ -177,7 +202,12 @@ fn build_image_body(req: &ImageGenRequest, model: &str) -> serde_json::Value {
         "messages": [ { "role": "user", "content": content } ],
         "max_tokens": req.max_tokens,
         "stream": false,
-    })
+    });
+    if let Some((w, h)) = size {
+        body["width"] = serde_json::json!(w);
+        body["height"] = serde_json::json!(h);
+    }
+    body
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -2250,6 +2280,51 @@ data: [DONE]\n\n";
     }
 
     #[test]
+    fn aspect_to_resolution_maps_all_five() {
+        assert_eq!(aspect_to_resolution("1:1"), Some((1024, 1024)));
+        assert_eq!(aspect_to_resolution("3:4"), Some((900, 1200)));
+        assert_eq!(aspect_to_resolution("4:3"), Some((1200, 900)));
+        assert_eq!(aspect_to_resolution("9:16"), Some((720, 1280)));
+        assert_eq!(aspect_to_resolution("16:9"), Some((1280, 720)));
+        assert_eq!(aspect_to_resolution("5:2"), None);
+    }
+
+    #[test]
+    fn build_image_body_sends_size_not_text_hint() {
+        let req = ImageGenRequest {
+            model: "m".into(),
+            prompt: "a cat".into(),
+            aspect_ratio: Some("9:16".into()),
+            max_tokens: 4096,
+            ..Default::default()
+        };
+        let body = build_image_body(&req, "m");
+        // size is sent as real params
+        assert_eq!(body["width"], 720);
+        assert_eq!(body["height"], 1280);
+        // prompt text is clean — no folded hint
+        let text = body["messages"][0]["content"][0]["text"].as_str().unwrap();
+        assert!(!text.contains("aspect ratio"), "no text hint: {text}");
+        assert!(!text.contains("resolution"), "no text hint: {text}");
+        assert_eq!(text, "a cat");
+    }
+
+    #[test]
+    fn build_image_body_prefers_explicit_resolution() {
+        let req = ImageGenRequest {
+            model: "m".into(),
+            prompt: "x".into(),
+            aspect_ratio: Some("1:1".into()),
+            resolution: Some("768x1024".into()),
+            max_tokens: 4096,
+            ..Default::default()
+        };
+        let body = build_image_body(&req, "m");
+        assert_eq!(body["width"], 768);
+        assert_eq!(body["height"], 1024);
+    }
+
+    #[test]
     fn image_body_has_modalities_and_optional_face_ref() {
         let req = ImageGenRequest {
             model: "m".into(),
@@ -2269,7 +2344,8 @@ data: [DONE]\n\n";
         // text-only content block when no face ref
         assert_eq!(content.as_array().unwrap().len(), 1);
         assert!(content[0]["text"].as_str().unwrap().contains("a cat"));
-        assert!(content[0]["text"].as_str().unwrap().contains("3:4"));
+        // aspect ratio is now sent as width/height params, not folded into text
+        assert!(!content[0]["text"].as_str().unwrap().contains("3:4"));
 
         let req2 = ImageGenRequest {
             face_ref_url: Some("https://x/a.png".into()),

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -1189,6 +1189,13 @@
               "null"
             ]
           },
+          "prev_image_url": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Optional URL of the previously generated image, for iteration. Selected\nwhen the PDE chooses `image_ref = previous`. Same validation as\n`face_ref_url`; the engine never fetches it — it is embedded in the\nOpenRouter body and fetched by the image provider at generation time, so\nclients backed by a private store should pass a short-lived signed URL."
+          },
           "resolution": {
             "type": [
               "string",

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -1822,6 +1822,90 @@ async fn run_input_filter(
     None // chain exhausted → keep
 }
 
+/// Assemble the composer's user message from the appearance, recent scene, seed
+/// subject, style, and aspect ratio. Pure (kept separate so it is testable
+/// without a network call).
+fn compose_user_payload(
+    appearance: &str,
+    recent_scene: &str,
+    seed_subject: &str,
+    style: &str,
+    aspect_ratio: &str,
+) -> String {
+    format!(
+        "[人物外观]\n{appearance}\n\n[最近场景]\n{recent_scene}\n\n[画面主题种子]\n{seed_subject}\n\n[风格]\n{style}\n\n[画幅]\n{aspect_ratio}"
+    )
+}
+
+/// Enrich the image subject via the optional composer LLM. Walks
+/// `[model] + fallback` on transport failure (error/timeout/empty); returns the
+/// trimmed enriched subject on first success, or `None` (caller falls back to
+/// the seed). Never blocks or fails the image turn. Mirrors `run_input_filter`.
+async fn run_image_prompt_compose(
+    state: &AppState,
+    c: &eros_engine_llm::model_config::ResolvedImagePromptCompose,
+    persona: &eros_engine_core::persona::CompanionPersona,
+    seed_subject: &str,
+    recent_scene: &str,
+    aspect_ratio: Option<&str>,
+    style: &str,
+) -> Option<String> {
+    use eros_engine_llm::openrouter::{ChatMessage, ChatRequest};
+    let appearance = crate::prompt::meta_str(persona, "appearance")
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or("（无）");
+    let scene = if recent_scene.trim().is_empty() {
+        "（无）"
+    } else {
+        recent_scene
+    };
+    let ar = aspect_ratio.unwrap_or("（未指定）");
+    let user_payload = compose_user_payload(appearance, scene, seed_subject, style, ar);
+    let chain: Vec<String> = std::iter::once(c.model.clone())
+        .chain(c.fallback_model.iter().cloned())
+        .collect();
+    for model_id in &chain {
+        let req = ChatRequest {
+            model: model_id.clone(),
+            fallback_model: vec![],
+            messages: vec![
+                ChatMessage {
+                    role: "system".into(),
+                    content: c.compose_prompt.clone(),
+                },
+                ChatMessage {
+                    role: "user".into(),
+                    content: user_payload.clone(),
+                },
+            ],
+            temperature: c.temperature as f32,
+            max_tokens: c.max_tokens,
+            reasoning: c.reasoning.clone(),
+            ..Default::default()
+        };
+        let resp = match tokio::time::timeout(FILTER_TIMEOUT, state.openrouter.execute(req)).await {
+            Ok(Ok(r)) => r,
+            Ok(Err(e)) => {
+                tracing::warn!(model = %model_id, error = %e, "image-compose: model error; next");
+                continue;
+            }
+            Err(_) => {
+                tracing::warn!(model = %model_id, "image-compose: timeout; next");
+                continue;
+            }
+        };
+        super::log_openrouter_usage("chat_image_prompt_compose", None, &resp);
+        let text = resp.reply.trim().to_string();
+        if text.is_empty() {
+            tracing::warn!(model = %model_id, "image-compose: empty reply; next");
+            continue;
+        }
+        return Some(text);
+    }
+    None
+}
+
 /// Try to emit a pseudo-ghost on chain exhaustion.
 ///
 /// Picks a configured fallback phrase from `engine.error_handling_config`,
@@ -2153,6 +2237,7 @@ pub fn run_stream(
         // it on opted-out / text turns would consume image-model slots and skew
         // the sequencing of later opted-in image turns.
         let resolved_image_gen = state.model_config.resolve_image_gen();
+        let resolved_compose = state.model_config.resolve_image_prompt_compose();
         let req_image = user_msg.image.as_ref();
         let image_chain = req_image.and_then(|i| {
             eros_engine_llm::model_config::effective_image_chain(
@@ -2355,13 +2440,33 @@ pub fn run_stream(
                             .and_then(|i| i.style)
                             .or_else(|| resolved_image_gen.as_ref().map(|r| r.default_style))
                             .unwrap_or_default();
+                        let style_str = serde_json::to_value(style)
+                            .ok()
+                            .and_then(|v| v.as_str().map(String::from))
+                            .unwrap_or_else(|| "realistic".to_string());
                         let (ref_url, ref_kind) = select_image_ref(plan.image_ref, req_image);
                         let face_used = ref_url.is_some();
+                        let final_subject = match resolved_compose.as_ref() {
+                            Some(c) => run_image_prompt_compose(
+                                &state,
+                                c,
+                                &input.persona,
+                                &subject,
+                                &pde_transcript,
+                                plan.aspect_ratio
+                                    .as_deref()
+                                    .or_else(|| req_image.and_then(|i| i.aspect_ratio.as_deref())),
+                                &style_str,
+                            )
+                            .await
+                            .unwrap_or_else(|| subject.clone()),
+                            None => subject.clone(),
+                        };
                         let req = build_image_gen_request(
                             primary,
                             fallback,
                             &input.persona,
-                            plan.image_prompt.as_deref(),
+                            Some(final_subject.as_str()),
                             req_image,
                             resolved_image_gen.as_ref(),
                             "",
@@ -2383,12 +2488,8 @@ pub fn run_stream(
                                 // Mirror the other in-stream task log sites
                                 // (vision / filters / pde): session_id = None.
                                 super::log_openrouter_usage("chat_image_generation", None, &cr);
-                                let style_str = serde_json::to_value(style)
-                                    .ok()
-                                    .and_then(|v| v.as_str().map(String::from))
-                                    .unwrap_or_else(|| "realistic".to_string());
                                 let image_meta = serde_json::json!({
-                                    "prompt": subject,
+                                    "prompt": final_subject,
                                     "style": style_str,
                                     "model": resp.model,
                                     "aspect_ratio": ar,
@@ -2448,7 +2549,7 @@ pub fn run_stream(
                                     message_id: ulid_string(msg_ulid),
                                     data_url: resp.images[0].clone(),
                                     mime,
-                                    image_prompt: Some(subject.clone()),
+                                    image_prompt: Some(final_subject.clone()),
                                     model: resp.model.clone(),
                                     generation_id: resp.generation_id.clone(),
                                 };
@@ -2752,13 +2853,33 @@ pub fn run_stream(
                             .and_then(|i| i.style)
                             .or_else(|| resolved_image_gen.as_ref().map(|r| r.default_style))
                             .unwrap_or_default();
+                        let style_str = serde_json::to_value(style)
+                            .ok()
+                            .and_then(|v| v.as_str().map(String::from))
+                            .unwrap_or_else(|| "realistic".to_string());
                         let (ref_url, ref_kind) = select_image_ref(plan.image_ref, req_image);
                         let face_used = ref_url.is_some();
+                        let final_subject = match resolved_compose.as_ref() {
+                            Some(c) => run_image_prompt_compose(
+                                &state,
+                                c,
+                                &input.persona,
+                                &subject,
+                                &pde_transcript,
+                                plan.aspect_ratio
+                                    .as_deref()
+                                    .or_else(|| req_image.and_then(|i| i.aspect_ratio.as_deref())),
+                                &style_str,
+                            )
+                            .await
+                            .unwrap_or_else(|| subject.clone()),
+                            None => subject.clone(),
+                        };
                         let req = build_image_gen_request(
                             primary,
                             fallback,
                             &input.persona,
-                            plan.image_prompt.as_deref(),
+                            Some(final_subject.as_str()),
                             req_image,
                             resolved_image_gen.as_ref(),
                             "",
@@ -2779,12 +2900,8 @@ pub fn run_stream(
                                 // Mirror the other in-stream task log sites
                                 // (vision / filters / pde): session_id = None.
                                 super::log_openrouter_usage("chat_image_generation", None, &cr);
-                                let style_str = serde_json::to_value(style)
-                                    .ok()
-                                    .and_then(|v| v.as_str().map(String::from))
-                                    .unwrap_or_else(|| "realistic".to_string());
                                 let image_meta = serde_json::json!({
-                                    "prompt": subject,
+                                    "prompt": final_subject,
                                     "style": style_str,
                                     "model": resp.model,
                                     "aspect_ratio": ar,
@@ -2812,7 +2929,7 @@ pub fn run_stream(
                                     message_id: ulid_string(Ulid::from(msg_uuid)),
                                     data_url: resp.images[0].clone(),
                                     mime,
-                                    image_prompt: Some(subject.clone()),
+                                    image_prompt: Some(final_subject.clone()),
                                     model: resp.model.clone(),
                                     generation_id: resp.generation_id.clone(),
                                 };
@@ -3156,6 +3273,21 @@ mod tests {
         assert!(req.prompt.starts_with("Photorealistic"));
         assert!(req.prompt.contains("a selfie")); // plan image_prompt wins over fallback subject
         assert_eq!(req.aspect_ratio.as_deref(), Some("3:4"));
+    }
+
+    #[test]
+    fn compose_user_payload_includes_all_parts() {
+        let p = compose_user_payload(
+            "freckled, red hair",
+            "（无）",
+            "on a rooftop",
+            "realistic",
+            "9:16",
+        );
+        assert!(p.contains("freckled, red hair"));
+        assert!(p.contains("on a rooftop"));
+        assert!(p.contains("realistic"));
+        assert!(p.contains("9:16"));
     }
 
     #[test]

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -2455,7 +2455,12 @@ pub fn run_stream(
                                 &pde_transcript,
                                 plan.aspect_ratio
                                     .as_deref()
-                                    .or_else(|| req_image.and_then(|i| i.aspect_ratio.as_deref())),
+                                    .or_else(|| req_image.and_then(|i| i.aspect_ratio.as_deref()))
+                                    .or_else(|| {
+                                        resolved_image_gen
+                                            .as_ref()
+                                            .map(|r| r.default_aspect_ratio.as_str())
+                                    }),
                                 &style_str,
                             )
                             .await
@@ -2868,7 +2873,12 @@ pub fn run_stream(
                                 &pde_transcript,
                                 plan.aspect_ratio
                                     .as_deref()
-                                    .or_else(|| req_image.and_then(|i| i.aspect_ratio.as_deref())),
+                                    .or_else(|| req_image.and_then(|i| i.aspect_ratio.as_deref()))
+                                    .or_else(|| {
+                                        resolved_image_gen
+                                            .as_ref()
+                                            .map(|r| r.default_aspect_ratio.as_str())
+                                    }),
                                 &style_str,
                             )
                             .await
@@ -3285,6 +3295,7 @@ mod tests {
             "9:16",
         );
         assert!(p.contains("freckled, red hair"));
+        assert!(p.contains("（无）"));
         assert!(p.contains("on a rooftop"));
         assert!(p.contains("realistic"));
         assert!(p.contains("9:16"));

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -162,14 +162,24 @@ fn build_image_gen_request(
         })
         .unwrap_or(fallback_subject);
     let prompt = crate::pipeline::handlers::compose_image_prompt(style, persona, subject);
-    let aspect_ratio = plan_aspect_ratio
+    // A per-turn aspect (PDE/plan or per-request) — NOT the config default — wins.
+    let turn_aspect = plan_aspect_ratio
         .filter(|s| !s.trim().is_empty())
         .map(str::to_string)
-        .or_else(|| req_image.and_then(|i| i.aspect_ratio.clone()))
+        .or_else(|| req_image.and_then(|i| i.aspect_ratio.clone()));
+    let aspect_ratio = turn_aspect
+        .clone()
         .or_else(|| resolved.map(|r| r.default_aspect_ratio.clone()));
-    let resolution = req_image
-        .and_then(|i| i.resolution.clone())
-        .or_else(|| resolved.and_then(|r| r.default_resolution.clone()));
+    let resolution = req_image.and_then(|i| i.resolution.clone()).or_else(|| {
+        // Don't let a static config default_resolution override a per-turn aspect
+        // choice — build_image_body prefers resolution over aspect_ratio, so a
+        // default_resolution would otherwise defeat the PDE's per-scene ratio.
+        if turn_aspect.is_some() {
+            None
+        } else {
+            resolved.and_then(|r| r.default_resolution.clone())
+        }
+    });
     eros_engine_llm::openrouter::ImageGenRequest {
         model: primary,
         fallback_model: chain,
@@ -2237,7 +2247,6 @@ pub fn run_stream(
         // it on opted-out / text turns would consume image-model slots and skew
         // the sequencing of later opted-in image turns.
         let resolved_image_gen = state.model_config.resolve_image_gen();
-        let resolved_compose = state.model_config.resolve_image_prompt_compose();
         let req_image = user_msg.image.as_ref();
         let image_chain = req_image.and_then(|i| {
             eros_engine_llm::model_config::effective_image_chain(
@@ -2446,10 +2455,10 @@ pub fn run_stream(
                             .unwrap_or_else(|| "realistic".to_string());
                         let (ref_url, ref_kind) = select_image_ref(plan.image_ref, req_image);
                         let face_used = ref_url.is_some();
-                        let final_subject = match resolved_compose.as_ref() {
+                        let final_subject = match state.model_config.resolve_image_prompt_compose() {
                             Some(c) => run_image_prompt_compose(
                                 &state,
-                                c,
+                                &c,
                                 &input.persona,
                                 &subject,
                                 &pde_transcript,
@@ -2864,10 +2873,10 @@ pub fn run_stream(
                             .unwrap_or_else(|| "realistic".to_string());
                         let (ref_url, ref_kind) = select_image_ref(plan.image_ref, req_image);
                         let face_used = ref_url.is_some();
-                        let final_subject = match resolved_compose.as_ref() {
+                        let final_subject = match state.model_config.resolve_image_prompt_compose() {
                             Some(c) => run_image_prompt_compose(
                                 &state,
-                                c,
+                                &c,
                                 &input.persona,
                                 &subject,
                                 &pde_transcript,
@@ -3283,6 +3292,37 @@ mod tests {
         assert!(req.prompt.starts_with("Photorealistic"));
         assert!(req.prompt.contains("a selfie")); // plan image_prompt wins over fallback subject
         assert_eq!(req.aspect_ratio.as_deref(), Some("3:4"));
+    }
+
+    #[test]
+    fn build_image_gen_request_plan_aspect_beats_config_default_resolution() {
+        let persona = test_persona_with_meta(&[]);
+        // Both default_aspect_ratio and default_resolution are set in the config.
+        let resolved = eros_engine_llm::model_config::ModelConfig::from_toml_str(
+            "[tasks.chat_image_generation]\nmodel=\"img\"\ndefault_style=\"realistic\"\ndefault_aspect_ratio=\"3:4\"\ndefault_resolution=\"1024x1024\"\n",
+        )
+        .unwrap()
+        .resolve_image_gen();
+        let req = build_image_gen_request(
+            "img".into(),
+            vec![],
+            &persona,
+            None, /* plan_image_prompt */
+            None, /* req_image */
+            resolved.as_ref(),
+            "fallback subject",
+            None,         /* ref_url */
+            Some("9:16"), /* plan_aspect_ratio */
+        );
+        assert_eq!(
+            req.aspect_ratio.as_deref(),
+            Some("9:16"),
+            "plan aspect wins"
+        );
+        assert_eq!(
+            req.resolution, None,
+            "config default_resolution dropped when a plan aspect is set"
+        );
     }
 
     #[test]

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -1619,6 +1619,32 @@ struct InputRewrite {
 /// Recent rows fed to the rewrite LLM as `[最近对话]` context.
 const INPUT_FILTER_CONTEXT_TURNS: i64 = 8;
 
+/// Render an assistant transcript line. Image turns persist empty `content`
+/// with the image facts under `metadata.image`; surface a terse marker so the
+/// judge / input filter see that an image was sent (and what it depicted)
+/// instead of a blank `AI:` line. Non-image assistant rows fall back to
+/// `content`. Pure.
+fn assistant_transcript_line(content: &str, metadata: Option<&serde_json::Value>) -> String {
+    if let Some(img) = metadata.and_then(|m| m.get("image")) {
+        let subject = img
+            .get("prompt")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .unwrap_or("（无描述）");
+        let ar = img
+            .get("aspect_ratio")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        return if ar.is_empty() {
+            format!("（发送了一张图片：{subject}）")
+        } else {
+            format!("（发送了一张图片：{subject}，画幅 {ar}）")
+        };
+    }
+    content.to_string()
+}
+
 /// Build the compact transcript block for the input filter, excluding the turn
 /// being rewritten. Best-effort: a DB error yields an empty transcript.
 async fn build_input_filter_transcript(
@@ -1638,9 +1664,15 @@ async fn build_input_filter_transcript(
         // User/gift rows use the EFFECTIVE text (a prior turn's own rewrite when
         // present) so the filter sees the same conversation the chat model does;
         // assistant rows use content (their pre_filter_content means the opposite).
-        let (label, text) = match m.role.as_str() {
-            "user" | "gift_user" => ("用户", crate::pipeline::handlers::effective_user_text(&m)),
-            "assistant" => ("AI", m.content.as_str()),
+        let (label, text): (&str, String) = match m.role.as_str() {
+            "user" | "gift_user" => (
+                "用户",
+                crate::pipeline::handlers::effective_user_text(&m).to_string(),
+            ),
+            "assistant" => (
+                "AI",
+                assistant_transcript_line(&m.content, m.metadata.as_ref()),
+            ),
             _ => continue,
         };
         lines.push(format!("{label}: {text}"));
@@ -3176,6 +3208,31 @@ mod tests {
         assert!(parse_pde_verdict("not json").is_none());
         // unknown action → None
         assert!(parse_pde_verdict("{\"action\":\"frobnicate\"}").is_none());
+    }
+
+    #[test]
+    fn assistant_transcript_line_marks_image_turns() {
+        // image turn: empty content, facts under metadata.image
+        let meta =
+            serde_json::json!({"image":{"prompt":"on the beach at sunset","aspect_ratio":"3:4"}});
+        let line = assistant_transcript_line("", Some(&meta));
+        assert!(
+            line.contains("on the beach at sunset"),
+            "subject surfaced: {line}"
+        );
+        assert!(line.contains("3:4"), "aspect surfaced: {line}");
+        assert_ne!(line.trim(), "", "image turn must not be a blank line");
+
+        // image turn without aspect_ratio: still marks, no panic
+        let meta2 = serde_json::json!({"image":{"prompt":"a portrait"}});
+        assert!(assistant_transcript_line("", Some(&meta2)).contains("a portrait"));
+
+        // plain text turn: content passes through unchanged
+        assert_eq!(assistant_transcript_line("hi there", None), "hi there");
+
+        // metadata present but no image key: content passes through
+        let meta3 = serde_json::json!({"tip": 5});
+        assert_eq!(assistant_transcript_line("hello", Some(&meta3)), "hello");
     }
 
     #[test]

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -146,6 +146,7 @@ fn build_image_gen_request(
     resolved: Option<&eros_engine_llm::model_config::ResolvedImageGen>,
     fallback_subject: &str,
     ref_url: Option<String>,
+    plan_aspect_ratio: Option<&str>,
 ) -> eros_engine_llm::openrouter::ImageGenRequest {
     use eros_engine_llm::model_config::StyleKey;
     let style: StyleKey = req_image
@@ -161,8 +162,10 @@ fn build_image_gen_request(
         })
         .unwrap_or(fallback_subject);
     let prompt = crate::pipeline::handlers::compose_image_prompt(style, persona, subject);
-    let aspect_ratio = req_image
-        .and_then(|i| i.aspect_ratio.clone())
+    let aspect_ratio = plan_aspect_ratio
+        .filter(|s| !s.trim().is_empty())
+        .map(str::to_string)
+        .or_else(|| req_image.and_then(|i| i.aspect_ratio.clone()))
         .or_else(|| resolved.map(|r| r.default_aspect_ratio.clone()));
     let resolution = req_image
         .and_then(|i| i.resolution.clone())
@@ -2363,6 +2366,7 @@ pub fn run_stream(
                             resolved_image_gen.as_ref(),
                             "",
                             ref_url.clone(),
+                            plan.aspect_ratio.as_deref(),
                         );
                         let ar = req.aspect_ratio.clone();
                         let res = req.resolution.clone();
@@ -2759,6 +2763,7 @@ pub fn run_stream(
                             resolved_image_gen.as_ref(),
                             "",
                             ref_url.clone(),
+                            plan.aspect_ratio.as_deref(),
                         );
                         let ar = req.aspect_ratio.clone();
                         let res = req.resolution.clone();
@@ -3145,6 +3150,7 @@ mod tests {
             resolved.as_ref(),
             "fallback subject",
             None, /* ref_url */
+            None, /* plan_aspect_ratio */
         );
         assert_eq!(req.model, "img");
         assert!(req.prompt.starts_with("Photorealistic"));

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -109,6 +109,28 @@ fn frame_action_for(a: eros_engine_core::types::ActionType) -> FrameActionType {
     }
 }
 
+/// Pick the reference image for an image turn and report which kind was used.
+/// `Previous` falls back to the face ref when no previous URL is supplied.
+/// Empty strings are treated as absent. Pure.
+fn select_image_ref(
+    image_ref: eros_engine_core::types::ImageRef,
+    req: Option<&crate::routes::companion_stream::ImageReplyParams>,
+) -> (Option<String>, &'static str) {
+    let face = req
+        .and_then(|i| i.face_ref_url.clone())
+        .filter(|s| !s.is_empty());
+    let prev = req
+        .and_then(|i| i.prev_image_url.clone())
+        .filter(|s| !s.is_empty());
+    match image_ref {
+        eros_engine_core::types::ImageRef::Previous => match prev {
+            Some(u) => (Some(u), "previous"),
+            None => (face, "face"),
+        },
+        eros_engine_core::types::ImageRef::Face => (face, "face"),
+    }
+}
+
 /// Assemble an `ImageGenRequest` from the per-turn image executor chain, the
 /// resolved `chat_image_generation` defaults, the persona, and the optional
 /// per-turn `ImageReplyParams`. Pure (no I/O). Per-turn overrides win over the
@@ -123,6 +145,7 @@ fn build_image_gen_request(
     req_image: Option<&crate::routes::companion_stream::ImageReplyParams>,
     resolved: Option<&eros_engine_llm::model_config::ResolvedImageGen>,
     fallback_subject: &str,
+    ref_url: Option<String>,
 ) -> eros_engine_llm::openrouter::ImageGenRequest {
     use eros_engine_llm::model_config::StyleKey;
     let style: StyleKey = req_image
@@ -148,7 +171,7 @@ fn build_image_gen_request(
         model: primary,
         fallback_model: chain,
         prompt,
-        face_ref_url: req_image.and_then(|i| i.face_ref_url.clone()),
+        face_ref_url: ref_url,
         aspect_ratio,
         resolution,
         max_tokens: resolved.map(|r| r.max_tokens).unwrap_or(4096),
@@ -2329,9 +2352,8 @@ pub fn run_stream(
                             .and_then(|i| i.style)
                             .or_else(|| resolved_image_gen.as_ref().map(|r| r.default_style))
                             .unwrap_or_default();
-                        let face_used = req_image
-                            .and_then(|i| i.face_ref_url.as_deref())
-                            .is_some_and(|s| !s.is_empty());
+                        let (ref_url, ref_kind) = select_image_ref(plan.image_ref, req_image);
+                        let face_used = ref_url.is_some();
                         let req = build_image_gen_request(
                             primary,
                             fallback,
@@ -2340,6 +2362,7 @@ pub fn run_stream(
                             req_image,
                             resolved_image_gen.as_ref(),
                             "",
+                            ref_url.clone(),
                         );
                         let ar = req.aspect_ratio.clone();
                         let res = req.resolution.clone();
@@ -2368,6 +2391,7 @@ pub fn run_stream(
                                     "resolution": res,
                                     "generation_id": resp.generation_id,
                                     "face_ref_used": face_used,
+                                    "image_ref": ref_kind,
                                 });
                                 let mime = data_url_mime(&resp.images[0]);
                                 let msg_ulid = Ulid::new();
@@ -2724,9 +2748,8 @@ pub fn run_stream(
                             .and_then(|i| i.style)
                             .or_else(|| resolved_image_gen.as_ref().map(|r| r.default_style))
                             .unwrap_or_default();
-                        let face_used = req_image
-                            .and_then(|i| i.face_ref_url.as_deref())
-                            .is_some_and(|s| !s.is_empty());
+                        let (ref_url, ref_kind) = select_image_ref(plan.image_ref, req_image);
+                        let face_used = ref_url.is_some();
                         let req = build_image_gen_request(
                             primary,
                             fallback,
@@ -2735,6 +2758,7 @@ pub fn run_stream(
                             req_image,
                             resolved_image_gen.as_ref(),
                             "",
+                            ref_url.clone(),
                         );
                         let ar = req.aspect_ratio.clone();
                         let res = req.resolution.clone();
@@ -2762,6 +2786,7 @@ pub fn run_stream(
                                     "resolution": res,
                                     "generation_id": resp.generation_id,
                                     "face_ref_used": face_used,
+                                    "image_ref": ref_kind,
                                 });
                                 let mime = data_url_mime(&resp.images[0]);
                                 // merge_assistant_image_meta wraps under {"image":..}
@@ -3069,6 +3094,39 @@ mod tests {
     }
 
     #[test]
+    fn select_image_ref_picks_and_falls_back() {
+        use crate::routes::companion_stream::ImageReplyParams;
+        use eros_engine_core::types::ImageRef;
+
+        let both = ImageReplyParams {
+            face_ref_url: Some("https://x/face.png".into()),
+            prev_image_url: Some("https://x/prev.png".into()),
+            ..Default::default()
+        };
+        // previous chosen, prev present → previous
+        assert_eq!(
+            select_image_ref(ImageRef::Previous, Some(&both)),
+            (Some("https://x/prev.png".into()), "previous")
+        );
+        // face chosen → face
+        assert_eq!(
+            select_image_ref(ImageRef::Face, Some(&both)),
+            (Some("https://x/face.png".into()), "face")
+        );
+        // previous chosen but absent → fall back to face
+        let face_only = ImageReplyParams {
+            face_ref_url: Some("https://x/face.png".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            select_image_ref(ImageRef::Previous, Some(&face_only)),
+            (Some("https://x/face.png".into()), "face")
+        );
+        // nothing supplied → no url, kind reflects request fallback
+        assert_eq!(select_image_ref(ImageRef::Previous, None), (None, "face"));
+    }
+
+    #[test]
     fn build_image_gen_request_uses_subject_chain_and_style() {
         let persona = test_persona_with_meta(&[]);
         let plan_prompt = Some("a selfie".to_string());
@@ -3086,6 +3144,7 @@ mod tests {
             None, /* req_image */
             resolved.as_ref(),
             "fallback subject",
+            None, /* ref_url */
         );
         assert_eq!(req.model, "img");
         assert!(req.prompt.starts_with("Photorealistic"));

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -7111,7 +7111,15 @@ data: [DONE]\n\n";
         assert_eq!(v["json_schema"]["name"], "pde_verdict");
         assert_eq!(v["json_schema"]["strict"], true);
         let req = v["json_schema"]["schema"]["required"].as_array().unwrap();
-        assert_eq!(req.len(), 4, "all four properties required: {v}");
+        assert_eq!(req.len(), 6, "all six properties required: {v}");
+        assert!(
+            req.iter().any(|x| x == "image_ref"),
+            "image_ref required: {v}"
+        );
+        assert!(
+            req.iter().any(|x| x == "aspect_ratio"),
+            "aspect_ratio required: {v}"
+        );
         let actions = v["json_schema"]["schema"]["properties"]["action"]["enum"]
             .as_array()
             .unwrap();

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -1073,6 +1073,10 @@ pub(crate) struct PdeVerdict {
     image_prompt: Option<String>,
     #[serde(default)]
     reason: Option<String>,
+    #[serde(default)]
+    image_ref: eros_engine_core::types::ImageRef,
+    #[serde(default)]
+    aspect_ratio: Option<String>,
 }
 
 /// Parse the judge reply: direct JSON first, then a balanced JSON block in prose
@@ -1158,13 +1162,16 @@ fn pde_response_format() -> serde_json::Value {
             "schema": {
                 "type": "object",
                 "additionalProperties": false,
-                "required": ["action", "inner_state", "image_prompt", "reason"],
+                "required": ["action", "inner_state", "image_prompt", "reason", "image_ref", "aspect_ratio"],
                 "properties": {
                     "action": { "type": "string",
                         "enum": ["reply_text", "ghost", "reply_image", "reply_text_image"] },
                     "inner_state": { "type": "string" },
                     "image_prompt": { "type": ["string", "null"] },
-                    "reason": { "type": ["string", "null"] }
+                    "reason": { "type": ["string", "null"] },
+                    "image_ref": { "type": "string", "enum": ["face", "previous"] },
+                    "aspect_ratio": { "type": ["string", "null"],
+                        "enum": ["1:1", "3:4", "4:3", "9:16", "16:9", null] }
                 }
             }
         }
@@ -1459,6 +1466,9 @@ struct VerdictAudit<'a> {
     image_prompt: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     reason: Option<&'a str>,
+    image_ref: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    aspect_ratio: Option<&'a str>,
 }
 
 impl<'a> From<&'a PdeVerdict> for VerdictAudit<'a> {
@@ -1468,6 +1478,11 @@ impl<'a> From<&'a PdeVerdict> for VerdictAudit<'a> {
             inner_state: &v.inner_state,
             image_prompt: v.image_prompt.as_deref(),
             reason: v.reason.as_deref(),
+            image_ref: match v.image_ref {
+                eros_engine_core::types::ImageRef::Face => "face",
+                eros_engine_core::types::ImageRef::Previous => "previous",
+            },
+            aspect_ratio: v.aspect_ratio.as_deref(),
         }
     }
 }
@@ -2161,15 +2176,18 @@ pub fn run_stream(
                             // Capture the judge's image prompt while `v` is still
                             // borrowed here (the run/verdict is moved into the
                             // audit task below). Only image actions carry it.
-                            let img_prompt = if matches!(
+                            let is_image = matches!(
                                 action,
                                 ActionType::ReplyImage | ActionType::ReplyTextImage
-                            ) {
-                                v.image_prompt.clone()
+                            );
+                            let img_prompt = if is_image { v.image_prompt.clone() } else { None };
+                            let img_ref = if is_image {
+                                v.image_ref
                             } else {
-                                None
+                                eros_engine_core::types::ImageRef::Face
                             };
-                            pde::plan_for(&input, action, hints, img_prompt, eros_engine_core::types::ImageRef::Face, None)
+                            let img_aspect = if is_image { v.aspect_ratio.clone() } else { None };
+                            pde::plan_for(&input, action, hints, img_prompt, img_ref, img_aspect)
                         }
                         _ => pde::decide(&input), // fail-open
                     };
@@ -3217,6 +3235,29 @@ mod tests {
         assert!(parse_pde_verdict("not json").is_none());
         // unknown action → None
         assert!(parse_pde_verdict("{\"action\":\"frobnicate\"}").is_none());
+    }
+
+    #[test]
+    fn parse_pde_verdict_image_ref_and_aspect() {
+        // defaults when omitted (backward compat)
+        let v = parse_pde_verdict("{\"action\":\"reply_image\",\"inner_state\":\"ok\"}").unwrap();
+        assert_eq!(v.image_ref, eros_engine_core::types::ImageRef::Face);
+        assert_eq!(v.aspect_ratio, None);
+
+        // explicit values
+        let j = "{\"action\":\"reply_image\",\"inner_state\":\"x\",\"image_ref\":\"previous\",\"aspect_ratio\":\"9:16\"}";
+        let v = parse_pde_verdict(j).unwrap();
+        assert_eq!(v.image_ref, eros_engine_core::types::ImageRef::Previous);
+        assert_eq!(v.aspect_ratio.as_deref(), Some("9:16"));
+    }
+
+    #[test]
+    fn verdict_audit_includes_image_ref_and_aspect() {
+        let j = "{\"action\":\"reply_image\",\"inner_state\":\"x\",\"image_ref\":\"previous\",\"aspect_ratio\":\"3:4\"}";
+        let v = parse_pde_verdict(j).unwrap();
+        let payload = serde_json::to_value(VerdictAudit::from(&v)).unwrap();
+        assert_eq!(payload["image_ref"], "previous");
+        assert_eq!(payload["aspect_ratio"], "3:4");
     }
 
     #[test]

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -1331,7 +1331,14 @@ fn apply_ghosting_killswitch(
     hints: Vec<String>,
 ) -> eros_engine_core::types::ActionPlan {
     if !ghosting_enabled && plan.action_type == ActionType::Ghost {
-        eros_engine_core::pde::plan_for(input, ActionType::ReplyText, hints, None)
+        eros_engine_core::pde::plan_for(
+            input,
+            ActionType::ReplyText,
+            hints,
+            None,
+            eros_engine_core::types::ImageRef::Face,
+            None,
+        )
     } else {
         plan
     }
@@ -2162,7 +2169,7 @@ pub fn run_stream(
                             } else {
                                 None
                             };
-                            pde::plan_for(&input, action, hints, img_prompt)
+                            pde::plan_for(&input, action, hints, img_prompt, eros_engine_core::types::ImageRef::Face, None)
                         }
                         _ => pde::decide(&input), // fail-open
                     };
@@ -2196,6 +2203,8 @@ pub fn run_stream(
                 action,
                 plan.context_hints.clone(),
                 req_image.and_then(|i| i.image_prompt.clone()),
+                eros_engine_core::types::ImageRef::Face,
+                None,
             );
         }
 
@@ -3395,7 +3404,14 @@ mod tests {
     #[test]
     fn killswitch_downgrades_ghost_keeping_hints() {
         let input = pde_test_input();
-        let ghost_plan = eros_engine_core::pde::plan_for(&input, ActionType::Ghost, vec![], None);
+        let ghost_plan = eros_engine_core::pde::plan_for(
+            &input,
+            ActionType::Ghost,
+            vec![],
+            None,
+            eros_engine_core::types::ImageRef::Face,
+            None,
+        );
         // ghosting enabled → unchanged
         let kept = apply_ghosting_killswitch(ghost_plan.clone(), true, &input, vec!["想躲".into()]);
         assert_eq!(kept.action_type, ActionType::Ghost);
@@ -3412,7 +3428,14 @@ mod tests {
         assert_eq!(acted, ActionType::Ghost); // permitted
 
         let hints = vec![sanitize_inner_state("有点想躲")];
-        let plan = pde::plan_for(&input, acted, hints.clone(), None);
+        let plan = pde::plan_for(
+            &input,
+            acted,
+            hints.clone(),
+            None,
+            eros_engine_core::types::ImageRef::Face,
+            None,
+        );
         // ghosting disabled → suppressed to reply, hints preserved
         let final_plan = apply_ghosting_killswitch(plan, false, &input, hints.clone());
         assert_eq!(final_plan.action_type, ActionType::ReplyText);

--- a/crates/eros-engine-server/src/routes/companion_stream.rs
+++ b/crates/eros-engine-server/src/routes/companion_stream.rs
@@ -97,6 +97,13 @@ pub struct ImageReplyParams {
     pub resolution: Option<String>,
     #[serde(default)]
     pub face_ref_url: Option<String>,
+    /// Optional URL of the previously generated image, for iteration. Selected
+    /// when the PDE chooses `image_ref = previous`. Same validation as
+    /// `face_ref_url`; the engine never fetches it — it is embedded in the
+    /// OpenRouter body and fetched by the image provider at generation time, so
+    /// clients backed by a private store should pass a short-lived signed URL.
+    #[serde(default)]
+    pub prev_image_url: Option<String>,
 }
 
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
@@ -274,6 +281,17 @@ fn validate_payload(req: &StreamSendRequest) -> Result<(), AppError> {
                     code: "unprocessable",
                     message: "face_ref_url must be an absolute http(s) URL".into(),
                     user_message: "脸部参考图链接无效".into(),
+                    original_user_message_id: None,
+                }));
+            }
+        }
+        if let Some(url) = img.prev_image_url.as_deref() {
+            if !image_url_is_valid(url) {
+                return Err(AppError::StreamPre(StreamPreError {
+                    status: StatusCode::UNPROCESSABLE_ENTITY,
+                    code: "unprocessable",
+                    message: "prev_image_url must be an absolute http(s) URL".into(),
+                    user_message: "上一张图片链接无效".into(),
                     original_user_message_id: None,
                 }));
             }
@@ -1192,5 +1210,23 @@ mod validate_payload_tests {
             ..Default::default()
         });
         assert!(validate_payload(&req2).is_err());
+    }
+
+    #[test]
+    fn validate_rejects_bad_prev_image_url() {
+        let mut req = minimal_req();
+        req.image = Some(ImageReplyParams {
+            prev_image_url: Some("ftp://nope".into()),
+            ..Default::default()
+        });
+        assert!(validate_payload(&req).is_err());
+
+        // a valid absolute https URL is accepted
+        let mut ok = minimal_req();
+        ok.image = Some(ImageReplyParams {
+            prev_image_url: Some("https://example.test/a.png".into()),
+            ..Default::default()
+        });
+        assert!(validate_payload(&ok).is_ok());
     }
 }

--- a/docs/spec/image-iteration-and-aspect.md
+++ b/docs/spec/image-iteration-and-aspect.md
@@ -1,0 +1,104 @@
+# Image generation: prior-image awareness, ref iteration, real aspect ratio, prompt composer
+
+**Status:** design (ready for implementation)
+**Area:** chat stream pipeline — interaction director (PDE) and image generation.
+
+The per-turn interaction director (PDE) can emit `reply_image` / `reply_text_image`
+and the engine generates an image via OpenRouter. This design closes four gaps in
+that path. It covers **engine code support only**; the PDE prompt text and the
+prompt-composer task definition live in the deployment's `model_config.toml`
+(downstream) and are out of scope here.
+
+## Problems (verified against source)
+
+1. **PDE is blind to prior images.** `build_input_filter_transcript`
+   (`crates/eros-engine-server/src/pipeline/stream.rs`) emits only `m.content` for
+   assistant rows. Image turns persist empty `content`, so the transcript shows a
+   blank `AI:` line. The image facts are persisted at `chat_messages.metadata.image`
+   (written around `stream.rs:2304-2326`) but never surfaced to the judge.
+2. **Only one reference image.** `ImageGenRequest.face_ref_url` is a single URL the
+   client supplies; the engine forwards it into one `image_url` block
+   (`crates/eros-engine-llm/src/openrouter.rs:164-168`). No way to continue from the
+   previous generated image.
+3. **Aspect ratio is ignored.** `build_image_body` folds aspect ratio into the
+   **text prompt** as `"(aspect ratio: …)"` (`openrouter.rs:152-181`), which image
+   models do not honor — output stays at the model default.
+4. **Thin prompts.** The PDE writes `image_prompt` while also choosing the action
+   and `inner_state`, on a tight token budget.
+
+## Changes
+
+### 1. Surface prior images into the judge transcript
+- `build_input_filter_transcript`: for assistant rows that carry `metadata.image`,
+  render a marker line instead of the empty `content`, e.g.
+  `AI:（image sent: <subject summary>, ratio <ar>）` (wording set by implementation;
+  keep it terse). This transcript is also consumed by the input filter, where the
+  marker is harmless context.
+- **Dependency:** `ChatRepo::history(...)` rows must expose `metadata`. Confirm; if
+  the row struct/query omits it, extend them.
+
+### 2. PDE output schema: `image_ref` + `aspect_ratio`
+- Extend `PdeVerdict` (`stream.rs`) and the resulting `ActionPlan`
+  (`crates/eros-engine-core/src/pde.rs`, `types.rs`) with:
+  - `image_ref`: enum `{ face, previous }`, default `face`.
+  - `aspect_ratio`: optional, validated against `{1:1, 3:4, 4:3, 9:16, 16:9}`;
+    unknown/missing → `None` (caller falls back, see §4).
+- Update `parse_pde_verdict` and `VerdictAudit` (`stream.rs:1440`) so the new fields
+  are parsed and recorded into the decision-event payload.
+- All new fields `#[serde(default)]` so existing prompts that omit them still parse.
+
+### 3. Reference iteration: accept and select a previous-image ref
+- `ImageReplyParams` (`crates/eros-engine-server/src/routes/companion_stream.rs:81-100`):
+  add `prev_image_url: Option<String>`, validated as an absolute `http(s)` URL with
+  the same rule as `face_ref_url` (`companion_stream.rs:270`). It points at the
+  previous generated image; clients backed by a private object store should pass a
+  short-lived signed URL (the engine does not fetch it — the URL is embedded in the
+  OpenRouter request body and fetched by the image provider at generation time).
+- At the image-draw sites (`stream.rs` `ReplyImage` path ~2256 and `ReplyTextImage`
+  path ~2648), select the reference:
+  `ref = (plan.image_ref == previous && prev_image_url present) ? prev_image_url : face_ref_url`.
+  Thread the chosen URL through `build_image_gen_request` into
+  `ImageGenRequest.face_ref_url`. Record which kind of ref was used in
+  `metadata.image` (extend the existing `face_ref_used` field).
+
+### 4. Real aspect-ratio control
+- Aspect-ratio resolution priority becomes
+  `plan.aspect_ratio > req_image.aspect_ratio > config default`
+  (extends `stream.rs:141`; the image-draw paths must pass `plan.aspect_ratio`).
+- `build_image_body` (`openrouter.rs:152-181`): stop appending the
+  `(aspect ratio: …)` / `(resolution: …)` text hints. Send the aspect ratio as a
+  **real generation parameter**, with an explicit `width×height` resolution as the
+  fallback for models that do not accept an aspect parameter.
+- **Feasibility risk — resolve first:** the accepted parameter differs per image
+  model. Verify it for each configured image model (probe the model's
+  `/models/{slug}/endpoints` and/or a live test) before relying on it; keep the
+  resolution fallback for models without aspect support.
+
+### 5. Prompt composer task (`image_prompt_compose`)
+- New optional config task parsed alongside the others in
+  `crates/eros-engine-llm/src/model_config.rs` (e.g. `ResolvedImagePromptCompose`
+  with `model`, `fallback`, `temperature`, `max_tokens`, `filter_prompt`). Feature is
+  **off** when the task is absent (mirrors the `chat_vision` gating pattern).
+- In the pipeline, after an image action is decided and before image generation,
+  call the composer with: persona genome (`art_metadata` + `system_prompt`), the PDE
+  seed subject (`plan.image_prompt`), recent scene context (transcript), the chosen
+  aspect ratio, and the style. Use the enriched result as the image subject.
+- **Fallback:** on composer failure / timeout / empty, use `plan.image_prompt`
+  unchanged. The composer must never block or fail the image turn.
+
+## Backward compatibility
+- New PDE output fields and `ImageReplyParams.prev_image_url` are optional.
+- The `image_prompt_compose` task is optional; absent ⇒ current behavior.
+- The aspect-parameter change is internal to image-body construction.
+
+## Out of scope
+- Multiple reference images in one request (single ref covers iteration).
+- Persisting the real action type for image rows (today's hardcoded `"reply"`);
+  `metadata.image` remains the source of truth for "was an image sent."
+
+## Open items for implementation
+1. Confirm/extend `ChatRepo::history` to expose `metadata` (§1).
+2. Verify the real aspect-ratio parameter accepted by each configured image
+   model (§4) — the one feasibility risk.
+3. Decide whether the PDE task's `max_tokens` needs raising for richer seed
+   subjects (config-side; coordinate with the downstream `model_config.toml`).

--- a/docs/superpowers/specs/2026-06-28-image-iteration-and-aspect-design.md
+++ b/docs/superpowers/specs/2026-06-28-image-iteration-and-aspect-design.md
@@ -98,9 +98,14 @@ prompt-composer task definition live in the deployment's `model_config.toml`
   product-identity-free built-in default prompt (`DEFAULT_COMPOSE_PROMPT`) and is
   gated on the task being *present* (a model configured). A non-blank `filter_prompt`
   overrides the default; a blank/absent one falls back to it. The built-in text stays
-  generic — no product name, brand aesthetic, or explicit content (the runtime payload
-  carries appearance/scene/subject) — so the OSS repo stays identity-free while
+  generic — no product name or brand — so the OSS repo stays identity-free while
   deployments can layer product flavor via the override.
+- **Built-in default is expand-only.** It faithfully expands the seed subject + appearance
+  into a detailed prompt and does not soften, downgrade, or refuse, and adds no
+  content-moderation layer of its own — moderation is delegated to the image-model
+  provider and the downstream deployment, not this step. (A generic behavioral stance;
+  no explicit content or model name in engine code. The composer model is a config-side
+  choice.)
 - In the pipeline, after an image action is decided and before image generation,
   call the composer with: persona genome (`art_metadata` + `system_prompt`), the PDE
   seed subject (`plan.image_prompt`), recent scene context (transcript), the chosen

--- a/docs/superpowers/specs/2026-06-28-image-iteration-and-aspect-design.md
+++ b/docs/superpowers/specs/2026-06-28-image-iteration-and-aspect-design.md
@@ -34,15 +34,22 @@ prompt-composer task definition live in the deployment's `model_config.toml`
   `AI:（image sent: <subject summary>, ratio <ar>）` (wording set by implementation;
   keep it terse). This transcript is also consumed by the input filter, where the
   marker is harmless context.
-- **Dependency:** `ChatRepo::history(...)` rows must expose `metadata`. Confirm; if
-  the row struct/query omits it, extend them.
+- **Dependency (already satisfied):** the transcript builder reads
+  `chat_repo.history(...)` (`stream.rs:1630`), which returns `ChatMessage` rows that
+  already carry `metadata` (`crates/eros-engine-store/src/chat.rs:69`, `#[serde(default)]`;
+  covered by the `history_row_exposes_metadata_column` test at `chat.rs:2068`). No
+  struct/query change needed — the impl just reads `m.metadata.image` and renders the
+  marker. (The narrower `history_slim`/`ChatMessageSlim` path drops `metadata`, so do
+  **not** switch the transcript builder to it.)
 
 ### 2. PDE output schema: `image_ref` + `aspect_ratio`
 - Extend `PdeVerdict` (`stream.rs`) and the resulting `ActionPlan`
   (`crates/eros-engine-core/src/pde.rs`, `types.rs`) with:
   - `image_ref`: enum `{ face, previous }`, default `face`.
   - `aspect_ratio`: optional, validated against `{1:1, 3:4, 4:3, 9:16, 16:9}`;
-    unknown/missing → `None` (caller falls back, see §4).
+    unknown/missing → `None` (caller falls back, see §4). This is the **same set**
+    already enforced on the request input at `companion_stream.rs:283`; factor it into
+    one shared constant/helper so the PDE-output and request-input checks can't drift.
 - Update `parse_pde_verdict` and `VerdictAudit` (`stream.rs:1440`) so the new fields
   are parsed and recorded into the decision-event payload.
 - All new fields `#[serde(default)]` so existing prompts that omit them still parse.
@@ -69,6 +76,13 @@ prompt-composer task definition live in the deployment's `model_config.toml`
   `(aspect ratio: …)` / `(resolution: …)` text hints. Send the aspect ratio as a
   **real generation parameter**, with an explicit `width×height` resolution as the
   fallback for models that do not accept an aspect parameter.
+- **Define the aspect → `width×height` mapping.** The resolution fallback needs a
+  concrete pixel size when only an aspect ratio is known. Add a small table mapping
+  each of the five ratios to a `width×height` (e.g. anchor on a fixed long edge per
+  orientation) so the fallback is deterministic. The plumbing already exists
+  (`ImageGenRequest.resolution`, `req_image.resolution`, config `default_resolution`);
+  this only defines how a chosen aspect becomes a resolution when no explicit one is
+  supplied.
 - **Feasibility risk — resolve first:** the accepted parameter differs per image
   model. Verify it for each configured image model (probe the model's
   `/models/{slug}/endpoints` and/or a live test) before relying on it; keep the
@@ -97,8 +111,8 @@ prompt-composer task definition live in the deployment's `model_config.toml`
   `metadata.image` remains the source of truth for "was an image sent."
 
 ## Open items for implementation
-1. Confirm/extend `ChatRepo::history` to expose `metadata` (§1).
-2. Verify the real aspect-ratio parameter accepted by each configured image
+1. Verify the real aspect-ratio parameter accepted by each configured image
    model (§4) — the one feasibility risk.
+2. Settle the aspect → `width×height` mapping for the resolution fallback (§4).
 3. Decide whether the PDE task's `max_tokens` needs raising for richer seed
    subjects (config-side; coordinate with the downstream `model_config.toml`).

--- a/docs/superpowers/specs/2026-06-28-image-iteration-and-aspect-design.md
+++ b/docs/superpowers/specs/2026-06-28-image-iteration-and-aspect-design.md
@@ -93,6 +93,14 @@ prompt-composer task definition live in the deployment's `model_config.toml`
   `crates/eros-engine-llm/src/model_config.rs` (e.g. `ResolvedImagePromptCompose`
   with `model`, `fallback`, `temperature`, `max_tokens`, `filter_prompt`). Feature is
   **off** when the task is absent (mirrors the `chat_vision` gating pattern).
+- **Prompt source — built-in default + config override.** Unlike the other tasks
+  (whose prompt must come from config), the composer ships a generic,
+  product-identity-free built-in default prompt (`DEFAULT_COMPOSE_PROMPT`) and is
+  gated on the task being *present* (a model configured). A non-blank `filter_prompt`
+  overrides the default; a blank/absent one falls back to it. The built-in text stays
+  generic — no product name, brand aesthetic, or explicit content (the runtime payload
+  carries appearance/scene/subject) — so the OSS repo stays identity-free while
+  deployments can layer product flavor via the override.
 - In the pipeline, after an image action is decided and before image generation,
   call the composer with: persona genome (`art_metadata` + `system_prompt`), the PDE
   seed subject (`plan.image_prompt`), recent scene context (transcript), the chosen

--- a/docs/superpowers/specs/2026-06-28-image-iteration-and-aspect-design.md
+++ b/docs/superpowers/specs/2026-06-28-image-iteration-and-aspect-design.md
@@ -88,7 +88,7 @@ prompt-composer task definition live in the deployment's `model_config.toml`
   `/models/{slug}/endpoints` and/or a live test) before relying on it; keep the
   resolution fallback for models without aspect support.
 
-### 5. Prompt composer task (`image_prompt_compose`)
+### 5. Prompt composer task (`chat_image_prompt_compose`)
 - New optional config task parsed alongside the others in
   `crates/eros-engine-llm/src/model_config.rs` (e.g. `ResolvedImagePromptCompose`
   with `model`, `fallback`, `temperature`, `max_tokens`, `filter_prompt`). Feature is
@@ -102,7 +102,7 @@ prompt-composer task definition live in the deployment's `model_config.toml`
 
 ## Backward compatibility
 - New PDE output fields and `ImageReplyParams.prev_image_url` are optional.
-- The `image_prompt_compose` task is optional; absent ⇒ current behavior.
+- The `chat_image_prompt_compose` task is optional; absent ⇒ current behavior.
 - The aspect-parameter change is internal to image-body construction.
 
 ## Out of scope


### PR DESCRIPTION
Phase 1 (engine, OSS) of the image-generation overhaul. Adds engine-side support for prior-image awareness, previous-image iteration, real aspect-ratio control, and an optional image-prompt composer. All backward-compatible and inert until downstream config opts in.

Spec: `docs/superpowers/specs/2026-06-28-image-iteration-and-aspect-design.md`

## What's in it
1. **Prior-image marker in the judge transcript** — assistant image turns (empty `content`, facts under `metadata.image`) now render a terse marker for the PDE instead of a blank `AI:` line.
2. **PDE verdict gains `image_ref` + `aspect_ratio`** — threaded through `ActionPlan`, parsed, schema-validated, and recorded in the decision audit. `#[serde(default)]` so existing prompts still parse.
3. **Previous-image iteration** — request `prev_image_url` (validated like `face_ref_url`); `select_image_ref` picks avatar vs. previous per the PDE's `image_ref`, falling back to face. Ref kind recorded in `metadata.image`.
4. **Real aspect ratio** — `build_image_body` sends a real `width`/`height` size (mapped from the chosen ratio, explicit resolution preferred) and drops the ignored `(aspect ratio: …)` text hint. Priority `plan > req > config default`.
5. **Optional `chat_image_prompt_compose` task** — enriches the image subject via an LLM; **built-in expand-only default prompt**, config-overridable; gated on the task being present; fail-open to the seed subject. Off when the task is absent.

## Backward compatibility
With no config change: new PDE fields default `face`/`none`; composer off; `prev_image_url` unset ⇒ avatar; image size derived from existing req/config aspect. i.e. today's behavior, minus the ignored text hint.

## Verification
- `cargo test --workspace`: 642 passed / 0 failed (core 56, llm 164, server 325, store 97)
- fmt clean; `clippy --workspace --all-targets -D warnings` clean; OpenAPI snapshot regenerated (no drift)

## Open item (deferred, not a blocker)
The real per-model image-size wire parameter (`width`/`height` vs `size:"WxH"` vs nested) needs live verification against the configured image models before production reliance; the engine ships a deterministic `width`/`height` + resolution fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)