### PR TITLE
feat: reply_to_message_id context anchoring

### DIFF
--- a/crates/eros-engine-core/src/pde.rs
+++ b/crates/eros-engine-core/src/pde.rs
@@ -265,6 +265,7 @@ mod tests {
             memory_scope: Default::default(),
             affinity_scope: Default::default(),
             tips_amount_usd: None,
+            history_anchor: Default::default(),
         }
     }
 
@@ -278,6 +279,7 @@ mod tests {
             memory_scope: Default::default(),
             affinity_scope: Default::default(),
             tips_amount_usd: Some(amount),
+            history_anchor: Default::default(),
         }
     }
 

--- a/crates/eros-engine-core/src/types.rs
+++ b/crates/eros-engine-core/src/types.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //! Public types for the companion engine.
 
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -35,6 +36,7 @@ pub struct LlmAudit {
 
 /// Events that drive the engine pipeline.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(clippy::large_enum_variant)] // UserMessage is intentionally large; boxing would add indirection
 pub enum Event {
     UserMessage {
         content: String,
@@ -68,9 +70,28 @@ pub enum Event {
         /// gets a tip fragment. `None` for normal messages.
         #[serde(default)]
         tips_amount_usd: Option<f64>,
+        /// Optional caller-supplied reply anchor (#reply_to). Defaults to
+        /// `Latest` (normal tail window) when absent.
+        #[serde(default)]
+        history_anchor: HistoryAnchor,
     },
     ProactiveTrigger,
     AppOpen,
+}
+
+/// Where the turn's main conversation history is anchored. `Latest` (default):
+/// the normal tail window. `At`: rewind to a quoted message — history up to and
+/// including `sent_at`, then the new message. `DropHistory`: the caller's
+/// `reply_to_message_id` was unresolvable, so inject no prior turns.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum HistoryAnchor {
+    #[default]
+    Latest,
+    At {
+        message_id: Uuid,
+        sent_at: DateTime<Utc>,
+    },
+    DropHistory,
 }
 
 /// Which reference image an image turn should build on. `Face` = the static
@@ -296,5 +317,29 @@ mod tests {
         assert!(ActionType::ReplyTextImage.is_text_reply());
         assert!(!ActionType::Ghost.is_text_reply());
         assert!(!ActionType::Proactive.is_text_reply());
+    }
+
+    #[test]
+    fn history_anchor_defaults_to_latest_and_event_omits_it() {
+        // Default is Latest.
+        assert_eq!(HistoryAnchor::default(), HistoryAnchor::Latest);
+
+        // An event JSON without `history_anchor` still parses, defaulting to Latest.
+        let raw = r#"{"UserMessage":{"content":"hi","message_id":"00000000-0000-0000-0000-000000000001"}}"#;
+        let ev: Event = serde_json::from_str(raw).unwrap();
+        match ev {
+            Event::UserMessage { history_anchor, .. } => {
+                assert_eq!(history_anchor, HistoryAnchor::Latest);
+            }
+            _ => panic!("expected UserMessage"),
+        }
+
+        // At{...} round-trips through serde.
+        let at = HistoryAnchor::At {
+            message_id: uuid::Uuid::nil(),
+            sent_at: chrono::DateTime::<chrono::Utc>::from_timestamp(0, 0).unwrap(),
+        };
+        let s = serde_json::to_string(&at).unwrap();
+        assert_eq!(serde_json::from_str::<HistoryAnchor>(&s).unwrap(), at);
     }
 }

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -1486,6 +1486,14 @@
               "$ref": "#/components/schemas/PromptTraitDto"
             }
           },
+          "reply_to_message_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "Optional id of a `chat_messages` row in this session to anchor context on.\nWhen valid, history rewinds to (and includes) that message; when present\nbut unresolvable, history is dropped for this turn (recorded in metadata)."
+          },
           "tier": {
             "type": [
               "string",

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -1430,6 +1430,7 @@ mod tests {
             memory_scope: Default::default(),
             affinity_scope: Default::default(),
             tips_amount_usd: None,
+            history_anchor: Default::default(),
         };
         let extracted = audit_from_event(&ev);
         assert_eq!(extracted, Some(&audit));

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -40,6 +40,23 @@ const CHAT_TASK: &str = "chat_companion";
 /// Maximum number of recent messages pulled into the prompt.
 const HISTORY_WINDOW: i64 = 20;
 
+/// Resolved fetch strategy for the main history of a turn. Pure mapping of the
+/// event's `HistoryAnchor`, factored out so it can be unit-tested.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HistoryFetch {
+    Latest,
+    Anchored(Option<chrono::DateTime<chrono::Utc>>),
+}
+
+fn history_fetch_for(anchor: eros_engine_core::types::HistoryAnchor) -> HistoryFetch {
+    use eros_engine_core::types::HistoryAnchor;
+    match anchor {
+        HistoryAnchor::Latest => HistoryFetch::Latest,
+        HistoryAnchor::At { sent_at, .. } => HistoryFetch::Anchored(Some(sent_at)),
+        HistoryAnchor::DropHistory => HistoryFetch::Anchored(None),
+    }
+}
+
 /// Partition caller traits by a tier's resolved allow-list.
 /// - `allow == None` → no gating: all kept, none dropped.
 /// - `allow == Some(set)` → keep only traits whose `tag` ∈ `set`; the rest
@@ -565,7 +582,18 @@ pub(super) async fn build_reply_request(
     user_message_id: Uuid,
 ) -> Result<(ChatRequest, Vec<String>), AppError> {
     let chat_repo = ChatRepo { pool: &state.pool };
-    let history = chat_repo.history(session_id, HISTORY_WINDOW, 0).await?;
+    let history_anchor = match &input.event {
+        eros_engine_core::types::Event::UserMessage { history_anchor, .. } => *history_anchor,
+        _ => eros_engine_core::types::HistoryAnchor::Latest,
+    };
+    let history = match history_fetch_for(history_anchor) {
+        HistoryFetch::Latest => chat_repo.history(session_id, HISTORY_WINDOW, 0).await?,
+        HistoryFetch::Anchored(anchor) => {
+            chat_repo
+                .history_anchored(session_id, user_message_id, anchor, HISTORY_WINDOW)
+                .await?
+        }
+    };
 
     // Recall query for the current user turn: the effective caption, or — for an
     // image-only turn — the vision description (recall_query_text), so a photo
@@ -1873,5 +1901,26 @@ mod tests {
         );
         assert_eq!(pairs_after[0], ("u0".to_string(), "a0".to_string()));
         assert_eq!(pairs_after[1], ("u1".to_string(), "a1".to_string()));
+    }
+
+    #[test]
+    fn history_fetch_for_maps_each_anchor() {
+        use eros_engine_core::types::HistoryAnchor;
+        let ts = chrono::DateTime::<chrono::Utc>::from_timestamp(123, 0).unwrap();
+        assert_eq!(
+            history_fetch_for(HistoryAnchor::Latest),
+            HistoryFetch::Latest
+        );
+        assert_eq!(
+            history_fetch_for(HistoryAnchor::At {
+                message_id: uuid::Uuid::nil(),
+                sent_at: ts
+            }),
+            HistoryFetch::Anchored(Some(ts)),
+        );
+        assert_eq!(
+            history_fetch_for(HistoryAnchor::DropHistory),
+            HistoryFetch::Anchored(None),
+        );
     }
 }

