### PR TITLE
feat(affinity): Bond/Chemistry lines, tiered labels, sparser eval distribution

### DIFF
--- a/crates/eros-engine-core/src/affinity.rs
+++ b/crates/eros-engine-core/src/affinity.rs
@@ -396,7 +396,6 @@ mod tests {
         assert_eq!(a.tension, 0.0);
     }
 
-
     #[test]
     fn bond_chemistry_scores_fold_axes_with_warmth_floored() {
         let mut a = fresh();

--- a/crates/eros-engine-core/src/affinity.rs
+++ b/crates/eros-engine-core/src/affinity.rs
@@ -95,6 +95,128 @@ fn clamp(v: f64, lo: f64, hi: f64) -> f64 {
     }
 }
 
+// ─── Bond / Chemistry lines (read-layer folds of the 6 axes) ────────
+//
+// Two composites folded from the unchanged 6-axis base. `warmth` is shared into
+// both and FLOORED at 0 (a neutral/cold session contributes nothing, so a fresh
+// session sits near 0). `patience` is rule-owned and excluded.
+//
+// Mirrored by the `bond`/`chemistry` GENERATED columns in store migration 0029
+// (warmth floored via GREATEST(warmth,0)). Keep the formula in sync.
+
+/// Tier upper bounds on a line's 0..1 score. Widening by design: easy early, a
+/// grind near the top. Tier 1 = [0, T1), 2 = [T1, T2), 3 = [T2, T3), 4 = [T3, 1].
+/// Tunable.
+const TIER1_HI: f64 = 0.15;
+const TIER2_HI: f64 = 0.35;
+const TIER3_HI: f64 = 0.62;
+
+/// 1..=4 tier index for a 0..1 line score.
+fn tier_index(score: f64) -> u8 {
+    if score < TIER1_HI {
+        1
+    } else if score < TIER2_HI {
+        2
+    } else if score < TIER3_HI {
+        3
+    } else {
+        4
+    }
+}
+
+/// Map a 0..1 line score to a 0..1 bar fill: each tier fills an even 25% band,
+/// linear within. Higher tiers span more raw score, so the bar fills fast early
+/// and crawls near the top. Tunable alongside the thresholds.
+pub fn bar(score: f64) -> f64 {
+    let (lo, hi, band_lo) = match tier_index(score) {
+        1 => (0.0, TIER1_HI, 0.0),
+        2 => (TIER1_HI, TIER2_HI, 0.25),
+        3 => (TIER2_HI, TIER3_HI, 0.50),
+        _ => (TIER3_HI, 1.0, 0.75),
+    };
+    let within = ((score - lo) / (hi - lo)).clamp(0.0, 1.0);
+    (band_lo + within * 0.25).clamp(0.0, 1.0)
+}
+
+/// Friendship-line tier (pure function of `bond_score`). Serialised snake_case
+/// key is the frontend's lookup; Chinese display lives in the frontend.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BondLabel {
+    Acquaintance,
+    Friend,
+    CloseFriend,
+    Confidant,
+}
+
+impl BondLabel {
+    pub fn as_key(self) -> &'static str {
+        match self {
+            BondLabel::Acquaintance => "acquaintance",
+            BondLabel::Friend => "friend",
+            BondLabel::CloseFriend => "close_friend",
+            BondLabel::Confidant => "confidant",
+        }
+    }
+}
+
+/// Romance-line tier (pure function of `chemistry_score`).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ChemistryLabel {
+    Spark,
+    Flirtation,
+    Crush,
+    Lover,
+}
+
+impl ChemistryLabel {
+    pub fn as_key(self) -> &'static str {
+        match self {
+            ChemistryLabel::Spark => "spark",
+            ChemistryLabel::Flirtation => "flirtation",
+            ChemistryLabel::Crush => "crush",
+            ChemistryLabel::Lover => "lover",
+        }
+    }
+}
+
+impl Affinity {
+    /// 0..1 friendship composite. warmth floored at 0; mirrors the `bond`
+    /// generated column in migration 0029.
+    pub fn bond_score(&self) -> f64 {
+        let warm_pos = self.warmth.max(0.0);
+        clamp((warm_pos + self.trust + self.intrigue) / 3.0, 0.0, 1.0)
+    }
+
+    /// 0..1 romance composite. warmth floored at 0; mirrors the `chemistry`
+    /// generated column in migration 0029.
+    pub fn chemistry_score(&self) -> f64 {
+        let warm_pos = self.warmth.max(0.0);
+        clamp((warm_pos + self.intimacy + self.tension) / 3.0, 0.0, 1.0)
+    }
+
+    /// Friendship-line tier label.
+    pub fn bond_label(&self) -> BondLabel {
+        match tier_index(self.bond_score()) {
+            1 => BondLabel::Acquaintance,
+            2 => BondLabel::Friend,
+            3 => BondLabel::CloseFriend,
+            _ => BondLabel::Confidant,
+        }
+    }
+
+    /// Romance-line tier label.
+    pub fn chemistry_label(&self) -> ChemistryLabel {
+        match tier_index(self.chemistry_score()) {
+            1 => ChemistryLabel::Spark,
+            2 => ChemistryLabel::Flirtation,
+            3 => ChemistryLabel::Crush,
+            _ => ChemistryLabel::Lover,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -271,5 +393,66 @@ mod tests {
     fn infer_label_stranger_when_no_thresholds_met() {
         let a = fresh();
         assert_eq!(a.infer_label(), Some(RelationshipLabel::Stranger));
+    }
+
+    #[test]
+    fn bond_chemistry_scores_fold_axes_with_warmth_floored() {
+        let mut a = fresh();
+        a.warmth = 0.2;
+        a.trust = 0.4;
+        a.intrigue = 0.6;
+        a.intimacy = 0.1;
+        a.tension = 0.3;
+        // bond = (0.2 + 0.4 + 0.6)/3 = 0.4
+        assert!((a.bond_score() - 0.4).abs() < 1e-9);
+        // chemistry = (0.2 + 0.1 + 0.3)/3 = 0.2
+        assert!((a.chemistry_score() - 0.2).abs() < 1e-9);
+        // negative warmth floors to 0 in the composite
+        a.warmth = -1.0;
+        a.trust = 0.0;
+        a.intrigue = 0.0;
+        assert!((a.bond_score()).abs() < 1e-9);
+    }
+
+    #[test]
+    fn tier_index_boundaries() {
+        assert_eq!(tier_index(0.0), 1);
+        assert_eq!(tier_index(0.149), 1);
+        assert_eq!(tier_index(0.15), 2);
+        assert_eq!(tier_index(0.349), 2);
+        assert_eq!(tier_index(0.35), 3);
+        assert_eq!(tier_index(0.619), 3);
+        assert_eq!(tier_index(0.62), 4);
+        assert_eq!(tier_index(1.0), 4);
+    }
+
+    #[test]
+    fn bar_maps_tiers_to_even_bands() {
+        assert!((bar(0.0)).abs() < 1e-9);
+        assert!((bar(0.15) - 0.25).abs() < 1e-9);
+        assert!((bar(0.35) - 0.50).abs() < 1e-9);
+        assert!((bar(0.62) - 0.75).abs() < 1e-9);
+        assert!((bar(1.0) - 1.0).abs() < 1e-9);
+        // midpoint of tier 1 [0,0.15) → 0.075 → half of the 0..0.25 band
+        assert!((bar(0.075) - 0.125).abs() < 1e-9);
+    }
+
+    #[test]
+    fn labels_map_from_scores() {
+        let mut a = fresh();
+        a.warmth = 0.0;
+        a.trust = 0.0;
+        a.intrigue = 0.0;
+        assert_eq!(a.bond_label(), BondLabel::Acquaintance); // bond 0
+        a.trust = 0.6;
+        a.intrigue = 0.6; // bond = 0.4 → tier 3
+        assert_eq!(a.bond_label(), BondLabel::CloseFriend);
+        a.warmth = 0.0;
+        a.intimacy = 0.0;
+        a.tension = 0.0;
+        assert_eq!(a.chemistry_label(), ChemistryLabel::Spark); // chem 0
+        a.intimacy = 1.0;
+        a.tension = 1.0; // chem = 0.667 → tier 4
+        assert_eq!(a.chemistry_label(), ChemistryLabel::Lover);
     }
 }

--- a/crates/eros-engine-core/src/affinity.rs
+++ b/crates/eros-engine-core/src/affinity.rs
@@ -185,6 +185,45 @@ impl ChemistryLabel {
     }
 }
 
+/// One line's tier transition this turn, as serialised keys.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LabelTransition {
+    pub from: String,
+    pub to: String,
+}
+
+/// Per-turn tier transition across the two lines. Serde skips `None` fields, so
+/// a JSON object only carries the line(s) that actually moved.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TurnLabelChanges {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bond: Option<LabelTransition>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chemistry: Option<LabelTransition>,
+}
+
+impl TurnLabelChanges {
+    pub fn is_empty(&self) -> bool {
+        self.bond.is_none() && self.chemistry.is_none()
+    }
+}
+
+/// Tier transition over a delta-only span (before = post-decay/pre-delta,
+/// after = post-delta). `None` when neither line crossed a tier.
+pub fn diff_labels(before: &Affinity, after: &Affinity) -> Option<TurnLabelChanges> {
+    let bond = (before.bond_label() != after.bond_label()).then(|| LabelTransition {
+        from: before.bond_label().as_key().to_string(),
+        to: after.bond_label().as_key().to_string(),
+    });
+    let chemistry =
+        (before.chemistry_label() != after.chemistry_label()).then(|| LabelTransition {
+            from: before.chemistry_label().as_key().to_string(),
+            to: after.chemistry_label().as_key().to_string(),
+        });
+    let changes = TurnLabelChanges { bond, chemistry };
+    (!changes.is_empty()).then_some(changes)
+}
+
 impl Affinity {
     /// 0..1 friendship composite. warmth floored at 0; mirrors the `bond`
     /// generated column in migration 0029.
@@ -464,5 +503,48 @@ mod tests {
         a.trust = 0.0;
         a.intrigue = 0.0;
         assert_eq!(a.legacy_relationship_label(), RelationshipLabel::SlowBurn);
+    }
+
+    #[test]
+    fn diff_labels_none_when_no_tier_change() {
+        let a = fresh();
+        let b = a.clone();
+        assert!(diff_labels(&a, &b).is_none());
+    }
+
+    #[test]
+    fn diff_labels_reports_single_line_change() {
+        let mut before = fresh();
+        before.warmth = 0.0;
+        before.trust = 0.0;
+        before.intrigue = 0.0;
+        before.intimacy = 0.0;
+        before.tension = 0.0; // bond + chem both tier 1
+        let mut after = before.clone();
+        after.trust = 0.9;
+        after.intrigue = 0.9; // bond = 0.6 → tier 3 (close_friend)
+        let d = diff_labels(&before, &after).unwrap();
+        let bond = d.bond.unwrap();
+        assert_eq!(bond.from, "acquaintance");
+        assert_eq!(bond.to, "close_friend");
+        assert!(d.chemistry.is_none());
+    }
+
+    #[test]
+    fn diff_labels_reports_both_lines() {
+        let mut before = fresh();
+        before.warmth = 0.0;
+        before.trust = 0.0;
+        before.intrigue = 0.0;
+        before.intimacy = 0.0;
+        before.tension = 0.0;
+        let mut after = before.clone();
+        after.trust = 0.9;
+        after.intrigue = 0.9; // bond → close_friend
+        after.intimacy = 0.9;
+        after.tension = 0.9; // chem = 0.6 → tier 3 (crush)
+        let d = diff_labels(&before, &after).unwrap();
+        assert_eq!(d.bond.unwrap().to, "close_friend");
+        assert_eq!(d.chemistry.unwrap().to, "crush");
     }
 }

--- a/crates/eros-engine-core/src/affinity.rs
+++ b/crates/eros-engine-core/src/affinity.rs
@@ -67,21 +67,25 @@ impl Affinity {
         self.tension = clamp(self.tension - 0.005 * days, 0.0, 1.0);
     }
 
-    pub fn infer_label(&self) -> Option<RelationshipLabel> {
-        // Priority: romantic > friend > frenemy > slow_burn > stranger
-        if self.warmth >= 0.7 && self.tension >= 0.3 && self.intimacy >= 0.4 {
-            return Some(RelationshipLabel::Romantic);
+    /// Legacy 5-name relationship label (back-compat), derived purely from the
+    /// two line scores — replaces the old multi-axis `infer_label` heuristic.
+    /// New consumers should read `bond_label`/`chemistry_label`. `frenemy` is
+    /// retired from emission (kept in the enum for parse compat).
+    pub fn legacy_relationship_label(&self) -> RelationshipLabel {
+        let bond = self.bond_score();
+        let chem = self.chemistry_score();
+        if tier_index(bond) == 1 && tier_index(chem) == 1 {
+            return RelationshipLabel::Stranger;
         }
-        if self.warmth >= 0.7 && self.trust >= 0.6 && self.tension < 0.2 {
-            return Some(RelationshipLabel::Friend);
+        if chem > bond {
+            if tier_index(chem) >= 3 {
+                RelationshipLabel::Romantic
+            } else {
+                RelationshipLabel::SlowBurn
+            }
+        } else {
+            RelationshipLabel::Friend
         }
-        if self.warmth < 0.4 && self.tension >= 0.6 && self.intrigue >= 0.5 {
-            return Some(RelationshipLabel::Frenemy);
-        }
-        if self.intrigue >= 0.6 && self.tension >= 0.4 && self.intimacy < 0.4 {
-            return Some(RelationshipLabel::SlowBurn);
-        }
-        Some(RelationshipLabel::Stranger)
     }
 }
 
@@ -353,47 +357,6 @@ mod tests {
         assert_eq!(a.tension, 0.0);
     }
 
-    #[test]
-    fn infer_label_romantic_when_warm_intimate_and_tense() {
-        let mut a = fresh();
-        a.warmth = 0.8;
-        a.tension = 0.4;
-        a.intimacy = 0.5;
-        assert_eq!(a.infer_label(), Some(RelationshipLabel::Romantic));
-    }
-
-    #[test]
-    fn infer_label_friend_when_warm_trusted_low_tension() {
-        let mut a = fresh();
-        a.warmth = 0.75;
-        a.trust = 0.7;
-        a.tension = 0.1;
-        assert_eq!(a.infer_label(), Some(RelationshipLabel::Friend));
-    }
-
-    #[test]
-    fn infer_label_frenemy_when_cold_tense_intrigued() {
-        let mut a = fresh();
-        a.warmth = 0.3;
-        a.tension = 0.7;
-        a.intrigue = 0.6;
-        assert_eq!(a.infer_label(), Some(RelationshipLabel::Frenemy));
-    }
-
-    #[test]
-    fn infer_label_slow_burn_when_intrigued_tense_not_yet_intimate() {
-        let mut a = fresh();
-        a.intrigue = 0.7;
-        a.tension = 0.5;
-        a.intimacy = 0.2;
-        assert_eq!(a.infer_label(), Some(RelationshipLabel::SlowBurn));
-    }
-
-    #[test]
-    fn infer_label_stranger_when_no_thresholds_met() {
-        let a = fresh();
-        assert_eq!(a.infer_label(), Some(RelationshipLabel::Stranger));
-    }
 
     #[test]
     fn bond_chemistry_scores_fold_axes_with_warmth_floored() {
@@ -454,5 +417,52 @@ mod tests {
         a.intimacy = 1.0;
         a.tension = 1.0; // chem = 0.667 → tier 4
         assert_eq!(a.chemistry_label(), ChemistryLabel::Lover);
+    }
+
+    #[test]
+    fn legacy_label_stranger_when_both_tier1() {
+        let mut a = fresh();
+        a.warmth = 0.0;
+        a.trust = 0.0;
+        a.intrigue = 0.0;
+        a.intimacy = 0.0;
+        a.tension = 0.0;
+        assert_eq!(a.legacy_relationship_label(), RelationshipLabel::Stranger);
+    }
+
+    #[test]
+    fn legacy_label_friend_when_bond_leads() {
+        let mut a = fresh();
+        // bond = (0.3+0.6+0.6)/3 = 0.5 ; chem = (0.3+0+0)/3 = 0.1
+        a.warmth = 0.3;
+        a.trust = 0.6;
+        a.intrigue = 0.6;
+        a.intimacy = 0.0;
+        a.tension = 0.0;
+        assert_eq!(a.legacy_relationship_label(), RelationshipLabel::Friend);
+    }
+
+    #[test]
+    fn legacy_label_romantic_when_chemistry_high() {
+        let mut a = fresh();
+        // chem = (0.3+0.9+0.9)/3 = 0.7 (tier4) ; bond = 0.1
+        a.warmth = 0.3;
+        a.intimacy = 0.9;
+        a.tension = 0.9;
+        a.trust = 0.0;
+        a.intrigue = 0.0;
+        assert_eq!(a.legacy_relationship_label(), RelationshipLabel::Romantic);
+    }
+
+    #[test]
+    fn legacy_label_slow_burn_when_chemistry_leads_but_mid() {
+        let mut a = fresh();
+        // chem = (0.3+0.3+0.2)/3 ≈ 0.267 (tier2) ; bond = 0.1 (tier1)
+        a.warmth = 0.3;
+        a.intimacy = 0.3;
+        a.tension = 0.2;
+        a.trust = 0.0;
+        a.intrigue = 0.0;
+        assert_eq!(a.legacy_relationship_label(), RelationshipLabel::SlowBurn);
     }
 }

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -944,7 +944,6 @@
           "event_id",
           "event_type",
           "effective_deltas",
-          "effective_deltas_computed",
           "created_at"
         ],
         "properties": {
@@ -957,8 +956,15 @@
             "description": "Post-EMA effective change of the latest user-turn event. All-zero for\na ghost turn (AI didn't reply; no axis moved)."
           },
           "effective_deltas_computed": {
-            "$ref": "#/components/schemas/BondChemistryDeltas",
-            "description": "The post-EMA delta folded into the two lines (raw-composite units)."
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/BondChemistryDeltas",
+                "description": "Exact per-turn bond/chemistry delta (floored), read from the stored event\ncolumn. None on pre-migration rows."
+              }
+            ]
           },
           "event_id": {
             "type": "string",
@@ -1139,7 +1145,7 @@
       },
       "BondChemistryDeltas": {
         "type": "object",
-        "description": "One turn's post-EMA delta folded into the two lines (raw-composite units).",
+        "description": "One turn's exact per-turn bond/chemistry line delta, computed at persist time\nfrom the floored before/after scores and read from the stored event column.",
         "required": [
           "bond",
           "chemistry"

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -778,6 +778,17 @@
               }
             ]
           },
+          "effective_deltas_computed": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/BondChemistryDeltas",
+                "description": "Post-EMA delta folded into the two lines (raw-composite units). None for\npre-0014 rows with no `effective_deltas`."
+              }
+            ]
+          },
           "event_id": {
             "type": "string",
             "format": "uuid",
@@ -785,6 +796,17 @@
           },
           "event_type": {
             "type": "string"
+          },
+          "label_changes": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/TurnLabelChangesDto",
+                "description": "Per-turn tier transition; absent when no tier moved."
+              }
+            ]
           }
         }
       },
@@ -848,9 +870,31 @@
           "tension",
           "ghost_streak",
           "total_ghosts",
-          "updated_at"
+          "updated_at",
+          "bond",
+          "chemistry",
+          "bond_label",
+          "chemistry_label"
         ],
         "properties": {
+          "bond": {
+            "type": "number",
+            "format": "double",
+            "description": "Friendship bar fill, 0..1 (curve-applied; render as %)."
+          },
+          "bond_label": {
+            "type": "string",
+            "description": "Friendship tier key (`acquaintance`/`friend`/`close_friend`/`confidant`)."
+          },
+          "chemistry": {
+            "type": "number",
+            "format": "double",
+            "description": "Romance bar fill, 0..1 (curve-applied; render as %)."
+          },
+          "chemistry_label": {
+            "type": "string",
+            "description": "Romance tier key (`spark`/`flirtation`/`crush`/`lover`)."
+          },
           "ghost_streak": {
             "type": "integer",
             "format": "int32"
@@ -900,6 +944,7 @@
           "event_id",
           "event_type",
           "effective_deltas",
+          "effective_deltas_computed",
           "created_at"
         ],
         "properties": {
@@ -911,6 +956,10 @@
             "$ref": "#/components/schemas/AffinityDeltasDto",
             "description": "Post-EMA effective change of the latest user-turn event. All-zero for\na ghost turn (AI didn't reply; no axis moved)."
           },
+          "effective_deltas_computed": {
+            "$ref": "#/components/schemas/BondChemistryDeltas",
+            "description": "The post-EMA delta folded into the two lines (raw-composite units)."
+          },
           "event_id": {
             "type": "string",
             "format": "uuid",
@@ -918,6 +967,17 @@
           },
           "event_type": {
             "type": "string"
+          },
+          "label_changes": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/TurnLabelChangesDto",
+                "description": "Engine-authoritative per-turn tier transition; absent when no tier moved."
+              }
+            ]
           }
         }
       },
@@ -1077,6 +1137,24 @@
           }
         }
       },
