### PR TITLE
feat: image-gen failure diagnostics + composed→original retry (#122)

### DIFF
--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -108,11 +108,12 @@ fn build_vision_body(req: &VisionRequest, model: &str) -> serde_json::Value {
 /// Which prompt variant an image attempt used. `Single` = no compose retry
 /// (compose off, or it left the subject unchanged); `Composed`/`Original` =
 /// the two variants tried per model when compose rewrote the subject.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PromptVariant {
     Composed,
     Original,
+    #[default]
     Single,
 }
 
@@ -217,6 +218,9 @@ pub struct ImageGenResponse {
     /// Failed attempts that preceded the successful one (empty when the first
     /// try succeeded). Lets the success record show "A refused, B drew it".
     pub attempts: Vec<ImageAttempt>,
+    /// Which prompt variant actually produced the returned image. Lets callers
+    /// report the true prompt (composed vs original) on the retry path.
+    pub winning_variant: PromptVariant,
 }
 
 /// Pull all image URLs out of the first choice's `message.images[]`.
@@ -908,6 +912,7 @@ impl OpenRouterClient {
                 usage: parsed.usage,
                 finish_reason,
                 attempts,
+                winning_variant: variant,
             });
         }
         Err(ImageGenError::ChainExhausted { attempts })

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -155,7 +155,11 @@ impl std::fmt::Display for ImageGenError {
         match self {
             ImageGenError::Config(m) => write!(f, "image-gen config error: {m}"),
             ImageGenError::ChainExhausted { attempts } => {
-                write!(f, "image-gen chain exhausted after {} attempt(s)", attempts.len())
+                write!(
+                    f,
+                    "image-gen chain exhausted after {} attempt(s)",
+                    attempts.len()
+                )
             }
         }
     }
@@ -811,13 +815,18 @@ impl OpenRouterClient {
     /// One-shot image-generation call. Walks `[model] + fallback_model` on
     /// transport failure OR a zero-image success. Returns the first attempt that
     /// yields ≥1 image. Non-streaming.
-    pub async fn execute_image(&self, req: ImageGenRequest) -> Result<ImageGenResponse, ImageGenError> {
+    pub async fn execute_image(
+        &self,
+        req: ImageGenRequest,
+    ) -> Result<ImageGenResponse, ImageGenError> {
         let candidates: Vec<&str> = std::iter::once(req.model.as_str())
             .chain(req.fallback_model.iter().map(String::as_str))
             .filter(|s| !s.is_empty())
             .collect();
         if candidates.is_empty() {
-            return Err(ImageGenError::Config("openrouter: image-gen has no models".into()));
+            return Err(ImageGenError::Config(
+                "openrouter: image-gen has no models".into(),
+            ));
         }
         if self.api_key.is_empty() {
             return Err(ImageGenError::Config("openrouter: api key not set".into()));
@@ -845,7 +854,9 @@ impl OpenRouterClient {
                     attempts.push(ImageAttempt {
                         model: model.to_string(),
                         variant,
-                        outcome: AttemptOutcome::Transport { message: e.to_string() },
+                        outcome: AttemptOutcome::Transport {
+                            message: e.to_string(),
+                        },
                     });
                     continue;
                 }
@@ -871,7 +882,9 @@ impl OpenRouterClient {
                     attempts.push(ImageAttempt {
                         model: model.to_string(),
                         variant,
-                        outcome: AttemptOutcome::Decode { message: e.to_string() },
+                        outcome: AttemptOutcome::Decode {
+                            message: e.to_string(),
+                        },
                     });
                     continue;
                 }
@@ -2530,7 +2543,10 @@ data: [DONE]\n\n";
         let a = ImageAttempt {
             model: "openai/x".into(),
             variant: PromptVariant::Composed,
-            outcome: AttemptOutcome::Status { status: 400, message: "policy".into() },
+            outcome: AttemptOutcome::Status {
+                status: 400,
+                message: "policy".into(),
+            },
         };
         let v = serde_json::to_value(&a).unwrap();
         assert_eq!(v["model"], "openai/x");

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -105,6 +105,74 @@ fn build_vision_body(req: &VisionRequest, model: &str) -> serde_json::Value {
     body
 }
 
+/// Which prompt variant an image attempt used. `Single` = no compose retry
+/// (compose off, or it left the subject unchanged); `Composed`/`Original` =
+/// the two variants tried per model when compose rewrote the subject.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PromptVariant {
+    Composed,
+    Original,
+    Single,
+}
+
+/// Outcome of one image-gen attempt (one model × one prompt variant).
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+pub enum AttemptOutcome {
+    /// HTTP non-2xx. `status` distinguishes a 400 content-policy refusal from a
+    /// 404 / 5xx; `message` is the provider body (capped).
+    Status { status: u16, message: String },
+    /// 2xx but zero images in the response.
+    ZeroImages,
+    /// Transport failure (connection/TLS) before a response arrived.
+    Transport { message: String },
+    /// 2xx but the body failed to decode as an OpenRouter response.
+    Decode { message: String },
+}
+
+/// One recorded image-gen attempt. Serializes flat:
+/// `{ "model": .., "variant": .., "outcome": .., "status"?: .., "message"?: .. }`.
+#[derive(Debug, Clone, Serialize)]
+pub struct ImageAttempt {
+    pub model: String,
+    pub variant: PromptVariant,
+    #[serde(flatten)]
+    pub outcome: AttemptOutcome,
+}
+
+/// Error from [`OpenRouterClient::execute_image`]. `Config` is a pre-flight
+/// failure (no api key / no models) with no attempts; `ChainExhausted` carries
+/// every failed attempt in order so the caller can persist a diagnostic.
+#[derive(Debug)]
+pub enum ImageGenError {
+    Config(String),
+    ChainExhausted { attempts: Vec<ImageAttempt> },
+}
+
+impl std::fmt::Display for ImageGenError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ImageGenError::Config(m) => write!(f, "image-gen config error: {m}"),
+            ImageGenError::ChainExhausted { attempts } => {
+                write!(f, "image-gen chain exhausted after {} attempt(s)", attempts.len())
+            }
+        }
+    }
+}
+impl std::error::Error for ImageGenError {}
+
+/// Cap a provider error body to a bounded length for persistence/logs.
+fn cap_provider_message(s: &str) -> String {
+    const MAX: usize = 600;
+    let t = s.trim();
+    if t.chars().count() <= MAX {
+        t.to_string()
+    } else {
+        t.chars().take(MAX).collect::<String>() + "…"
+    }
+}
+
 /// One-shot image-generation request. The model is expected to return
 /// generated images in `message.images[]` on the wire response.
 #[derive(Debug, Clone, Default)]
@@ -122,6 +190,11 @@ pub struct ImageGenRequest {
     /// size parameter (see `build_image_body`); preferred over `aspect_ratio`.
     pub resolution: Option<String>,
     pub max_tokens: u32,
+    /// The original (pre-compose) PDE prompt, retried after `prompt` for each
+    /// model. `None` ⇒ no second variant (compose off, or it left the subject
+    /// unchanged). Set by `build_image_gen_request` only when
+    /// `chat_image_prompt_compose` actually rewrote the subject.
+    pub prompt_original: Option<String>,
 }
 
 /// Response from a successful image-generation call.