--- a/crates/eros-engine-server/src/pipeline/post_process.rs
+++ b/crates/eros-engine-server/src/pipeline/post_process.rs
@@ -1014,6 +1014,7 @@ mod tests {
             memory_scope: Default::default(),
             affinity_scope: Default::default(),
             tips_amount_usd: None,
+            history_anchor: Default::default(),
         };
         // Only `user` is taken; session_id/metadata are ignored by design.
         assert_eq!(client_id_from_event(&event).as_deref(), Some("u_abc"));
@@ -1030,6 +1031,7 @@ mod tests {
             memory_scope: Default::default(),
             affinity_scope: Default::default(),
             tips_amount_usd: None,
+            history_anchor: Default::default(),
         };
         assert_eq!(client_id_from_event(&event), None);
     }

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -2156,6 +2156,9 @@ pub struct PersistedUserMessage {
     pub image_url: Option<String>,
     /// Image reply parameters supplied by the client, forwarded from the request.
     pub image: Option<crate::routes::companion_stream::ImageReplyParams>,
+    /// Where this turn's main history is anchored (resolved from the request's
+    /// `reply_to_message_id`). `Latest` for ordinary turns.
+    pub history_anchor: eros_engine_core::types::HistoryAnchor,
 }
 
 /// Produce a stream of `ProtocolFrame` events for a single burst. The
@@ -2225,6 +2228,7 @@ pub fn run_stream(
                 memory_scope: user_msg.memory_scope,
                 affinity_scope: user_msg.affinity_scope,
                 tips_amount_usd: user_msg.tips_amount_usd,
+                history_anchor: user_msg.history_anchor,
             },
             affinity: affinity.clone(),
             persona,
@@ -2630,6 +2634,7 @@ pub fn run_stream(
                         memory_scope: user_msg.memory_scope,
                         affinity_scope: user_msg.affinity_scope,
                         tips_amount_usd: user_msg.tips_amount_usd,
+                        history_anchor: user_msg.history_anchor,
                     };
                     let user_id_bg = user_msg.user_id;
                     let instance_id_bg = user_msg.instance_id;
@@ -3001,6 +3006,7 @@ pub fn run_stream(
                     memory_scope: user_msg.memory_scope,
                     affinity_scope: user_msg.affinity_scope,
                     tips_amount_usd: user_msg.tips_amount_usd,
+                    history_anchor: user_msg.history_anchor,
                 };
                 let user_id_bg = user_msg.user_id;
                 let instance_id_bg = user_msg.instance_id;
@@ -3611,6 +3617,7 @@ mod tests {
                 memory_scope: Default::default(),
                 affinity_scope: Default::default(),
                 tips_amount_usd: None,
+                history_anchor: Default::default(),
             },
             affinity: pde_test_affinity(),
             persona: pde_test_persona(),
@@ -3808,6 +3815,7 @@ mod tests {
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
+                history_anchor: Default::default(),
             },
         )
         .collect()
@@ -3943,6 +3951,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
+                history_anchor: Default::default(),
             },
         )
         .collect()
@@ -4028,6 +4037,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
+                history_anchor: Default::default(),
             },
         )
         .collect()
@@ -4129,6 +4139,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
+                history_anchor: Default::default(),
             },
         )
         .collect()
@@ -4445,6 +4456,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
+                history_anchor: Default::default(),
             },
         )
         .collect()
@@ -4569,6 +4581,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
+                history_anchor: Default::default(),
             },
         )
         .collect()
@@ -4706,6 +4719,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
+                history_anchor: Default::default(),
             },
         )
         .collect()
@@ -4858,6 +4872,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
+                history_anchor: Default::default(),
             },
         )
         .collect()
@@ -4972,6 +4987,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
+                history_anchor: Default::default(),
             },
         )
         .collect()
@@ -5067,6 +5083,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: Some(20.0),
                 image_url: None,
                 image: None,
+                history_anchor: Default::default(),
             },
         )
         .collect()
@@ -5174,6 +5191,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
+                history_anchor: Default::default(),
             },
         )
         .collect()
@@ -5283,6 +5301,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
+                history_anchor: Default::default(),
             },
         )
         .collect()