+      "BondChemistryDeltas": {
+        "type": "object",
+        "description": "One turn's post-EMA delta folded into the two lines (raw-composite units).",
+        "required": [
+          "bond",
+          "chemistry"
+        ],
+        "properties": {
+          "bond": {
+            "type": "number",
+            "format": "double"
+          },
+          "chemistry": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
       "ChatHistoryEntry": {
         "type": "object",
         "required": [
@@ -1207,6 +1285,22 @@
               "string",
               "null"
             ]
+          }
+        }
+      },
+      "LabelTransitionDto": {
+        "type": "object",
+        "description": "One line's tier transition (serialised keys). Read-side mirror of\n`eros_engine_core::affinity::LabelTransition`.",
+        "required": [
+          "from",
+          "to"
+        ],
+        "properties": {
+          "from": {
+            "type": "string"
+          },
+          "to": {
+            "type": "string"
           }
         }
       },
@@ -1506,6 +1600,32 @@
               "null"
             ],
             "format": "double"
+          }
+        }
+      },
+      "TurnLabelChangesDto": {
+        "type": "object",
+        "description": "Per-turn tier transition across the two lines, read from the stored\n`companion_affinity_events.label_changes` JSONB.",
+        "properties": {
+          "bond": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/LabelTransitionDto"
+              }
+            ]
+          },
+          "chemistry": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/LabelTransitionDto"
+              }
+            ]
           }
         }
       }

--- a/crates/eros-engine-server/src/pipeline/post_process.rs
+++ b/crates/eros-engine-server/src/pipeline/post_process.rs
@@ -408,11 +408,12 @@ pub(crate) fn find_json_block(raw: &str) -> Option<&str> {
     None
 }
 
-/// Per-axis safety cap on the LLM's raw delta, applied before the pacing
-/// gain. A guardrail against a misbehaving model — independent of
-/// `ema_inertia`. The two jobs (safety cap vs. pacing) are deliberately
-/// separate (see the design spec §5).
-const LLM_AXIS_CAP: f64 = 0.15;
+/// Per-axis safety caps on the LLM's raw delta, applied before the pacing gain.
+/// Asymmetric by design (spec §4.5): losses may be larger and fire more readily
+/// than gains, so a single bad turn can bite while gains stay earned.
+/// Independent of `ema_inertia` (safety cap vs. pacing are separate jobs).
+const LLM_AXIS_POS_CAP: f64 = 0.4;
+const LLM_AXIS_NEG_CAP: f64 = -0.6;
 
 /// Raw shape of the affinity evaluator's JSON output. `patience` is
 /// intentionally absent — it is rule-owned, so any `patience` the model
