### PR TITLE
fix(regex-filter): strip artifact-only replies to empty (drop fail-safe)

### DIFF
--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -407,11 +407,11 @@ pub struct RegexStripOutcome {
 
 /// Apply every rule whose `models` contains `model_id`, in declaration order.
 /// Pure & deterministic. No fail-safe: a reply that is *entirely* an artifact
-/// (e.g. a bare `[你给对方发送了一张照片：…]`) strips to an empty string, and the
-/// match is still reported. The caller persists the audit (raw on
-/// `pre_filter_content`) and emits no content bubble — downstream decides how
-/// to render an empty/NULL reply (the web client simply doesn't show it, a
-/// ghost-like effect).
+/// (e.g. a bare `[你给对方发送了一张照片：…]`, or one wrapped in incidental
+/// whitespace) strips to an empty string, and the match is still reported. The
+/// caller persists the audit (raw on `pre_filter_content`) and emits no content
+/// bubble — downstream decides how to render an empty/NULL reply (the web
+/// client simply doesn't show it, a ghost-like effect).
 pub fn apply_output_regex(
     rules: &[CompiledRegexRule],
     model_id: &str,
@@ -428,6 +428,15 @@ pub fn apply_output_regex(
             matched_rules.push(i);
             cleaned = next.into_owned();
         }
+    }
+    // An unanchored rule (e.g. `\[[^\]]*\]`) can leave incidental whitespace
+    // behind when the reply was artifact-only (the common `<正文>\n\n[...]`
+    // shape with an empty 正文). Collapse a whitespace-only *stripped* result to
+    // a true empty string so the caller suppresses the bubble — the stream
+    // layer gates on `is_empty()`, not `trim().is_empty()`. Only when a rule
+    // actually matched: an untouched whitespace-only reply is left as-is.
+    if !matched_rules.is_empty() && cleaned.trim().is_empty() {
+        cleaned.clear();
     }
     RegexStripOutcome {
         cleaned,
@@ -3273,6 +3282,26 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
         assert_eq!(
             out.cleaned, "",
             "artifact-only reply strips to empty (no fail-safe)"
+        );
+        assert_eq!(
+            out.matched_rules,
+            vec![0],
+            "the matching rule is still reported"
+        );
+    }
+
+    #[test]
+    fn apply_output_regex_collapses_whitespace_only_result_to_empty() {
+        // An UNANCHORED rule (e.g. `\[[^\]]*\]`) drops the bracket but leaves
+        // any surrounding whitespace. A reply that is artifact + incidental
+        // whitespace (the common `<正文>\n\n[...]` shape with an empty 正文)
+        // must still collapse to "" so the caller suppresses the bubble — the
+        // stream layer only checks `is_empty()`, not `trim().is_empty()`.
+        let rules = compiled(&[("m", r#"\[[^\]]*\]"#, "")]); // drop any [...]
+        let out = apply_output_regex(&rules, "m", "\n\n[你给对方发送了一张照片：x]\n");
+        assert_eq!(
+            out.cleaned, "",
+            "a whitespace-only strip result collapses to empty"
         );
         assert_eq!(
             out.matched_rules,

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -406,8 +406,12 @@ pub struct RegexStripOutcome {
 }
 
 /// Apply every rule whose `models` contains `model_id`, in declaration order.
-/// Pure & deterministic. Fail-safe: if stripping empties a non-empty reply,
-/// the raw text is returned unchanged with no matched rules.
+/// Pure & deterministic. No fail-safe: a reply that is *entirely* an artifact
+/// (e.g. a bare `[你给对方发送了一张照片：…]`) strips to an empty string, and the
+/// match is still reported. The caller persists the audit (raw on
+/// `pre_filter_content`) and emits no content bubble — downstream decides how
+/// to render an empty/NULL reply (the web client simply doesn't show it, a
+/// ghost-like effect).
 pub fn apply_output_regex(
     rules: &[CompiledRegexRule],
     model_id: &str,
@@ -424,13 +428,6 @@ pub fn apply_output_regex(
             matched_rules.push(i);
             cleaned = next.into_owned();
         }
-    }
-    // Fail-safe: never let a strip produce a blank reply from a non-blank one.
-    if !matched_rules.is_empty() && cleaned.trim().is_empty() && !text.trim().is_empty() {
-        return RegexStripOutcome {
-            cleaned: text.to_string(),
-            matched_rules: Vec::new(),
-        };
     }
     RegexStripOutcome {
         cleaned,
@@ -3265,11 +3262,23 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
     }
 
     #[test]
-    fn apply_output_regex_empty_result_failsafes_to_raw() {
-        let rules = compiled(&[("m", r#"^\[.*\]$"#, "")]); // whole reply is the artifact
+    fn apply_output_regex_strips_to_empty_when_reply_is_artifact_only() {
+        // A reply that is ENTIRELY the artifact strips to empty. There is no
+        // fail-safe: the empty result is honest, and the match is reported so
+        // the caller persists the audit (pre_filter_content = raw) and the
+        // client receives no content bubble (downstream decides how to render
+        // an empty/NULL reply).
+        let rules = compiled(&[("m", r#"\[[^\]]*\]"#, "")]); // drop any [...]
         let out = apply_output_regex(&rules, "m", "[你给对方发送了一张照片：x]");
-        assert_eq!(out.cleaned, "[你给对方发送了一张照片：x]"); // kept raw
-        assert!(out.matched_rules.is_empty(), "fail-safe reports no change");
+        assert_eq!(
+            out.cleaned, "",
+            "artifact-only reply strips to empty (no fail-safe)"
+        );
+        assert_eq!(
+            out.matched_rules,
+            vec![0],
+            "the matching rule is still reported"
+        );
     }
 
     #[test]

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -8124,6 +8124,184 @@ data: [DONE]\n\n";
         );
     }
 
+    /// When the reply is ENTIRELY the artifact (a bare `[...]` with nothing
+    /// else), the strip empties it. There is no fail-safe: the client receives
+    /// NO content bubble (no Delta), the row persists empty `content` (""), and
+    /// the audit still records the strip (`pre_filter_content` = raw,
+    /// `filter_model` = "<regex>"). Downstream renders the empty reply however
+    /// it likes (the web client just doesn't show it — a ghost-like effect).
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn regex_artifact_only_reply_persists_empty_no_bubble(pool: PgPool) {
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+        use futures_util::StreamExt;
+        use wiremock::matchers::path as wm_path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        // ── 1. Mock OpenRouter: reply is ONLY the bracket artifact ─────────────
+        let mock = MockServer::start().await;
+        let chat_body = "data: {\"choices\":[{\"delta\":{\"content\":\"[你给对方发送了一张照片：海边自拍]\"}}],\
+\"usage\":{\"prompt_tokens\":2,\"completion_tokens\":8,\"total_tokens\":10},\
+\"id\":\"gen-bo\",\"model\":\"mock/cydonia\"}\n\n\
+data: [DONE]\n\n";
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(chat_body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+
+        // ── 2. Seed persona + session ──────────────────────────────────────────
+        let user_id = uuid::Uuid::new_v4();
+        let (_g, _instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+
+        // ── 3. AppState with a rule that drops any [...] for mock/cydonia ──────
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        let regex_cfg = eros_engine_llm::model_config::ModelConfig::from_toml_str(
+            "[tasks.chat_companion]\nmodel=\"mock/cydonia\"\n\
+             [[tasks.chat_companion.output_regex]]\n\
+             models=[\"mock/cydonia\"]\n\
+             pattern=\"\\\\[[^\\\\]]*\\\\]\"\n",
+        )
+        .unwrap();
+        state.output_regex = std::sync::Arc::new(
+            regex_cfg
+                .compile_output_regex()
+                .expect("artifact pattern compiles"),
+        );
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                eros_engine_llm::openrouter::AppAttribution::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+        let state = std::sync::Arc::new(state);
+
+        // ── 4. Insert the user message ─────────────────────────────────────────
+        let chat_repo = ChatRepo { pool: &pool };
+        let user_message_id = match chat_repo
+            .upsert_user_message_idempotent(
+                session_id,
+                "晚安",
+                "01JT5REGEXBONLY0000000000C",
+                "user",
+                None,
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
+
+        // ── 5. Drive drive_chat_burst (ReplyText, no LLM filter) ───────────────
+        let req = eros_engine_llm::openrouter::ChatRequest {
+            model: "mock/cydonia".into(),
+            fallback_model: vec![],
+            messages: vec![eros_engine_llm::openrouter::ChatMessage {
+                role: "user".into(),
+                content: "晚安".into(),
+            }],
+            temperature: 0.0,
+            max_tokens: 64,
+            ..Default::default()
+        };
+        let outcome = std::sync::Arc::new(std::sync::Mutex::new(BurstOutcome::default()));
+        let burst = drive_chat_burst(
+            state.clone(),
+            session_id,
+            user_message_id,
+            FrameActionType::Reply,
+            "reply",
+            ActionType::ReplyText,
+            req,
+            None,
+            None, // filter = None: regex-only turn
+            vec![],
+            None,
+            Default::default(),
+            Default::default(),
+            None,
+            outcome.clone(),
+        );
+        let frames: Vec<ProtocolFrame> = Box::pin(burst).collect().await;
+
+        // ── 6. Assertions ─────────────────────────────────────────────────────
+        // No error frame, and crucially NO Delta (no content bubble reaches the client).
+        assert!(
+            !frames
+                .iter()
+                .any(|f| matches!(f, ProtocolFrame::Error { .. })),
+            "no error frame expected; got {frames:?}",
+        );
+        let deltas: Vec<&str> = frames
+            .iter()
+            .filter_map(|f| match f {
+                ProtocolFrame::Delta { content, .. } => Some(content.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            deltas.is_empty(),
+            "an artifact-only reply must emit NO Delta bubble; got {deltas:?}",
+        );
+
+        // The strip fired (filtered=true) and extract sees the empty text.
+        {
+            let o = outcome.lock().unwrap();
+            assert!(o.filtered, "outcome.filtered must be true: the strip ran");
+            assert_eq!(
+                o.produced.len(),
+                1,
+                "one produced message; got {:?}",
+                o.produced
+            );
+            assert_eq!(
+                o.produced[0].full_text, "",
+                "extract/memory must see the empty (stripped) text",
+            );
+        }
+
+        // DB row: content == "" (empty, not the raw artifact); audit recorded.
+        let (content, pre_filter, filter_model, filter_triggers): (
+            String,
+            Option<String>,
+            Option<String>,
+            Option<serde_json::Value>,
+        ) = sqlx::query_as(
+            "SELECT content, pre_filter_content, filter_model, filter_triggers \
+             FROM engine.chat_messages \
+             WHERE session_id = $1 AND role = 'assistant' \
+             ORDER BY sent_at DESC LIMIT 1",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            content, "",
+            "persisted content must be empty; got {content:?}"
+        );
+        assert_eq!(
+            pre_filter.as_deref(),
+            Some("[你给对方发送了一张照片：海边自拍]"),
+            "pre_filter_content must hold the raw artifact; got {pre_filter:?}",
+        );
+        assert_eq!(
+            filter_model.as_deref(),
+            Some("<regex>"),
+            "filter_model must be '<regex>'; got {filter_model:?}",
+        );
+        assert_eq!(
+            filter_triggers,
+            Some(serde_json::json!({ "regex": [0usize] })),
+            "filter_triggers must be {{\"regex\":[0]}}; got {filter_triggers:?}",
+        );
+    }
+
     /// Both layers fire on the SAME turn: the per-model output_regex strips the
     /// artifact (layer 0) AND the LLM output_filter rewrites the reply. The LLM
     /// filter must run on the regex-CLEANED text (not the raw `acc`); the

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -739,8 +739,16 @@ fn drive_chat_burst(
                 String,
                 Option<eros_engine_store::chat::FilterAudit>,
                 Option<FilterFailOpen>,
-            ) = match f_opt {
-                Some(f) => {
+            ) = if !regex_indices.is_empty() && cleaned.is_empty() {
+                // The regex strip emptied the WHOLE reply (artifact-only): this
+                // is terminal. Do NOT hand "" to the LLM output_filter — a
+                // rewrite model can return non-empty text and resurrect a bubble,
+                // defeating the no-content-bubble guarantee. Emit nothing; the
+                // regex audit (raw on pre_filter_content) still records the strip.
+                (String::new(), regex_audit(&acc), None)
+            } else {
+                match f_opt {
+                    Some(f) => {
                     let hits = f.trigger.should_filter(model_id, &tag_refs, random_draw);
                     match hits {
                         Some(h) => match run_output_filter(&state, f, &cleaned).await {
@@ -795,6 +803,7 @@ fn drive_chat_burst(
                     }
                 }
                 None => (cleaned.clone(), regex_audit(&acc), None), // regex-only turn
+                }
             };
 
             if !visible.is_empty() {
@@ -8550,6 +8559,202 @@ data: [DONE]\n\n"
             triggers.get("regex"),
             Some(&serde_json::json!([0])),
             "filter_triggers must fold in the regex key; got {triggers:?}",
+        );
+    }
+
+    /// When the regex strip empties the WHOLE reply (artifact-only) AND an LLM
+    /// `output_filter` is configured and fires, the LLM filter must be SKIPPED:
+    /// handing "" to a rewrite model could resurrect a bubble. The client sees
+    /// no Delta, the row persists empty `content`, the audit stays the regex
+    /// one (`filter_model = "<regex>"`), and the filter model is never called.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn regex_strip_to_empty_skips_llm_filter(pool: PgPool) {
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+        use futures_util::StreamExt;
+        use wiremock::matchers::{body_string_contains, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let raw_reply = "[你给对方发送了一张照片：海边自拍]"; // artifact-only
+
+        // ── 1. Dual mock: chat model (SSE, artifact-only) + filter model (JSON). ─
+        let mock = MockServer::start().await;
+        let chat_body = format!(
+            "data: {{\"choices\":[{{\"delta\":{{\"content\":\"{raw_reply}\"}}}}],\
+\"usage\":{{\"prompt_tokens\":2,\"completion_tokens\":8,\"total_tokens\":10}},\
+\"id\":\"gen-skip\",\"model\":\"mock/euryale\"}}\n\n\
+data: [DONE]\n\n"
+        );
+        // The filter model WOULD return a valid (>=80 char) rewrite if called —
+        // proving that, absent the skip, an empty reply resurrects a bubble.
+        let filt_text = "FILT_START 她轻轻地望向窗外，思绪飘向了远方。阳光洒在她的脸上，温柔而明亮。她记得那个夏天的每一天，岁月如流水般逝去，带走了所有的悲欢离合。 FILT_END";
+        let filt_body = serde_json::json!({
+            "id": "gf", "model": "fast/m",
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            "choices": [{"message": {"content": filt_text}}],
+        });
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("fast/m"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(filt_body))
+            .mount(&mock)
+            .await;
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("mock/euryale"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(chat_body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+
+        // ── 2. Seed persona + session ──────────────────────────────────────────
+        let user_id = uuid::Uuid::new_v4();
+        let (_g, _instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+
+        // ── 3. AppState: rule drops any [...] for mock/euryale → empties reply. ──
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        let regex_cfg = eros_engine_llm::model_config::ModelConfig::from_toml_str(
+            "[tasks.chat_companion]\nmodel=\"mock/euryale\"\n\
+             [[tasks.chat_companion.output_regex]]\n\
+             models=[\"mock/euryale\"]\n\
+             pattern=\"\\\\[[^\\\\]]*\\\\]\"\n",
+        )
+        .unwrap();
+        state.output_regex = std::sync::Arc::new(
+            regex_cfg
+                .compile_output_regex()
+                .expect("artifact pattern compiles"),
+        );
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                eros_engine_llm::openrouter::AppAttribution::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+        let state = std::sync::Arc::new(state);
+
+        // ── 4. Insert the user message ─────────────────────────────────────────
+        let chat_repo = ChatRepo { pool: &pool };
+        let user_message_id = match chat_repo
+            .upsert_user_message_idempotent(
+                session_id,
+                "晚安",
+                "01JT5REGEXSKIPLLM0000000C",
+                "user",
+                None,
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
+
+        // ── 5. LLM output filter that fires on mock/euryale. ───────────────────
+        let filter = eros_engine_llm::model_config::ResolvedOutputFilter {
+            model: "fast/m".into(),
+            fallback_model: vec![],
+            temperature: 0.0,
+            max_tokens: 256,
+            filter_prompt: "REWRITE".into(),
+            trigger: eros_engine_llm::model_config::OutputFilterTrigger {
+                random: None,
+                models: Some(vec!["mock/euryale".into()]),
+                traits: None,
+            },
+            timing: eros_engine_llm::model_config::FilterTiming::AfterExtract,
+            retry_depth: 0,
+            reasoning: None,
+        };
+
+        let req = eros_engine_llm::openrouter::ChatRequest {
+            model: "mock/euryale".into(),
+            fallback_model: vec![],
+            messages: vec![eros_engine_llm::openrouter::ChatMessage {
+                role: "user".into(),
+                content: "晚安".into(),
+            }],
+            temperature: 0.0,
+            max_tokens: 64,
+            ..Default::default()
+        };
+        let outcome = std::sync::Arc::new(std::sync::Mutex::new(BurstOutcome::default()));
+        let burst = drive_chat_burst(
+            state.clone(),
+            session_id,
+            user_message_id,
+            FrameActionType::Reply,
+            "reply",
+            ActionType::ReplyText,
+            req,
+            None,
+            Some(filter),
+            vec![],
+            None,
+            Default::default(),
+            Default::default(),
+            None,
+            outcome.clone(),
+        );
+        let frames: Vec<ProtocolFrame> = Box::pin(burst).collect().await;
+
+        // ── 6. Assertions ─────────────────────────────────────────────────────
+        assert!(
+            !frames
+                .iter()
+                .any(|f| matches!(f, ProtocolFrame::Error { .. })),
+            "no error frame expected; got {frames:?}",
+        );
+        let deltas: Vec<&str> = frames
+            .iter()
+            .filter_map(|f| match f {
+                ProtocolFrame::Delta { content, .. } => Some(content.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            deltas.is_empty(),
+            "artifact-only reply must emit NO Delta even with an LLM filter armed; got {deltas:?}",
+        );
+
+        // The filter model must NEVER have been called (empty reply is terminal).
+        let received = mock
+            .received_requests()
+            .await
+            .expect("recording enabled by default");
+        assert!(
+            !received
+                .iter()
+                .any(|r| String::from_utf8_lossy(&r.body).contains("fast/m")),
+            "LLM filter model must not be called when the regex strip emptied the reply",
+        );
+
+        // DB row: empty content, regex audit (NOT the LLM model).
+        let (content, pre_filter, filter_model): (String, Option<String>, Option<String>) =
+            sqlx::query_as(
+                "SELECT content, pre_filter_content, filter_model \
+                 FROM engine.chat_messages \
+                 WHERE session_id = $1 AND role = 'assistant' \
+                 ORDER BY sent_at DESC LIMIT 1",
+            )
+            .bind(session_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            content, "",
+            "persisted content must be empty; got {content:?}"
+        );
+        assert_eq!(
+            pre_filter.as_deref(),
+            Some(raw_reply),
+            "pre_filter_content must hold the raw artifact; got {pre_filter:?}",
+        );
+        assert_eq!(
+            filter_model.as_deref(),
+            Some("<regex>"),
+            "filter_model must be '<regex>' (LLM filter skipped); got {filter_model:?}",
         );
     }
 }

--- a/docs/model-config.md
+++ b/docs/model-config.md
@@ -241,11 +241,16 @@ The matched text therefore reaches **neither** the client **nor** the stored
 These columns are set only when at least one rule actually changes the reply (same
 as the LLM filter — a no-op strip leaves them null).
 
-#### Empty-result fail-safe
+#### Artifact-only reply ⇒ empty bubble
 
-A strip that would reduce a non-empty reply to an empty string is a **no-op** — the
-original reply is delivered unchanged and the audit columns are not set. This
-prevents an over-broad pattern from silencing the companion.
+When the reply is **entirely** an artifact (e.g. a bare
+`[你给对方发送了一张照片：…]` with nothing else), the strip empties it. There is
+**no fail-safe**: the client receives **no content bubble** (no delta is sent),
+the row persists empty `content` (`""`), and the audit columns are still set
+(`pre_filter_content` = the raw reply, `filter_model` = `"<regex>"`). The
+downstream client decides how to render an empty/NULL reply — the reference web
+client simply doesn't show it, which reads as a ghost-like non-reply and tends
+to make the user follow up (closer to chatting with a real person).
 
 #### `filtered` flag
 

--- a/docs/superpowers/specs/2026-06-28-per-model-output-regex-filter-design.md
+++ b/docs/superpowers/specs/2026-06-28-per-model-output-regex-filter-design.md
@@ -217,10 +217,19 @@ Because the strip is layer 0, `cleaned` becomes the single new baseline for
 and extract input. The artifact therefore reaches none of those channels,
 regardless of the LLM filter's `after_extract` / `before_extract` timing.
 
-**Edge case — empty result:** if `cleaned.trim()` is empty (the model emitted
-*only* the artifact), **fail-safe to the raw `acc`**: emit/persist the raw text
-(never an empty bubble), record no strip, and log at `warn`. This is a defensive
-guard; `reply_text_image` text is not expected to be bracket-only.
+**Edge case — empty result** *(revised 2026-06-29; the original fail-safe was a
+bug — see below):* if `cleaned.trim()` is empty (the model emitted *only* the
+artifact, e.g. a bare `[你给对方发送了一张照片：…]`), the strip is **honored**, not
+fail-safed: `cleaned` becomes `""`. The client receives **no content bubble**
+(the buffered branch only emits a `Delta` when `visible` is non-empty), the row
+persists empty `content` (`""`), and the audit is still written
+(`pre_filter_content` = raw `acc`, `filter_model = "<regex>"`). The downstream
+client decides how to render an empty/NULL reply — the reference web client
+simply doesn't show it (a ghost-like non-reply that nudges the user to follow
+up). **History:** the original design fail-safed to the raw `acc` on the
+assumption that "`reply_text_image` text is not expected to be bracket-only."
+Production disproved that — small roleplay models do emit bracket-only replies —
+so the raw artifact leaked to the user. The fail-safe was removed.
 
 `extract_text` (the original-vs-visible chooser) is unaffected in shape: its
 `original` argument is now `cleaned` (post-strip) rather than the raw `acc`, so
@@ -281,7 +290,8 @@ path) are unaffected. `output_regex` set on other task blocks parses but is iner
   - multiple matching rules apply in declaration order;
   - `replacement` non-empty is honored;
   - pattern matches nothing ⇒ unchanged, no audit;
-  - **empty/blank result ⇒ fail-safe returns raw, flagged "no change".**
+  - **empty/blank result ⇒ `cleaned == ""` with the matched rule still
+    reported** (no fail-safe; the artifact-only reply is fully stripped).
 - **Mode selection:** chain with a targeted model ⇒ buffered; chain with no
   targeted model ⇒ live (byte-identical to today).
 - **Stream (wiremock for chat model):**
@@ -294,7 +304,9 @@ path) are unaffected. `output_regex` set on other task blocks parses but is iner
   - regex + LLM `output_filter` both configured ⇒ LLM runs on the cleaned text;
     `filter_model` = LLM model, `filter_triggers` carries both `reason` and
     `regex`; `pre_filter_content` = raw;
-  - strip empties the reply ⇒ raw emitted/persisted, no empty bubble, no audit.
+  - strip empties the reply (artifact-only) ⇒ NO `Delta` reaches the client,
+    row persists empty `content` (`""`), audit recorded (`pre_filter_content` =
+    raw, `filter_model = "<regex>"`, `filter_triggers.regex` = matched indices).
 - **Final frame:** `filtered = true` on a regex strip; `false` when no rule
   matched. Update existing `final_frame_*` constructor tests if needed.
 - **Committed example config:** parses; with `output_regex` absent/commented,
@@ -311,7 +323,7 @@ path) are unaffected. `output_regex` set on other task blocks parses but is iner
   (no lookaround/backrefs).
 - `docs/model-config.md`: document the field, exact-model-id matching, the
   layer-0 / extract semantics (artifact removed from client + history + memory),
-  the empty-result fail-safe, and the `pre_filter_content` audit
+  the artifact-only ⇒ empty-bubble behavior, and the `pre_filter_content` audit
   (`filter_model = "<regex>"`).
 - Additive TOML schema; default behavior unchanged (off unless configured).
 - Dev-track feature: lands on a `feat/output-regex-filter` branch → PR into


### PR DESCRIPTION
## Problem

The per-model `output_regex` strip leaked the **raw artifact** to the user whenever a reply was **entirely** the artifact — a bare `[你给对方发送了一张照片：…]` (or any `[...]`) with no other text.

`apply_output_regex` had an empty-result **fail-safe**: if a strip would reduce a non-empty reply to empty, it returned the **raw** text flagged "no change". The spec assumed `reply_text_image` replies are never bracket-only — production disproved it. Small roleplay models (cydonia, euryale, …) do emit bracket-only replies, so the strip emptied them, the fail-safe handed the raw bracket back, no audit was written, and the user saw `[aaa]`.

Confirmed in prod (read-only): a `thedrummer/cydonia-24b-v4.1` assistant row whose `content` is bracket-only with `filter_model` / `pre_filter_content` both `NULL` — i.e. the strip matched but the fail-safe swallowed it.

This is **not** a config/regex issue — the deployed web rule covers the whole rotation and its pattern `\[[^\]]*\]` matches. It is purely the engine fail-safe. (Also unrelated to primary-vs-fallback selection: the chain-wide gate already buffers these turns correctly.)

## Fix

Remove the fail-safe. An artifact-only reply now strips to `""`:

- the buffered branch already emits a `Delta` only when `visible` is non-empty, so **no content bubble reaches the client**;
- the row persists empty `content` (`""`; the column is `NOT NULL`, so empty string, not NULL);
- the audit is still recorded — `pre_filter_content` = raw reply, `filter_model = "<regex>"`, `filter_triggers.regex` = matched indices.

Downstream decides how to render an empty/NULL reply. The reference web client simply doesn't show it — a ghost-like non-reply that nudges the user to follow up (intentional "feels like a real person" behavior).

## Changes

- `crates/eros-engine-llm/src/model_config.rs` — drop the empty-result fail-safe in `apply_output_regex`; an empty result is honest and still reports the matched rule. Unit test rewritten to assert the new behavior.
- `crates/eros-engine-server/src/pipeline/stream.rs` — new integration test `regex_artifact_only_reply_persists_empty_no_bubble` (no Delta, `content = ""`, audit recorded).
- `docs/model-config.md` + the committed design spec — updated to the artifact-only ⇒ empty-bubble behavior.

## Verification

- TDD on both tests (watched RED → GREEN). The integration test, run against the *old* fail-safe, fails by streaming the raw `[...]` as a Delta — i.e. it reproduces the prod bug.
- `cargo fmt --check` clean; `clippy` clean on both crates; `eros-engine-llm` (167) and `pipeline::stream` (83) all green.

## Rollout note

The `output_regex` feature (#114) is **dev-only** (not in any release tag yet), so prod runs a dev build — this fix needs a **redeploy** to take effect. No migration, no API change, additive only.