@@ -5411,6 +5430,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
+                history_anchor: Default::default(),
             },
         )
         .collect()
@@ -5612,6 +5632,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
+                history_anchor: Default::default(),
             },
         )
         .collect()
@@ -5756,6 +5777,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
+                history_anchor: Default::default(),
             },
         )
         .collect()
@@ -5866,6 +5888,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: Some(0.5),
                 image_url: None,
                 image: None,
+                history_anchor: Default::default(),
             },
         )
         .collect()
@@ -6041,6 +6064,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: Some("https://x/y.png".into()),
                 image: None,
+                history_anchor: Default::default(),
             },
         )
         .collect()
@@ -6200,6 +6224,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
+                history_anchor: Default::default(),
             },
         )
         .collect()
@@ -6342,6 +6367,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
+                history_anchor: Default::default(),
             },
         )
         .collect()
@@ -6464,6 +6490,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
+                history_anchor: Default::default(),
             },
         )
         .collect()
@@ -6600,6 +6627,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: Some(1.0),
                 image_url: None,
                 image: None,
+                history_anchor: Default::default(),
             },
         )
         .collect()
@@ -6750,6 +6778,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: Some(1.0),
                 image_url: None,
                 image: None,
+                history_anchor: Default::default(),
             },
         )
         .collect()
@@ -7080,6 +7109,7 @@ data: [DONE]\n\n";
                 memory_scope: Default::default(),
                 affinity_scope: Default::default(),
                 tips_amount_usd: None,
+                history_anchor: Default::default(),
             },
             affinity: test_affinity(),
             persona: p,
@@ -7131,6 +7161,7 @@ data: [DONE]\n\n";
                 memory_scope: Default::default(),
                 affinity_scope: Default::default(),
                 tips_amount_usd: None,
+                history_anchor: Default::default(),
             },
             affinity: test_affinity(),
             persona: p,
@@ -7368,6 +7399,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
+                history_anchor: Default::default(),
             },
         )
         .collect()

--- a/crates/eros-engine-server/src/routes/companion_stream.rs
+++ b/crates/eros-engine-server/src/routes/companion_stream.rs
@@ -514,6 +514,7 @@ pub async fn send_message_stream(
                     tips_amount_usd: req.tips_amount_usd,
                     image_url: req.image_url.clone(),
                     image: req.image.clone(),
+                    history_anchor: eros_engine_core::types::HistoryAnchor::Latest,
                 };
                 Box::pin(run_stream(state_arc, user_msg))
             }

--- a/crates/eros-engine-server/src/routes/companion_stream.rs
+++ b/crates/eros-engine-server/src/routes/companion_stream.rs
@@ -127,6 +127,11 @@ pub struct StreamSendRequest {
     pub image_url: Option<String>,
     #[serde(default)]
     pub image: Option<ImageReplyParams>,
+    /// Optional id of a `chat_messages` row in this session to anchor context on.
+    /// When valid, history rewinds to (and includes) that message; when present
+    /// but unresolvable, history is dropped for this turn (recorded in metadata).
+    #[serde(default)]
+    pub reply_to_message_id: Option<Uuid>,
 }
 
 /// Pre-stream error body per spec §1.3. Schema-only struct for utoipa;
@@ -425,6 +430,21 @@ pub async fn send_message_stream(
             })
         })?;
 
+    // Resolve the optional reply anchor BEFORE the upsert so the outcome can be
+    // recorded in the new row's metadata. A present-but-unresolvable id does not
+    // fail the request — we drop history for this turn and flag it (DropHistory).
+    use eros_engine_core::types::HistoryAnchor;
+    let history_anchor = match req.reply_to_message_id {
+        None => HistoryAnchor::Latest,
+        Some(id) => match chat_repo.message_sent_at_in_session(session_id, id).await? {
+            Some(sent_at) => HistoryAnchor::At {
+                message_id: id,
+                sent_at,
+            },
+            None => HistoryAnchor::DropHistory,
+        },
+    };
+
     // Build metadata: conditionally include tips_amount_usd, tier, and image_url.
     // tier is omitted entirely (not written as null) when absent — keeps JSONB shape sparse.
     let mut meta_map = serde_json::Map::new();
@@ -463,6 +483,15 @@ pub async fn send_message_stream(
             .map(|t| serde_json::json!({"tag": t.tag, "text": t.text}))
             .collect();
         meta_map.insert("prompt_traits_raw".into(), serde_json::Value::Array(arr));
+    }
+    match history_anchor {
+        HistoryAnchor::At { message_id, .. } => {
+            meta_map.insert("reply_to_message_id".into(), serde_json::json!(message_id));
+        }
+        HistoryAnchor::DropHistory => {
+            meta_map.insert("reply_to_error".into(), serde_json::json!("not_found"));
+        }
+        HistoryAnchor::Latest => {}
     }
     let persisted_metadata: Option<serde_json::Value> = if meta_map.is_empty() {
         None
@@ -514,7 +543,7 @@ pub async fn send_message_stream(
                     tips_amount_usd: req.tips_amount_usd,
                     image_url: req.image_url.clone(),
                     image: req.image.clone(),
-                    history_anchor: eros_engine_core::types::HistoryAnchor::Latest,
+                    history_anchor,
                 };
                 Box::pin(run_stream(state_arc, user_msg))
             }
@@ -670,6 +699,7 @@ mod tests {
             tips_amount_usd: None,
             image_url: None,
             image: None,
+            reply_to_message_id: None,
         }
     }
 
@@ -685,6 +715,7 @@ mod tests {
             tips_amount_usd: amount,
             image_url: None,
             image: None,
+            reply_to_message_id: None,
         }
     }
 