@@ -137,6 +210,9 @@ pub struct ImageGenResponse {
     pub usage: Option<serde_json::Value>,
     /// `finish_reason` from the first choice in the wire response.
     pub finish_reason: Option<String>,
+    /// Failed attempts that preceded the successful one (empty when the first
+    /// try succeeded). Lets the success record show "A refused, B drew it".
+    pub attempts: Vec<ImageAttempt>,
 }
 
 /// Pull all image URLs out of the first choice's `message.images[]`.
@@ -170,7 +246,7 @@ fn parse_resolution(res: &str) -> Option<(u32, u32)> {
 }
 
 /// Build the OpenRouter wire body for one image-gen attempt. Pure (no I/O).
-fn build_image_body(req: &ImageGenRequest, model: &str) -> serde_json::Value {
+fn build_image_body(req: &ImageGenRequest, model: &str, prompt: &str) -> serde_json::Value {
     // Size is a real generation parameter: prefer an explicit resolution, else
     // derive a concrete width×height from the aspect ratio. (The old text-hint
     // "(aspect ratio: …)" was ignored by image models — removed.)
@@ -185,7 +261,7 @@ fn build_image_body(req: &ImageGenRequest, model: &str) -> serde_json::Value {
                 .filter(|s| !s.is_empty())
                 .and_then(aspect_to_resolution)
         });
-    let mut content = vec![serde_json::json!({ "type": "text", "text": req.prompt })];
+    let mut content = vec![serde_json::json!({ "type": "text", "text": prompt })];
     if let Some(face) = req.face_ref_url.as_deref().filter(|s| !s.is_empty()) {
         content.push(serde_json::json!({
             "type": "image_url",
@@ -208,6 +284,28 @@ fn build_image_body(req: &ImageGenRequest, model: &str) -> serde_json::Value {
         body["height"] = serde_json::json!(h);
     }
     body
+}
+
+/// Expand the model chain × prompt variants into the ordered attempt plan.
+/// Model-outer, variant-inner: `[A,B]` with a distinct original yields
+/// `A·composed, A·original, B·composed, B·original`. With no original it is a
+/// single `Single` variant per model.
+fn plan_attempts<'a>(
+    candidates: &[&'a str],
+    prompt: &'a str,
+    prompt_original: Option<&'a str>,
+) -> Vec<(&'a str, PromptVariant, &'a str)> {
+    let variants: Vec<(PromptVariant, &str)> = match prompt_original {
+        Some(orig) => vec![
+            (PromptVariant::Composed, prompt),
+            (PromptVariant::Original, orig),
+        ],
+        None => vec![(PromptVariant::Single, prompt)],
+    };
+    candidates
+        .iter()
+        .flat_map(|m| variants.iter().map(move |(v, p)| (*m, *v, *p)))
+        .collect()
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -713,22 +811,21 @@ impl OpenRouterClient {
     /// One-shot image-generation call. Walks `[model] + fallback_model` on
     /// transport failure OR a zero-image success. Returns the first attempt that
     /// yields ≥1 image. Non-streaming.
-    pub async fn execute_image(&self, req: ImageGenRequest) -> Result<ImageGenResponse, LlmError> {
+    pub async fn execute_image(&self, req: ImageGenRequest) -> Result<ImageGenResponse, ImageGenError> {
         let candidates: Vec<&str> = std::iter::once(req.model.as_str())
             .chain(req.fallback_model.iter().map(String::as_str))
             .filter(|s| !s.is_empty())
             .collect();
         if candidates.is_empty() {
-            return Err(LlmError::Config(
-                "openrouter: image-gen has no models".into(),
-            ));
+            return Err(ImageGenError::Config("openrouter: image-gen has no models".into()));
         }
         if self.api_key.is_empty() {
-            return Err(LlmError::Config("openrouter: api key not set".into()));
+            return Err(ImageGenError::Config("openrouter: api key not set".into()));
         }
-        let mut last_err: Option<LlmError> = None;
-        for model in &candidates {
-            let mut body = build_image_body(&req, model);
+        let plan = plan_attempts(&candidates, &req.prompt, req.prompt_original.as_deref());
+        let mut attempts: Vec<ImageAttempt> = Vec::new();
+        for (model, variant, prompt) in plan {
+            let mut body = build_image_body(&req, model, prompt);
             if let Some(prefs) = self.provider_prefs() {
                 if let Ok(v) = serde_json::to_value(&prefs) {
                     body["provider"] = v;
@@ -744,30 +841,49 @@ impl OpenRouterClient {
             {
                 Ok(r) => r,
                 Err(e) => {
-                    tracing::warn!(model = %model, error = %e, "openrouter: image attempt failed (transport); next");
-                    last_err = Some(e.into());
+                    tracing::warn!(model = %model, ?variant, error = %e, "openrouter: image attempt failed (transport); next");
+                    attempts.push(ImageAttempt {
+                        model: model.to_string(),
+                        variant,
+                        outcome: AttemptOutcome::Transport { message: e.to_string() },
+                    });
                     continue;
                 }
             };
             let status = resp.status();
             if !status.is_success() {
                 let text = resp.text().await.unwrap_or_default();
-                tracing::warn!(model = %model, %status, "openrouter: image attempt failed (status); next");
-                last_err = Some(LlmError::Status(status, text));
+                tracing::warn!(model = %model, ?variant, %status, "openrouter: image attempt failed (status); next");
+                attempts.push(ImageAttempt {
+                    model: model.to_string(),
+                    variant,
+                    outcome: AttemptOutcome::Status {
+                        status: status.as_u16(),
+                        message: cap_provider_message(&text),
+                    },
+                });
                 continue;
             }
             let parsed: WireResponse = match resp.json().await {
                 Ok(p) => p,
                 Err(e) => {
-                    tracing::warn!(model = %model, error = %e, "openrouter: image attempt failed (decode); next");
-                    last_err = Some(e.into());
+                    tracing::warn!(model = %model, ?variant, error = %e, "openrouter: image attempt failed (decode); next");
+                    attempts.push(ImageAttempt {
+                        model: model.to_string(),
+                        variant,
+                        outcome: AttemptOutcome::Decode { message: e.to_string() },
+                    });
                     continue;
                 }
             };
             let images = images_from_wire(&parsed);
             if images.is_empty() {
-                tracing::warn!(model = %model, "openrouter: image attempt returned zero images; next");
-                last_err = Some(LlmError::Provider("image-gen returned no images".into()));
+                tracing::warn!(model = %model, ?variant, "openrouter: image attempt returned zero images; next");
+                attempts.push(ImageAttempt {
+                    model: model.to_string(),
+                    variant,
+                    outcome: AttemptOutcome::ZeroImages,
+                });
                 continue;
             }
             let first = parsed.choices.into_iter().next();
@@ -778,9 +894,10 @@ impl OpenRouterClient {
                 model: parsed.model,
                 usage: parsed.usage,
                 finish_reason,
+                attempts,
             });
         }
-        Err(last_err.unwrap_or_else(|| LlmError::Config("openrouter: image-gen no models".into())))
+        Err(ImageGenError::ChainExhausted { attempts })
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -2298,7 +2415,7 @@ data: [DONE]\n\n";
             max_tokens: 4096,
             ..Default::default()
         };
-        let body = build_image_body(&req, "m");
+        let body = build_image_body(&req, "m", &req.prompt);
         // size is sent as real params
         assert_eq!(body["width"], 720);
         assert_eq!(body["height"], 1280);
@@ -2319,7 +2436,7 @@ data: [DONE]\n\n";
             max_tokens: 4096,
             ..Default::default()
         };
-        let body = build_image_body(&req, "m");
+        let body = build_image_body(&req, "m", &req.prompt);
         assert_eq!(body["width"], 768);
         assert_eq!(body["height"], 1024);
     }
@@ -2334,8 +2451,9 @@ data: [DONE]\n\n";
             aspect_ratio: Some("3:4".into()),
             resolution: None,
             max_tokens: 4096,
+            prompt_original: None,
         };
-        let body = build_image_body(&req, "m");
+        let body = build_image_body(&req, "m", &req.prompt);
         // #101: image-gen requests image-only output so image-only OpenRouter
         // models (e.g. bytedance-seed/seedream-4.5) don't 404. The engine never
         // uses the image model's text, so we never ask for the text modality.
@@ -2351,7 +2469,7 @@ data: [DONE]\n\n";
             face_ref_url: Some("https://x/a.png".into()),
             ..req
         };
-        let body2 = build_image_body(&req2, "m");
+        let body2 = build_image_body(&req2, "m", &req2.prompt);
         let content2 = &body2["messages"][0]["content"];
         assert_eq!(content2.as_array().unwrap().len(), 2);
         assert_eq!(content2[1]["type"], "image_url");
@@ -2375,5 +2493,60 @@ data: [DONE]\n\n";
         let parsed: WireResponse = serde_json::from_value(wire).unwrap();
         let imgs = images_from_wire(&parsed);
         assert_eq!(imgs, vec!["data:image/png;base64,AAAA".to_string()]);
+    }
+
+    #[test]
+    fn plan_attempts_interleaves_composed_then_original_per_model() {
+        let cands = ["A", "B", "C"];
+        let plan = plan_attempts(&cands, "CP", Some("OP"));
+        assert_eq!(
+            plan,
+            vec![
+                ("A", PromptVariant::Composed, "CP"),
+                ("A", PromptVariant::Original, "OP"),
+                ("B", PromptVariant::Composed, "CP"),
+                ("B", PromptVariant::Original, "OP"),
+                ("C", PromptVariant::Composed, "CP"),
+                ("C", PromptVariant::Original, "OP"),
+            ]
+        );
+    }
+
+    #[test]
+    fn plan_attempts_single_variant_when_no_original() {
+        let cands = ["A", "B"];
+        let plan = plan_attempts(&cands, "P", None);
+        assert_eq!(
+            plan,
+            vec![
+                ("A", PromptVariant::Single, "P"),
+                ("B", PromptVariant::Single, "P"),
+            ]
+        );
+    }
+
+    #[test]
+    fn image_attempt_serializes_flat() {
+        let a = ImageAttempt {
+            model: "openai/x".into(),
+            variant: PromptVariant::Composed,
+            outcome: AttemptOutcome::Status { status: 400, message: "policy".into() },
+        };
+        let v = serde_json::to_value(&a).unwrap();
+        assert_eq!(v["model"], "openai/x");
+        assert_eq!(v["variant"], "composed");
+        assert_eq!(v["outcome"], "status");
+        assert_eq!(v["status"], 400);
+        assert_eq!(v["message"], "policy");
+
+        let z = ImageAttempt {
+            model: "m".into(),
+            variant: PromptVariant::Original,
+            outcome: AttemptOutcome::ZeroImages,
+        };
+        let zv = serde_json::to_value(&z).unwrap();
+        assert_eq!(zv["variant"], "original");
+        assert_eq!(zv["outcome"], "zero_images");
+        assert!(zv.get("status").is_none());
     }
 }

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -3489,13 +3489,29 @@ mod tests {
         .unwrap()
         .resolve_image_gen();
         let req = build_image_gen_request(
-            "img".into(), vec![], &persona, Some("scene"), None,
-            resolved.as_ref(), "", None, None, None,
+            "img".into(),
+            vec![],
+            &persona,
+            Some("scene"),
+            None,
+            resolved.as_ref(),
+            "",
+            None,
+            None,
+            None,
         );
         assert!(req.prompt_original.is_none());
         let req_blank = build_image_gen_request(
-            "img".into(), vec![], &persona, Some("scene"), None,
-            resolved.as_ref(), "", None, None, Some("   "),
+            "img".into(),
+            vec![],
+            &persona,
+            Some("scene"),
+            None,
+            resolved.as_ref(),
+            "",
+            None,
+            None,
+            Some("   "),
         );
         assert!(req_blank.prompt_original.is_none(), "blank original ⇒ None");
     }
@@ -3507,7 +3523,10 @@ mod tests {
             ImageAttempt {
                 model: "A".into(),
                 variant: PromptVariant::Composed,
-                outcome: AttemptOutcome::Status { status: 400, message: "policy".into() },
+                outcome: AttemptOutcome::Status {
+                    status: 400,
+                    message: "policy".into(),
+                },
             },
             ImageAttempt {
                 model: "A".into(),

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -147,6 +147,7 @@ fn build_image_gen_request(
     fallback_subject: &str,
     ref_url: Option<String>,
     plan_aspect_ratio: Option<&str>,
+    original_subject: Option<&str>,
 ) -> eros_engine_llm::openrouter::ImageGenRequest {
     use eros_engine_llm::model_config::StyleKey;
     let style: StyleKey = req_image
@@ -180,10 +181,15 @@ fn build_image_gen_request(
             resolved.and_then(|r| r.default_resolution.clone())
         }
     });
+    let prompt_original = original_subject
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| crate::pipeline::handlers::compose_image_prompt(style, persona, s));
     eros_engine_llm::openrouter::ImageGenRequest {
         model: primary,
         fallback_model: chain,
         prompt,
+        prompt_original,
         face_ref_url: ref_url,
         aspect_ratio,
         resolution,
@@ -2490,6 +2496,7 @@ pub fn run_stream(
                             "",
                             ref_url.clone(),
                             plan.aspect_ratio.as_deref(),
+                            None, /* original_subject — activated in retry task */
                         );
                         let ar = req.aspect_ratio.clone();
                         let res = req.resolution.clone();
@@ -2581,14 +2588,22 @@ pub fn run_stream(
                             }
                             Ok(_) => {
                                 tracing::warn!(
-                                    "stream(image): execute_image returned zero images; \
+                                    "stream(image): execute_image returned zero images \
+                                     (unexpected); falling through to text"
+                                );
+                            }
+                            Err(eros_engine_llm::openrouter::ImageGenError::Config(m)) => {
+                                tracing::warn!(
+                                    "stream(image): execute_image config error: {m}; \
                                      falling through to text"
                                 );
                             }
-                            Err(e) => {
+                            Err(eros_engine_llm::openrouter::ImageGenError::ChainExhausted {
+                                attempts,
+                            }) => {
                                 tracing::warn!(
-                                    "stream(image): execute_image failed: {e}; \
-                                     falling through to text"
+                                    attempts = attempts.len(),
+                                    "stream(image): image chain exhausted; falling through to text"
                                 );
                             }
                         }
@@ -2909,6 +2924,7 @@ pub fn run_stream(
                             "",
                             ref_url.clone(),
                             plan.aspect_ratio.as_deref(),
+                            None, /* original_subject — activated in retry task */
                         );
                         let ar = req.aspect_ratio.clone();
                         let res = req.resolution.clone();
@@ -2960,13 +2976,22 @@ pub fn run_stream(
                             }
                             Ok(_) => {
                                 tracing::warn!(
-                                    "stream(text_image): execute_image returned zero images; \
+                                    "stream(text_image): execute_image returned zero images \
+                                     (unexpected); no Image frame (text already delivered)"
+                                );
+                            }
+                            Err(eros_engine_llm::openrouter::ImageGenError::Config(m)) => {
+                                tracing::warn!(
+                                    "stream(text_image): execute_image config error: {m}; \
                                      no Image frame (text already delivered)"
                                 );
                             }
-                            Err(e) => {
+                            Err(eros_engine_llm::openrouter::ImageGenError::ChainExhausted {
+                                attempts,
+                            }) => {
                                 tracing::warn!(
-                                    "stream(text_image): execute_image failed: {e}; \
+                                    attempts = attempts.len(),
+                                    "stream(text_image): image chain exhausted; \
                                      no Image frame (text already delivered)"
                                 );
                             }
@@ -3293,6 +3318,7 @@ mod tests {
             "fallback subject",
             None, /* ref_url */
             None, /* plan_aspect_ratio */
+            None, /* original_subject */
         );
         assert_eq!(req.model, "img");
         assert!(req.prompt.starts_with("Photorealistic"));
@@ -3319,6 +3345,7 @@ mod tests {
             "fallback subject",
             None,         /* ref_url */
             Some("9:16"), /* plan_aspect_ratio */
+            None,         /* original_subject */
         );
         assert_eq!(
             req.aspect_ratio.as_deref(),
@@ -3329,6 +3356,53 @@ mod tests {
             req.resolution, None,
             "config default_resolution dropped when a plan aspect is set"
         );
+    }
+
+    #[test]
+    fn build_image_gen_request_sets_prompt_original_when_provided() {
+        let persona = test_persona_with_meta(&[]);
+        let resolved = eros_engine_llm::model_config::ModelConfig::from_toml_str(
+            "[tasks.chat_image_generation]\nmodel=\"img\"\ndefault_style=\"realistic\"\n",
+        )
+        .unwrap()
+        .resolve_image_gen();
+        // composed subject as primary, original subject as the retry variant
+        let req = build_image_gen_request(
+            "img".into(),
+            vec![],
+            &persona,
+            Some("composed scene"),
+            None,
+            resolved.as_ref(),
+            "",
+            None,
+            None,
+            Some("original scene"), /* original_subject */
+        );
+        let po = req.prompt_original.expect("prompt_original set");
+        assert!(po.contains("original scene"));
+        assert!(po.starts_with("Photorealistic")); // style wrapping applied to both
+        assert!(req.prompt.contains("composed scene"));
+    }
+
+    #[test]
+    fn build_image_gen_request_no_prompt_original_when_none_or_blank() {
+        let persona = test_persona_with_meta(&[]);
+        let resolved = eros_engine_llm::model_config::ModelConfig::from_toml_str(
+            "[tasks.chat_image_generation]\nmodel=\"img\"\ndefault_style=\"realistic\"\n",
+        )
+        .unwrap()
+        .resolve_image_gen();
+        let req = build_image_gen_request(
+            "img".into(), vec![], &persona, Some("scene"), None,
+            resolved.as_ref(), "", None, None, None,
+        );
+        assert!(req.prompt_original.is_none());
+        let req_blank = build_image_gen_request(
+            "img".into(), vec![], &persona, Some("scene"), None,
+            resolved.as_ref(), "", None, None, Some("   "),
+        );
+        assert!(req_blank.prompt_original.is_none(), "blank original ⇒ None");
     }
 
     #[test]

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -197,6 +197,29 @@ fn build_image_gen_request(
     }
 }
 
+/// Build the `metadata.image_failed` diagnostic for a fully-failed image chain.
+/// `composed_prompt` is the composed `final_subject` (the most useful debug
+/// field); `attempts` is the per-model/per-variant failure list.
+fn build_image_failed_meta(
+    composed_prompt: &str,
+    style: &str,
+    aspect_ratio: Option<&str>,
+    resolution: Option<&str>,
+    image_ref: &str,
+    face_ref_used: bool,
+    attempts: &[eros_engine_llm::openrouter::ImageAttempt],
+) -> serde_json::Value {
+    serde_json::json!({
+        "prompt": composed_prompt,
+        "style": style,
+        "aspect_ratio": aspect_ratio,
+        "resolution": resolution,
+        "image_ref": image_ref,
+        "face_ref_used": face_ref_used,
+        "attempts": attempts,
+    })
+}
+
 /// Parse the MIME type out of a `data:` URL prefix (e.g.
 /// `data:image/png;base64,AAAA` → `"image/png"`). Defaults to `"image/png"`
 /// when the input is not a recognizable `data:<mime>;` URL.
@@ -2439,6 +2462,7 @@ pub fn run_stream(
                 // runs as usual and the Image frame is appended after the text
                 // `done`.
                 let mut image_only_done = false;
+                let mut image_failed_meta: Option<serde_json::Value> = None;
                 let mut image_only_produced: Vec<crate::pipeline::post_process::ProducedMessage> =
                     Vec::new();
 
@@ -2513,7 +2537,7 @@ pub fn run_stream(
                                 // Mirror the other in-stream task log sites
                                 // (vision / filters / pde): session_id = None.
                                 super::log_openrouter_usage("chat_image_generation", None, &cr);
-                                let image_meta = serde_json::json!({
+                                let mut image_meta = serde_json::json!({
                                     "prompt": final_subject,
                                     "style": style_str,
                                     "model": resp.model,
@@ -2523,6 +2547,10 @@ pub fn run_stream(
                                     "face_ref_used": face_used,
                                     "image_ref": ref_kind,
                                 });
+                                if !resp.attempts.is_empty() {
+                                    image_meta["attempts"] =
+                                        serde_json::to_value(&resp.attempts).unwrap_or_default();
+                                }
                                 let mime = data_url_mime(&resp.images[0]);
                                 let msg_ulid = Ulid::new();
                                 let msg_uuid: Uuid = msg_ulid.into();
@@ -2603,8 +2631,18 @@ pub fn run_stream(
                             }) => {
                                 tracing::warn!(
                                     attempts = attempts.len(),
-                                    "stream(image): image chain exhausted; falling through to text"
+                                    "stream(image): image chain exhausted; persisting \
+                                     image_failed onto the fallthrough text row"
                                 );
+                                image_failed_meta = Some(build_image_failed_meta(
+                                    &final_subject,
+                                    &style_str,
+                                    ar.as_deref(),
+                                    res.as_deref(),
+                                    ref_kind,
+                                    face_used,
+                                    &attempts,
+                                ));
                             }
                         }
                     }
@@ -2848,6 +2886,31 @@ pub fn run_stream(
                     (g.produced.clone(), g.filtered, g.retries_chat, g.retries_filter)
                 };
 
+                // If image-only generation failed (ChainExhausted), attach the
+                // diagnostic onto the fallthrough text row that the burst just
+                // produced.
+                if let Some(meta) = image_failed_meta.take() {
+                    if let Some(last) = produced.last() {
+                        if let Err(e) = chat_repo
+                            .merge_assistant_metadata_key(
+                                user_msg.session_id,
+                                last.message_id,
+                                "image_failed",
+                                &meta,
+                            )
+                            .await
+                        {
+                            tracing::warn!(
+                                "stream(image): persist image_failed onto text row failed: {e}"
+                            );
+                        }
+                    } else {
+                        tracing::warn!(
+                            "stream(image): no fallthrough text row to carry image_failed"
+                        );
+                    }
+                }
+
                 // Reset ghost streak (mirrors sync pipeline policy).
                 if let Err(e) = sqlx::query(
                     "UPDATE engine.companion_affinity SET ghost_streak = 0, updated_at = now() \
@@ -2940,7 +3003,7 @@ pub fn run_stream(
                                 // Mirror the other in-stream task log sites
                                 // (vision / filters / pde): session_id = None.
                                 super::log_openrouter_usage("chat_image_generation", None, &cr);
-                                let image_meta = serde_json::json!({
+                                let mut image_meta = serde_json::json!({
                                     "prompt": final_subject,
                                     "style": style_str,
                                     "model": resp.model,
@@ -2950,6 +3013,10 @@ pub fn run_stream(
                                     "face_ref_used": face_used,
                                     "image_ref": ref_kind,
                                 });
+                                if !resp.attempts.is_empty() {
+                                    image_meta["attempts"] =
+                                        serde_json::to_value(&resp.attempts).unwrap_or_default();
+                                }
                                 let mime = data_url_mime(&resp.images[0]);
                                 // merge_assistant_image_meta wraps under {"image":..}
                                 // itself — pass the raw image_meta.
@@ -2991,9 +3058,31 @@ pub fn run_stream(
                             }) => {
                                 tracing::warn!(
                                     attempts = attempts.len(),
-                                    "stream(text_image): image chain exhausted; \
-                                     no Image frame (text already delivered)"
+                                    "stream(text_image): image chain exhausted; persisting \
+                                     image_failed onto the text row"
                                 );
+                                let meta = build_image_failed_meta(
+                                    &final_subject,
+                                    &style_str,
+                                    ar.as_deref(),
+                                    res.as_deref(),
+                                    ref_kind,
+                                    face_used,
+                                    &attempts,
+                                );
+                                if let Err(e) = chat_repo
+                                    .merge_assistant_metadata_key(
+                                        user_msg.session_id,
+                                        msg_uuid,
+                                        "image_failed",
+                                        &meta,
+                                    )
+                                    .await
+                                {
+                                    tracing::warn!(
+                                        "stream(text_image): persist image_failed failed: {e}"
+                                    );
+                                }
                             }
                         }
                     }
@@ -3403,6 +3492,40 @@ mod tests {
             resolved.as_ref(), "", None, None, Some("   "),
         );
         assert!(req_blank.prompt_original.is_none(), "blank original ⇒ None");
+    }
+
+    #[test]
+    fn build_image_failed_meta_shape() {
+        use eros_engine_llm::openrouter::{AttemptOutcome, ImageAttempt, PromptVariant};
+        let attempts = vec![
+            ImageAttempt {
+                model: "A".into(),
+                variant: PromptVariant::Composed,
+                outcome: AttemptOutcome::Status { status: 400, message: "policy".into() },
+            },
+            ImageAttempt {
+                model: "A".into(),
+                variant: PromptVariant::Original,
+                outcome: AttemptOutcome::ZeroImages,
+            },
+        ];
+        let v = build_image_failed_meta(
+            "composed final",
+            "realistic",
+            Some("3:4"),
+            None,
+            "face",
+            true,
+            &attempts,
+        );
+        assert_eq!(v["prompt"], "composed final");
+        assert_eq!(v["style"], "realistic");
+        assert_eq!(v["aspect_ratio"], "3:4");
+        assert!(v["resolution"].is_null());
+        assert_eq!(v["image_ref"], "face");
+        assert_eq!(v["face_ref_used"], true);
+        assert_eq!(v["attempts"][0]["status"], 400);
+        assert_eq!(v["attempts"][1]["outcome"], "zero_images");
     }
 
     #[test]

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -197,6 +197,20 @@ fn build_image_gen_request(
     }
 }
 
+/// The subject-level prompt that actually drew the image, given which variant
+/// won. `Original` → the pre-compose subject; `Composed`/`Single` → the composed
+/// `final_subject`. Used so persisted/emitted prompt reflects the retry winner.
+fn winning_image_prompt(
+    variant: eros_engine_llm::openrouter::PromptVariant,
+    composed: &str,
+    original: &str,
+) -> String {
+    match variant {
+        eros_engine_llm::openrouter::PromptVariant::Original => original.to_string(),
+        _ => composed.to_string(),
+    }
+}
+
 /// Build the `metadata.image_failed` diagnostic for a fully-failed image chain.
 /// `composed_prompt` is the composed `final_subject` (the most useful debug
 /// field); `attempts` is the per-model/per-variant failure list.
@@ -2529,6 +2543,11 @@ pub fn run_stream(
                         let res = req.resolution.clone();
                         match state.openrouter.execute_image(req).await {
                             Ok(resp) if !resp.images.is_empty() => {
+                                let won_prompt = winning_image_prompt(
+                                    resp.winning_variant,
+                                    &final_subject,
+                                    &subject,
+                                );
                                 // Usage logging via the ChatResponse adapter.
                                 let cr = eros_engine_llm::openrouter::ChatResponse {
                                     reply: String::new(),
@@ -2541,7 +2560,7 @@ pub fn run_stream(
                                 // (vision / filters / pde): session_id = None.
                                 super::log_openrouter_usage("chat_image_generation", None, &cr);
                                 let mut image_meta = serde_json::json!({
-                                    "prompt": final_subject,
+                                    "prompt": won_prompt,
                                     "style": style_str,
                                     "model": resp.model,
                                     "aspect_ratio": ar,
@@ -2605,7 +2624,7 @@ pub fn run_stream(
                                     message_id: ulid_string(msg_ulid),
                                     data_url: resp.images[0].clone(),
                                     mime,
-                                    image_prompt: Some(final_subject.clone()),
+                                    image_prompt: Some(won_prompt.clone()),
                                     model: resp.model.clone(),
                                     generation_id: resp.generation_id.clone(),
                                 };
@@ -2999,6 +3018,11 @@ pub fn run_stream(
                         let res = req.resolution.clone();
                         match state.openrouter.execute_image(req).await {
                             Ok(resp) if !resp.images.is_empty() => {
+                                let won_prompt = winning_image_prompt(
+                                    resp.winning_variant,
+                                    &final_subject,
+                                    &subject,
+                                );
                                 let cr = eros_engine_llm::openrouter::ChatResponse {
                                     reply: String::new(),
                                     generation_id: resp.generation_id.clone(),
@@ -3010,7 +3034,7 @@ pub fn run_stream(
                                 // (vision / filters / pde): session_id = None.
                                 super::log_openrouter_usage("chat_image_generation", None, &cr);
                                 let mut image_meta = serde_json::json!({
-                                    "prompt": final_subject,
+                                    "prompt": won_prompt,
                                     "style": style_str,
                                     "model": resp.model,
                                     "aspect_ratio": ar,
@@ -3042,7 +3066,7 @@ pub fn run_stream(
                                     message_id: ulid_string(Ulid::from(msg_uuid)),
                                     data_url: resp.images[0].clone(),
                                     mime,
-                                    image_prompt: Some(final_subject.clone()),
+                                    image_prompt: Some(won_prompt.clone()),
                                     model: resp.model.clone(),
                                     generation_id: resp.generation_id.clone(),
                                 };
@@ -3551,6 +3575,14 @@ mod tests {
         assert_eq!(v["face_ref_used"], true);
         assert_eq!(v["attempts"][0]["status"], 400);
         assert_eq!(v["attempts"][1]["outcome"], "zero_images");
+    }
+
+    #[test]
+    fn winning_image_prompt_picks_variant() {
+        use eros_engine_llm::openrouter::PromptVariant;
+        assert_eq!(winning_image_prompt(PromptVariant::Original, "C", "O"), "O");
+        assert_eq!(winning_image_prompt(PromptVariant::Composed, "C", "O"), "C");
+        assert_eq!(winning_image_prompt(PromptVariant::Single, "C", "O"), "C");
     }
 
     #[test]

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -2510,6 +2510,9 @@ pub fn run_stream(
                             .unwrap_or_else(|| subject.clone()),
                             None => subject.clone(),
                         };
+                        let original_subject = (!subject.trim().is_empty()
+                            && final_subject.trim() != subject.trim())
+                            .then_some(subject.as_str());
                         let req = build_image_gen_request(
                             primary,
                             fallback,
@@ -2520,7 +2523,7 @@ pub fn run_stream(
                             "",
                             ref_url.clone(),
                             plan.aspect_ratio.as_deref(),
-                            None, /* original_subject — activated in retry task */
+                            original_subject,
                         );
                         let ar = req.aspect_ratio.clone();
                         let res = req.resolution.clone();
@@ -2977,6 +2980,9 @@ pub fn run_stream(
                             .unwrap_or_else(|| subject.clone()),
                             None => subject.clone(),
                         };
+                        let original_subject = (!subject.trim().is_empty()
+                            && final_subject.trim() != subject.trim())
+                            .then_some(subject.as_str());
                         let req = build_image_gen_request(
                             primary,
                             fallback,
@@ -2987,7 +2993,7 @@ pub fn run_stream(
                             "",
                             ref_url.clone(),
                             plan.aspect_ratio.as_deref(),
-                            None, /* original_subject — activated in retry task */
+                            original_subject,
                         );
                         let ar = req.aspect_ratio.clone();
                         let res = req.resolution.clone();

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -2756,6 +2756,9 @@ mod tests {
                 .await
                 .unwrap();
         let meta2 = meta2.unwrap();
-        assert!(meta2.get("x").is_none(), "cross-session write must be a no-op");
+        assert!(
+            meta2.get("x").is_none(),
+            "cross-session write must be a no-op"
+        );
     }
 }

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -2749,12 +2749,13 @@ mod tests {
         repo.merge_assistant_metadata_key(Uuid::new_v4(), msg_id, "x", &serde_json::json!(1))
             .await
             .unwrap();
-        let meta2: serde_json::Value =
+        let meta2: Option<serde_json::Value> =
             sqlx::query_scalar("SELECT metadata FROM engine.chat_messages WHERE id = $1")
                 .bind(msg_id)
                 .fetch_one(&pool)
                 .await
                 .unwrap();
+        let meta2 = meta2.unwrap();
         assert!(meta2.get("x").is_none(), "cross-session write must be a no-op");
     }
 }

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -731,6 +731,32 @@ impl<'a> ChatRepo<'a> {
         Ok(())
     }
 
+    /// Shallow-merge `{ key: value }` into an assistant row's `metadata`
+    /// (`metadata = COALESCE(metadata,'{}') || {key:value}`). Generic sibling of
+    /// `merge_assistant_image_meta` (which hardcodes the `"image"` key). Scoped
+    /// by `session_id` and `role = 'assistant'` (IDOR guard). No-op if no row
+    /// matches.
+    pub async fn merge_assistant_metadata_key(
+        &self,
+        session_id: Uuid,
+        message_id: Uuid,
+        key: &str,
+        value: &serde_json::Value,
+    ) -> Result<(), sqlx::Error> {
+        let patch = serde_json::json!({ key: value });
+        sqlx::query(
+            "UPDATE engine.chat_messages \
+             SET metadata = COALESCE(metadata, '{}'::jsonb) || $3 \
+             WHERE id = $1 AND session_id = $2 AND role = 'assistant'",
+        )
+        .bind(message_id)
+        .bind(session_id)
+        .bind(patch)
+        .execute(self.pool)
+        .await?;
+        Ok(())
+    }
+
     /// Persist the client-written-back storage URL for a generated image, nested
     /// under `metadata.image.url`. Idempotent (re-POST overwrites). Scoped by
     /// `session_id` to prevent cross-session write-back (IDOR): a user may only
@@ -2668,5 +2694,67 @@ mod tests {
             vec!["B", "M", "U"],
             "limit caps total incl. U; oldest (A) trimmed; U survives"
         );
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn merge_assistant_metadata_key_writes_under_named_key(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let s = repo
+            .create_session(Uuid::new_v4(), Uuid::new_v4())
+            .await
+            .unwrap();
+        let user_msg_id = match repo
+            .upsert_user_message_idempotent(s.id, "hi", "01J0000000000000000000002A", "user", None)
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            other => panic!("{other:?}"),
+        };
+        let msg_id = Uuid::new_v4();
+        repo.insert_assistant_batch(
+            s.id,
+            user_msg_id,
+            &[AssistantInsert {
+                id: msg_id,
+                content: "fell through to text".into(),
+                assistant_action_type: "reply".into(),
+                continues_from_message_id: None,
+                truncated: false,
+                model: Some("m".into()),
+                usage: None,
+                generation_id: None,
+                filter_audit: None,
+                metadata: None,
+            }],
+        )
+        .await
+        .unwrap();
+
+        let value = serde_json::json!({ "prompt": "a selfie", "attempts": [] });
+        repo.merge_assistant_metadata_key(s.id, msg_id, "image_failed", &value)
+            .await
+            .unwrap();
+
+        let meta: Option<serde_json::Value> =
+            sqlx::query_scalar("SELECT metadata FROM engine.chat_messages WHERE id = $1")
+                .bind(msg_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        let meta = meta.unwrap();
+        assert_eq!(meta["image_failed"]["prompt"], "a selfie");
+
+        // Wrong session must not write (IDOR guard).
+        repo.merge_assistant_metadata_key(Uuid::new_v4(), msg_id, "x", &serde_json::json!(1))
+            .await
+            .unwrap();
+        let meta2: serde_json::Value =
+            sqlx::query_scalar("SELECT metadata FROM engine.chat_messages WHERE id = $1")
+                .bind(msg_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert!(meta2.get("x").is_none(), "cross-session write must be a no-op");
     }
 }

--- a/docs/superpowers/specs/2026-06-29-image-gen-failure-diagnostics-and-composed-retry-design.md
+++ b/docs/superpowers/specs/2026-06-29-image-gen-failure-diagnostics-and-composed-retry-design.md
@@ -1,0 +1,258 @@
+# Image-gen failure diagnostics + composed→original retry
+
+**Date:** 2026-06-29
+**Issues:** #122 (failure observability) + composed→original fallback retry
+**Scope:** one combined PR — both tasks rewrite the same `execute_image` loop.
+
+## Problem
+
+Two gaps in the image-generation path, both centered on `execute_image`
+(`crates/eros-engine-llm/src/openrouter.rs:716`):
+
+1. **#122 — failures persist nothing.** When the whole image model chain fails
+   (every candidate returns an HTTP error or a zero-image response), the turn
+   falls through to text and *nothing about the attempt is written to the DB* —
+   only `tracing::warn!` lines that scroll away. The composed prompt that
+   triggered a content-policy refusal (HTTP 400) is unrecoverable, and per-model
+   detail is lost because `execute_image` returns only the **last** `LlmError`.
+   This makes a common, real failure mode (all providers refuse a prompt)
+   undebuggable from persisted data.
+
+2. **Retry only walks models, never prompts.** When `chat_image_prompt_compose`
+   is enabled, the LLM-rewritten "composed" prompt is the only thing tried — if
+   the composer over-edits or trips a content filter, the original PDE prompt is
+   never attempted, even though it might have drawn fine.
+
+Both converge on `execute_image`'s contract, so they ship together: doing them
+separately would refactor the same function twice, and #122's attempts list
+should naturally capture the composed→original tries.
+
+## Background — the two prompt layers
+
+- `subject` = the PDE/request image prompt (`plan.image_prompt`, falling back to
+  `req_image.image_prompt`). The **original** subject.
+- `final_subject` = when `chat_image_prompt_compose` is configured,
+  `run_image_prompt_compose(...)` rewrites `subject` into the **composed**
+  subject; otherwise `final_subject == subject`. On compose failure/empty it
+  degrades to `subject.clone()` (`stream.rs:2462-2482`, `:2881-2901`).
+- `build_image_gen_request` (`stream.rs:140`) wraps the chosen subject via
+  `compose_image_prompt(style, persona, subject)` (style preset + appearance +
+  subject) into the wire `prompt`. This wrapping applies to **both** variants
+  identically; the composed/original distinction lives purely at the subject
+  layer.
+
+Two call sites drive image-gen:
+
+- **image-only** (`ActionType::ReplyImage`, `stream.rs:2496`): on success emits
+  Meta→Image→Done and returns; on failure logs and **falls through to the text
+  path** (`image_only_done` stays false → stream continues to vision/filter/text
+  burst).
+- **text+image** (`ActionType::ReplyTextImage`, `stream.rs:2915`): text has
+  already streamed; the image is appended after. Target row is
+  `produced.last()` (`:2859`). On failure, no Image frame.
+
+## Design
+
+### 1. Shared core — `execute_image`'s new contract (`eros-engine-llm`)
+
+New types in `openrouter.rs`, all `#[derive(Serialize)]` so the server layer can
+serialize them straight into turn metadata:
+
+```rust
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PromptVariant { Composed, Original, Single }
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+pub enum AttemptOutcome {
+    Status { status: u16, message: String },  // HTTP non-2xx (400 content-policy, 404, …)
+    ZeroImages,
+    Transport { message: String },
+    Decode { message: String },
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ImageAttempt {
+    pub model: String,
+    pub variant: PromptVariant,
+    #[serde(flatten)]
+    pub outcome: AttemptOutcome,
+}
+
+#[derive(Debug)]
+pub enum ImageGenError {
+    Config(String),                              // pre-flight: no api key / no models — no attempts
+    ChainExhausted { attempts: Vec<ImageAttempt> },
+}
+```
+
+Serialized `ImageAttempt` shape (matches the approved schema):
+
+```jsonc
+{ "model": "A", "variant": "composed", "outcome": "status", "status": 400, "message": "…" }
+{ "model": "A", "variant": "original", "outcome": "zero_images" }
+```
+
+`execute_image` returns `Result<ImageGenResponse, ImageGenError>`:
+
+- `ImageGenResponse` gains `pub attempts: Vec<ImageAttempt>` — the failures that
+  **preceded** the win (empty when the first try succeeded).
+- Total failure → `Err(ImageGenError::ChainExhausted { attempts })` carrying
+  every failed try, in attempt order.
+- Pre-flight config failures stay `Err(ImageGenError::Config(_))` (no attempts to
+  persist).
+
+The current callers' `Ok(_)` "zero images" arm is effectively dead —
+`execute_image` only ever returns `Ok` with ≥1 image — so it folds into the
+`Err` arm at both sites.
+
+### 2. Composed→original interleave (Task 2)
+
+`ImageGenRequest` gains:
+
+```rust
+/// The original PDE prompt, retried after `prompt` per model. Set only when
+/// `chat_image_prompt_compose` actually changed the subject; `None` otherwise.
+pub prompt_original: Option<String>,
+```
+
+The loop becomes **model-outer / variant-inner**:
+
+```text
+for model in candidates:                       # [A, B, C]
+    for (variant, prompt) in variants(req):    # [(Composed, prompt), (Original, prompt_original)]
+        send → record ImageAttempt → return ImageGenResponse on first ≥1-image success
+```
+
+`variants(req)` = `[(Composed, &prompt), (Original, original)]` when
+`prompt_original` is `Some`, else `[(Single, &prompt)]`.
+
+For `[A,B,C]` with a distinct original, the order is exactly:
+
+```
+A·composed → A·original → B·composed → B·original → C·composed → C·original
+```
+
+**Guard — when is `prompt_original` set?** Only when the composer ran *and changed
+the subject*: `compose enabled && final_subject != subject && !subject.is_empty()`.
+When compose is off, failed, returned empty, or returned text identical to the
+subject, `final_subject == subject` → `prompt_original = None`, variant `Single`,
+behavior **identical to today** (no duplicate attempt). When the original subject
+is empty (no PDE/request prompt at all), there is no original to fall back to →
+`None`.
+
+`build_image_gen_request` gains `original_subject: Option<&str>`; when `Some`, it
+wraps it via the existing `compose_image_prompt(style, persona, …)` into
+`prompt_original` (same style+appearance wrapping as the primary). The caller at
+each image site passes `Some(subject)` only when the guard holds.
+
+> Naming note: `ImageGenRequest` already has `fallback_model` (the model chain)
+> and `build_image_gen_request` already has a `fallback_subject` param (a *default*
+> subject when plan/request prompts are blank — unrelated to retry). The new field
+> is named `prompt_original` / `original_subject` to keep it distinct from both.
+
+**Testability:** extract the ordering into a pure helper
+
+```rust
+fn plan_attempts<'a>(
+    candidates: &'a [&'a str],
+    prompt: &'a str,
+    prompt_original: Option<&'a str>,
+) -> Vec<(&'a str /*model*/, PromptVariant, &'a str /*prompt*/)>
+```
+
+so the 6-step interleave and the `Single` collapse are unit-tested without HTTP.
+`execute_image` iterates the returned plan, performing the network call per step.
+
+### 3. Persist diagnostics on total failure (#122)
+
+A **separate `metadata.image_failed` key** (chosen over reusing `metadata.image`
+with `failed:true`, so a consumer can never mistake a failure for a success and
+`where metadata ? 'image_failed'` cleanly selects refusals):
+
+```jsonc
+metadata.image_failed = {
+  "prompt": "<composed final_subject>",   // the single most useful debug field
+  "style": "realistic",
+  "aspect_ratio": "3:4",
+  "resolution": null,
+  "image_ref": null,
+  "face_ref_used": false,
+  "attempts": [
+    { "model": "A", "variant": "composed", "outcome": "status", "status": 400, "message": "…" },
+    { "model": "A", "variant": "original", "outcome": "zero_images" },
+    { "model": "B", "variant": "composed", "outcome": "transport", "message": "…" }
+  ]
+}
+```
+
+The builder (a small `fn` in `stream.rs` taking the context fields + `attempts`)
+is shared by both failure sites. Attachment:
+
+- **text+image failure** (`stream.rs:2961-2972`): merge `image_failed` onto
+  `produced.last()` — the already-streamed text row already in hand (`:2859`).
+- **image-only failure** (`stream.rs:2582-2593`): the diagnostic is built at the
+  failure site but the fallen-through text row does not exist yet. Stash it in a
+  `let mut image_failure_meta: Option<serde_json::Value> = None;` declared before
+  the image block; after the text burst captures `produced` (`:2831`), if `Some`,
+  merge it onto `produced.last()`. Text fallthrough is otherwise unchanged — this
+  is purely additive. (If the burst produced no row — e.g. a pseudo-ghost edge —
+  the merge is a no-op `UPDATE … WHERE id = …`; the diagnostic is dropped, same
+  as today. Acceptable: the common case has a text row.)
+
+**Store helper:** add a generalized sibling of `merge_assistant_image_meta`
+(`chat.rs:714`, which hardcodes the `"image"` wrapper):
+
+```rust
+pub async fn merge_assistant_metadata_key(
+    &self, session_id: Uuid, message_id: Uuid, key: &str, value: &serde_json::Value,
+) -> Result<(), sqlx::Error>   // metadata = COALESCE(metadata,'{}') || {key: value}, role='assistant', scoped by session
+```
+
+`merge_assistant_image_meta` can be reimplemented in terms of it (or left as-is);
+the new key path uses `merge_assistant_metadata_key(.., "image_failed", ..)`.
+
+### 4. Attempts on the success path (nice-to-have, included)
+
+When earlier models failed before one drew the image, surface those skipped tries
+on the **success** record too ("provider A refused, provider B drew it"). Since
+`execute_image` now returns `resp.attempts` (the pre-win failures), thread it into
+the existing `image_meta` JSON at both success sites — include `"attempts"` only
+when non-empty:
+
+- image-only success (`stream.rs:2509`): add to the `image_meta` json before the
+  `AssistantInsert`.
+- text+image success (`stream.rs:2927`): add to the `image_meta` json before
+  `merge_assistant_image_meta`.
+
+`attempts` carries the same `ImageAttempt` shape (failures only — the winner is
+already named by `metadata.image.model` / `generation_id`), so the field is
+consistent between the success and failure records.
+
+## Testing
+
+- **Pure / no network:**
+  - `plan_attempts` — `[A,B,C]` + distinct original → the exact 6-step interleave;
+    `prompt_original = None` → 3-step `Single` plan.
+  - `ImageAttempt` / `AttemptOutcome` serialization — `Status` →
+    `{outcome,status,message}`, `ZeroImages` → `{outcome:"zero_images"}`, etc.
+  - `build_image_gen_request` — sets `prompt_original` when composed≠original,
+    `None` when equal / compose off / empty subject. Extend the existing
+    `build_image_gen_request_*` tests (`stream.rs:3277+`).
+- **Existing tests:** update call sites/signatures (`build_image_gen_request`
+  gains a param; `execute_image` callers match the new `Result` shape).
+- Network-driven all-fail persistence is covered by the pure builder + the shared
+  attachment path; full live mocking of OpenRouter is out of scope (consistent
+  with the existing image tests, which don't mock the provider).
+
+## Non-goals
+
+- No change to text-fallthrough behavior (purely additive observability + an extra
+  retry variant).
+- No retry/backoff/timeout semantics change beyond inserting the original-prompt
+  variant into the existing walk.
+- `prompt_original` is engine-internal — **no new request field** exposed to web
+  clients.
+- No DB migration — `metadata` is `jsonb`; both `image_failed` and the new
+  `attempts` are additive keys.


### PR DESCRIPTION
Closes #122 and adds a composed→original fallback retry for image generation. One combined change — both rewrite the contract of `execute_image`.

## What changed

**#122 — persist image-gen failure diagnostics.** When the whole image model chain fails (every candidate errors or returns zero images), the turn previously persisted nothing (only `tracing::warn!`). Now:
- `execute_image` returns `Result<ImageGenResponse, ImageGenError>` and records every per-attempt outcome (`ImageAttempt { model, variant, outcome, status?, message? }`) — distinguishing HTTP 400 content-policy refusals from 404 / transport / decode / zero-images.
- On total failure the server persists `metadata.image_failed` onto the turn's assistant row: the composed prompt + `style`/`aspect_ratio`/`resolution`/`image_ref`/`face_ref_used` + the `attempts` list. Image-only failures attach onto the fallthrough text row; text+image merges onto its text row. All persistence is fail-soft.
- Success also records skipped earlier attempts under `metadata.image.attempts` ("A refused, B drew it").

**Composed→original retry.** When `chat_image_prompt_compose` rewrote the subject, `execute_image` now walks each model with the composed prompt then the original PDE prompt (model-outer / variant-inner: `A·composed → A·original → B·composed → B·original → …`). Guarded so it only activates when compose genuinely changed a non-empty subject — otherwise behavior is identical to before.

## Notes
- **No migration** — `metadata` is `jsonb`; `image_failed` and `attempts` are additive keys.
- **No OpenAPI change** — `prompt_original` is engine-internal; diagnostics are freeform metadata, never exposed via the public history route (operator-only).
- `metadata.image_failed` is a separate key from the success `metadata.image`, so no consumer of the success shape is affected.

## Verification
- 670 tests pass (core 57 / llm 167 / server 343 / store 103)
- `cargo fmt --check` + `cargo clippy --workspace --all-targets -D warnings` clean
- OpenAPI snapshot unchanged

Spec: `docs/superpowers/specs/2026-06-29-image-gen-failure-diagnostics-and-composed-retry-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