@@ -445,7 +446,7 @@ fn parse_affinity_eval(raw: &str) -> (eros_engine_core::affinity::AffinityDeltas
     let Some(e) = parsed else {
         return (AffinityDeltas::default(), String::new());
     };
-    let cap = |v: f64| v.clamp(-LLM_AXIS_CAP, LLM_AXIS_CAP);
+    let cap = |v: f64| v.clamp(LLM_AXIS_NEG_CAP, LLM_AXIS_POS_CAP);
     (
         AffinityDeltas {
             warmth: cap(e.warmth),
@@ -1074,11 +1075,8 @@ mod tests {
     fn parse_affinity_eval_clamps_out_of_range() {
         let raw = r#"{"warmth":5.0,"trust":-2.0,"reason":"x"}"#;
         let (d, _) = parse_affinity_eval(raw);
-        assert!((d.warmth - 0.15).abs() < 1e-9, "warmth caps at +0.15");
-        assert!(
-            (d.trust - (-0.15)).abs() < 1e-9,
-            "trust delta caps at -0.15"
-        );
+        assert!((d.warmth - 0.4).abs() < 1e-9, "warmth caps at +0.4");
+        assert!((d.trust - (-0.6)).abs() < 1e-9, "trust delta caps at -0.6");
     }
 
     #[test]

--- a/crates/eros-engine-server/src/prompt.rs
+++ b/crates/eros-engine-server/src/prompt.rs
@@ -214,7 +214,11 @@ pub fn affinity_eval_prompt(
          \n\
          判断这一轮应让 warmth、trust、intrigue、intimacy、tension 各变化多少\
          （是【变化量】，不是绝对值；patience 不要输出）。\n\
-         普通寒暄接近 0；真正动情或暧昧的瞬间幅度更大，每个维度大致在 ±0.15 之间。\n\
+         绝大多数普通对话、寒暄、附和都给 0（就是数字 0，不是小数）。\n\
+         只有出现真正推进关系的时刻（真诚的温暖、自我袒露、脆弱、成功的调情暧昧）\
+         才给正分；这种时刻不常见，但一旦出现可以给较大正分（每个维度最高约 +0.4）。\n\
+         负面时刻（冷淡、敷衍、重复、无聊、越界、冲突、被无视）要更敢扣、也更常见，\
+         扣分可以更大（每个维度最低约 -0.6）。\n\
          严格只输出 JSON，reason 用一句中文简述：\n\
          {{\"warmth\": 0.0, \"trust\": 0.0, \"intrigue\": 0.0, \"intimacy\": 0.0, \"tension\": 0.0, \"reason\": \"...\"}}",
         warmth = affinity.warmth,
@@ -1471,6 +1475,9 @@ mod tests {
             ),
             "five-axis JSON output schema (+reason) must be present"
         );
+        // new sparse/asymmetric scoring guidance present
+        assert!(p.contains("+0.4"), "positive cap guidance present");
+        assert!(p.contains("-0.6"), "negative cap guidance present");
     }
 
     // ─── Insight prompt tests ──────────────────────────────────────

--- a/crates/eros-engine-server/src/routes/bff/affinity.rs
+++ b/crates/eros-engine-server/src/routes/bff/affinity.rs
@@ -30,8 +30,10 @@ pub struct BffAffinityDelta {
     /// Post-EMA effective change of the latest user-turn event. All-zero for
     /// a ghost turn (AI didn't reply; no axis moved).
     pub effective_deltas: AffinityDeltasDto,
-    /// The post-EMA delta folded into the two lines (raw-composite units).
-    pub effective_deltas_computed: BondChemistryDeltas,
+    /// Exact per-turn bond/chemistry delta (floored), read from the stored event
+    /// column. None on pre-migration rows.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub effective_deltas_computed: Option<BondChemistryDeltas>,
     /// Engine-authoritative per-turn tier transition; absent when no tier moved.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub label_changes: Option<TurnLabelChangesDto>,
@@ -76,8 +78,9 @@ async fn bff_get_affinity_delta(
             // Pre-0014 rows have NULL effective_deltas → omit (don't fabricate).
             let effective = r.effective_deltas?;
             let effective_deltas: AffinityDeltasDto = serde_json::from_value(effective).ok()?;
-            let effective_deltas_computed =
-                BondChemistryDeltas::from_axis_deltas(&effective_deltas);
+            let effective_deltas_computed = r
+                .effective_line_deltas
+                .and_then(|v| serde_json::from_value::<BondChemistryDeltas>(v).ok());
             let label_changes = r
                 .label_changes
                 .and_then(|v| serde_json::from_value::<TurnLabelChangesDto>(v).ok());
@@ -269,11 +272,12 @@ mod tests {
 
         sqlx::query(
             "INSERT INTO engine.companion_affinity_events \
-               (affinity_id, event_type, deltas, effective_deltas, label_changes, created_at) \
-             VALUES ($1, 'message', '{}'::jsonb, $2, $3, now())",
+               (affinity_id, event_type, deltas, effective_deltas, effective_line_deltas, label_changes, created_at) \
+             VALUES ($1, 'message', '{}'::jsonb, $2, $3, $4, now())",
         )
         .bind(aid)
         .bind(json!({ "warmth": 0.3, "trust": 0.3 }))
+        .bind(json!({ "bond": 0.2, "chemistry": 0.1 }))
         .bind(json!({ "bond": { "from": "acquaintance", "to": "friend" } }))
         .execute(&pool)
         .await
@@ -285,7 +289,6 @@ mod tests {
         let (status, body) = send_request(&mut app, req(&token, session_id)).await;
         assert_eq!(status, StatusCode::OK, "body={body}");
         let ev = &body["event"];
-        // fold: bond = (0.3+0.3+0)/3 = 0.2 ; chemistry = (0.3+0+0)/3 = 0.1
         assert!((ev["effective_deltas_computed"]["bond"].as_f64().unwrap() - 0.2).abs() < 1e-9);
         assert!(
             (ev["effective_deltas_computed"]["chemistry"]

--- a/crates/eros-engine-server/src/routes/bff/affinity.rs
+++ b/crates/eros-engine-server/src/routes/bff/affinity.rs
@@ -17,6 +17,7 @@ use eros_engine_store::affinity::AffinityRepo;
 use crate::auth::middleware::AuthUser;
 use crate::error::AppError;
 use crate::routes::companion::{require_session_for_user, AffinityDeltasDto};
+use crate::routes::dto::{BondChemistryDeltas, TurnLabelChangesDto};
 use crate::state::AppState;
 
 // ─── DTOs ───────────────────────────────────────────────────────────
@@ -29,6 +30,11 @@ pub struct BffAffinityDelta {
     /// Post-EMA effective change of the latest user-turn event. All-zero for
     /// a ghost turn (AI didn't reply; no axis moved).
     pub effective_deltas: AffinityDeltasDto,
+    /// The post-EMA delta folded into the two lines (raw-composite units).
+    pub effective_deltas_computed: BondChemistryDeltas,
+    /// Engine-authoritative per-turn tier transition; absent when no tier moved.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label_changes: Option<TurnLabelChangesDto>,
     pub created_at: DateTime<Utc>,
 }
 
@@ -70,10 +76,16 @@ async fn bff_get_affinity_delta(
             // Pre-0014 rows have NULL effective_deltas → omit (don't fabricate).
             let effective = r.effective_deltas?;
             let effective_deltas: AffinityDeltasDto = serde_json::from_value(effective).ok()?;
+            let effective_deltas_computed = BondChemistryDeltas::from_axis_deltas(&effective_deltas);
+            let label_changes = r
+                .label_changes
+                .and_then(|v| serde_json::from_value::<TurnLabelChangesDto>(v).ok());
             Some(BffAffinityDelta {
                 event_id: r.id,
                 event_type: r.event_type,
                 effective_deltas,
+                effective_deltas_computed,
+                label_changes,
                 created_at: r.created_at,
             })
         });
@@ -244,6 +256,38 @@ mod tests {
         let token = mint_test_jwt(intruder);
         let (status, _b) = send_request(&mut app, req(&token, session_id)).await;
         assert_eq!(status, StatusCode::FORBIDDEN);
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn bff_affinity_includes_computed_delta_and_label_changes(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+        let aid = seed_affinity(&pool, session_id, user_id, instance_id).await;
+
+        sqlx::query(
+            "INSERT INTO engine.companion_affinity_events \
+               (affinity_id, event_type, deltas, effective_deltas, label_changes, created_at) \
+             VALUES ($1, 'message', '{}'::jsonb, $2, $3, now())",
+        )
+        .bind(aid)
+        .bind(json!({ "warmth": 0.3, "trust": 0.3 }))
+        .bind(json!({ "bond": { "from": "acquaintance", "to": "friend" } }))
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let state = test_state(pool);
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+        let (status, body) = send_request(&mut app, req(&token, session_id)).await;
+        assert_eq!(status, StatusCode::OK, "body={body}");
+        let ev = &body["event"];
+        // fold: bond = (0.3+0.3+0)/3 = 0.2 ; chemistry = (0.3+0+0)/3 = 0.1
+        assert!((ev["effective_deltas_computed"]["bond"].as_f64().unwrap() - 0.2).abs() < 1e-9);
+        assert!((ev["effective_deltas_computed"]["chemistry"].as_f64().unwrap() - 0.1).abs() < 1e-9);
+        assert_eq!(ev["label_changes"]["bond"]["to"], "friend");
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/crates/eros-engine-server/src/routes/bff/affinity.rs
+++ b/crates/eros-engine-server/src/routes/bff/affinity.rs
@@ -76,7 +76,8 @@ async fn bff_get_affinity_delta(
             // Pre-0014 rows have NULL effective_deltas → omit (don't fabricate).
             let effective = r.effective_deltas?;
             let effective_deltas: AffinityDeltasDto = serde_json::from_value(effective).ok()?;
-            let effective_deltas_computed = BondChemistryDeltas::from_axis_deltas(&effective_deltas);
+            let effective_deltas_computed =
+                BondChemistryDeltas::from_axis_deltas(&effective_deltas);
             let label_changes = r
                 .label_changes
                 .and_then(|v| serde_json::from_value::<TurnLabelChangesDto>(v).ok());
@@ -286,7 +287,14 @@ mod tests {
         let ev = &body["event"];
         // fold: bond = (0.3+0.3+0)/3 = 0.2 ; chemistry = (0.3+0+0)/3 = 0.1
         assert!((ev["effective_deltas_computed"]["bond"].as_f64().unwrap() - 0.2).abs() < 1e-9);
-        assert!((ev["effective_deltas_computed"]["chemistry"].as_f64().unwrap() - 0.1).abs() < 1e-9);
+        assert!(
+            (ev["effective_deltas_computed"]["chemistry"]
+                .as_f64()
+                .unwrap()
+                - 0.1)
+                .abs()
+                < 1e-9
+        );
         assert_eq!(ev["label_changes"]["bond"]["to"], "friend");
     }
 

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -956,9 +956,9 @@ mod tests {
             .unwrap();
         let (status, body) = send_request(&mut app, req).await;
         assert_eq!(status, StatusCode::OK, "got body: {body}");
-        // Defaults from migration: warmth=0.3, intrigue=0.5
-        assert!((body["warmth"].as_f64().unwrap() - 0.3).abs() < 1e-9);
-        assert!((body["intrigue"].as_f64().unwrap() - 0.5).abs() < 1e-9);
+        // Defaults from migration 0029: warmth=0.1, intrigue=0.0 (lowered seed §4.8)
+        assert!((body["warmth"].as_f64().unwrap() - 0.1).abs() < 1e-9);
+        assert!((body["intrigue"].as_f64().unwrap() - 0.0).abs() < 1e-9);
     }
 
     // ─── Prompt-traits validator unit tests ─────────────────────────

--- a/crates/eros-engine-server/src/routes/debug.rs
+++ b/crates/eros-engine-server/src/routes/debug.rs
@@ -20,7 +20,7 @@ use eros_engine_store::affinity::AffinityRepo;
 use crate::auth::middleware::AuthUser;
 use crate::error::AppError;
 use crate::routes::companion::{require_session_for_user, AffinityDeltasDto};
-use crate::routes::dto::AffinitySnapshot;
+use crate::routes::dto::{AffinitySnapshot, BondChemistryDeltas, TurnLabelChangesDto};
 use crate::state::AppState;
 
 /// Back-compat alias retained for one release so in-crate callers that
@@ -89,6 +89,13 @@ pub struct AffinityEventEntry {
     pub deltas: AffinityDeltasDto,
     /// Post-EMA effective change (after − before). None for pre-0014 rows.
     pub effective_deltas: Option<AffinityDeltasDto>,
+    /// Post-EMA delta folded into the two lines (raw-composite units). None for
+    /// pre-0014 rows with no `effective_deltas`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub effective_deltas_computed: Option<BondChemistryDeltas>,
+    /// Per-turn tier transition; absent when no tier moved.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label_changes: Option<TurnLabelChangesDto>,
     pub created_at: DateTime<Utc>,
 }
 
@@ -146,14 +153,23 @@ async fn get_affinity_events(
 
     let events: Vec<AffinityEventEntry> = rows
         .into_iter()
-        .map(|r| AffinityEventEntry {
-            event_id: r.id,
-            event_type: r.event_type,
-            deltas: serde_json::from_value(r.deltas).unwrap_or_default(),
-            effective_deltas: r
-                .effective_deltas
-                .and_then(|v| serde_json::from_value(v).ok()),
-            created_at: r.created_at,
+        .map(|r| {
+            let effective_deltas: Option<AffinityDeltasDto> =
+                r.effective_deltas.and_then(|v| serde_json::from_value(v).ok());
+            let effective_deltas_computed =
+                effective_deltas.as_ref().map(BondChemistryDeltas::from_axis_deltas);
+            let label_changes = r
+                .label_changes
+                .and_then(|v| serde_json::from_value::<TurnLabelChangesDto>(v).ok());
+            AffinityEventEntry {
+                event_id: r.id,
+                event_type: r.event_type,
+                deltas: serde_json::from_value(r.deltas).unwrap_or_default(),
+                effective_deltas,
+                effective_deltas_computed,
+                label_changes,
+                created_at: r.created_at,
+            }
         })
         .collect();
     let total = events.len();
@@ -324,6 +340,46 @@ mod tests {
         let token = mint_test_jwt(intruder);
         let (status, _b) = send_request(&mut app, req(&token, session_id, "")).await;
         assert_eq!(status, StatusCode::FORBIDDEN);
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn affinity_events_includes_computed_delta_and_label_changes(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+        let affinity_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.companion_affinity (session_id, user_id, instance_id) \
+             VALUES ($1, $2, $3) RETURNING id",
+        )
+        .bind(session_id)
+        .bind(user_id)
+        .bind(instance_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO engine.companion_affinity_events \
+               (affinity_id, event_type, deltas, effective_deltas, label_changes) \
+             VALUES ($1, 'message', '{}'::jsonb, $2, $3)",
+        )
+        .bind(affinity_id)
+        .bind(json!({ "warmth": 0.3, "intimacy": 0.3 }))
+        .bind(json!({ "chemistry": { "from": "spark", "to": "flirtation" } }))
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let state = test_state(pool);
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+        let (status, body) = send_request(&mut app, req(&token, session_id, "")).await;
+        assert_eq!(status, StatusCode::OK, "body={body}");
+        let ev = &body["events"][0];
+        // fold: bond = (0.3+0+0)/3 = 0.1 ; chemistry = (0.3+0.3+0)/3 = 0.2
+        assert!((ev["effective_deltas_computed"]["bond"].as_f64().unwrap() - 0.1).abs() < 1e-9);
+        assert!((ev["effective_deltas_computed"]["chemistry"].as_f64().unwrap() - 0.2).abs() < 1e-9);
+        assert_eq!(ev["label_changes"]["chemistry"]["to"], "flirtation");
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/crates/eros-engine-server/src/routes/debug.rs
+++ b/crates/eros-engine-server/src/routes/debug.rs
@@ -154,10 +154,12 @@ async fn get_affinity_events(
     let events: Vec<AffinityEventEntry> = rows
         .into_iter()
         .map(|r| {
-            let effective_deltas: Option<AffinityDeltasDto> =
-                r.effective_deltas.and_then(|v| serde_json::from_value(v).ok());
-            let effective_deltas_computed =
-                effective_deltas.as_ref().map(BondChemistryDeltas::from_axis_deltas);
+            let effective_deltas: Option<AffinityDeltasDto> = r
+                .effective_deltas
+                .and_then(|v| serde_json::from_value(v).ok());
+            let effective_deltas_computed = effective_deltas
+                .as_ref()
+                .map(BondChemistryDeltas::from_axis_deltas);
             let label_changes = r
                 .label_changes
                 .and_then(|v| serde_json::from_value::<TurnLabelChangesDto>(v).ok());
@@ -378,7 +380,14 @@ mod tests {
         let ev = &body["events"][0];
         // fold: bond = (0.3+0+0)/3 = 0.1 ; chemistry = (0.3+0.3+0)/3 = 0.2
         assert!((ev["effective_deltas_computed"]["bond"].as_f64().unwrap() - 0.1).abs() < 1e-9);
-        assert!((ev["effective_deltas_computed"]["chemistry"].as_f64().unwrap() - 0.2).abs() < 1e-9);
+        assert!(
+            (ev["effective_deltas_computed"]["chemistry"]
+                .as_f64()
+                .unwrap()
+                - 0.2)
+                .abs()
+                < 1e-9
+        );
         assert_eq!(ev["label_changes"]["chemistry"]["to"], "flirtation");
     }
 

--- a/crates/eros-engine-server/src/routes/debug.rs
+++ b/crates/eros-engine-server/src/routes/debug.rs
@@ -157,9 +157,9 @@ async fn get_affinity_events(
             let effective_deltas: Option<AffinityDeltasDto> = r
                 .effective_deltas
                 .and_then(|v| serde_json::from_value(v).ok());
-            let effective_deltas_computed = effective_deltas
-                .as_ref()
-                .map(BondChemistryDeltas::from_axis_deltas);
+            let effective_deltas_computed = r
+                .effective_line_deltas
+                .and_then(|v| serde_json::from_value::<BondChemistryDeltas>(v).ok());
             let label_changes = r
                 .label_changes
                 .and_then(|v| serde_json::from_value::<TurnLabelChangesDto>(v).ok());
@@ -362,11 +362,12 @@ mod tests {
         .unwrap();
         sqlx::query(
             "INSERT INTO engine.companion_affinity_events \
-               (affinity_id, event_type, deltas, effective_deltas, label_changes) \
-             VALUES ($1, 'message', '{}'::jsonb, $2, $3)",
+               (affinity_id, event_type, deltas, effective_deltas, effective_line_deltas, label_changes) \
+             VALUES ($1, 'message', '{}'::jsonb, $2, $3, $4)",
         )
         .bind(affinity_id)
         .bind(json!({ "warmth": 0.3, "intimacy": 0.3 }))
+        .bind(json!({ "bond": 0.1, "chemistry": 0.2 }))
         .bind(json!({ "chemistry": { "from": "spark", "to": "flirtation" } }))
         .execute(&pool)
         .await
@@ -378,7 +379,6 @@ mod tests {
         let (status, body) = send_request(&mut app, req(&token, session_id, "")).await;
         assert_eq!(status, StatusCode::OK, "body={body}");
         let ev = &body["events"][0];
-        // fold: bond = (0.3+0+0)/3 = 0.1 ; chemistry = (0.3+0.3+0)/3 = 0.2
         assert!((ev["effective_deltas_computed"]["bond"].as_f64().unwrap() - 0.1).abs() < 1e-9);
         assert!(
             (ev["effective_deltas_computed"]["chemistry"]

--- a/crates/eros-engine-server/src/routes/dto.rs
+++ b/crates/eros-engine-server/src/routes/dto.rs
@@ -8,7 +8,6 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::routes::companion::AffinityDeltasDto;
 use eros_engine_core::affinity::{bar, Affinity, RelationshipLabel};
 
 /// Point-in-time projection of a session's `Affinity`. Same field set
@@ -71,23 +70,12 @@ impl From<Affinity> for AffinitySnapshot {
     }
 }
 
-/// One turn's post-EMA delta folded into the two lines (raw-composite units).
-#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
+/// One turn's exact per-turn bond/chemistry line delta, computed at persist time
+/// from the floored before/after scores and read from the stored event column.
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct BondChemistryDeltas {
     pub bond: f64,
     pub chemistry: f64,
-}
-
-impl BondChemistryDeltas {
-    /// Linear fold of a per-axis (post-EMA) delta into the two lines. Exact while
-    /// warmth stays ≥ 0 across the turn (warmth is floored at 0 in the absolute
-    /// composite); a good per-turn pulse otherwise.
-    pub fn from_axis_deltas(d: &AffinityDeltasDto) -> Self {
-        Self {
-            bond: (d.warmth + d.trust + d.intrigue) / 3.0,
-            chemistry: (d.warmth + d.intimacy + d.tension) / 3.0,
-        }
-    }
 }
 
 /// One line's tier transition (serialised keys). Read-side mirror of
@@ -159,20 +147,5 @@ mod tests {
         assert_eq!(snap.relationship_label.as_deref(), Some("stranger"));
         assert_eq!(snap.bond_label, "acquaintance");
         assert_eq!(snap.chemistry_label, "spark");
-    }
-
-    #[test]
-    fn bond_chemistry_deltas_fold_axes() {
-        let d = crate::routes::companion::AffinityDeltasDto {
-            warmth: 0.3,
-            trust: 0.3,
-            intrigue: 0.0,
-            intimacy: 0.6,
-            patience: 0.0,
-            tension: 0.0,
-        };
-        let f = BondChemistryDeltas::from_axis_deltas(&d);
-        assert!((f.bond - 0.2).abs() < 1e-9); // (0.3+0.3+0)/3
-        assert!((f.chemistry - 0.3).abs() < 1e-9); // (0.3+0.6+0)/3
     }
 }

--- a/crates/eros-engine-server/src/routes/dto.rs
+++ b/crates/eros-engine-server/src/routes/dto.rs
@@ -58,7 +58,10 @@ impl From<Affinity> for AffinitySnapshot {
             tension: a.tension,
             ghost_streak: a.ghost_streak,
             total_ghosts: a.total_ghosts,
-            relationship_label: a.relationship_label.map(label_to_str),
+            // Legacy field, derived on read (like bond/chemistry below) so it is
+            // always consistent with the new lines — never NULL on a fresh row
+            // and never a stale pre-migration value from the stored column.
+            relationship_label: Some(label_to_str(a.legacy_relationship_label())),
             updated_at: a.updated_at.to_rfc3339(),
             bond: bar(a.bond_score()),
             chemistry: bar(a.chemistry_score()),
@@ -142,6 +145,20 @@ mod tests {
         // bar(0.6): tier3 band 0.50 + (0.6-0.35)/0.27*0.25
         assert!((snap.bond - (0.50 + (0.6 - 0.35) / 0.27 * 0.25)).abs() < 1e-9);
         assert!((snap.chemistry).abs() < 1e-9);
+        // legacy label derived on read: bond (tier3) leads, neither tier1 → friend
+        assert_eq!(snap.relationship_label.as_deref(), Some("friend"));
+    }
+
+    #[test]
+    fn snapshot_legacy_label_derived_on_read_not_stored() {
+        // Fresh low-seed row (warmth 0.1, rest 0) with a NULL stored label still
+        // reads as "stranger" — the legacy field is derived, not read from the
+        // column. Guards the "fresh session = stranger" goal (codex #132 P2).
+        let a = affinity(0.1, 0.0, 0.0, 0.0, 0.0); // relationship_label: None
+        let snap = AffinitySnapshot::from(a);
+        assert_eq!(snap.relationship_label.as_deref(), Some("stranger"));
+        assert_eq!(snap.bond_label, "acquaintance");
+        assert_eq!(snap.chemistry_label, "spark");
     }
 
     #[test]

--- a/crates/eros-engine-server/src/routes/dto.rs
+++ b/crates/eros-engine-server/src/routes/dto.rs
@@ -8,8 +8,8 @@
 
 use serde::{Deserialize, Serialize};
 
-use eros_engine_core::affinity::{bar, Affinity, RelationshipLabel};
 use crate::routes::companion::AffinityDeltasDto;
+use eros_engine_core::affinity::{bar, Affinity, RelationshipLabel};
 
 /// Point-in-time projection of a session's `Affinity`. Same field set
 /// as the historical `AffinityDebugResponse`; renamed because it now

--- a/crates/eros-engine-server/src/routes/dto.rs
+++ b/crates/eros-engine-server/src/routes/dto.rs
@@ -6,9 +6,10 @@
 //!     vector, used by both `/comp/affinity/{sid}` (debug) and
 //!     `/bff/v1/comp/chat/start` (Plan C).
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-use eros_engine_core::affinity::{Affinity, RelationshipLabel};
+use eros_engine_core::affinity::{bar, Affinity, RelationshipLabel};
+use crate::routes::companion::AffinityDeltasDto;
 
 /// Point-in-time projection of a session's `Affinity`. Same field set
 /// as the historical `AffinityDebugResponse`; renamed because it now
@@ -25,6 +26,14 @@ pub struct AffinitySnapshot {
     pub total_ghosts: i32,
     pub relationship_label: Option<String>,
     pub updated_at: String,
+    /// Friendship bar fill, 0..1 (curve-applied; render as %).
+    pub bond: f64,
+    /// Romance bar fill, 0..1 (curve-applied; render as %).
+    pub chemistry: f64,
+    /// Friendship tier key (`acquaintance`/`friend`/`close_friend`/`confidant`).
+    pub bond_label: String,
+    /// Romance tier key (`spark`/`flirtation`/`crush`/`lover`).
+    pub chemistry_label: String,
 }
 
 fn label_to_str(l: RelationshipLabel) -> String {
@@ -51,6 +60,102 @@ impl From<Affinity> for AffinitySnapshot {
             total_ghosts: a.total_ghosts,
             relationship_label: a.relationship_label.map(label_to_str),
             updated_at: a.updated_at.to_rfc3339(),
+            bond: bar(a.bond_score()),
+            chemistry: bar(a.chemistry_score()),
+            bond_label: a.bond_label().as_key().to_string(),
+            chemistry_label: a.chemistry_label().as_key().to_string(),
         }
+    }
+}
+
+/// One turn's post-EMA delta folded into the two lines (raw-composite units).
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
+pub struct BondChemistryDeltas {
+    pub bond: f64,
+    pub chemistry: f64,
+}
+
+impl BondChemistryDeltas {
+    /// Linear fold of a per-axis (post-EMA) delta into the two lines. Exact while
+    /// warmth stays ≥ 0 across the turn (warmth is floored at 0 in the absolute
+    /// composite); a good per-turn pulse otherwise.
+    pub fn from_axis_deltas(d: &AffinityDeltasDto) -> Self {
+        Self {
+            bond: (d.warmth + d.trust + d.intrigue) / 3.0,
+            chemistry: (d.warmth + d.intimacy + d.tension) / 3.0,
+        }
+    }
+}
+
+/// One line's tier transition (serialised keys). Read-side mirror of
+/// `eros_engine_core::affinity::LabelTransition`.
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct LabelTransitionDto {
+    pub from: String,
+    pub to: String,
+}
+
+/// Per-turn tier transition across the two lines, read from the stored
+/// `companion_affinity_events.label_changes` JSONB.
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct TurnLabelChangesDto {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bond: Option<LabelTransitionDto>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chemistry: Option<LabelTransitionDto>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use eros_engine_core::affinity::Affinity;
+    use uuid::Uuid;
+
+    fn affinity(warmth: f64, trust: f64, intrigue: f64, intimacy: f64, tension: f64) -> Affinity {
+        let now = chrono::Utc::now();
+        Affinity {
+            id: Uuid::nil(),
+            session_id: Uuid::nil(),
+            user_id: Uuid::nil(),
+            instance_id: Uuid::nil(),
+            warmth,
+            trust,
+            intrigue,
+            intimacy,
+            patience: 0.5,
+            tension,
+            ghost_streak: 0,
+            last_ghost_at: None,
+            total_ghosts: 0,
+            relationship_label: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    #[test]
+    fn snapshot_exposes_bond_chemistry_bars_and_labels() {
+        // bond = (0+0.9+0.9)/3 = 0.6 → tier3 close_friend ; chemistry = 0 → spark
+        let snap = AffinitySnapshot::from(affinity(0.0, 0.9, 0.9, 0.0, 0.0));
+        assert_eq!(snap.bond_label, "close_friend");
+        assert_eq!(snap.chemistry_label, "spark");
+        // bar(0.6): tier3 band 0.50 + (0.6-0.35)/0.27*0.25
+        assert!((snap.bond - (0.50 + (0.6 - 0.35) / 0.27 * 0.25)).abs() < 1e-9);
+        assert!((snap.chemistry).abs() < 1e-9);
+    }
+
+    #[test]
+    fn bond_chemistry_deltas_fold_axes() {
+        let d = crate::routes::companion::AffinityDeltasDto {
+            warmth: 0.3,
+            trust: 0.3,
+            intrigue: 0.0,
+            intimacy: 0.6,
+            patience: 0.0,
+            tension: 0.0,
+        };
+        let f = BondChemistryDeltas::from_axis_deltas(&d);
+        assert!((f.bond - 0.2).abs() < 1e-9); // (0.3+0.3+0)/3
+        assert!((f.chemistry - 0.3).abs() < 1e-9); // (0.3+0.6+0)/3
     }
 }

--- a/crates/eros-engine-store/migrations/0029_affinity_bond_chemistry.sql
+++ b/crates/eros-engine-store/migrations/0029_affinity_bond_chemistry.sql
@@ -1,0 +1,23 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+
+-- Derived bond/chemistry composites, kept in lockstep with the 6 axes by the DB.
+-- Mirror of eros_engine_core::affinity::{bond_score,chemistry_score}
+-- (warmth floored at 0 via GREATEST). Keep in sync if the formula changes.
+ALTER TABLE engine.companion_affinity
+    ADD COLUMN bond DOUBLE PRECISION
+        GENERATED ALWAYS AS (LEAST(1, GREATEST(0, (GREATEST(warmth, 0) + trust + intrigue) / 3))) STORED,
+    ADD COLUMN chemistry DOUBLE PRECISION
+        GENERATED ALWAYS AS (LEAST(1, GREATEST(0, (GREATEST(warmth, 0) + intimacy + tension) / 3))) STORED;
+
+-- Lower the new-row default seed so a fresh session reads as "stranger" with
+-- near-empty bars (existing rows unaffected by ALTER ... SET DEFAULT). warmth
+-- stays slightly positive (neutral "平淡" tone, not 冷淡); patience keeps 0.5.
+ALTER TABLE engine.companion_affinity
+    ALTER COLUMN warmth   SET DEFAULT 0.1,
+    ALTER COLUMN trust    SET DEFAULT 0.0,
+    ALTER COLUMN intrigue SET DEFAULT 0.0,
+    ALTER COLUMN tension  SET DEFAULT 0.0;
+
+-- Per-turn tier transition (bond/chemistry); NULL when no tier moved this turn.
+ALTER TABLE engine.companion_affinity_events
+    ADD COLUMN label_changes JSONB;

--- a/crates/eros-engine-store/migrations/0029_affinity_bond_chemistry.sql
+++ b/crates/eros-engine-store/migrations/0029_affinity_bond_chemistry.sql
@@ -21,3 +21,9 @@ ALTER TABLE engine.companion_affinity
 -- Per-turn tier transition (bond/chemistry); NULL when no tier moved this turn.
 ALTER TABLE engine.companion_affinity_events
     ADD COLUMN label_changes JSONB;
+
+-- Exact per-turn line deltas (floored before/after bond/chemistry scores),
+-- computed at persist time so the per-turn pulse is exact even when warmth < 0
+-- (the linear axis fold was wrong below the warmth floor). NULL on pre-migration rows.
+ALTER TABLE engine.companion_affinity_events
+    ADD COLUMN effective_line_deltas JSONB;

--- a/crates/eros-engine-store/src/affinity.rs
+++ b/crates/eros-engine-store/src/affinity.rs
@@ -970,7 +970,10 @@ mod tests {
             .await
             .unwrap();
         let reloaded = repo.load(session_id).await.unwrap().unwrap();
-        assert_eq!(reloaded.relationship_label, Some(RelationshipLabel::Romantic));
+        assert_eq!(
+            reloaded.relationship_label,
+            Some(RelationshipLabel::Romantic)
+        );
     }
 
     #[sqlx::test(migrations = "./migrations")]
@@ -1013,7 +1016,10 @@ mod tests {
         .unwrap();
         assert_eq!(rows.len(), 2);
         let first = rows[0].as_ref().expect("first turn records a label change");
-        assert!(first.get("bond").is_some(), "bond transition recorded: {first}");
+        assert!(
+            first.get("bond").is_some(),
+            "bond transition recorded: {first}"
+        );
         assert!(rows[1].is_none(), "flat turn records NULL label_changes");
     }
 

--- a/crates/eros-engine-store/src/affinity.rs
+++ b/crates/eros-engine-store/src/affinity.rs
@@ -86,9 +86,10 @@ fn label_to_str(label: RelationshipLabel) -> &'static str {
 pub struct AffinityEventRow {
     pub id: Uuid,
     pub event_type: String,
-    pub deltas: serde_json::Value,                   // pre-EMA
-    pub effective_deltas: Option<serde_json::Value>, // post-EMA (NULL pre-0014)
-    pub label_changes: Option<serde_json::Value>,    // per-turn tier transition (NULL = none)
+    pub deltas: serde_json::Value,                        // pre-EMA
+    pub effective_deltas: Option<serde_json::Value>,      // post-EMA (NULL pre-0014)
+    pub label_changes: Option<serde_json::Value>,         // per-turn tier transition (NULL = none)
+    pub effective_line_deltas: Option<serde_json::Value>, // exact {bond,chemistry} per-turn delta (NULL pre-migration)
     pub created_at: DateTime<Utc>,
 }
 
@@ -143,7 +144,7 @@ impl<'a> AffinityRepo<'a> {
         event_type: Option<&str>,
     ) -> Result<Vec<AffinityEventRow>, sqlx::Error> {
         sqlx::query_as::<_, AffinityEventRow>(
-            "SELECT e.id, e.event_type, e.deltas, e.effective_deltas, e.label_changes, e.created_at \
+            "SELECT e.id, e.event_type, e.deltas, e.effective_deltas, e.label_changes, e.effective_line_deltas, e.created_at \
              FROM engine.companion_affinity_events e \
              JOIN engine.companion_affinity a ON a.id = e.affinity_id \
              WHERE a.session_id = $1 \
@@ -168,7 +169,7 @@ impl<'a> AffinityRepo<'a> {
         session_id: Uuid,
     ) -> Result<Option<AffinityEventRow>, sqlx::Error> {
         sqlx::query_as::<_, AffinityEventRow>(
-            "SELECT e.id, e.event_type, e.deltas, e.effective_deltas, e.label_changes, e.created_at \
+            "SELECT e.id, e.event_type, e.deltas, e.effective_deltas, e.label_changes, e.effective_line_deltas, e.created_at \
              FROM engine.companion_affinity_events e \
              JOIN engine.companion_affinity a ON a.id = e.affinity_id \
              WHERE a.session_id = $1 \
@@ -267,6 +268,14 @@ impl<'a> AffinityRepo<'a> {
         let label_changes = eros_engine_core::affinity::diff_labels(&before_affinity, &current)
             .and_then(|c| serde_json::to_value(&c).ok());
 
+        // Exact per-turn line delta from the floored before/after scores
+        // (the absolute bond/chemistry formulas use max(warmth,0), so a raw axis
+        // fold would misreport when warmth < 0). Always written for delta events.
+        let effective_line_deltas = serde_json::json!({
+            "bond": current.bond_score() - before_affinity.bond_score(),
+            "chemistry": current.chemistry_score() - before_affinity.chemistry_score(),
+        });
+
         // Post-EMA effective change = after − before (captures EMA + clamping).
         let effective = AffinityDeltas {
             warmth: current.warmth - before.warmth,
@@ -299,15 +308,16 @@ impl<'a> AffinityRepo<'a> {
         let effective_json = serde_json::to_value(&effective).unwrap_or_default();
         sqlx::query(
             "INSERT INTO engine.companion_affinity_events \
-               (affinity_id, event_type, deltas, effective_deltas, label_changes, context, \
+               (affinity_id, event_type, deltas, effective_deltas, label_changes, effective_line_deltas, context, \
                 model, usage, generation_id) \
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)",
         )
         .bind(current.id)
         .bind(event_type)
         .bind(deltas_json)
         .bind(effective_json)
         .bind(label_changes)
+        .bind(effective_line_deltas)
         .bind(context)
         .bind(meta.and_then(|m| m.model.clone()))
         .bind(meta.and_then(|m| m.usage.clone()))
@@ -342,13 +352,15 @@ impl<'a> AffinityRepo<'a> {
         .await?;
 
         let zero = serde_json::to_value(AffinityDeltas::default()).unwrap_or_default();
+        let zero_line = serde_json::json!({ "bond": 0.0, "chemistry": 0.0 });
         sqlx::query(
             "INSERT INTO engine.companion_affinity_events \
-               (affinity_id, event_type, deltas, effective_deltas, context) \
-             VALUES ($1, 'ghost', '{}'::jsonb, $2, '{}'::jsonb)",
+               (affinity_id, event_type, deltas, effective_deltas, effective_line_deltas, context) \
+             VALUES ($1, 'ghost', '{}'::jsonb, $2, $3, '{}'::jsonb)",
         )
         .bind(affinity.id)
         .bind(zero)
+        .bind(zero_line)
         .execute(self.pool)
         .await?;
 
@@ -1021,6 +1033,42 @@ mod tests {
             "bond transition recorded: {first}"
         );
         assert!(rows[1].is_none(), "flat turn records NULL label_changes");
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn effective_line_deltas_are_floored_exact(pool: PgPool) {
+        let repo = AffinityRepo { pool: &pool };
+        let user_id = Uuid::new_v4();
+        let instance_id = Uuid::new_v4();
+        let session_id = make_session(&pool, user_id, instance_id).await;
+        let mut a = repo
+            .load_or_create(session_id, user_id, instance_id)
+            .await
+            .unwrap();
+        // Seed warmth negative so a raw axis fold would differ from the floored truth.
+        // Fresh seed warmth=0.1; push it to -0.3 this turn (ema 0.0 = full apply).
+        let deltas = AffinityDeltas {
+            warmth: -0.4,
+            ..Default::default()
+        };
+        repo.persist_with_event(&mut a, &deltas, 0.0, "message", serde_json::json!({}), None)
+            .await
+            .unwrap();
+        // before: warmth 0.1, bond=(0.1+0+0)/3=0.0333 ; after: warmth -0.3 → floored 0 → bond 0.
+        // exact line delta = 0 - 0.0333 = -0.0333 (a raw fold would give -0.4/3 = -0.133).
+        let line: serde_json::Value = sqlx::query_scalar(
+            "SELECT effective_line_deltas FROM engine.companion_affinity_events \
+             WHERE affinity_id = $1 ORDER BY created_at DESC, id DESC LIMIT 1",
+        )
+        .bind(a.id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let bond = line["bond"].as_f64().unwrap();
+        assert!(
+            (bond - (-0.033333)).abs() < 1e-4,
+            "floored exact bond delta, got {bond}"
+        );
     }
 
     #[sqlx::test(migrations = "./migrations")]

--- a/crates/eros-engine-store/src/affinity.rs
+++ b/crates/eros-engine-store/src/affinity.rs
@@ -88,6 +88,7 @@ pub struct AffinityEventRow {
     pub event_type: String,
     pub deltas: serde_json::Value,                   // pre-EMA
     pub effective_deltas: Option<serde_json::Value>, // post-EMA (NULL pre-0014)
+    pub label_changes: Option<serde_json::Value>,    // per-turn tier transition (NULL = none)
     pub created_at: DateTime<Utc>,
 }
 
@@ -142,7 +143,7 @@ impl<'a> AffinityRepo<'a> {
         event_type: Option<&str>,
     ) -> Result<Vec<AffinityEventRow>, sqlx::Error> {
         sqlx::query_as::<_, AffinityEventRow>(
-            "SELECT e.id, e.event_type, e.deltas, e.effective_deltas, e.created_at \
+            "SELECT e.id, e.event_type, e.deltas, e.effective_deltas, e.label_changes, e.created_at \
              FROM engine.companion_affinity_events e \
              JOIN engine.companion_affinity a ON a.id = e.affinity_id \
              WHERE a.session_id = $1 \
@@ -167,7 +168,7 @@ impl<'a> AffinityRepo<'a> {
         session_id: Uuid,
     ) -> Result<Option<AffinityEventRow>, sqlx::Error> {
         sqlx::query_as::<_, AffinityEventRow>(
-            "SELECT e.id, e.event_type, e.deltas, e.effective_deltas, e.created_at \
+            "SELECT e.id, e.event_type, e.deltas, e.effective_deltas, e.label_changes, e.created_at \
              FROM engine.companion_affinity_events e \
              JOIN engine.companion_affinity a ON a.id = e.affinity_id \
              WHERE a.session_id = $1 \
@@ -249,6 +250,7 @@ impl<'a> AffinityRepo<'a> {
         // Decay from the locked row, then snapshot the pre-delta baseline so
         // effective_deltas captures only the delta application, not decay.
         current.apply_time_decay();
+        let before_affinity = current.clone();
         let before = AffinityDeltas {
             warmth: current.warmth,
             trust: current.trust,
@@ -261,6 +263,9 @@ impl<'a> AffinityRepo<'a> {
         current.apply_deltas(deltas, ema_inertia);
         let label = current.legacy_relationship_label();
         current.relationship_label = Some(label);
+
+        let label_changes = eros_engine_core::affinity::diff_labels(&before_affinity, &current)
+            .and_then(|c| serde_json::to_value(&c).ok());
 
         // Post-EMA effective change = after − before (captures EMA + clamping).
         let effective = AffinityDeltas {
@@ -294,14 +299,15 @@ impl<'a> AffinityRepo<'a> {
         let effective_json = serde_json::to_value(&effective).unwrap_or_default();
         sqlx::query(
             "INSERT INTO engine.companion_affinity_events \
-               (affinity_id, event_type, deltas, effective_deltas, context, \
+               (affinity_id, event_type, deltas, effective_deltas, label_changes, context, \
                 model, usage, generation_id) \
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
         )
         .bind(current.id)
         .bind(event_type)
         .bind(deltas_json)
         .bind(effective_json)
+        .bind(label_changes)
         .bind(context)
         .bind(meta.and_then(|m| m.model.clone()))
         .bind(meta.and_then(|m| m.usage.clone()))
@@ -382,9 +388,9 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(a1.id, a2.id);
-        // Defaults from migration
-        assert!((a1.warmth - 0.3).abs() < 1e-9);
-        assert!((a1.intrigue - 0.5).abs() < 1e-9);
+        // Lowered seed (stranger start) from migration 0029.
+        assert!((a1.warmth - 0.1).abs() < 1e-9);
+        assert!((a1.intrigue).abs() < 1e-9);
     }
 
     #[sqlx::test(migrations = "./migrations")]
@@ -509,7 +515,8 @@ mod tests {
             .load_or_create(session_id, user_id, instance_id)
             .await
             .unwrap();
-        // trust starts at 0.2; push it past the [0,1] ceiling with no smoothing.
+        // trust starts at 0.0 (lowered seed from migration 0029); push it past
+        // the [0,1] ceiling with no smoothing.
         let deltas = AffinityDeltas {
             trust: 5.0,
             ..Default::default()
@@ -525,8 +532,8 @@ mod tests {
         .fetch_one(&pool)
         .await
         .unwrap();
-        // Effective is the CLAMPED change (1.0 − 0.2 = 0.8), not the raw 5.0.
-        assert!((eff.unwrap()["trust"].as_f64().unwrap() - 0.8).abs() < 1e-9);
+        // Effective is the CLAMPED change (1.0 − 0.0 = 1.0), not the raw 5.0.
+        assert!((eff.unwrap()["trust"].as_f64().unwrap() - 1.0).abs() < 1e-9);
     }
 
     #[sqlx::test(migrations = "./migrations")]
@@ -910,6 +917,104 @@ mod tests {
             vec!["上一轮".to_string()],
             "an affinity event created after the cutoff message must be excluded"
         );
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn generated_bond_chemistry_match_core(pool: PgPool) {
+        let repo = AffinityRepo { pool: &pool };
+        let user_id = Uuid::new_v4();
+        let instance_id = Uuid::new_v4();
+        let session_id = make_session(&pool, user_id, instance_id).await;
+        let mut a = repo
+            .load_or_create(session_id, user_id, instance_id)
+            .await
+            .unwrap();
+        let deltas = AffinityDeltas {
+            warmth: 0.5,
+            trust: 0.4,
+            intrigue: 0.6,
+            intimacy: 0.3,
+            patience: 0.0,
+            tension: 0.2,
+        };
+        repo.persist_with_event(&mut a, &deltas, 0.0, "message", serde_json::json!({}), None)
+            .await
+            .unwrap();
+        let (bond, chemistry): (f64, f64) =
+            sqlx::query_as("SELECT bond, chemistry FROM engine.companion_affinity WHERE id = $1")
+                .bind(a.id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert!((bond - a.bond_score()).abs() < 1e-9);
+        assert!((chemistry - a.chemistry_score()).abs() < 1e-9);
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn persist_writes_new_legacy_label(pool: PgPool) {
+        let repo = AffinityRepo { pool: &pool };
+        let user_id = Uuid::new_v4();
+        let instance_id = Uuid::new_v4();
+        let session_id = make_session(&pool, user_id, instance_id).await;
+        let mut a = repo
+            .load_or_create(session_id, user_id, instance_id)
+            .await
+            .unwrap();
+        // Push chemistry high → romantic.
+        let deltas = AffinityDeltas {
+            intimacy: 0.9,
+            tension: 0.9,
+            ..Default::default()
+        };
+        repo.persist_with_event(&mut a, &deltas, 0.0, "message", serde_json::json!({}), None)
+            .await
+            .unwrap();
+        let reloaded = repo.load(session_id).await.unwrap().unwrap();
+        assert_eq!(reloaded.relationship_label, Some(RelationshipLabel::Romantic));
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn label_changes_recorded_on_tier_crossing_and_null_otherwise(pool: PgPool) {
+        let repo = AffinityRepo { pool: &pool };
+        let user_id = Uuid::new_v4();
+        let instance_id = Uuid::new_v4();
+        let session_id = make_session(&pool, user_id, instance_id).await;
+        let mut a = repo
+            .load_or_create(session_id, user_id, instance_id)
+            .await
+            .unwrap();
+        // Big positive turn crosses bond tier 1 → 4.
+        let deltas = AffinityDeltas {
+            trust: 0.9,
+            intrigue: 0.9,
+            ..Default::default()
+        };
+        repo.persist_with_event(&mut a, &deltas, 0.0, "message", serde_json::json!({}), None)
+            .await
+            .unwrap();
+        // Flat turn crosses nothing.
+        repo.persist_with_event(
+            &mut a,
+            &AffinityDeltas::default(),
+            0.0,
+            "message",
+            serde_json::json!({}),
+            None,
+        )
+        .await
+        .unwrap();
+        let rows: Vec<Option<serde_json::Value>> = sqlx::query_scalar(
+            "SELECT label_changes FROM engine.companion_affinity_events \
+             WHERE affinity_id = $1 ORDER BY created_at ASC, id ASC",
+        )
+        .bind(a.id)
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+        assert_eq!(rows.len(), 2);
+        let first = rows[0].as_ref().expect("first turn records a label change");
+        assert!(first.get("bond").is_some(), "bond transition recorded: {first}");
+        assert!(rows[1].is_none(), "flat turn records NULL label_changes");
     }
 
     #[sqlx::test(migrations = "./migrations")]

--- a/crates/eros-engine-store/src/affinity.rs
+++ b/crates/eros-engine-store/src/affinity.rs
@@ -259,8 +259,8 @@ impl<'a> AffinityRepo<'a> {
         };
 
         current.apply_deltas(deltas, ema_inertia);
-        let label = current.infer_label();
-        current.relationship_label = label;
+        let label = current.legacy_relationship_label();
+        current.relationship_label = Some(label);
 
         // Post-EMA effective change = after − before (captures EMA + clamping).
         let effective = AffinityDeltas {
@@ -286,7 +286,7 @@ impl<'a> AffinityRepo<'a> {
         .bind(current.intimacy)
         .bind(current.patience)
         .bind(current.tension)
-        .bind(label.map(label_to_str))
+        .bind(label_to_str(label))
         .execute(&mut *tx)
         .await?;
 

--- a/docs/affinity-model.md
+++ b/docs/affinity-model.md
@@ -263,10 +263,11 @@ the existing `effective_deltas` (per-axis, post-EMA), the event now carries:
 }
 ```
 
-- `effective_deltas_computed` — the per-axis `effective_deltas` folded
-  linearly into the two lines (`Δbond = (Δwarmth + Δtrust + Δintrigue) / 3`,
-  `Δchemistry = (Δwarmth + Δintimacy + Δtension) / 3`). Raw-composite units
-  (not bar-percent). Good for a per-turn "+X bond / +Y chemistry" pulse.
+- `effective_deltas_computed` — the exact per-turn bond/chemistry delta
+  computed at persist time from the floored before/after scores and stored on
+  the event row (`companion_affinity_events.effective_line_deltas`). Raw-composite
+  units (not bar-percent). Good for a per-turn "+X bond / +Y chemistry" pulse.
+  `null` / absent on pre-migration rows.
 - `label_changes` — engine-authoritative tier transition for this turn; `null`
   (or absent) when no tier moved. The frontend stops computing transitions
   itself.

--- a/docs/affinity-model.md
+++ b/docs/affinity-model.md
@@ -221,13 +221,13 @@ Returned by `GET /comp/affinity/{session_id}` (debug) and
   "intimacy": 0.05,
   "patience": 0.55,
   "tension": 0.04,
-  "bond": 0.31,
-  "chemistry": 0.18,
-  "bond_label": "acquaintance",
-  "chemistry_label": "spark",
+  "bond": 0.32,
+  "chemistry": 0.28,
+  "bond_label": "friend",
+  "chemistry_label": "flirtation",
   "ghost_streak": 0,
   "total_ghosts": 0,
-  "relationship_label": "stranger",
+  "relationship_label": "friend",
   "updated_at": "2026-06-30T12:00:00.000000Z"
 }
 ```

--- a/docs/affinity-model.md
+++ b/docs/affinity-model.md
@@ -2,103 +2,284 @@
 
 [English](affinity-model.md) · [中文](affinity-model.zh.md)
 
-A six-dimensional vector that mutates with every chat turn. It's the load-bearing piece that makes the persona feel like a person and not a chatbot.
+A six-dimensional vector that mutates with every chat turn, folded into two
+derived lines — **Bond** (friendship axis) and **Chemistry** (romance axis) —
+each tiered and labeled. The engine is the single source of truth for scores,
+labels, and per-turn label transitions.
 
-## The six dimensions
+## The six base axes
 
-| Field | Range | Default | What it shapes |
-|-------|-------|---------|----------------|
-| `warmth` | −1.0 ↔ 1.0 | `0.3` | Tone, address. Negative = guarded, hostile; positive = warm, affectionate. |
-| `trust` | 0.0 ↔ 1.0 | `0.2` | Topic depth, willingness to disclose self. |
-| `intrigue` | 0.0 ↔ 1.0 | `0.5` | Curiosity, follow-up questions, anti-ghost driver. |
-| `intimacy` | 0.0 ↔ 1.0 | `0.0` | Inside jokes, nicknames, callbacks to earlier details. |
-| `patience` | 0.0 ↔ 1.0 | `0.5` | Tolerance for short / low-effort messages; ghost-threshold input. |
-| `tension` | 0.0 ↔ 1.0 | `0.1` | Push-pull, playful friction, "tsundere" affordance. |
+| Axis | Range | Default seed | What it shapes |
+|------|-------|--------------|----------------|
+| `warmth` | −1.0 ↔ 1.0 | `0.1` | Tone, address. Negative = guarded/hostile; positive = warm/affectionate. Shared into both Bond and Chemistry (floored at 0 when folding). |
+| `trust` | 0.0 ↔ 1.0 | `0.0` | Topic depth, willingness to disclose self. Bond axis. |
+| `intrigue` | 0.0 ↔ 1.0 | `0.0` | Curiosity, follow-up questions, anti-ghost driver. Bond axis. |
+| `intimacy` | 0.0 ↔ 1.0 | `0.0` | Inside jokes, nicknames, callbacks to earlier details. Chemistry axis. |
+| `patience` | 0.0 ↔ 1.0 | `0.5` | Tolerance for short / low-effort messages; ghost-threshold input. Rule-owned — never scored by the evaluator; excluded from both lines. |
+| `tension` | 0.0 ↔ 1.0 | `0.0` | Push-pull, playful friction, tsundere affordance. Chemistry axis. |
 
-`warmth` is the only dimension that can go negative. The other five are bounded `[0, 1]`. All six are clamped on every update.
+`warmth` is the only axis that can go negative. The other five are bounded
+`[0, 1]`. All six are clamped on every update.
 
-## EMA smoothing
+The **default seed** values above apply only to new rows (sessions that start
+after migration `0029`). Existing rows are unaffected.
 
-LLM-evaluated deltas are applied through exponential moving average to avoid lurches:
+### EMA smoothing
+
+LLM-evaluated deltas are applied through an exponential moving average to
+prevent lurches:
 
 ```
 new_value = clamp(old_value + (1 − ema_inertia) × delta)
 ```
 
-Default `ema_inertia = 0.8` (configurable via `EMA_INERTIA`). With the default, an LLM-suggested delta of `+0.5` only moves the value by `+0.1` on this turn — the rest catches up over subsequent turns if the same direction holds.
+Default `ema_inertia = 0.8` (configurable via `EMA_INERTIA`). With the
+default, a delta of `+0.5` moves the axis by only `+0.1` on this turn.
 
-```rust
-// From crates/eros-engine-core/src/affinity.rs
-pub fn apply_deltas(&mut self, d: &AffinityDeltas, ema_inertia: f64) {
-    let blend = 1.0 - ema_inertia;
-    self.warmth   = clamp(self.warmth   + blend * d.warmth,   -1.0, 1.0);
-    self.trust    = clamp(self.trust    + blend * d.trust,     0.0, 1.0);
-    // … same for intrigue, intimacy, patience, tension
-    self.updated_at = Utc::now();
-}
-```
+### Time decay
 
-### Worked example
-
-Initial `warmth = 0.3`. LLM evaluates this turn's delta as `+0.5`. Default inertia.
-
-```
-new_warmth = clamp(0.3 + (1 − 0.8) × 0.5)
-           = clamp(0.3 + 0.10)
-           = 0.40
-```
-
-After three consecutive `+0.5` deltas (still under default inertia), warmth has moved 0.3 → 0.4 → 0.5 → 0.6. The persona warms up over four turns instead of jumping in one.
-
-## Time decay
-
-Three of the six dimensions drift on real time when no one's around. Decay is computed lazily — on every load, by reading `updated_at`:
+Three axes drift on real time when there is no activity. Decay is computed
+lazily on every load (reads `updated_at`):
 
 ```
 days_elapsed = (now − updated_at) / 1 day
 
-intrigue = clamp(intrigue − 0.01  × days_elapsed,  0.0, 1.0)
-patience = clamp(patience + 0.005 × days_elapsed,  0.0, 1.0)
-tension  = clamp(tension  − 0.005 × days_elapsed,  0.0, 1.0)
+intrigue = clamp(intrigue − 0.01  × days_elapsed, 0.0, 1.0)
+patience = clamp(patience + 0.005 × days_elapsed, 0.0, 1.0)
+tension  = clamp(tension  − 0.005 × days_elapsed, 0.0, 1.0)
 ```
 
-`warmth`, `trust`, and `intimacy` don't decay — they're "deep" dimensions. Once you've earned trust, walking away for a week shouldn't reset it; the persona just becomes a little less curious and a little more forgiving in the meantime.
+`warmth`, `trust`, and `intimacy` do not decay — they are "deep" dimensions.
 
-10 days of silence:
-- `intrigue` drops by `0.10`
-- `patience` recovers by `0.05`
-- `tension` softens by `0.05`
+## The two derived lines
 
-## Relationship labels
+Two composite scores are computed from the six axes. `warm_pos` is
+`warmth.max(0.0)` — floored at zero (not shifted; a neutral/cold session
+contributes nothing):
 
-Five labels emerge from threshold rules; they are not user-selectable. The match is priority-ordered (first hit wins):
+```
+bond      = (warm_pos + trust   + intrigue) / 3    ∈ [0, 1]
+chemistry = (warm_pos + intimacy + tension)  / 3    ∈ [0, 1]
+```
 
-| Label | Condition |
-|-------|-----------|
-| `romantic` | `warmth ≥ 0.7` AND `tension ≥ 0.3` AND `intimacy ≥ 0.4` |
-| `friend` | `warmth ≥ 0.7` AND `trust ≥ 0.6` AND `tension < 0.2` |
-| `frenemy` | `warmth < 0.4` AND `tension ≥ 0.6` AND `intrigue ≥ 0.5` |
-| `slow_burn` | `intrigue ≥ 0.6` AND `tension ≥ 0.4` AND `intimacy < 0.4` |
-| `stranger` | none of the above |
+`warmth` is shared into both lines: cold replies tank both Bond and Chemistry.
+`patience` is excluded from both — it is rule-owned, never evaluated per-turn.
 
-The label feeds back into the persona's system prompt — `prompt.rs` rewrites the attitude directive based on the current label. The user never sees the label; they feel its consequences in the persona's tone.
+With the default seed (`warmth 0.1`, `trust/intrigue/tension 0`), a fresh
+session starts at bond ≈ chemistry ≈ 0.033 — both in tier 1 (stranger).
+
+> **Naming note:** `AffinityScope::bond()/chemistry()` (used for
+> prompt-injection scoping, `length_score`) use a *different* axis grouping —
+> that is an older, separate split that is intentionally left alone to avoid
+> reply-length regressions. The `bond_score`/`chemistry_score` derived here are
+> independent.
+
+## Tiers and bar curve
+
+Each line has **four tiers** with widening raw-score gaps (each step costs
+more):
+
+| Tier | Raw range | Gap |
+|------|-----------|-----|
+| 1 | `[0.00, 0.15)` | 0.15 |
+| 2 | `[0.15, 0.35)` | 0.20 |
+| 3 | `[0.35, 0.62)` | 0.27 |
+| 4 | `[0.62, 1.00]` | 0.38 |
+
+**Bar value (0–1, rendered by the frontend):** each tier maps to an even 25%
+band, linear within the band:
+
+```
+bar(raw) = band_lo(tier) + (raw − tier_lo) / (tier_hi − tier_lo) × 0.25
+  Tier 1: 0.00 + (raw − 0.00) / 0.15 × 0.25  →  [0.00, 0.25)
+  Tier 2: 0.25 + (raw − 0.15) / 0.20 × 0.25  →  [0.25, 0.50)
+  Tier 3: 0.50 + (raw − 0.35) / 0.27 × 0.25  →  [0.50, 0.75)
+  Tier 4: 0.75 + (raw − 0.62) / 0.38 × 0.25  →  [0.75, 1.00]
+clamped to [0, 1]
+```
+
+Because higher tiers span more raw affinity, the bar fills quickly early and
+crawls near 100% — easy first two tiers, grind at the top — without a literal
+`exp()`. A fixed per-turn raw delta also moves the bar *less* in higher tiers.
+
+All thresholds and bands are tunable constants.
+
+## Tiered labels
+
+Two independent sets of four labels, one per line (serialized snake_case):
+
+| Line | Tier 1 | Tier 2 | Tier 3 | Tier 4 |
+|------|--------|--------|--------|--------|
+| **Bond** | `acquaintance` | `friend` | `close_friend` | `confidant` |
+| **Chemistry** | `spark` | `flirtation` | `crush` | `lover` |
+
+`bond_label` and `chemistry_label` are always one of their respective four
+values — they never emit `stranger`. The `stranger` state is conveyed only by
+the legacy field (see below).
+
+## Legacy `relationship_label`
+
+The legacy field keeps its old name set for backward compatibility with
+existing consumers. It is now a pure function of the two raw scores (replacing
+the old ad-hoc `infer_label` heuristic):
+
+```
+legacy_relationship_label(bond, chemistry):
+  if tier(bond) == 1 AND tier(chemistry) == 1  →  stranger
+  let higher = (chemistry > bond) ? Chemistry : Bond   // tie → Bond
+  match higher:
+    Bond                                         →  friend
+    Chemistry if tier(chemistry) in {1, 2}       →  slow_burn
+    Chemistry if tier(chemistry) in {3, 4}       →  romantic
+```
+
+`frenemy` is retired from emission but kept parseable in the enum (for
+historical rows). `stranger` is now the explicit "both tier 1" case — it
+no longer requires all five old threshold conditions to miss.
+
+## Eval distribution and asymmetric cap
+
+**Cap (asymmetric).** The evaluator's raw per-axis output is clamped
+asymmetrically in `parse_affinity_eval`:
+
+```
+POS_CAP = +0.4    NEG_CAP = −0.6
+effective_delta = raw.clamp(NEG_CAP, POS_CAP)
+```
+
+With EMA blend 0.2 (`ema_inertia = 0.8`), the per-turn axis maxima are
+**+0.08** (gain) and **−0.12** (loss) — versus the old symmetric ±0.03.
+
+**Distribution (prompt-shaped).** The evaluator is guided to produce:
+
+- **Most turns: exactly `0`** — ordinary chitchat and acknowledgements score
+  nothing.
+- **Rare positive** — only on genuine relationship-advancing moments (real
+  warmth, self-disclosure, vulnerability, flirtation that lands); may be large
+  (up to ≈ +0.4 per axis).
+- **Readier negative** — fires for coldness, perfunctory/repetitive replies,
+  boredom, boundary-crossing, conflict, or being ignored; may be larger
+  (down to ≈ −0.6 per axis).
+
+EMA smoothing and time decay are **unchanged** — only the cap and prompt
+guidance changed.
 
 ## Persistence
 
-One row per chat session in `engine.companion_affinity` (1:1 via `session_id UNIQUE FK`). Every mutation also appends to `engine.companion_affinity_events`:
+### Generated columns
 
-| `event_type` | When |
-|--------------|------|
-| `message` | Reply succeeded; deltas evaluated by LLM |
-| `ghost` | Ghost decision; ghost_streak/total_ghosts incremented (no deltas) |
-| `gift` | Legacy — the standalone gift-event endpoint was removed; tips now flow through a normal turn and record as `message`. Still a valid filter value for historical rows. |
-| `time_decay` | Reserved (currently unused — decay is applied lazily on load) |
+Migration `0029` adds `bond` and `chemistry` as Postgres `GENERATED ALWAYS …
+STORED` columns on `engine.companion_affinity`. The DB recomputes them from
+the six axes on every row insert or update — they can never drift and existing
+rows auto-populate at migration time (no backfill, no engine write code):
 
-Events are append-only and never edited. Full history is queryable for analysis, audit, or reconstructing how a relationship evolved.
+```sql
+bond      GENERATED ALWAYS AS (LEAST(1, GREATEST(0, (GREATEST(warmth,0) + trust    + intrigue) / 3))) STORED
+chemistry GENERATED ALWAYS AS (LEAST(1, GREATEST(0, (GREATEST(warmth,0) + intimacy + tension)  / 3))) STORED
+```
+
+The bar curve and tier labels live only in the core read layer; the raw
+composite stored in the DB and the API-level bar value are distinct.
+
+### Lowered default seed
+
+The new-row column defaults (also migration `0029`) are set so a fresh session
+starts at bond ≈ chemistry ≈ 0.033 — tier 1 on both lines, legacy `stranger`.
+Existing rows are unaffected.
+
+### Per-turn label changes
+
+Migration `0029` also adds `label_changes JSONB` on
+`engine.companion_affinity_events`. After each turn the engine compares tiers
+before and after the delta (decay-scoped, same window as `effective_deltas`):
+
+```
+label_changes = {
+  bond:      { from: "<tier_key>", to: "<tier_key>" }  // if bond tier changed
+  chemistry: { from: "<tier_key>", to: "<tier_key>" }  // if chemistry tier changed
+}
+// NULL when neither tier moved this turn
+```
+
+`from`/`to` are tier keys (e.g. `"acquaintance"`, `"friend"`). The legacy
+`relationship_label` transition is not included — it is derivable. Decay-only
+tier drift is not recorded as a discrete event; the absolute snapshot is always
+available.
+
+## API surfaces
+
+### `AffinitySnapshot`
+
+Returned by `GET /comp/affinity/{session_id}` (debug) and
+`POST /bff/v1/comp/chat/start`. The snapshot now includes:
+
+```json
+{
+  "warmth": 0.42,
+  "trust": 0.08,
+  "intrigue": 0.12,
+  "intimacy": 0.05,
+  "patience": 0.55,
+  "tension": 0.04,
+  "bond": 0.31,
+  "chemistry": 0.18,
+  "bond_label": "acquaintance",
+  "chemistry_label": "spark",
+  "ghost_streak": 0,
+  "total_ghosts": 0,
+  "relationship_label": "stranger",
+  "updated_at": "2026-06-30T12:00:00.000000Z"
+}
+```
+
+- `bond` / `chemistry` — bar values (0–1, curve-applied), not raw composites.
+- `bond_label` / `chemistry_label` — one of the 8 tier keys above.
+- `relationship_label` — legacy mapped value (`stranger / friend / slow_burn / romantic`).
+
+### BFF `/bff/v1/comp/affinity/{session_id}/event`
+
+Per-turn affinity delta, not gated by `EXPOSE_AFFINITY_DEBUG`. In addition to
+the existing `effective_deltas` (per-axis, post-EMA), the event now carries:
+
+```json
+{
+  "session_id": "…",
+  "event": {
+    "event_id": "…",
+    "event_type": "message",
+    "effective_deltas": {
+      "warmth": 0.06, "trust": 0.02, "intrigue": 0.0,
+      "intimacy": 0.0, "patience": 0.0, "tension": -0.02
+    },
+    "effective_deltas_computed": {
+      "bond": 0.027,
+      "chemistry": 0.013
+    },
+    "label_changes": {
+      "bond": { "from": "acquaintance", "to": "friend" }
+    },
+    "created_at": "…"
+  }
+}
+```
+
+- `effective_deltas_computed` — the per-axis `effective_deltas` folded
+  linearly into the two lines (`Δbond = (Δwarmth + Δtrust + Δintrigue) / 3`,
+  `Δchemistry = (Δwarmth + Δintimacy + Δtension) / 3`). Raw-composite units
+  (not bar-percent). Good for a per-turn "+X bond / +Y chemistry" pulse.
+- `label_changes` — engine-authoritative tier transition for this turn; `null`
+  (or absent) when no tier moved. The frontend stops computing transitions
+  itself.
+
+Both fields are also mirrored on debug
+`GET /comp/affinity/{session_id}/event` entries.
 
 ## Source
 
-- `crates/eros-engine-core/src/affinity.rs` — types, EMA, time decay, label inference (10 unit tests)
-- `crates/eros-engine-store/src/affinity.rs` — `AffinityRepo` (persist_with_event, record_ghost)
-- `crates/eros-engine-server/src/pipeline/post_process.rs` — LLM evaluation of per-turn deltas
-- `crates/eros-engine-server/src/prompt.rs` — affinity → attitude directive
+- `crates/eros-engine-core/src/affinity.rs` — types, EMA, time decay, bond/chemistry scores, tiers, bar, labels, diff_labels
+- `crates/eros-engine-store/src/affinity.rs` — `AffinityRepo` (persist_with_event, record_ghost), migration 0029
+- `crates/eros-engine-server/src/pipeline/post_process.rs` — LLM evaluation, asymmetric clamp
+- `crates/eros-engine-server/src/prompt.rs` — affinity → attitude directive + eval prompt
+- `crates/eros-engine-server/src/routes/dto.rs` — `AffinitySnapshot` (bar + labels)
+- `crates/eros-engine-server/src/routes/bff/affinity.rs` — BFF event surface
+- `crates/eros-engine-server/src/routes/debug.rs` — debug event log

--- a/docs/affinity-model.zh.md
+++ b/docs/affinity-model.zh.md
@@ -2,104 +2,234 @@
 
 [English](affinity-model.md) · [中文](affinity-model.zh.md)
 
-每輪對話都會變動的六維向量。它是讓人格感覺像人而不是聊天機械人的承重結構。
+每轮对话都会变动的六维向量，折叠成两条衍生线——**Bond**（友情轴）和
+**Chemistry**（爱情轴）——每条线都有分层和标签。引擎是分数、标签、以及每轮标签变化的单一权威来源。
 
-## 六個維度
+## 六个基础轴
 
-| 字段 | 範圍 | 默認值 | 影響甚麼 |
-|------|------|--------|----------|
-| `warmth` | −1.0 ↔ 1.0 | `0.3` | 語氣、稱呼。負值＝戒備、敵意；正值＝溫暖、親暱。 |
-| `trust` | 0.0 ↔ 1.0 | `0.2` | 話題深度，是否願意暴露自己。 |
-| `intrigue` | 0.0 ↔ 1.0 | `0.5` | 好奇心、追問動力，抗 ghost 的主力。 |
-| `intimacy` | 0.0 ↔ 1.0 | `0.0` | 內部梗、暱稱、回頭呼應之前的細節。 |
-| `patience` | 0.0 ↔ 1.0 | `0.5` | 對短消息／敷衍回覆的容忍度；ghost 閾值的輸入。 |
-| `tension` | 0.0 ↔ 1.0 | `0.1` | 推拉、玩鬧式的小摩擦、傲嬌空間。 |
+| 轴 | 范围 | 默认种子 | 影响什么 |
+|------|-------|--------------|----------------|
+| `warmth` | −1.0 ↔ 1.0 | `0.1` | 语气、称呼。负值 = 戒备/敌意；正值 = 温暖/亲昵。折叠时对两条线均有贡献（取 0 为下界）。 |
+| `trust` | 0.0 ↔ 1.0 | `0.0` | 话题深度，是否愿意暴露自己。Bond 轴。 |
+| `intrigue` | 0.0 ↔ 1.0 | `0.0` | 好奇心、追问动力，抗 ghost 的主力。Bond 轴。 |
+| `intimacy` | 0.0 ↔ 1.0 | `0.0` | 内部梗、昵称、回头呼应之前的细节。Chemistry 轴。 |
+| `patience` | 0.0 ↔ 1.0 | `0.5` | 对短消息/敷衍回复的容忍度；ghost 阈值的输入。规则所有——不参与评估，不计入两条线。 |
+| `tension` | 0.0 ↔ 1.0 | `0.0` | 推拉、玩闹式的小摩擦、傲娇空间。Chemistry 轴。 |
 
-只有 `warmth` 可以變負值。其餘五個被 `[0, 1]` 鎖定。每次更新都做夾鉗（clamp）。
+只有 `warmth` 可以为负值。其余五个被 `[0, 1]` 锁定。每次更新都做夹钳（clamp）。
 
-## EMA 平滑
+**默认种子**值仅对迁移 `0029` 之后创建的新行生效，已有行不受影响。
 
-LLM 評估出來的 deltas 走指數移動平均應用，避免大上大落：
+### EMA 平滑
+
+LLM 评估出来的 deltas 走指数移动平均应用，避免大幅跳变：
 
 ```
 new_value = clamp(old_value + (1 − ema_inertia) × delta)
 ```
 
-默認 `ema_inertia = 0.8`（環境變量 `EMA_INERTIA` 可調）。默認下，LLM 建議的 `+0.5` 變化在這一輪只會把值移動 `+0.1`——其餘部份在後續對話延續同一方向時補上。
+默认 `ema_inertia = 0.8`（环境变量 `EMA_INERTIA` 可调）。默认下，delta `+0.5` 这一轮只移动 `+0.1`。
 
-```rust
-// crates/eros-engine-core/src/affinity.rs
-pub fn apply_deltas(&mut self, d: &AffinityDeltas, ema_inertia: f64) {
-    let blend = 1.0 - ema_inertia;
-    self.warmth   = clamp(self.warmth   + blend * d.warmth,   -1.0, 1.0);
-    self.trust    = clamp(self.trust    + blend * d.trust,     0.0, 1.0);
-    // … intrigue / intimacy / patience / tension 同樣處理
-    self.updated_at = Utc::now();
-}
-```
+### 时间衰退
 
-### 實例計算
-
-初始 `warmth = 0.3`。LLM 評估這輪 delta 為 `+0.5`。默認慣性。
-
-```
-new_warmth = clamp(0.3 + (1 − 0.8) × 0.5)
-           = clamp(0.3 + 0.10)
-           = 0.40
-```
-
-連續三輪 `+0.5` deltas（仍然默認慣性）下，warmth 會走 0.3 → 0.4 → 0.5 → 0.6。人格在四輪裡慢慢熱起來，而不是一輪暴走。
-
-## 時間衰退
-
-六維裡有三個會在沒人陪它的時候按真實時間漂移。衰退是 **懶式計算**——每次加載時讀 `updated_at` 算：
+六轴中有三个会在没有活动时按真实时间漂移。衰退是懒式计算——每次加载时读 `updated_at` 算：
 
 ```
 days_elapsed = (now − updated_at) / 1 天
 
-intrigue = clamp(intrigue − 0.01  × days_elapsed,  0.0, 1.0)
-patience = clamp(patience + 0.005 × days_elapsed,  0.0, 1.0)
-tension  = clamp(tension  − 0.005 × days_elapsed,  0.0, 1.0)
+intrigue = clamp(intrigue − 0.01  × days_elapsed, 0.0, 1.0)
+patience = clamp(patience + 0.005 × days_elapsed, 0.0, 1.0)
+tension  = clamp(tension  − 0.005 × days_elapsed, 0.0, 1.0)
 ```
 
-`warmth`、`trust`、`intimacy` 不衰退——它們是「深層」維度。一旦贏得了信任，離開一星期不應該歸零；只是這段時間人格會稍微少了點好奇心、多了點寬容。
+`warmth`、`trust`、`intimacy` 不衰退——它们是"深层"维度。
 
-10 天沒回：
+## 两条衍生线
 
-- `intrigue` 跌 `0.10`
-- `patience` 漲 `0.05`
-- `tension` 軟化 `0.05`
+两个合成分数由六轴计算而来。`warm_pos` 是 `warmth.max(0.0)` —— 以 0 为下界（非平移；中性/冷漠会话贡献为零）：
 
-## 關係標籤
+```
+bond      = (warm_pos + trust   + intrigue) / 3    ∈ [0, 1]
+chemistry = (warm_pos + intimacy + tension)  / 3    ∈ [0, 1]
+```
 
-五個標籤從閾值規則湧現出來，不是用戶選的。匹配按優先級（先中先得）：
+`warmth` 对两条线均有贡献：冷漠的回复会同时拉低 Bond 和 Chemistry。
+`patience` 不计入任何一条线——它由规则所有，不参与每轮评估。
 
-| 標籤 | 條件 |
-|------|------|
-| `romantic` | `warmth ≥ 0.7` 且 `tension ≥ 0.3` 且 `intimacy ≥ 0.4` |
-| `friend` | `warmth ≥ 0.7` 且 `trust ≥ 0.6` 且 `tension < 0.2` |
-| `frenemy` | `warmth < 0.4` 且 `tension ≥ 0.6` 且 `intrigue ≥ 0.5` |
-| `slow_burn` | `intrigue ≥ 0.6` 且 `tension ≥ 0.4` 且 `intimacy < 0.4` |
-| `stranger` | 以上都不命中 |
+以默认种子（`warmth 0.1`，`trust/intrigue/tension 0`）开始，新会话的
+bond ≈ chemistry ≈ 0.033——两条线均在第 1 档（陌生人）。
 
-標籤反饋進人格的 system prompt——`prompt.rs` 會根據當前標籤改寫態度指令。用戶看不到標籤，只會在人格的語氣裡感覺到它的後果。
+> **命名注意：** `AffinityScope::bond()/chemistry()`（用于 prompt 注入范围控制、`length_score`）采用的是*不同的*轴分组——那是一套更早的独立划分，为避免回复长度的回归而有意保留。此处的 `bond_score`/`chemistry_score` 与其完全独立。
+
+## 分档与进度条曲线
+
+每条线有**四档**，分档的原始分数区间逐档拉宽（越往上越难）：
+
+| 档位 | 原始分数区间 | 区间宽度 |
+|------|-----------|-----|
+| 1 | `[0.00, 0.15)` | 0.15 |
+| 2 | `[0.15, 0.35)` | 0.20 |
+| 3 | `[0.35, 0.62)` | 0.27 |
+| 4 | `[0.62, 1.00]` | 0.38 |
+
+**进度条值（0–1，由前端渲染）：** 每档映射到均匀的 25% 区间，区间内线性：
+
+```
+bar(raw) = band_lo(档位) + (raw − tier_lo) / (tier_hi − tier_lo) × 0.25
+  第 1 档: 0.00 + (raw − 0.00) / 0.15 × 0.25  →  [0.00, 0.25)
+  第 2 档: 0.25 + (raw − 0.15) / 0.20 × 0.25  →  [0.25, 0.50)
+  第 3 档: 0.50 + (raw − 0.35) / 0.27 × 0.25  →  [0.50, 0.75)
+  第 4 档: 0.75 + (raw − 0.62) / 0.38 × 0.25  →  [0.75, 1.00]
+夹钳到 [0, 1]
+```
+
+由于高档跨越更大的原始好感度区间，进度条在前期填充很快，接近 100% 时极其缓慢——前两档简单、后两档是磨练——无需字面的 `exp()`。固定的每轮原始 delta 在高档时对进度条的推动也*更小*。
+
+所有阈值和区间均为可调常量。
+
+## 分档标签
+
+两组各四个标签，每条线各一组（序列化为蛇形命名键）：
+
+| 线 | 第 1 档 | 第 2 档 | 第 3 档 | 第 4 档 |
+|------|--------|--------|--------|--------|
+| **Bond** | `acquaintance`（点头之交） | `friend`（朋友） | `close_friend`（好友） | `confidant`（知己） |
+| **Chemistry** | `spark`（来电） | `flirtation`（暧昧） | `crush`（心动） | `lover`（恋人） |
+
+`bond_label` 和 `chemistry_label` 始终是各自四个值之一——永不输出 `stranger`。`stranger` 状态仅由遗留字段传达（见下文）。
+
+## 遗留 `relationship_label`
+
+遗留字段保留旧名称集，保持对现有消费者的向后兼容。它现在是两个原始分数的纯函数（取代旧的临时 `infer_label` 启发式）：
+
+```
+legacy_relationship_label(bond, chemistry):
+  if tier(bond) == 1 AND tier(chemistry) == 1  →  stranger
+  let higher = (chemistry > bond) ? Chemistry : Bond   // 平局 → Bond
+  match higher:
+    Bond                                         →  friend
+    Chemistry if tier(chemistry) in {1, 2}       →  slow_burn
+    Chemistry if tier(chemistry) in {3, 4}       →  romantic
+```
+
+`frenemy` 已停止输出，但枚举中仍可解析（供历史行使用）。`stranger` 现在是明确的"两条线均在第 1 档"情况——不再需要旧五个阈值条件全部未命中。
+
+## 评估分布与非对称上限
+
+**上限（非对称）。** 评估器的每轴原始输出在 `parse_affinity_eval` 中被非对称夹钳：
+
+```
+POS_CAP = +0.4    NEG_CAP = −0.6
+effective_delta = raw.clamp(NEG_CAP, POS_CAP)
+```
+
+以 EMA blend 0.2（`ema_inertia = 0.8`）计，每轮单轴最大值为 **+0.08**（增益）和 **−0.12**（损失）——相比旧的对称 ±0.03 有显著变化。
+
+**分布（通过 prompt 塑造）。** 评估器被引导产出：
+
+- **绝大多数轮次：恰好 `0`** —— 普通闲聊和应答得分为零。
+- **罕见正值** —— 仅在真正推动关系的时刻（真实的温暖、自我披露、脆弱坦露、成功的调情）才产生；可以较大（单轴最高约 +0.4）。
+- **更易触发的负值** —— 冷漠、敷衍/重复的回复、无聊、越界、冲突、被无视均会触发；可以更大（单轴最低约 −0.6）。
+
+EMA 平滑和时间衰退**不变**——只有上限和 prompt 指引发生了变化。
 
 ## 持久化
 
-`engine.companion_affinity` 表，每個 chat session 一行（`session_id UNIQUE FK` 鎖 1:1）。每次變動同時往 `engine.companion_affinity_events` 追加一條：
+### 生成列
 
-| `event_type` | 何時 |
-|--------------|------|
-| `message` | Reply 成功；deltas 由 LLM 評估 |
-| `ghost` | Ghost 判定命中；ghost_streak / total_ghosts 加一（無 deltas） |
-| `gift` | 旧版遗留——独立的礼物事件端点已移除；打赏现在走普通对话轮，记为 `message`。仍是查询历史行的有效过滤值。 |
-| `time_decay` | 預留（目前未用——衰退在加載時懶算） |
+迁移 `0029` 在 `engine.companion_affinity` 上新增 `bond` 和 `chemistry` 两个 Postgres `GENERATED ALWAYS … STORED` 列。DB 在每次行插入或更新时从六轴重新计算它们——永远不会错位，且已有行在迁移时自动填充（无需回填，引擎写路径无需改动）：
 
-事件表只追加、永不修改。完整歷史可查、可審計、可重建一段關係的演變過程。
+```sql
+bond      GENERATED ALWAYS AS (LEAST(1, GREATEST(0, (GREATEST(warmth,0) + trust    + intrigue) / 3))) STORED
+chemistry GENERATED ALWAYS AS (LEAST(1, GREATEST(0, (GREATEST(warmth,0) + intimacy + tension)  / 3))) STORED
+```
 
-## 源碼
+进度条曲线和分档标签仅存在于核心读层；DB 存储的原始合成值与 API 层面的进度条值是不同的概念。
 
-- `crates/eros-engine-core/src/affinity.rs`——類型、EMA、時間衰退、標籤推導（10 個單元測試）
-- `crates/eros-engine-store/src/affinity.rs`——`AffinityRepo`（persist_with_event、record_ghost）
-- `crates/eros-engine-server/src/pipeline/post_process.rs`——LLM 對每輪 deltas 的評估
-- `crates/eros-engine-server/src/prompt.rs`——好感度 → 態度指令
+### 降低的默认种子
+
+新行的列默认值（同样在迁移 `0029` 中）被设置为使新会话的 bond ≈ chemistry ≈ 0.033——两条线均在第 1 档，遗留标签为 `stranger`。已有行不受影响。
+
+### 每轮标签变化
+
+迁移 `0029` 还在 `engine.companion_affinity_events` 上新增了 `label_changes JSONB` 列。每轮之后，引擎对比 delta 前后的档位（衰退范围，与 `effective_deltas` 同窗口）：
+
+```
+label_changes = {
+  bond:      { from: "<档位键>", to: "<档位键>" }  // 若 bond 档位发生变化
+  chemistry: { from: "<档位键>", to: "<档位键>" }  // 若 chemistry 档位发生变化
+}
+// 本轮无档位变化时为 NULL
+```
+
+`from`/`to` 是档位键（如 `"acquaintance"`、`"friend"`）。遗留 `relationship_label` 的变化不包含在内——可由快照推导。纯衰退导致的档位漂移不记录为离散事件；绝对快照始终可通过快照端点获取。
+
+## API 接口
+
+### `AffinitySnapshot`
+
+由 `GET /comp/affinity/{session_id}`（调试）和 `POST /bff/v1/comp/chat/start` 返回。快照现包含：
+
+```json
+{
+  "warmth": 0.42,
+  "trust": 0.08,
+  "intrigue": 0.12,
+  "intimacy": 0.05,
+  "patience": 0.55,
+  "tension": 0.04,
+  "bond": 0.31,
+  "chemistry": 0.18,
+  "bond_label": "acquaintance",
+  "chemistry_label": "spark",
+  "ghost_streak": 0,
+  "total_ghosts": 0,
+  "relationship_label": "stranger",
+  "updated_at": "2026-06-30T12:00:00.000000Z"
+}
+```
+
+- `bond` / `chemistry` —— 进度条值（0–1，曲线映射后），非原始合成值。
+- `bond_label` / `chemistry_label` —— 上述 8 个档位键之一。
+- `relationship_label` —— 遗留映射值（`stranger / friend / slow_burn / romantic`）。
+
+### BFF `/bff/v1/comp/affinity/{session_id}/event`
+
+每轮好感度 delta，不受 `EXPOSE_AFFINITY_DEBUG` 控制。除现有的 `effective_deltas`（每轴 EMA 后）外，事件现还包含：
+
+```json
+{
+  "session_id": "…",
+  "event": {
+    "event_id": "…",
+    "event_type": "message",
+    "effective_deltas": {
+      "warmth": 0.06, "trust": 0.02, "intrigue": 0.0,
+      "intimacy": 0.0, "patience": 0.0, "tension": -0.02
+    },
+    "effective_deltas_computed": {
+      "bond": 0.027,
+      "chemistry": 0.013
+    },
+    "label_changes": {
+      "bond": { "from": "acquaintance", "to": "friend" }
+    },
+    "created_at": "…"
+  }
+}
+```
+
+- `effective_deltas_computed` —— 将每轴 `effective_deltas` 线性折叠到两条线（`Δbond = (Δwarmth + Δtrust + Δintrigue) / 3`，`Δchemistry = (Δwarmth + Δintimacy + Δtension) / 3`）。单位为原始合成增量（非进度条百分比），适合每轮"+X bond / +Y chemistry"的脉冲显示。
+- `label_changes` —— 本轮引擎权威的档位变化；无档位变化时为 `null`（或缺省）。前端无需自行计算变化，直接消费此字段。
+
+两个字段同样镜像到调试接口 `GET /comp/affinity/{session_id}/event` 的条目上。
+
+## 源码
+
+- `crates/eros-engine-core/src/affinity.rs` —— 类型、EMA、时间衰退、bond/chemistry 分数、分档、进度条、标签、diff_labels
+- `crates/eros-engine-store/src/affinity.rs` —— `AffinityRepo`（persist_with_event、record_ghost），迁移 0029
+- `crates/eros-engine-server/src/pipeline/post_process.rs` —— LLM 评估，非对称夹钳
+- `crates/eros-engine-server/src/prompt.rs` —— 好感度 → 态度指令 + 评估 prompt
+- `crates/eros-engine-server/src/routes/dto.rs` —— `AffinitySnapshot`（进度条 + 标签）
+- `crates/eros-engine-server/src/routes/bff/affinity.rs` —— BFF 事件接口
+- `crates/eros-engine-server/src/routes/debug.rs` —— 调试事件日志

--- a/docs/affinity-model.zh.md
+++ b/docs/affinity-model.zh.md
@@ -178,13 +178,13 @@ label_changes = {
   "intimacy": 0.05,
   "patience": 0.55,
   "tension": 0.04,
-  "bond": 0.31,
-  "chemistry": 0.18,
-  "bond_label": "acquaintance",
-  "chemistry_label": "spark",
+  "bond": 0.32,
+  "chemistry": 0.28,
+  "bond_label": "friend",
+  "chemistry_label": "flirtation",
   "ghost_streak": 0,
   "total_ghosts": 0,
-  "relationship_label": "stranger",
+  "relationship_label": "friend",
   "updated_at": "2026-06-30T12:00:00.000000Z"
 }
 ```

--- a/docs/affinity-model.zh.md
+++ b/docs/affinity-model.zh.md
@@ -219,7 +219,7 @@ label_changes = {
 }
 ```
 
-- `effective_deltas_computed` —— 将每轴 `effective_deltas` 线性折叠到两条线（`Δbond = (Δwarmth + Δtrust + Δintrigue) / 3`，`Δchemistry = (Δwarmth + Δintimacy + Δtension) / 3`）。单位为原始合成增量（非进度条百分比），适合每轮"+X bond / +Y chemistry"的脉冲显示。
+- `effective_deltas_computed` —— 本轮精确的 bond/chemistry 行增量，在持久化时从取下界前后的分数计算得出，存储于事件行（`companion_affinity_events.effective_line_deltas`）。单位为原始合成增量（非进度条百分比），适合每轮"+X bond / +Y chemistry"的脉冲显示。迁移前的旧行此字段为 `null` / 缺省。
 - `label_changes` —— 本轮引擎权威的档位变化；无档位变化时为 `null`（或缺省）。前端无需自行计算变化，直接消费此字段。
 
 两个字段同样镜像到调试接口 `GET /comp/affinity/{session_id}/event` 的条目上。

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -568,10 +568,10 @@ or only time-decay), or when the latest event predates affinity migration
 `0014`. `event_type` ∈ `message | gift | proactive | ghost`; a ghost turn
 reports all-zero `effective_deltas`.
 
-- `effective_deltas_computed` — `effective_deltas` folded into Bond/Chemistry
-  lines (`Δbond = (Δwarmth + Δtrust + Δintrigue) / 3`, same for Chemistry).
-  Raw-composite units (not bar-percent). Good for a "+X bond / +Y chemistry"
-  per-turn pulse. Absent on pre-migration-0014 events.
+- `effective_deltas_computed` — exact floored per-turn line delta computed at
+  persist time from the floored before/after bond/chemistry scores; read from
+  the stored event column. Raw-composite units (not bar-percent). Good for a
+  "+X bond / +Y chemistry" per-turn pulse. May be absent on pre-migration rows.
 - `label_changes` — engine-authoritative tier transition (`null` / absent when
   no tier crossed this turn). Frontend stops computing this itself.
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -407,32 +407,45 @@ Current `companion_insights` JSONB plus a weighted `training_level`. Same `user_
 
 ### `GET /comp/affinity/{session_id}`
 
-Live 6-dim vector + ghost stats + relationship label. Gated by `EXPOSE_AFFINITY_DEBUG=true` env var; returns 404 when disabled.
+Live 6-axis vector + Bond/Chemistry bars and labels + ghost stats + legacy
+relationship label. Gated by `EXPOSE_AFFINITY_DEBUG=true` env var; returns 404
+when disabled.
 
 ```json
 {
   "warmth": 0.42,
-  "trust": 0.28,
-  "intrigue": 0.61,
-  "intimacy": 0.15,
+  "trust": 0.08,
+  "intrigue": 0.12,
+  "intimacy": 0.05,
   "patience": 0.55,
-  "tension": 0.18,
+  "tension": 0.04,
+  "bond": 0.31,
+  "chemistry": 0.18,
+  "bond_label": "acquaintance",
+  "chemistry_label": "spark",
   "ghost_streak": 0,
   "total_ghosts": 0,
   "relationship_label": "stranger",
-  "updated_at": "2026-05-05T19:42:00.000000Z"
+  "updated_at": "2026-06-30T12:00:00.000000Z"
 }
 ```
 
-Production deploys typically keep this off (the affinity vector is part of the magic — exposing it ruins the illusion). Turn it on if your frontend wants to render a live radar of the vector.
+- `bond` / `chemistry` — bar values (0–1, curve-applied).
+- `bond_label` ∈ `acquaintance | friend | close_friend | confidant`
+- `chemistry_label` ∈ `spark | flirtation | crush | lover`
+- `relationship_label` — legacy mapped value (`stranger | friend | slow_burn | romantic`; `frenemy` retired from emission).
+
+Production deploys typically keep this off. Turn it on if your frontend wants
+to render a live radar or inspect the derived lines.
 
 ### `GET /comp/affinity/{session_id}/event?limit=20&offset=0&event_type=message`
 
 Paginated affinity **event log** for the session, newest first. Same
 `EXPOSE_AFFINITY_DEBUG=true` gate as the vector route (404 when disabled). Each
-entry carries both the raw per-turn `deltas` (pre-EMA) and the applied
-`effective_deltas` (post-EMA). Optional `event_type` filters the log; `limit`
-defaults to 20 (capped at 100).
+entry carries the raw per-turn `deltas` (pre-EMA), the applied
+`effective_deltas` (post-EMA), the folded `effective_deltas_computed`, and
+`label_changes` when a tier crossed. Optional `event_type` filters the log;
+`limit` defaults to 20 (capped at 100).
 
 ```json
 {
@@ -442,6 +455,8 @@ defaults to 20 (capped at 100).
       "event_type": "message",
       "deltas":           { "warmth": 0.06, "trust": 0.02, "intrigue": 0.0, "intimacy": 0.0, "patience": 0.0, "tension": -0.02 },
       "effective_deltas": { "warmth": 0.03, "trust": 0.01, "intrigue": 0.0, "intimacy": 0.0, "patience": 0.0, "tension": -0.01 },
+      "effective_deltas_computed": { "bond": 0.02, "chemistry": 0.006 },
+      "label_changes": null,
       "created_at": "…"
     }
   ]
@@ -536,6 +551,13 @@ this surface) — but it is still JWT + ownership checked.
       "warmth": 0.03, "trust": 0.01, "intrigue": 0.0,
       "intimacy": 0.0, "patience": 0.0, "tension": -0.01
     },
+    "effective_deltas_computed": {
+      "bond": 0.013,
+      "chemistry": 0.006
+    },
+    "label_changes": {
+      "bond": { "from": "acquaintance", "to": "friend" }
+    },
     "created_at": "…"
   }
 }
@@ -545,6 +567,13 @@ this surface) — but it is still JWT + ownership checked.
 or only time-decay), or when the latest event predates affinity migration
 `0014`. `event_type` ∈ `message | gift | proactive | ghost`; a ghost turn
 reports all-zero `effective_deltas`.
+
+- `effective_deltas_computed` — `effective_deltas` folded into Bond/Chemistry
+  lines (`Δbond = (Δwarmth + Δtrust + Δintrigue) / 3`, same for Chemistry).
+  Raw-composite units (not bar-percent). Good for a "+X bond / +Y chemistry"
+  per-turn pulse. Absent on pre-migration-0014 events.
+- `label_changes` — engine-authoritative tier transition (`null` / absent when
+  no tier crossed this turn). Frontend stops computing this itself.
 
 ## Error responses
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -419,13 +419,13 @@ when disabled.
   "intimacy": 0.05,
   "patience": 0.55,
   "tension": 0.04,
-  "bond": 0.31,
-  "chemistry": 0.18,
-  "bond_label": "acquaintance",
-  "chemistry_label": "spark",
+  "bond": 0.32,
+  "chemistry": 0.28,
+  "bond_label": "friend",
+  "chemistry_label": "flirtation",
   "ghost_streak": 0,
   "total_ghosts": 0,
-  "relationship_label": "stranger",
+  "relationship_label": "friend",
   "updated_at": "2026-06-30T12:00:00.000000Z"
 }
 ```

--- a/docs/api-reference.zh.md
+++ b/docs/api-reference.zh.md
@@ -516,7 +516,7 @@ time-decay），或最近一次事件早于 affinity migration `0014`。`event_t
 ∈ `message | gift | proactive | ghost`；ghost 轮次的 `effective_deltas`
 全为零。
 
-- `effective_deltas_computed` —— `effective_deltas` 折叠到 Bond/Chemistry 两条线（`Δbond = (Δwarmth + Δtrust + Δintrigue) / 3`，Chemistry 同理）。单位为原始合成增量（非进度条百分比），适合每轮 "+X bond / +Y chemistry" 脉冲显示。迁移 0014 之前的事件中缺省。
+- `effective_deltas_computed` —— 精确的每轮行增量，在持久化时从取下界前后的 bond/chemistry 分数计算得出，存储于事件行。单位为原始合成增量（非进度条百分比），适合每轮 "+X bond / +Y chemistry" 脉冲显示。迁移前的旧行可能缺省。
 - `label_changes` —— 引擎权威的档位变化（本轮无档位跨越时为 `null` / 缺省）。前端无需自行计算变化。
 
 ## 錯誤響應

--- a/docs/api-reference.zh.md
+++ b/docs/api-reference.zh.md
@@ -366,30 +366,40 @@ curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json"
 
 ### `GET /comp/affinity/{session_id}`
 
-實時 6 維向量 + ghost 統計 + 關係標籤。受 `EXPOSE_AFFINITY_DEBUG=true` 環境變量控制；關閉時返 404。
+实时 6 轴向量 + Bond/Chemistry 进度条与标签 + ghost 统计 + 遗留关系标签。受 `EXPOSE_AFFINITY_DEBUG=true` 环境变量控制；关闭时返 404。
 
 ```json
 {
   "warmth": 0.42,
-  "trust": 0.28,
-  "intrigue": 0.61,
-  "intimacy": 0.15,
+  "trust": 0.08,
+  "intrigue": 0.12,
+  "intimacy": 0.05,
   "patience": 0.55,
-  "tension": 0.18,
+  "tension": 0.04,
+  "bond": 0.31,
+  "chemistry": 0.18,
+  "bond_label": "acquaintance",
+  "chemistry_label": "spark",
   "ghost_streak": 0,
   "total_ghosts": 0,
   "relationship_label": "stranger",
-  "updated_at": "2026-05-05T19:42:00.000000Z"
+  "updated_at": "2026-06-30T12:00:00.000000Z"
 }
 ```
 
-生產部署通常關著（好感度向量是魔法的一部份——把它暴露出來會破壞錯覺）。如果你的前端想實時畫好感度雷達圖，再把它打開。
+- `bond` / `chemistry` —— 进度条值（0–1，曲线映射后）。
+- `bond_label` ∈ `acquaintance | friend | close_friend | confidant`
+- `chemistry_label` ∈ `spark | flirtation | crush | lover`
+- `relationship_label` —— 遗留映射值（`stranger | friend | slow_burn | romantic`；`frenemy` 已停止输出）。
+
+生产部署通常关着。若前端需要渲染实时雷达图或检查衍生线，再打开。
 
 ### `GET /comp/affinity/{session_id}/event?limit=20&offset=0&event_type=message`
 
 该 session 的好感度**事件日志**，分页、最新在前。和向量路由一样受
 `EXPOSE_AFFINITY_DEBUG=true` 控制（关闭时 404）。每条同时带原始的每轮
-`deltas`（EMA 前）和实际应用的 `effective_deltas`（EMA 后）。`event_type`
+`deltas`（EMA 前）、实际应用的 `effective_deltas`（EMA 后）、折叠后的
+`effective_deltas_computed`，以及档位跨越时的 `label_changes`。`event_type`
 可选用于过滤；`limit` 默认 20（上限 100）。
 
 ```json
@@ -400,6 +410,8 @@ curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json"
       "event_type": "message",
       "deltas":           { "warmth": 0.06, "trust": 0.02, "intrigue": 0.0, "intimacy": 0.0, "patience": 0.0, "tension": -0.02 },
       "effective_deltas": { "warmth": 0.03, "trust": 0.01, "intrigue": 0.0, "intimacy": 0.0, "patience": 0.0, "tension": -0.01 },
+      "effective_deltas_computed": { "bond": 0.02, "chemistry": 0.006 },
+      "label_changes": null,
       "created_at": "…"
     }
   ]
@@ -473,9 +485,9 @@ canonical `/comp/*` 路由永遠不會為了遷就前端而被改形狀——而
 
 ### `GET /bff/v1/comp/affinity/{session_id}/event`
 
-最近一次用戶輪次的好感度 delta（post-EMA），供前端做逐輪觀測。與
-canonical 的 `/comp/affinity/{session_id}` debug 路由不同，它 **不受**
-`EXPOSE_AFFINITY_DEBUG` 控制（這塊歸前端所有）——但仍做 JWT + ownership 檢查。
+最近一次用户轮次的好感度 delta（post-EMA），供前端做逐轮观测。与
+canonical 的 `/comp/affinity/{session_id}` debug 路由不同，它**不受**
+`EXPOSE_AFFINITY_DEBUG` 控制（这块归前端所有）——但仍做 JWT + ownership 检查。
 
 ```json
 {
@@ -487,15 +499,25 @@ canonical 的 `/comp/affinity/{session_id}` debug 路由不同，它 **不受**
       "warmth": 0.03, "trust": 0.01, "intrigue": 0.0,
       "intimacy": 0.0, "patience": 0.0, "tension": -0.01
     },
+    "effective_deltas_computed": {
+      "bond": 0.013,
+      "chemistry": 0.006
+    },
+    "label_changes": {
+      "bond": { "from": "acquaintance", "to": "friend" }
+    },
     "created_at": "…"
   }
 }
 ```
 
-`event` 為 `null` 的情況：還沒有任何用戶輪次事件（全新 session，或只有
-time-decay），或最近一次事件早於 affinity migration `0014`。`event_type`
-∈ `message | gift | proactive | ghost`；ghost 輪次的 `effective_deltas`
-全為零。
+`event` 为 `null` 的情况：还没有任何用户轮次事件（全新 session，或只有
+time-decay），或最近一次事件早于 affinity migration `0014`。`event_type`
+∈ `message | gift | proactive | ghost`；ghost 轮次的 `effective_deltas`
+全为零。
+
+- `effective_deltas_computed` —— `effective_deltas` 折叠到 Bond/Chemistry 两条线（`Δbond = (Δwarmth + Δtrust + Δintrigue) / 3`，Chemistry 同理）。单位为原始合成增量（非进度条百分比），适合每轮 "+X bond / +Y chemistry" 脉冲显示。迁移 0014 之前的事件中缺省。
+- `label_changes` —— 引擎权威的档位变化（本轮无档位跨越时为 `null` / 缺省）。前端无需自行计算变化。
 
 ## 錯誤響應
 

--- a/docs/api-reference.zh.md
+++ b/docs/api-reference.zh.md
@@ -376,13 +376,13 @@ curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json"
   "intimacy": 0.05,
   "patience": 0.55,
   "tension": 0.04,
-  "bond": 0.31,
-  "chemistry": 0.18,
-  "bond_label": "acquaintance",
-  "chemistry_label": "spark",
+  "bond": 0.32,
+  "chemistry": 0.28,
+  "bond_label": "friend",
+  "chemistry_label": "flirtation",
   "ghost_streak": 0,
   "total_ghosts": 0,
-  "relationship_label": "stranger",
+  "relationship_label": "friend",
   "updated_at": "2026-06-30T12:00:00.000000Z"
 }
 ```

--- a/docs/superpowers/specs/2026-06-30-affinity-bond-chemistry-tiers-design.md
+++ b/docs/superpowers/specs/2026-06-30-affinity-bond-chemistry-tiers-design.md
@@ -1,0 +1,378 @@
+# Affinity: Bond / Chemistry lines, tiered labels, and a sparser eval distribution
+
+**Date:** 2026-06-30
+**Status:** Design (approved for spec review)
+**Related:** issue #130 (deferred `filter_prompt` override for `affinity_evaluation`),
+`docs/superpowers/specs/2026-05-20-affinity-event-delta-design.md` (BFF event surface)
+
+## 1. Motivation
+
+The companion's relationship state is computed from a 6-axis affinity vector but
+surfaced to users through two folded bars — **Bond** (friendship) and
+**Chemistry** (romance). Three problems today:
+
+1. **Labels are too coarse and tangled.** `Affinity::infer_label` produces only 5
+   states (`stranger / romantic / friend / frenemy / slow_burn`) from ad-hoc
+   multi-axis threshold conditions. It does not map cleanly onto the two bars.
+2. **The bars climb too fast, with no sense of achievement.** The 6→2 folding was
+   decided off-the-cuff and lives in the frontend; each bar rises quickly and
+   linearly, so reaching "100%" feels unearned.
+3. **The eval scoring band is too narrow and symmetric.** The evaluator emits
+   tiny per-axis deltas (≈±0.15 raw, EMA-compressed to ≈±0.03/turn). Gains are
+   easy and small, losses rare and slow. There is no "rare-but-big" gain and no
+   readily-firing loss.
+
+This change makes the engine the single source of truth for the two lines: it
+computes Bond/Chemistry, derives a tiered label per line, exposes them, and
+reshapes the eval distribution — **without changing the 6-axis base.**
+
+## 2. Goals / non-goals
+
+**Goals**
+
+- Two derived lines, **Bond** and **Chemistry**, each with **4 tiered labels**
+  (8 names) + a shared `stranger` → the "9 relationship states".
+- Each line's label is a **pure monotonic function of that line's value**
+  (kills the `infer_label` heuristic).
+- An **exponential-feel climb**: early tiers easy, top tiers a grind.
+- Engine **owns and exposes** Bond/Chemistry (value + label); the frontend only
+  renders.
+- Engine is the **single authority for per-turn label transitions** — computed
+  deterministically from the LLM's 6-axis deltas, stored on the event row, and
+  served to the frontend (which stops computing them itself).
+- A **sparser, asymmetric eval distribution**: most turns score 0; positive
+  moments are rare but can be large; negative moments fire more readily and can
+  be larger.
+
+**Non-goals (explicitly out of scope)**
+
+- The 6-axis representation, EMA smoothing (`apply_deltas`), and time decay
+  (`apply_time_decay`) are **unchanged**.
+- `AffinityScope` / `length_score` (prompt-injection scoping, issue #40) is
+  **untouched** — even though its `bond()`/`chemistry()` axis-sets use a
+  *different* grouping (see §4.1 naming note).
+- The chat companion prompt is unchanged.
+- The `filter_prompt` override for `affinity_evaluation` is **deferred** (#130);
+  the evaluator prompt stays a single in-code string — only its scoring guidance
+  changes (§4.5).
+- Frontend rendering (bar widths, colors, copy) is the frontend's concern.
+
+## 3. Current state (reference)
+
+- 6 axes on `Affinity` (`crates/eros-engine-core/src/affinity.rs`): `warmth`
+  (−1..1), `trust`/`intrigue`/`intimacy`/`patience`/`tension` (0..1).
+- `apply_deltas(d, ema_inertia)`: `blend = 1 − ema_inertia`; prod
+  `EMA_INERTIA=0.8` → blend 0.2.
+- `infer_label` → 5-state heuristic, written on every persist via the store
+  (`crates/eros-engine-store/src/affinity.rs` `persist_with_event`).
+- `parse_affinity_eval` (`pipeline/post_process.rs`) clamps each emitted axis to
+  `±LLM_AXIS_CAP` (0.15).
+- Surfaced only via `AffinitySnapshot` (`routes/dto.rs`) — used by
+  `/comp/affinity/{sid}` (debug) and `/bff/v1/comp/chat/start` — and the BFF
+  per-turn delta `/bff/v1/comp/affinity/{sid}/event`
+  (`routes/bff/affinity.rs`). The 2-axis (Bond/Chemistry) folding currently
+  lives in the frontend.
+
+## 4. Design
+
+### 4.1 Folding (core)
+
+Add two pure methods on `Affinity` (core). With `warm01 = (warmth + 1.0) / 2.0`:
+
+```
+bond_score      = (warm01 + trust   + intrigue) / 3      ∈ [0, 1]   // 友情
+chemistry_score = (warm01 + intimacy + tension)  / 3      ∈ [0, 1]   // 爱情
+```
+
+- **`warmth` is shared** into both lines (it underlies both friendship and
+  romance; cold replies should tank both).
+- **`patience` is excluded** from both — it is rule-owned (maintained by
+  decay/rules, never scored by the evaluator) and stays an internal pacing axis.
+
+> **Naming note (known wart, intentionally not fixed here):**
+> `AffinityScope::bond()/chemistry()` (used for prompt-injection scoping and
+> `length_score`) use a *different* grouping (`bond = warmth+intimacy+tension`,
+> `chemistry = trust+intrigue+patience`). That is the older off-the-cuff split.
+> We do **not** touch it to avoid reply-length regressions. The new
+> `bond_score`/`chemistry_score` are independent; document the distinction in
+> code comments. A future cleanup may unify them.
+
+### 4.2 Tiers + bar curve (core)
+
+Four tiers per line, with **widening raw-score gaps** (each step costs more):
+
+| tier | raw range      | gap   |
+|------|----------------|-------|
+| 1    | `[0.00, 0.15)` | 0.15  |
+| 2    | `[0.15, 0.35)` | 0.20  |
+| 3    | `[0.35, 0.62)` | 0.27  |
+| 4    | `[0.62, 1.00]` | 0.38  |
+
+**Bar value (0..1, what the frontend renders):** each tier maps to an even **25%
+band**, linear within:
+
+```
+bar(raw) = band_lo(tier) + (raw − tier_lo) / (tier_hi − tier_lo) * 0.25
+  T1: 0.00 + (raw − 0.00)/0.15 * 0.25   → [0.00, 0.25)
+  T2: 0.25 + (raw − 0.15)/0.20 * 0.25   → [0.25, 0.50)
+  T3: 0.50 + (raw − 0.35)/0.27 * 0.25   → [0.50, 0.75)
+  T4: 0.75 + (raw − 0.62)/0.38 * 0.25   → [0.75, 1.00]
+clamp to [0, 1]
+```
+
+Because higher tiers span more raw affinity, the bar fills fast early and crawls
+near 100% → the desired "前两级简单、后两级难" without a literal `exp()`. A fixed
+per-turn raw delta also moves the bar **less** in higher tiers.
+
+All thresholds and bands are **tunable constants** — flagged for review.
+
+### 4.3 Tiered labels (core)
+
+Two enums (serialized snake_case keys; Chinese display is a frontend concern,
+suggestions given for reference):
+
+| line          | tier 1                 | tier 2              | tier 3                  | tier 4            |
+|---------------|------------------------|---------------------|-------------------------|-------------------|
+| **Bond**      | `acquaintance` 点头之交 | `friend` 朋友        | `close_friend` 好友      | `confidant` 知己   |
+| **Chemistry** | `spark` 来电            | `flirtation` 暧昧    | `crush` 心动             | `lover` 恋人       |
+
+`bond_label()` / `chemistry_label()` return the tier of the respective score.
+These two fields are **always one of their 4 values** (never `stranger`);
+`stranger` is conveyed only by the legacy field (§4.4).
+
+### 4.4 Legacy `relationship_label` (back-compat)
+
+The legacy column + DTO field **keep the old name set**
+(`stranger / friend / slow_burn / romantic`; `frenemy` retired from emission but
+kept parseable in the enum). It is now a **pure function of the two raw scores**
+(replacing `infer_label`):
+
+```
+legacy_relationship_label(bond, chem):
+  if tier(bond) == 1 && tier(chem) == 1            -> stranger
+  let higher = (chem > bond) ? Chemistry : Bond     // tie -> Bond
+  match higher:
+    Bond                                            -> friend
+    Chemistry if tier(chem) in {1,2}                -> slow_burn
+    Chemistry if tier(chem) in {3,4}                -> romantic
+```
+
+The store writes this value to `companion_affinity.relationship_label` (so DB
+consumers stay valid); the DTO serves it. Mapping table is **tunable** — flagged
+for review.
+
+### 4.5 Eval distribution + asymmetric cap (post_process + prompt)
+
+**Cap.** Replace the symmetric `LLM_AXIS_CAP = 0.15` with an asymmetric clamp in
+`parse_affinity_eval`:
+
+```
+POS_CAP = +0.4   NEG_CAP = -0.6
+delta_axis = raw.clamp(NEG_CAP, POS_CAP)
+```
+
+With EMA blend 0.2 this yields per-turn maxima of **+0.08 / −0.12** on a single
+axis (vs. ±0.03 today). `patience` stays forced to 0 (rule-owned), unchanged.
+
+**Prompt (scoring guidance only).** Rewrite the magnitude guidance in
+`prompt::affinity_eval_prompt`. The structure (six current values shown, JSON
+output schema for warmth/trust/intrigue/intimacy/tension + `reason`) is
+**unchanged**; only the guidance sentence changes to express the new
+distribution:
+
+- Ordinary chitchat / acknowledgements → **exactly `0`** (not "≈0").
+- Positive deltas only on a genuine relationship-advancing moment (real warmth,
+  self-disclosure, vulnerability, flirtation that lands); these are **rare but
+  may be large** (up to ≈ +0.4 per axis).
+- Negative deltas should fire **readily** for coldness, perfunctory/repetitive
+  replies, boredom, boundary-crossing, conflict, or being ignored; these may be
+  **larger** (down to ≈ −0.6 per axis).
+
+Net effect: gains are hard (most turns 0) but a real moment can jump a bar;
+losses are more frequent and bite harder — all via the prompt + cap, with EMA and
+decay untouched (per decision).
+
+### 4.6 Persistence (store + migration)
+
+New migration `0029_affinity_bond_chemistry.sql`:
+
+```sql
+-- current-state raw composites on the affinity row
+ALTER TABLE engine.companion_affinity
+  ADD COLUMN bond      DOUBLE PRECISION NOT NULL DEFAULT 0,
+  ADD COLUMN chemistry DOUBLE PRECISION NOT NULL DEFAULT 0;
+
+-- backfill existing rows from current axes (raw composite)
+UPDATE engine.companion_affinity SET
+  bond      = LEAST(1, GREATEST(0, ((warmth + 1)/2 + trust   + intrigue) / 3)),
+  chemistry = LEAST(1, GREATEST(0, ((warmth + 1)/2 + intimacy + tension)  / 3));
+
+-- per-turn tier transition; NULL on turns where no tier changed
+ALTER TABLE engine.companion_affinity_events
+  ADD COLUMN label_changes JSONB;
+```
+
+The `companion_affinity` columns store the **raw composite** (0..1), not the bar
+value. Rationale: the curve/thresholds can be retuned later without rewriting
+history; the curve lives only in the read layer.
+
+**Per-turn label change (engine-computed, deterministic).** The LLM still only
+evaluates the 6 raw axes; the engine derives bond/chemistry, their tiers, and the
+tier *transition* for the turn. In `persist_with_event`, snapshot the tiers over
+the **same delta-only span as `effective_deltas`** (post-decay `before` →
+post-delta `after`):
+
+```
+before_bond = bond_tier(bond_score(before))   after_bond = bond_tier(current.bond_score())
+before_chem = chem_tier(chemistry_score(before)) after_chem = chem_tier(current.chemistry_score())
+
+label_changes = {
+  bond:      { from, to } if before_bond != after_bond,
+  chemistry: { from, to } if before_chem != after_chem,
+}  // NULL when neither tier moved
+```
+
+Delta-scoped (excludes decay) so it always agrees with `effective_deltas`.
+`from`/`to` are tier **keys**. The legacy `relationship_label` transition is
+**not** included (deprecated, derivable). Decay-induced tier drift is not
+recorded as a discrete event (the absolute label is always available via the
+snapshot); a follow-up could add it if needed.
+
+New core type (so the store serializes a typed value, mirroring how `effective`
+reuses `AffinityDeltas`):
+
+```rust
+pub struct LabelTransition { pub from: String, pub to: String }
+pub struct TurnLabelChanges {            // serde skips None fields
+    pub bond: Option<LabelTransition>,
+    pub chemistry: Option<LabelTransition>,
+}
+// core: diff_labels(before: &Affinity, after: &Affinity) -> Option<TurnLabelChanges>
+```
+
+Store changes (`crates/eros-engine-store/src/affinity.rs`):
+
+- `AffinityRow` + the `SELECT`/`INSERT`/`UPDATE` column lists gain `bond`,
+  `chemistry`; `AffinityEventRow` gains `label_changes: Option<serde_json::Value>`.
+- `persist_with_event`: clone the post-decay/pre-delta `current` as the `before`
+  baseline; after `apply_deltas`, write `bond`/`chemistry` (raw) +
+  `relationship_label` (new `legacy_relationship_label()`) on the row, and the
+  event's `label_changes` (NULL when empty).
+- `record_ghost`, `load_or_create`: set `bond`/`chemistry` from the current axes
+  (ghost: no axis change → no `label_changes`).
+
+### 4.7 DTO / API surfaces
+
+**`AffinitySnapshot`** (`routes/dto.rs`) — add four fields; compute on the fly
+from the axes (pure functions):
+
+```rust
+pub bond: f64,            // bar value 0..1 (curve-applied)
+pub chemistry: f64,       // bar value 0..1 (curve-applied)
+pub bond_label: String,   // one of the 4 bond keys
+pub chemistry_label: String, // one of the 4 chemistry keys
+// relationship_label: unchanged field, now the legacy-mapped value (old names)
+```
+
+**BFF `/bff/v1/comp/affinity/{sid}/event`** (`routes/bff/affinity.rs`) — add two
+siblings to `effective_deltas`:
+
+```rust
+pub effective_deltas_computed: BondChemistryDeltas, // { bond: f64, chemistry: f64 }
+pub label_changes: Option<TurnLabelChangesDto>,     // engine-authoritative tier transition
+```
+
+`effective_deltas_computed` is the existing **post-EMA per-axis**
+`effective_deltas` **folded linearly** into the two lines:
+
+```
+Δbond      = (Δwarmth/2 + Δtrust   + Δintrigue) / 3
+Δchemistry = (Δwarmth/2 + Δintimacy + Δtension)  / 3
+```
+
+Raw-composite increment (not bar-% units): zero-cost, good for a per-turn
+"+X bond / +Y chemistry" pulse.
+
+`label_changes` is read **straight from the stored event column** (§4.6) — the
+engine is the single authority, so the frontend stops computing transitions
+itself (today's drift risk). `None`/absent when no tier moved that turn.
+
+Both fields are mirrored onto the debug `/comp/affinity/{sid}/event` entries for
+consistency (`effective_deltas_computed` is `Option`, `None` for pre-0014 rows
+with no `effective_deltas`).
+
+## 5. Data flow
+
+```
+chat turn → post_process::evaluate_affinity
+  → eval LLM (new prompt) → per-axis raw deltas
+  → parse_affinity_eval (asymmetric clamp -0.6..+0.4)
+  → merge with rule deltas → apply_deltas (EMA 0.2, unchanged)
+  → store.persist_with_event:
+       before := post-decay/pre-delta snapshot
+       write 6 axes (unchanged)
+       write bond/chemistry = bond_score()/chemistry_score()   [raw]
+       write relationship_label = legacy_relationship_label()  [old names]
+       write event row (deltas, effective_deltas,
+                        label_changes = diff_labels(before, after) or NULL)
+
+read:
+  AffinitySnapshot.from(Affinity) → bar(bond_score), bar(chemistry_score),
+                                     bond_label, chemistry_label, legacy label
+  BFF /event → effective_deltas + effective_deltas_computed (folded)
+             + label_changes (read from the stored column)
+```
+
+## 6. Files touched + tests
+
+**Core** (`eros-engine-core/src/affinity.rs`)
+- Add `bond_score`, `chemistry_score`, the tier thresholds + `bar()` helper,
+  `BondLabel`/`ChemistryLabel` enums + `bond_label`/`chemistry_label`,
+  `legacy_relationship_label` (replaces `infer_label`), `LabelTransition` /
+  `TurnLabelChanges` + `diff_labels`.
+- Tests: score formulas; tier-boundary cases; `bar()` boundaries (0/0.15/0.35/
+  0.62/1.0 → 0/0.25/0.50/0.75/1.0); legacy mapping table incl. `stranger` and
+  tie→bond; `diff_labels` (single-line change, both, none→None); remove/replace
+  old `infer_label_*` tests.
+
+**Store** (`eros-engine-store/src/affinity.rs`, `migrations/0029_*.sql`)
+- Migration (add `bond`/`chemistry` + backfill; add events `label_changes`).
+  Row structs (`AffinityRow`, `AffinityEventRow`) + queries + writes for
+  bond/chemistry + new legacy label + per-event `label_changes`.
+- Tests: persisted bond/chemistry match `*_score()`; relationship_label uses new
+  mapping; a tier-crossing turn writes `label_changes`, a flat turn writes NULL.
+
+**post_process** (`pipeline/post_process.rs`)
+- Asymmetric clamp; update `parse_affinity_eval_clamps_out_of_range` (now
+  +0.4 / −0.6).
+
+**prompt** (`prompt.rs`)
+- Rewrite the magnitude-guidance sentence in `affinity_eval_prompt`; keep the
+  asserted six-value lines + JSON schema substrings so existing assertions hold.
+
+**DTO / routes** (`routes/dto.rs`, `routes/bff/affinity.rs`, `routes/debug.rs`)
+- `AffinitySnapshot` four new fields + tier→key serialization.
+- `BffAffinityDelta.effective_deltas_computed` + `.label_changes`; debug
+  `AffinityEventEntry` mirror. Tests: snapshot includes new fields/labels; BFF
+  folded delta correct; BFF `label_changes` present on a tier-crossing turn,
+  absent on a flat turn.
+
+**Docs**
+- Full rewrite of `docs/affinity-model.md` + `docs/affinity-model.zh.md` (stale):
+  6-axis base, the two derived lines + formulas, tiers + bar curve, labels,
+  legacy mapping, eval distribution + caps, persistence, DTO/BFF surfaces.
+- Light touch on `docs/api-reference*.md` where affinity fields are described.
+  OpenAPI schema updates automatically from the DTO `ToSchema` derives.
+
+## 7. Tunables (review these)
+
+- Tier thresholds `0.15 / 0.35 / 0.62` and the even 25% bands.
+- Tier name keys (8) — rename freely.
+- Caps `+0.4 / −0.6`.
+- Legacy mapping table (esp. retiring `frenemy`; chemistry tier 1–2 → `slow_burn`).
+- Folding weights (currently equal; `warmth` shared).
+
+## 8. Open items
+
+- None blocking. The naming overlap with `AffinityScope::bond()/chemistry()`
+  (§4.1) is deliberately left for a future unification.

--- a/docs/superpowers/specs/2026-06-30-affinity-bond-chemistry-tiers-design.md
+++ b/docs/superpowers/specs/2026-06-30-affinity-bond-chemistry-tiers-design.md
@@ -47,7 +47,8 @@ reshapes the eval distribution — **without changing the 6-axis base.**
 **Non-goals (explicitly out of scope)**
 
 - The 6-axis representation, EMA smoothing (`apply_deltas`), and time decay
-  (`apply_time_decay`) are **unchanged**.
+  (`apply_time_decay`) are **unchanged**. (The new-row *default seed* values are
+  lowered — §4.8 — but the axis mechanics and existing rows are untouched.)
 - `AffinityScope` / `length_score` (prompt-injection scoping, issue #40) is
   **untouched** — even though its `bond()`/`chemistry()` axis-sets use a
   *different* grouping (see §4.1 naming note).
@@ -77,15 +78,17 @@ reshapes the eval distribution — **without changing the 6-axis base.**
 
 ### 4.1 Folding (core)
 
-Add two pure methods on `Affinity` (core). With `warm01 = (warmth + 1.0) / 2.0`:
+Add two pure methods on `Affinity` (core). With `warm_pos = warmth.max(0.0)`
+(floored at 0 — **not** `(warmth+1)/2`; see §4.8):
 
 ```
-bond_score      = (warm01 + trust   + intrigue) / 3      ∈ [0, 1]   // 友情
-chemistry_score = (warm01 + intimacy + tension)  / 3      ∈ [0, 1]   // 爱情
+bond_score      = (warm_pos + trust   + intrigue) / 3    ∈ [0, 1]   // 友情
+chemistry_score = (warm_pos + intimacy + tension) / 3    ∈ [0, 1]   // 爱情
 ```
 
 - **`warmth` is shared** into both lines (it underlies both friendship and
-  romance; cold replies should tank both).
+  romance; cold replies tank both). Floored at 0, so a neutral/cold session
+  contributes nothing — a fresh session sits near 0, not at a 0.5 baseline.
 - **`patience` is excluded** from both — it is rule-owned (maintained by
   decay/rules, never scored by the evaluator) and stays an internal pacing axis.
 
@@ -198,13 +201,23 @@ New migration `0029_affinity_bond_chemistry.sql`:
 
 ```sql
 -- raw composites kept in lockstep with the axes by the DB (Postgres 12+).
--- Mirror of eros_engine_core::affinity::{bond_score,chemistry_score} — keep in
--- sync if the folding formula ever changes.
+-- Mirror of eros_engine_core::affinity::{bond_score,chemistry_score}
+-- (warmth floored at 0 via GREATEST) — keep in sync if the formula changes.
 ALTER TABLE engine.companion_affinity
   ADD COLUMN bond DOUBLE PRECISION
-    GENERATED ALWAYS AS (LEAST(1, GREATEST(0, ((warmth + 1)/2 + trust    + intrigue) / 3))) STORED,
+    GENERATED ALWAYS AS (LEAST(1, GREATEST(0, (GREATEST(warmth,0) + trust    + intrigue) / 3))) STORED,
   ADD COLUMN chemistry DOUBLE PRECISION
-    GENERATED ALWAYS AS (LEAST(1, GREATEST(0, ((warmth + 1)/2 + intimacy + tension)  / 3))) STORED;
+    GENERATED ALWAYS AS (LEAST(1, GREATEST(0, (GREATEST(warmth,0) + intimacy + tension)  / 3))) STORED;
+
+-- lower the new-row default seed so a fresh session reads as "stranger" with
+-- near-empty bars (existing rows unaffected by an ALTER ... SET DEFAULT).
+-- warmth kept slightly positive (0.1 → still "平淡"/neutral attitude, not 冷淡);
+-- patience keeps its 0.5 pacing default (rule-owned, not a bar). See §4.8.
+ALTER TABLE engine.companion_affinity
+  ALTER COLUMN warmth   SET DEFAULT 0.1,
+  ALTER COLUMN trust    SET DEFAULT 0.0,
+  ALTER COLUMN intrigue SET DEFAULT 0.0,
+  ALTER COLUMN tension  SET DEFAULT 0.0;
 
 -- per-turn tier transition; NULL on turns where no tier changed
 ALTER TABLE engine.companion_affinity_events
@@ -308,6 +321,29 @@ Both fields are mirrored onto the debug `/comp/affinity/{sid}/event` entries for
 consistency (`effective_deltas_computed` is `Option`, `None` for pre-0014 rows
 with no `effective_deltas`).
 
+### 4.8 Starting point (default seed)
+
+With the floored composite, a fresh session must still seed low enough to read as
+`stranger`. The current defaults (`warmth 0.3, trust 0.2, intrigue 0.5, …`) would
+put a brand-new session at bond ≈ 0.33 (tier 2) — past the "easy early" climb. So
+migration 0029 lowers the new-row default seed:
+
+| axis | old default | new default | why |
+|------|-------------|-------------|-----|
+| `warmth` | 0.3 | **0.1** | keep a neutral "平淡" opening tone (0 → 冷淡); near-zero bar |
+| `trust` | 0.2 | **0.0** | start with no earned trust |
+| `intrigue` | 0.5 | **0.0** | start with no built-up interest |
+| `tension` | 0.1 | **0.0** | no romantic tension yet |
+| `intimacy` | 0.0 | 0.0 | already zero |
+| `patience` | 0.5 | 0.5 | rule-owned pacing axis, not a bar — unchanged |
+
+Result: a fresh session has bond ≈ chemistry ≈ 0.033 → both tier 1 → legacy
+`stranger`; bars start ≈ 5–6%. Only **new** rows are affected (`ALTER COLUMN …
+SET DEFAULT` leaves existing rows alone). Side effects to expect (all benign,
+flagged for review): a brand-new session's reply-length tier and warmth attitude
+shift toward the strictest/neutral end, matching a true "just met" state. The
+seed values are **tunable**.
+
 ## 5. Data flow
 
 ```
@@ -342,12 +378,14 @@ read:
   old `infer_label_*` tests.
 
 **Store** (`eros-engine-store/src/affinity.rs`, `migrations/0029_*.sql`)
-- Migration: `bond`/`chemistry` as `GENERATED ALWAYS ... STORED`; events
-  `label_changes JSONB`. `AffinityEventRow` + `list_events`/`latest_turn_event`
-  add `label_changes`; `persist_with_event` writes new legacy label + per-event
-  `label_changes` (bond/chemistry are DB-generated, no write code).
+- Migration: `bond`/`chemistry` as `GENERATED ALWAYS ... STORED`; lowered
+  default seed (§4.8); events `label_changes JSONB`. `AffinityEventRow` +
+  `list_events`/`latest_turn_event` add `label_changes`; `persist_with_event`
+  writes new legacy label + per-event `label_changes` (bond/chemistry are
+  DB-generated, no write code).
 - Tests: generated bond/chemistry match `*_score()`; relationship_label uses new
-  mapping; a tier-crossing turn writes `label_changes`, a flat turn writes NULL.
+  mapping; a tier-crossing turn writes `label_changes`, a flat turn writes NULL;
+  update `load_or_create_idempotent` (now seeds `warmth 0.1`, `intrigue 0`).
 
 **post_process** (`pipeline/post_process.rs`)
 - Asymmetric clamp; update `parse_affinity_eval_clamps_out_of_range` (now
@@ -377,7 +415,8 @@ read:
 - Tier name keys (8) — rename freely.
 - Caps `+0.4 / −0.6`.
 - Legacy mapping table (esp. retiring `frenemy`; chemistry tier 1–2 → `slow_burn`).
-- Folding weights (currently equal; `warmth` shared).
+- Folding weights (currently equal; `warmth` shared, floored at 0).
+- The new-row default seed (§4.8: `warmth 0.1`, `trust/intrigue/tension 0`).
 
 ## 8. Open items
 

--- a/docs/superpowers/specs/2026-06-30-affinity-bond-chemistry-tiers-design.md
+++ b/docs/superpowers/specs/2026-06-30-affinity-bond-chemistry-tiers-design.md
@@ -306,12 +306,14 @@ pub label_changes: Option<TurnLabelChangesDto>,     // engine-authoritative tier
 `effective_deltas` **folded linearly** into the two lines:
 
 ```
-Δbond      = (Δwarmth/2 + Δtrust   + Δintrigue) / 3
-Δchemistry = (Δwarmth/2 + Δintimacy + Δtension)  / 3
+Δbond      = (Δwarmth + Δtrust   + Δintrigue) / 3
+Δchemistry = (Δwarmth + Δintimacy + Δtension)  / 3
 ```
 
 Raw-composite increment (not bar-% units): zero-cost, good for a per-turn
-"+X bond / +Y chemistry" pulse.
+"+X bond / +Y chemistry" pulse. Exact while warmth stays ≥ 0 across the turn
+(warmth is floored at 0 in the absolute composite); a fair approximation when a
+turn crosses warmth = 0.
 
 `label_changes` is read **straight from the stored event column** (§4.6) — the
 engine is the single authority, so the frontend stops computing transitions

--- a/docs/superpowers/specs/2026-06-30-affinity-bond-chemistry-tiers-design.md
+++ b/docs/superpowers/specs/2026-06-30-affinity-bond-chemistry-tiers-design.md
@@ -222,6 +222,12 @@ ALTER TABLE engine.companion_affinity
 -- per-turn tier transition; NULL on turns where no tier changed
 ALTER TABLE engine.companion_affinity_events
   ADD COLUMN label_changes JSONB;
+
+-- exact per-turn line deltas (floored before/after bond/chemistry scores),
+-- computed at persist time so the per-turn pulse is exact even when warmth < 0.
+-- NULL on pre-migration rows.
+ALTER TABLE engine.companion_affinity_events
+  ADD COLUMN effective_line_deltas JSONB;
 ```
 
 The `companion_affinity` columns store the **raw composite** (0..1), not the bar
@@ -270,8 +276,10 @@ pub struct TurnLabelChanges {            // serde skips None fields
 Store changes (`crates/eros-engine-store/src/affinity.rs`) — note `bond`/
 `chemistry` are DB-generated, so **no engine write code** for them:
 
-- `AffinityEventRow` gains `label_changes: Option<serde_json::Value>`; the
-  `list_events` / `latest_turn_event` `SELECT`s add `e.label_changes`.
+- `AffinityEventRow` gains `label_changes: Option<serde_json::Value>` and
+  `effective_line_deltas: Option<serde_json::Value>`; the
+  `list_events` / `latest_turn_event` `SELECT`s add both `e.label_changes` and
+  `e.effective_line_deltas`.
   (`AffinityRow` / `SELECT *` is unaffected — it ignores the new generated
   columns, and the read layer derives bond/chemistry from the axes anyway.)
 - `persist_with_event`: clone the post-decay/pre-delta `current` as the `before`
@@ -298,22 +306,19 @@ pub chemistry_label: String, // one of the 4 chemistry keys
 siblings to `effective_deltas`:
 
 ```rust
-pub effective_deltas_computed: BondChemistryDeltas, // { bond: f64, chemistry: f64 }
-pub label_changes: Option<TurnLabelChangesDto>,     // engine-authoritative tier transition
+pub effective_deltas_computed: Option<BondChemistryDeltas>, // { bond: f64, chemistry: f64 }; None on pre-migration rows
+pub label_changes: Option<TurnLabelChangesDto>,             // engine-authoritative tier transition
 ```
 
-`effective_deltas_computed` is the existing **post-EMA per-axis**
-`effective_deltas` **folded linearly** into the two lines:
+`effective_deltas_computed` is the **exact** per-turn bond/chemistry delta
+computed at persist time from the floored before/after scores (`bond_score()` /
+`chemistry_score()` floor warmth at 0 via `max(warmth, 0)`), stored on
+`companion_affinity_events.effective_line_deltas`, and read by the BFF and debug
+`/event` endpoints (like `label_changes`). `None` on pre-migration rows.
 
-```
-Δbond      = (Δwarmth + Δtrust   + Δintrigue) / 3
-Δchemistry = (Δwarmth + Δintimacy + Δtension)  / 3
-```
-
-Raw-composite increment (not bar-% units): zero-cost, good for a per-turn
-"+X bond / +Y chemistry" pulse. Exact while warmth stays ≥ 0 across the turn
-(warmth is floored at 0 in the absolute composite); a fair approximation when a
-turn crosses warmth = 0.
+The previous linear axis fold (`Δbond = (Δwarmth + Δtrust + Δintrigue) / 3`)
+was dropped: it ignored the warmth floor and reported phantom bond/chemistry
+gains when warmth < 0 across a turn.
 
 `label_changes` is read **straight from the stored event column** (§4.6) — the
 engine is the single authority, so the frontend stops computing transitions
@@ -363,7 +368,7 @@ chat turn → post_process::evaluate_affinity
 read:
   AffinitySnapshot.from(Affinity) → bar(bond_score), bar(chemistry_score),
                                      bond_label, chemistry_label, legacy label
-  BFF /event → effective_deltas + effective_deltas_computed (folded)
+  BFF /event → effective_deltas + effective_deltas_computed (exact, from stored column)
              + label_changes (read from the stored column)
 ```
 
@@ -381,10 +386,12 @@ read:
 
 **Store** (`eros-engine-store/src/affinity.rs`, `migrations/0029_*.sql`)
 - Migration: `bond`/`chemistry` as `GENERATED ALWAYS ... STORED`; lowered
-  default seed (§4.8); events `label_changes JSONB`. `AffinityEventRow` +
-  `list_events`/`latest_turn_event` add `label_changes`; `persist_with_event`
-  writes new legacy label + per-event `label_changes` (bond/chemistry are
-  DB-generated, no write code).
+  default seed (§4.8); events `label_changes JSONB` and `effective_line_deltas JSONB`.
+  `AffinityEventRow` + `list_events`/`latest_turn_event` add both columns;
+  `persist_with_event` writes new legacy label + per-event `label_changes`
+  (NULL when no tier moved) and `effective_line_deltas` (exact floored line delta);
+  `record_ghost` writes `effective_line_deltas = {bond:0,chemistry:0}`.
+  bond/chemistry on `companion_affinity` are DB-generated, no write code.
 - Tests: generated bond/chemistry match `*_score()`; relationship_label uses new
   mapping; a tier-crossing turn writes `label_changes`, a flat turn writes NULL;
   update `load_or_create_idempotent` (now seeds `warmth 0.1`, `intrigue 0`).

--- a/docs/superpowers/specs/2026-06-30-affinity-bond-chemistry-tiers-design.md
+++ b/docs/superpowers/specs/2026-06-30-affinity-bond-chemistry-tiers-design.md
@@ -197,15 +197,14 @@ decay untouched (per decision).
 New migration `0029_affinity_bond_chemistry.sql`:
 
 ```sql
--- current-state raw composites on the affinity row
+-- raw composites kept in lockstep with the axes by the DB (Postgres 12+).
+-- Mirror of eros_engine_core::affinity::{bond_score,chemistry_score} — keep in
+-- sync if the folding formula ever changes.
 ALTER TABLE engine.companion_affinity
-  ADD COLUMN bond      DOUBLE PRECISION NOT NULL DEFAULT 0,
-  ADD COLUMN chemistry DOUBLE PRECISION NOT NULL DEFAULT 0;
-
--- backfill existing rows from current axes (raw composite)
-UPDATE engine.companion_affinity SET
-  bond      = LEAST(1, GREATEST(0, ((warmth + 1)/2 + trust   + intrigue) / 3)),
-  chemistry = LEAST(1, GREATEST(0, ((warmth + 1)/2 + intimacy + tension)  / 3));
+  ADD COLUMN bond DOUBLE PRECISION
+    GENERATED ALWAYS AS (LEAST(1, GREATEST(0, ((warmth + 1)/2 + trust    + intrigue) / 3))) STORED,
+  ADD COLUMN chemistry DOUBLE PRECISION
+    GENERATED ALWAYS AS (LEAST(1, GREATEST(0, ((warmth + 1)/2 + intimacy + tension)  / 3))) STORED;
 
 -- per-turn tier transition; NULL on turns where no tier changed
 ALTER TABLE engine.companion_affinity_events
@@ -213,8 +212,13 @@ ALTER TABLE engine.companion_affinity_events
 ```
 
 The `companion_affinity` columns store the **raw composite** (0..1), not the bar
-value. Rationale: the curve/thresholds can be retuned later without rewriting
-history; the curve lives only in the read layer.
+value, and are **`GENERATED ALWAYS ... STORED`** — the DB recomputes them from the
+axes on every insert/update, so they can never drift per-row and existing rows
+auto-populate at migration time (no backfill, no engine write path, no
+`load_or_create`/`record_ghost` special-casing). The bar curve + tiers live only
+in the core read layer. Trade-off: the raw-composite formula is duplicated in SQL
+(cross-referenced by comment); the **read-facing** bar/labels always derive from
+core, so the API is correct even if the two ever diverged.
 
 **Per-turn label change (engine-computed, deterministic).** The LLM still only
 evaluates the 6 raw axes; the engine derives bond/chemistry, their tiers, and the
@@ -250,16 +254,19 @@ pub struct TurnLabelChanges {            // serde skips None fields
 // core: diff_labels(before: &Affinity, after: &Affinity) -> Option<TurnLabelChanges>
 ```
 
-Store changes (`crates/eros-engine-store/src/affinity.rs`):
+Store changes (`crates/eros-engine-store/src/affinity.rs`) — note `bond`/
+`chemistry` are DB-generated, so **no engine write code** for them:
 
-- `AffinityRow` + the `SELECT`/`INSERT`/`UPDATE` column lists gain `bond`,
-  `chemistry`; `AffinityEventRow` gains `label_changes: Option<serde_json::Value>`.
+- `AffinityEventRow` gains `label_changes: Option<serde_json::Value>`; the
+  `list_events` / `latest_turn_event` `SELECT`s add `e.label_changes`.
+  (`AffinityRow` / `SELECT *` is unaffected — it ignores the new generated
+  columns, and the read layer derives bond/chemistry from the axes anyway.)
 - `persist_with_event`: clone the post-decay/pre-delta `current` as the `before`
-  baseline; after `apply_deltas`, write `bond`/`chemistry` (raw) +
-  `relationship_label` (new `legacy_relationship_label()`) on the row, and the
-  event's `label_changes` (NULL when empty).
-- `record_ghost`, `load_or_create`: set `bond`/`chemistry` from the current axes
-  (ghost: no axis change → no `label_changes`).
+  baseline; after `apply_deltas`, write `relationship_label` (new
+  `legacy_relationship_label()`) and the event's `label_changes` (NULL when
+  empty). bond/chemistry update themselves.
+- `record_ghost`, `load_or_create`: unchanged for bond/chemistry (DB-generated);
+  ghost has no axis change → no `label_changes`.
 
 ### 4.7 DTO / API surfaces
 
@@ -310,8 +317,7 @@ chat turn → post_process::evaluate_affinity
   → merge with rule deltas → apply_deltas (EMA 0.2, unchanged)
   → store.persist_with_event:
        before := post-decay/pre-delta snapshot
-       write 6 axes (unchanged)
-       write bond/chemistry = bond_score()/chemistry_score()   [raw]
+       write 6 axes (unchanged) → bond/chemistry recomputed by the DB (generated)
        write relationship_label = legacy_relationship_label()  [old names]
        write event row (deltas, effective_deltas,
                         label_changes = diff_labels(before, after) or NULL)
@@ -336,10 +342,11 @@ read:
   old `infer_label_*` tests.
 
 **Store** (`eros-engine-store/src/affinity.rs`, `migrations/0029_*.sql`)
-- Migration (add `bond`/`chemistry` + backfill; add events `label_changes`).
-  Row structs (`AffinityRow`, `AffinityEventRow`) + queries + writes for
-  bond/chemistry + new legacy label + per-event `label_changes`.
-- Tests: persisted bond/chemistry match `*_score()`; relationship_label uses new
+- Migration: `bond`/`chemistry` as `GENERATED ALWAYS ... STORED`; events
+  `label_changes JSONB`. `AffinityEventRow` + `list_events`/`latest_turn_event`
+  add `label_changes`; `persist_with_event` writes new legacy label + per-event
+  `label_changes` (bond/chemistry are DB-generated, no write code).
+- Tests: generated bond/chemistry match `*_score()`; relationship_label uses new
   mapping; a tier-crossing turn writes `label_changes`, a flat turn writes NULL.
 
 **post_process** (`pipeline/post_process.rs`)


### PR DESCRIPTION
## Summary

Splits the relationship state into two **engine-owned** derived lines — **Bond** (friendship) and **Chemistry** (romance) — folded from the unchanged 6-axis affinity vector. Each line gets 4 value-derived tier labels; the legacy `relationship_label` is preserved for back-compat. The six-axis evaluator is made sparser and asymmetric so progress feels earned. The **6-axis base mechanics (EMA, time-decay) are unchanged**; only the new-row default *seed* is lowered.

Spec: `docs/superpowers/specs/2026-06-30-affinity-bond-chemistry-tiers-design.md`

## What changed

- **Folding (core):** `bond = (max(warmth,0)+trust+intrigue)/3`, `chemistry = (max(warmth,0)+intimacy+tension)/3`. warmth floored at 0 (no 0.5 baseline); patience excluded (rule-owned).
- **Tiers + bar curve:** 4 tiers per line with widening raw gaps (`0.15 / 0.35 / 0.62`), mapped to even 25% bands → fast early, grind near 100%.
- **Labels:** `bond_label` (acquaintance→confidant), `chemistry_label` (spark→lover). Legacy `relationship_label` now = the higher line mapped to an old name (stranger when both tier 1; `frenemy` retired from emission, kept parseable) — replaces the tangled `infer_label` heuristic.
- **Eval distribution:** asymmetric per-axis cap `−0.6 / +0.4` (losses bigger/easier than gains); prompt rewritten so ordinary turns score 0, gains are rare-but-large, losses fire more readily. EMA + decay untouched.
- **Per-turn label transitions:** deterministically computed over the delta-only span, stored on `companion_affinity_events.label_changes` (NULL when no tier moved), and served by the BFF + debug `/event` endpoints alongside a folded `effective_deltas_computed`.
- **Persistence (migration 0029):** `bond`/`chemistry` as Postgres `GENERATED ALWAYS … STORED` columns (auto-populate existing rows, can't drift); lowered new-row default seed (warmth 0.1, trust/intrigue/tension 0) so a fresh session reads as *stranger* with a neutral opening tone; `label_changes JSONB` column.
- **API:** `AffinitySnapshot` gains `bond`/`chemistry` bar fills + labels; new shared DTOs; OpenAPI snapshot refreshed.
- **Docs:** full rewrite of `affinity-model.md` / `.zh.md`; `api-reference` updated.

## Out of scope

`filter_prompt` override for `affinity_evaluation` — deferred, tracked in #130.

## Testing

- Full workspace suite green: 687 tests (core 63 / server-unit 168 / server-integration 350 / store 106).
- `cargo fmt --all` + `clippy --workspace --all-targets -D warnings` clean.
- OpenAPI snapshot regenerated and in sync (CI parity check passes).
- Migration is backward-compatible: generated columns auto-populate, `SET DEFAULT` affects new rows only, `label_changes` is nullable — existing rows untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