@@ -999,6 +1030,84 @@ mod tests {
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn stream_records_reply_to_message_id_in_metadata(pool: PgPool) {
+        use eros_engine_store::chat::ChatRepo;
+        let user_id = Uuid::new_v4();
+        let genome_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata) \
+             VALUES ('S', 'p', '{}'::jsonb) RETURNING id",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let instance_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_instances (genome_id, owner_uid) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(genome_id).bind(user_id).fetch_one(&pool).await.unwrap();
+        let session_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(user_id)
+        .bind(instance_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        // An earlier message to quote.
+        let chat_repo = ChatRepo { pool: &pool };
+        let quoted = chat_repo
+            .append_message(session_id, "assistant", "earlier line")
+            .await
+            .unwrap();
+
+        let state = crate::routes::companion::test_state(pool.clone());
+        let mut app = build_router(state);
+        let token = mint_jwt(user_id);
+
+        // (a) valid quote → metadata.reply_to_message_id set, 200.
+        let body = serde_json::to_vec(&json!({
+            "content": "replying", "client_msg_id": "01J7777777777777777777777A",
+            "reply_to_message_id": quoted.to_string()
+        }))
+        .unwrap();
+        let req = Request::builder()
+            .method("POST")
+            .uri(format!("/comp/chat/{session_id}/message/stream"))
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        let resp = app.call(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let meta: Value = sqlx::query_scalar(
+            "SELECT metadata FROM engine.chat_messages WHERE client_msg_id = '01J7777777777777777777777A'",
+        ).fetch_one(&pool).await.unwrap();
+        assert_eq!(meta["reply_to_message_id"], json!(quoted.to_string()));
+        assert!(meta.get("reply_to_error").is_none());
+
+        // (b) invalid quote (random id) → metadata.reply_to_error, still 200.
+        let body = serde_json::to_vec(&json!({
+            "content": "replying2", "client_msg_id": "01J8888888888888888888888A",
+            "reply_to_message_id": Uuid::new_v4().to_string()
+        }))
+        .unwrap();
+        let req = Request::builder()
+            .method("POST")
+            .uri(format!("/comp/chat/{session_id}/message/stream"))
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        let resp = app.call(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let meta: Value = sqlx::query_scalar(
+            "SELECT metadata FROM engine.chat_messages WHERE client_msg_id = '01J8888888888888888888888A'",
+        ).fetch_one(&pool).await.unwrap();
+        assert_eq!(meta["reply_to_error"], json!("not_found"));
+        assert!(meta.get("reply_to_message_id").is_none());
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
     async fn user_row_omits_scope_raw_keys_when_request_fields_are_none(pool: sqlx::PgPool) {
         use eros_engine_store::chat::ChatRepo;
         let chat_repo = ChatRepo { pool: &pool };
@@ -1048,6 +1157,7 @@ mod validate_payload_tests {
             tips_amount_usd: None,
             image_url: None,
             image: None,
+            reply_to_message_id: None,
         }
     }
 
@@ -1171,6 +1281,7 @@ mod validate_payload_tests {
             tips_amount_usd: None,
             image_url: None,
             image: None,
+            reply_to_message_id: None,
         }
     }
 

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -234,6 +234,67 @@ impl<'a> ChatRepo<'a> {
         Ok(rows)
     }
 
+    /// `sent_at` of message `id` within `session_id`; `None` if the id is not in
+    /// this session (or does not exist). Resolves a caller-supplied
+    /// `reply_to_message_id` into a history anchor.
+    pub async fn message_sent_at_in_session(
+        &self,
+        session_id: Uuid,
+        id: Uuid,
+    ) -> Result<Option<DateTime<Utc>>, sqlx::Error> {
+        sqlx::query_scalar(
+            "SELECT sent_at FROM engine.chat_messages WHERE id = $1 AND session_id = $2",
+        )
+        .bind(id)
+        .bind(session_id)
+        .fetch_optional(self.pool)
+        .await
+    }
+
+    /// History for a quote-anchored turn, chronological.
+    /// `anchor = Some(ts)` (rewind): the ≤`limit` messages with `sent_at <= ts`,
+    /// plus the current message `current_msg_id` (whose `sent_at > ts`) — i.e.
+    /// the window ending at the quoted message with the new message appended;
+    /// messages strictly between are excluded.
+    /// `anchor = None` (drop history): only the `current_msg_id` row.
+    /// Uses the existing `(session_id, sent_at DESC)` index — no migration.
+    pub async fn history_anchored(
+        &self,
+        session_id: Uuid,
+        current_msg_id: Uuid,
+        anchor: Option<DateTime<Utc>>,
+        limit: i64,
+    ) -> Result<Vec<ChatMessage>, sqlx::Error> {
+        let mut rows = match anchor {
+            Some(ts) => {
+                sqlx::query_as::<_, ChatMessage>(
+                    "SELECT * FROM engine.chat_messages \
+                     WHERE session_id = $1 AND (sent_at <= $2 OR id = $3) \
+                     ORDER BY sent_at DESC \
+                     LIMIT $4",
+                )
+                .bind(session_id)
+                .bind(ts)
+                .bind(current_msg_id)
+                .bind(limit)
+                .fetch_all(self.pool)
+                .await?
+            }
+            None => {
+                sqlx::query_as::<_, ChatMessage>(
+                    "SELECT * FROM engine.chat_messages \
+                     WHERE session_id = $1 AND id = $2",
+                )
+                .bind(session_id)
+                .bind(current_msg_id)
+                .fetch_all(self.pool)
+                .await?
+            }
+        };
+        rows.reverse();
+        Ok(rows)
+    }
+
     /// Projection-narrowed read used by BFF endpoints (and any caller that
     /// doesn't need `extracted_facts` / idempotency / SSE metadata). Same
     /// DESC+reverse trick as `history()` so the result is chronological.
@@ -2423,5 +2484,138 @@ mod tests {
             .unwrap();
         // Only the non-truncated assistant row, newest-first.
         assert_eq!(got, vec!["assistant-0".to_string()]);
+    }
+
+    async fn insert_at(
+        pool: &PgPool,
+        session_id: Uuid,
+        role: &str,
+        content: &str,
+        sent_at: DateTime<Utc>,
+    ) -> Uuid {
+        sqlx::query_scalar(
+            "INSERT INTO engine.chat_messages (session_id, role, content, sent_at) \
+             VALUES ($1, $2, $3, $4) RETURNING id",
+        )
+        .bind(session_id)
+        .bind(role)
+        .bind(content)
+        .bind(sent_at)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn message_sent_at_in_session_scopes_by_session(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let s = repo
+            .create_session(Uuid::new_v4(), Uuid::new_v4())
+            .await
+            .unwrap();
+        let other = repo
+            .create_session(Uuid::new_v4(), Uuid::new_v4())
+            .await
+            .unwrap();
+        let base = chrono::Utc::now();
+        let m = insert_at(&pool, s.id, "user", "hi", base).await;
+        let n = insert_at(&pool, other.id, "user", "yo", base).await;
+
+        assert!(repo
+            .message_sent_at_in_session(s.id, m)
+            .await
+            .unwrap()
+            .is_some());
+        // id exists but in a different session → None.
+        assert!(repo
+            .message_sent_at_in_session(s.id, n)
+            .await
+            .unwrap()
+            .is_none());
+        // nonexistent id → None.
+        assert!(repo
+            .message_sent_at_in_session(s.id, Uuid::new_v4())
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn history_anchored_rewind_drops_between_and_keeps_m_and_u(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let s = repo
+            .create_session(Uuid::new_v4(), Uuid::new_v4())
+            .await
+            .unwrap();
+        let base = chrono::Utc::now();
+        // A B M C D E U with strictly increasing sent_at.
+        let labels = ["A", "B", "M", "C", "D", "E", "U"];
+        let mut ids = Vec::new();
+        for (i, label) in labels.iter().enumerate() {
+            let role = if i % 2 == 0 { "user" } else { "assistant" };
+            ids.push(
+                insert_at(
+                    &pool,
+                    s.id,
+                    role,
+                    label,
+                    base + chrono::Duration::seconds(i as i64),
+                )
+                .await,
+            );
+        }
+        let m = ids[2];
+        let u = ids[6];
+        let m_ts = repo
+            .message_sent_at_in_session(s.id, m)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let rows = repo
+            .history_anchored(s.id, u, Some(m_ts), 20)
+            .await
+            .unwrap();
+        let got: Vec<&str> = rows.iter().map(|r| r.content.as_str()).collect();
+        assert_eq!(
+            got,
+            vec!["A", "B", "M", "U"],
+            "C/D/E dropped; M and U kept, chronological"
+        );
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn history_anchored_drop_history_returns_only_current(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let s = repo
+            .create_session(Uuid::new_v4(), Uuid::new_v4())
+            .await
+            .unwrap();
+        let base = chrono::Utc::now();
+        insert_at(&pool, s.id, "user", "old1", base).await;
+        insert_at(
+            &pool,
+            s.id,
+            "assistant",
+            "old2",
+            base + chrono::Duration::seconds(1),
+        )
+        .await;
+        let u = insert_at(
+            &pool,
+            s.id,
+            "user",
+            "current",
+            base + chrono::Duration::seconds(2),
+        )
+        .await;
+
+        let rows = repo.history_anchored(s.id, u, None, 20).await.unwrap();
+        let got: Vec<&str> = rows.iter().map(|r| r.content.as_str()).collect();
+        assert_eq!(
+            got,
+            vec!["current"],
+            "DropHistory → only the current message"
+        );
     }
 }

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -252,11 +252,18 @@ impl<'a> ChatRepo<'a> {
     }
 
     /// History for a quote-anchored turn, chronological.
-    /// `anchor = Some(ts)` (rewind): the ≤`limit` messages with `sent_at <= ts`,
-    /// plus the current message `current_msg_id` (whose `sent_at > ts`) — i.e.
-    /// the window ending at the quoted message with the new message appended;
-    /// messages strictly between are excluded.
+    ///
+    /// `anchor = Some(ts)` (rewind): returns **at most `limit` rows total**,
+    /// chronological. The current message (`current_msg_id`, whose
+    /// `sent_at > ts`) is always included and **counts toward `limit`**; it
+    /// sorts first under `DESC` so `LIMIT` only trims the oldest
+    /// below-anchor rows. Messages with `sent_at` strictly between `ts` and
+    /// the current message's `sent_at` are excluded. This matches the
+    /// `history()` window contract — both use `limit` rows total including
+    /// the newest (current) message.
+    ///
     /// `anchor = None` (drop history): only the `current_msg_id` row.
+    ///
     /// Uses the existing `(session_id, sent_at DESC)` index — no migration.
     pub async fn history_anchored(
         &self,
@@ -2616,6 +2623,50 @@ mod tests {
             got,
             vec!["current"],
             "DropHistory → only the current message"
+        );
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn history_anchored_rewind_counts_current_toward_limit(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let s = repo
+            .create_session(Uuid::new_v4(), Uuid::new_v4())
+            .await
+            .unwrap();
+        let base = chrono::Utc::now();
+        // A B M C D E U with strictly increasing sent_at.
+        let labels = ["A", "B", "M", "C", "D", "E", "U"];
+        let mut ids = Vec::new();
+        for (i, label) in labels.iter().enumerate() {
+            let role = if i % 2 == 0 { "user" } else { "assistant" };
+            ids.push(
+                insert_at(
+                    &pool,
+                    s.id,
+                    role,
+                    label,
+                    base + chrono::Duration::seconds(i as i64),
+                )
+                .await,
+            );
+        }
+        let m = ids[2];
+        let u = ids[6];
+        let m_ts = repo
+            .message_sent_at_in_session(s.id, m)
+            .await
+            .unwrap()
+            .unwrap();
+
+        // limit=3: qualifying rows are {A,B,M (sent_at<=ts)} + {U}; DESC = U,M,B,A; LIMIT 3 = U,M,B;
+        // reversed = [B, M, U]. The current message U always survives (highest sent_at sorts first
+        // under DESC); the oldest below-anchor row (A) is trimmed. U counts toward the limit.
+        let rows = repo.history_anchored(s.id, u, Some(m_ts), 3).await.unwrap();
+        let got: Vec<&str> = rows.iter().map(|r| r.content.as_str()).collect();
+        assert_eq!(
+            got,
+            vec!["B", "M", "U"],
+            "limit caps total incl. U; oldest (A) trimmed; U survives"
         );
     }
 }

--- a/docs/superpowers/specs/2026-06-29-reply-to-context-anchoring-design.md
+++ b/docs/superpowers/specs/2026-06-29-reply-to-context-anchoring-design.md
@@ -1,0 +1,233 @@
+# `reply_to_message_id`: rewind chat context to a quoted message
+
+**Status:** design (ready for implementation)
+**Area:** chat stream pipeline — request intake (`companion_stream.rs`) and reply context assembly (`pipeline/handlers.rs`, `pipeline/stream.rs`, store `chat.rs`).
+
+A downstream product can attach a `reply_to_message_id` (a `chat_messages.id` in
+the same session) to a stream request. When present and valid, the turn's
+conversation context **rewinds** to that message's position: the model sees the
+history up to and including the quoted message, then the new user message —
+everything in between is dropped, as if the user went back and replied at that
+point. Absent the field, behavior is unchanged (context anchored at the latest
+message). This covers **engine code support only**.
+
+## Current behavior (verified against source)
+
+- `POST /comp/chat/{session_id}/message/stream` deserializes `StreamSendRequest`
+  (`crates/eros-engine-server/src/routes/companion_stream.rs:109`), validates it,
+  builds a sparse `metadata` bag (the `*_raw` request-provenance keys, tips, tier,
+  image_url — `companion_stream.rs:430-471`), **upserts the new user message at the
+  tail** (`sent_at = now()`, `companion_stream.rs:481`), then calls `run_stream`
+  with a `PersistedUserMessage` (`companion_stream.rs:503-518`).
+- `run_stream` (`crates/eros-engine-server/src/pipeline/stream.rs:2165`) wraps the
+  `PersistedUserMessage` into `Event::UserMessage`
+  (`crates/eros-engine-core/src/types.rs:39`, the variant carried in `DecisionInput.event`).
+- `build_reply_request` (`crates/eros-engine-server/src/pipeline/handlers.rs:558`)
+  fetches `chat_repo.history(session_id, HISTORY_WINDOW /* 20 */, 0)`
+  (`handlers.rs:568`) — the last 20 messages by `sent_at`, which **already includes
+  the just-inserted user message** at the tail — and `assemble_chat_request`
+  (`handlers.rs:195`) turns those rows into the `system + user/assistant` array sent
+  to OpenRouter. `recall_query_text` finds the current user row inside `history` by
+  `id` (`handlers.rs:574-582`).
+- Separately, three "look-back" context blocks anchor on the **new** message id
+  (`user_message_id`): short-term memory `recent_turn_pairs_before_message(.., 3)`
+  (`handlers.rs:732`), avoid-repetition `recent_assistant_contents(.., 6)`
+  (`handlers.rs:645`), emotional trajectory `recent_emotional_reasons(.., 5)`
+  (`handlers.rs:660`). These are embedded in the **system prompt** via `build_prompt`.
+
+## API change
+
+Add one optional field to `StreamSendRequest` (`companion_stream.rs:109`):
+
+```jsonc
+{
+  "content": "...",
+  "client_msg_id": "...",
+  "reply_to_message_id": "0e2c…-uuid"   // optional; a chat_messages.id in this session
+}
+```
+
+`#[serde(default)] pub reply_to_message_id: Option<Uuid>`. Clients that omit it
+get byte-for-byte the current behavior.
+
+## Semantics — three cases
+
+The field resolves to a `HistoryAnchor` (below) that decides **only the main
+20-message history**. The system-prompt look-back blocks (short-term memory,
+emotional trajectory, avoid-repetition) and memory recall **always stay anchored
+on the new message** — they reflect the persona's latest state, not the rewound
+thread. (Deliberate: the quoted *thread* rewinds; persona-consistency signals do not.)
+
+| Case | Trigger | Main history fed to the model |
+|------|---------|-------------------------------|
+| **Latest** (default) | field absent | last-20 window ending at the new message — **unchanged** |
+| **Rewind** | valid id → message `M` | turns up to & including `M`, then the new message `U`; messages between `M` and `U` dropped |
+| **DropHistory** | invalid id (not found / not in this session / not older than `U`) | **no prior turns** — system prompt + look-back blocks + `U` only |
+
+Worked example — history `… A B M C D E U` with `reply_to_message_id = M`:
+model receives `… A B M` then `U` (C, D, E dropped). `M` itself is included.
+
+"Invalid" deliberately does **not** fall back to Latest: the caller asked to
+anchor at `M`; if `M` is unresolvable the engine refuses to guess a thread
+(silently using latest context could leak turns the caller meant to exclude), so
+it drops history and flags the error (below). Still returns `200`.
+
+## Resolution, validation & metadata
+
+Resolve once, in the **pre-stream phase** of `send_message_stream`, after
+`get_session` (`companion_stream.rs:379`) and **before** the user-message upsert
+(so the result can be written into that row's `metadata`):
+
+- New store method `ChatRepo::message_sent_at_in_session(session_id, id) ->
+  Result<Option<DateTime<Utc>>, sqlx::Error>` —
+  `SELECT sent_at FROM engine.chat_messages WHERE id = $1 AND session_id = $2`.
+  Uses the PK; one cheap query, only when `reply_to_message_id.is_some()`.
+- Resolution:
+  - field absent → `HistoryAnchor::Latest`.
+  - `Some(ts)` from the lookup → `HistoryAnchor::At { message_id, sent_at: ts }`.
+  - `None` from the lookup → `HistoryAnchor::DropHistory`. (At resolution time `U`
+    is not yet inserted, so the lookup naturally cannot return `U`; the "not older
+    than `U`" guard is therefore implicit — any resolvable row predates `U`.)
+- Metadata (built alongside the existing `*_raw` keys, `companion_stream.rs:430-471`):
+  - `At` → `"reply_to_message_id": "<uuid>"`.
+  - `DropHistory` → `"reply_to_error": "not_found"` (no `reply_to_message_id` key).
+  - `Latest` → neither key (keeps the JSONB bag sparse; metadata stays `NULL` when
+    otherwise empty, per `companion_stream.rs:467`).
+
+**Storage decision:** the link lives in `metadata`, not a dedicated column. The
+engine consumes it once (here) to compute the anchor and never reads it back, so
+it is request provenance — the same category as `memory_scope_raw` et al. — and
+keeping the valid value and the `reply_to_error` diagnostic together is cleaner
+than splitting across a column + metadata. (`continues_from_message_id` earns a
+column precisely because the engine *does* read it back, for assistant chaining;
+this does not.) Promote to a column only if the engine later needs to read it
+back or there's a concrete need to index replies at scale; until then the BFF can
+project it like `history_slim` already does for `tips_amount_usd`
+(`chat.rs:249`).
+
+`reply_to_message_id` is **not** part of the idempotency key (still just
+`client_msg_id`): a retry with the same `client_msg_id` replays the original
+stored frames regardless of `reply_to_message_id` — correct idempotent behavior.
+
+## Threading the anchor through the pipeline
+
+`HistoryAnchor` is defined in `eros-engine-core` (`types.rs`) so `Event` can carry
+it (core already depends on `chrono` + `serde`; `DateTime<Utc>` serializes there
+— cf. `affinity.rs`):
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub enum HistoryAnchor {
+    #[default]
+    Latest,
+    At { message_id: Uuid, sent_at: DateTime<Utc> },
+    DropHistory,
+}
+```
+
+Thread it along the existing request → handler path (mirrors how `memory_scope` /
+`affinity_scope` already flow):
+
+1. `Event::UserMessage` (`types.rs:39`): add `#[serde(default)] history_anchor:
+   HistoryAnchor`. The `#[serde(default)]` keeps existing serialized events parsing.
+2. `PersistedUserMessage` (`stream.rs:2142`): add `pub history_anchor: HistoryAnchor`.
+   Populated in `send_message_stream` from the resolution above.
+3. `run_stream` copies `user_msg.history_anchor` into the `Event::UserMessage` it
+   builds (`stream.rs:2219`). The background re-eval `Event::UserMessage`
+   constructions (`stream.rs:2624`, `:2995`, and any other site that rebuilds the
+   event from `user_msg`) copy it too — these re-decide the *same* user turn, so
+   they must use the same anchor.
+4. `build_reply_request` (`handlers.rs:558`) reads the anchor from `input.event`
+   (alongside the existing `memory_scope` / `affinity_scope` / `tier` match arms,
+   `handlers.rs:584-622`) and selects the history fetch (next section).
+
+## History fetch
+
+`build_reply_request` replaces the unconditional `history(session_id, 20, 0)` call
+(`handlers.rs:568`) with a match on the anchor:
+
+- **Latest** → `chat_repo.history(session_id, HISTORY_WINDOW, 0)` (existing).
+- **At { sent_at, .. }** → new `chat_repo.history_anchored(session_id,
+  user_message_id, Some(sent_at), HISTORY_WINDOW)`.
+- **DropHistory** → `chat_repo.history_anchored(session_id, user_message_id, None,
+  HISTORY_WINDOW)`.
+
+New store method `ChatRepo::history_anchored(session_id, current_msg_id, anchor:
+Option<DateTime<Utc>>, limit) -> Result<Vec<ChatMessage>, sqlx::Error>`:
+
+- `anchor = Some(ts)` (Rewind):
+  ```sql
+  SELECT * FROM engine.chat_messages
+  WHERE session_id = $1 AND (sent_at <= $ts OR id = $current)
+  ORDER BY sent_at DESC LIMIT $limit
+  ```
+  then `rows.reverse()` → `[…, M, U]`. The `OR id = $current` clause re-admits the
+  new message `U` (whose `sent_at > ts`), so the result always ends with `U`; the
+  `sent_at <= ts` clause includes `M` and everything before it within the window,
+  and excludes the between-messages. Uses the existing `(session_id, sent_at DESC)`
+  index — no migration. (Edge: rows sharing `M`'s exact `sent_at` are included —
+  same tolerance the existing `recent_turn_pairs` cutoff has, `chat.rs:301`.)
+- `anchor = None` (DropHistory):
+  ```sql
+  SELECT * FROM engine.chat_messages
+  WHERE session_id = $1 AND id = $current
+  ```
+  → `[U]` (or empty if `U` somehow absent). No prior turns.
+
+In every case the current message `U` is present in the returned vec, so
+`recall_query_text` (`handlers.rs:574`) and `model_facing_user_text` keep working
+unchanged. `assemble_chat_request` (`handlers.rs:195`) is untouched — it just
+receives a different slice. **No migration** (no schema change; the link rides in
+`metadata`).
+
+## Quotable roles
+
+Any real chat turn is a valid anchor: `assistant` (the primary use case — replying
+to something the AI said earlier), `user`, and `gift_user` (tip turns, which are
+user-authored — model-facing they already render under the `user` role,
+`handlers.rs:215`). Resolution keys only on `(id, session_id)`, so no role filter
+is applied. If `M` is a user/gift_user turn the model sees two consecutive user
+turns (`M` then `U`) — harmless; providers tolerate it.
+
+## Out of scope
+
+- Rendering the quoted message in any UI ("replying to: …") — downstream/BFF concern.
+- Changing which look-back blocks anchor where (they stay on the new message).
+- Persisting `reply_to` as a queryable column / FK, analytics, or threading models.
+- Any `model_config.toml` / prompt-text change.
+
+## Testing
+
+- **Unit (resolution):** field-absent → `Latest`; lookup `Some(ts)` → `At`; lookup
+  `None` → `DropHistory`. Pure mapping over `(Option<Uuid>, Option<DateTime>)`.
+- **Store (`sqlx::test`)** for `history_anchored`:
+  - Rewind: seed `A B M C D E` + `U`; `Some(M.sent_at)` returns `[A B M U]`
+    (excludes `C D E`, includes `M` and `U`, chronological).
+  - DropHistory: `None` returns `[U]` only.
+  - `message_sent_at_in_session`: returns `Some` for an in-session id; `None` for a
+    cross-session id and a non-existent id.
+- **Route (`sqlx::test`)** on `send_message_stream`:
+  - valid `reply_to_message_id` → `200`; new user row's `metadata.reply_to_message_id`
+    set; no `reply_to_error`.
+  - invalid (cross-session / nonexistent) `reply_to_message_id` → `200`;
+    `metadata.reply_to_error = "not_found"`; no `reply_to_message_id`.
+  - field absent → `200`; neither key present (regression guard on the existing
+    sparse-metadata contract).
+
+## Implementation touch-point checklist
+
+- `eros-engine-core/src/types.rs` — add `HistoryAnchor` enum; add `history_anchor`
+  to `Event::UserMessage` (`#[serde(default)]`). Update the event round-trip tests
+  (`types.rs:177`, `:222`) only if they assert exact field sets.
+- `eros-engine-store/src/chat.rs` — add `message_sent_at_in_session` and
+  `history_anchored`.
+- `eros-engine-server/src/routes/companion_stream.rs` — add `reply_to_message_id`
+  to `StreamSendRequest`; resolve + validate pre-stream; write metadata key; pass
+  `history_anchor` into `PersistedUserMessage`. Update the `StreamSendRequest` test
+  builders (`req_with_tier`, `req_tip`, `base`, `minimal_req`) for the new field.
+- `eros-engine-server/src/pipeline/stream.rs` — add `history_anchor` to
+  `PersistedUserMessage`; copy it into every `Event::UserMessage` built from
+  `user_msg`.
+- `eros-engine-server/src/pipeline/handlers.rs` — branch the history fetch in
+  `build_reply_request` on `input.event`'s `history_anchor`.
+- Regenerate the OpenAPI spec (new request field) per the repo's pre-PR checklist.


### PR DESCRIPTION
## Summary

Adds an optional `reply_to_message_id` to the chat stream request (`POST /comp/chat/{session_id}/message/stream`). When present, it **rewinds** the turn's main conversation history to the quoted message's position — the model replies as if continuing from that earlier point, rather than from the tail of the conversation.

Three cases (resolved into a `HistoryAnchor` that threads request → metadata → `Event::UserMessage` → `build_reply_request`):

| Case | Trigger | Main history fed to the model |
|------|---------|-------------------------------|
| **Latest** (default) | field absent | last-20 window — **unchanged**, byte-for-byte |
| **Rewind** | valid id → message `M` | turns up to & including `M`, then the new message `U`; messages between dropped |
| **DropHistory** | invalid id (not found / cross-session) | no prior turns — system prompt + look-back blocks + `U` only; still HTTP 200 |

## Design

- **Scope:** only the main 20-message history rewinds. The system-prompt look-back blocks (short-term memory, emotional trajectory, avoid-repetition) and memory recall stay anchored on the new message — the quoted *thread* rewinds, persona-consistency signals stay current.
- **Storage:** the link lives in `chat_messages.metadata` (`reply_to_message_id` when valid, `reply_to_error: "not_found"` when invalid) — **no DB migration**. It's request provenance the engine consumes once, not load-bearing structure, so it sits with the other `*_raw` keys rather than earning a column.
- **Invalid anchor → 200 + drop history:** the engine refuses to guess a thread it can't anchor (silently falling back to latest could leak turns the caller meant to exclude); it drops history and flags the error instead.
- **Idempotency unchanged:** `reply_to_message_id` is not part of the dedup key (`session_id` + `client_msg_id`).
- **Quotable roles:** user / gift_user / assistant (resolution keys only on `(id, session_id)`).

Spec: `docs/superpowers/specs/2026-06-29-reply-to-context-anchoring-design.md`

## Rewind SQL

`history_anchored` rewind query — `WHERE session_id=$1 AND (sent_at <= $ts OR id = $current) ORDER BY sent_at DESC LIMIT $n`, reversed. `U` (newest) sorts first under `DESC`, so `LIMIT` only trims the oldest below-anchor rows and `U` is never dropped; the window stays `limit` total including `U`, consistent with the `Latest` `history()` window. Between-messages are excluded.

## Testing

`cargo test --workspace` = **663 passed / 0 failed** (core 57, llm 164, server 340, store 102). `fmt --check` clean, `clippy --workspace --all-targets -D warnings` clean, OpenAPI regenerated (only the new optional field). New coverage: store rewind/DropHistory/cross-session-scoping (`sqlx::test`), DB-backed route test (valid + invalid metadata branches), and the pure `history_fetch_for` anchor mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)