### PR TITLE
feat: image-generation lifecycle frames (image_pending / image_attempt / image_failed) (#131)

### DIFF
--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -831,6 +831,11 @@ impl OpenRouterClient {
     /// One-shot image-generation call. Walks `[model] + fallback_model` on
     /// transport failure OR a zero-image success. Returns the first attempt that
     /// yields ≥1 image. Non-streaming.
+    ///
+    /// Retained as the stable public entry point for downstream library
+    /// consumers; in-tree callers that need live per-attempt progress use
+    /// [`OpenRouterClient::execute_image_inner`] instead. Do not remove as
+    /// "unused" — it has no in-tree callers by design.
     pub async fn execute_image(
         &self,
         req: ImageGenRequest,

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -888,7 +888,9 @@ impl OpenRouterClient {
                     attempts.push(ImageAttempt {
                         model: model.to_string(),
                         variant,
-                        outcome: AttemptOutcome::Transport { message: e.to_string() },
+                        outcome: AttemptOutcome::Transport {
+                            message: e.to_string(),
+                        },
                     });
                     continue;
                 }
@@ -914,7 +916,9 @@ impl OpenRouterClient {
                     attempts.push(ImageAttempt {
                         model: model.to_string(),
                         variant,
-                        outcome: AttemptOutcome::Decode { message: e.to_string() },
+                        outcome: AttemptOutcome::Decode {
+                            message: e.to_string(),
+                        },
                     });
                     continue;
                 }

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -142,6 +142,18 @@ pub struct ImageAttempt {
     pub outcome: AttemptOutcome,
 }
 
+/// Live progress for one image-gen attempt, surfaced to a streaming caller
+/// immediately before each HTTP post so the SSE layer can emit `image_attempt`
+/// frames as the fallback chain walks. `index` is 1-based; `total` is the full
+/// planned attempt count.
+#[derive(Debug, Clone)]
+pub struct ImageAttemptProgress {
+    pub model: String,
+    pub variant: PromptVariant,
+    pub index: u32,
+    pub total: u32,
+}
+
 /// Error from [`OpenRouterClient::execute_image`]. `Config` is a pre-flight
 /// failure (no api key / no models) with no attempts; `ChainExhausted` carries
 /// every failed attempt in order so the caller can persist a diagnostic.
@@ -823,6 +835,17 @@ impl OpenRouterClient {
         &self,
         req: ImageGenRequest,
     ) -> Result<ImageGenResponse, ImageGenError> {
+        self.execute_image_inner(req, |_| {}).await
+    }
+
+    /// Like [`execute_image`], but invokes `on_attempt` immediately before each
+    /// HTTP post so a streaming caller can surface fallback-chain progress live.
+    /// The hook is synchronous and best-effort — it must not block.
+    pub async fn execute_image_inner(
+        &self,
+        req: ImageGenRequest,
+        mut on_attempt: impl FnMut(ImageAttemptProgress),
+    ) -> Result<ImageGenResponse, ImageGenError> {
         let candidates: Vec<&str> = std::iter::once(req.model.as_str())
             .chain(req.fallback_model.iter().map(String::as_str))
             .filter(|s| !s.is_empty())
@@ -836,8 +859,15 @@ impl OpenRouterClient {
             return Err(ImageGenError::Config("openrouter: api key not set".into()));
         }
         let plan = plan_attempts(&candidates, &req.prompt, req.prompt_original.as_deref());
+        let total = plan.len() as u32;
         let mut attempts: Vec<ImageAttempt> = Vec::new();
-        for (model, variant, prompt) in plan {
+        for (i, (model, variant, prompt)) in plan.into_iter().enumerate() {
+            on_attempt(ImageAttemptProgress {
+                model: model.to_string(),
+                variant,
+                index: i as u32 + 1,
+                total,
+            });
             let mut body = build_image_body(&req, model, prompt);
             if let Some(prefs) = self.provider_prefs() {
                 if let Ok(v) = serde_json::to_value(&prefs) {
@@ -858,9 +888,7 @@ impl OpenRouterClient {
                     attempts.push(ImageAttempt {
                         model: model.to_string(),
                         variant,
-                        outcome: AttemptOutcome::Transport {
-                            message: e.to_string(),
-                        },
+                        outcome: AttemptOutcome::Transport { message: e.to_string() },
                     });
                     continue;
                 }
@@ -886,9 +914,7 @@ impl OpenRouterClient {
                     attempts.push(ImageAttempt {
                         model: model.to_string(),
                         variant,
-                        outcome: AttemptOutcome::Decode {
-                            message: e.to_string(),
-                        },
+                        outcome: AttemptOutcome::Decode { message: e.to_string() },
                     });
                     continue;
                 }
@@ -2569,5 +2595,41 @@ data: [DONE]\n\n";
         assert_eq!(zv["variant"], "original");
         assert_eq!(zv["outcome"], "zero_images");
         assert!(zv.get("status").is_none());
+    }
+
+    #[tokio::test]
+    async fn execute_image_inner_reports_each_attempt() {
+        // Every candidate returns 500 ⇒ each attempt fails (Status) ⇒ ChainExhausted.
+        let server = MockServer::start().await;
+        Mock::given(path("/api/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let client = OpenRouterClient::with_base_url(
+            "test-key".into(),
+            AppAttribution::default(),
+            format!("{}/api/v1/chat/completions", server.uri()),
+        );
+        let req = ImageGenRequest {
+            model: "m1".into(),
+            fallback_model: vec!["m2".into()],
+            prompt: "a cat".into(),
+            max_tokens: 4096,
+            ..Default::default()
+        };
+        // prompt_original is None ⇒ Single variant per model ⇒ 2 planned attempts.
+        let mut seen: Vec<(String, PromptVariant, u32, u32)> = Vec::new();
+        let result = client
+            .execute_image_inner(req, |p| seen.push((p.model, p.variant, p.index, p.total)))
+            .await;
+
+        assert!(
+            matches!(result, Err(ImageGenError::ChainExhausted { ref attempts }) if attempts.len() == 2),
+            "all-500 chain should exhaust with 2 attempts: {result:?}"
+        );
+        assert_eq!(seen.len(), 2, "on_attempt fires once per planned attempt");
+        assert_eq!(seen[0], ("m1".to_string(), PromptVariant::Single, 1, 2));
+        assert_eq!(seen[1], ("m2".to_string(), PromptVariant::Single, 2, 2));
     }
 }

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -36,6 +36,18 @@ pub enum FrameActionType {
     ReplyTextImage,
 }
 
+/// Why an image-generation turn failed, carried by the `image_failed` frame.
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ImageFailReason {
+    /// Every candidate model failed (transport / status / decode / zero-images).
+    ChainExhausted,
+    /// A success response carried zero images (defensive; unexpected).
+    ZeroImages,
+    /// Pre-flight failure: no api key or no models configured.
+    ConfigError,
+}
+
 /// One wire frame in the SSE protocol.
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -90,6 +102,20 @@ pub enum ProtocolFrame {
         model: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         generation_id: Option<String>,
+    },
+    ImagePending {
+        message_id: String,
+    },
+    ImageAttempt {
+        message_id: String,
+        model: String,
+        variant: eros_engine_llm::openrouter::PromptVariant,
+        index: u32,
+        total: u32,
+    },
+    ImageFailed {
+        message_id: String,
+        reason: ImageFailReason,
     },
 }
 
@@ -8756,5 +8782,46 @@ data: [DONE]\n\n"
             Some("<regex>"),
             "filter_model must be '<regex>' (LLM filter skipped); got {filter_model:?}",
         );
+    }
+
+    #[test]
+    fn image_pending_frame_serializes() {
+        let f = ProtocolFrame::ImagePending { message_id: ulid_string(Ulid::new()) };
+        let v: serde_json::Value = serde_json::to_value(&f).unwrap();
+        assert_eq!(v["type"], "image_pending");
+        assert_eq!(v["message_id"].as_str().unwrap().len(), 26);
+    }
+
+    #[test]
+    fn image_attempt_frame_serializes() {
+        let f = ProtocolFrame::ImageAttempt {
+            message_id: ulid_string(Ulid::new()),
+            model: "google/gemini-2.5-flash-image".into(),
+            variant: eros_engine_llm::openrouter::PromptVariant::Composed,
+            index: 1,
+            total: 3,
+        };
+        let v: serde_json::Value = serde_json::to_value(&f).unwrap();
+        assert_eq!(v["type"], "image_attempt");
+        assert_eq!(v["model"], "google/gemini-2.5-flash-image");
+        assert_eq!(v["variant"], "composed");
+        assert_eq!(v["index"], 1);
+        assert_eq!(v["total"], 3);
+    }
+
+    #[test]
+    fn image_failed_frame_serializes_each_reason() {
+        let mk = |r| {
+            serde_json::to_value(&ProtocolFrame::ImageFailed {
+                message_id: ulid_string(Ulid::new()),
+                reason: r,
+            })
+            .unwrap()
+        };
+        let chain = mk(ImageFailReason::ChainExhausted);
+        assert_eq!(chain["type"], "image_failed");
+        assert_eq!(chain["reason"], "chain_exhausted");
+        assert_eq!(mk(ImageFailReason::ZeroImages)["reason"], "zero_images");
+        assert_eq!(mk(ImageFailReason::ConfigError)["reason"], "config_error");
     }
 }

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -2562,6 +2562,16 @@ pub fn run_stream(
 
                 if matches!(plan.action_type, ActionType::ReplyImage) {
                     if let Some((primary, fallback)) = image_chain.clone() {
+                        // #131: pre-allocate the assistant id up front so the
+                        // image lifecycle frames can reference it before the
+                        // (blocking) generation. On success this same id labels
+                        // the persisted row + meta/image/done. On failure it is
+                        // never persisted — the turn degrades to a separate text
+                        // row (Y); image_failed(X) lets a consumer clear pending.
+                        let msg_ulid = Ulid::new();
+                        let msg_uuid: Uuid = msg_ulid.into();
+                        let img_mid = ulid_string(msg_ulid);
+                        yield ProtocolFrame::ImagePending { message_id: img_mid.clone() };
                         let subject = plan
                             .image_prompt
                             .as_deref()
@@ -2621,7 +2631,29 @@ pub fn run_stream(
                         );
                         let ar = req.aspect_ratio.clone();
                         let res = req.resolution.clone();
-                        match state.openrouter.execute_image(req).await {
+                        // #131: drive image-gen, forwarding each attempt as an
+                        // image_attempt frame; capture the single terminal Done.
+                        let mut img_events =
+                            Box::pin(drive_image_gen(state.openrouter.clone(), req));
+                        let mut img_outcome = None;
+                        {
+                            use futures_util::StreamExt as _;
+                            while let Some(ev) = img_events.next().await {
+                                match ev {
+                                    ImageGenEvent::Attempt(p) => {
+                                        yield ProtocolFrame::ImageAttempt {
+                                            message_id: img_mid.clone(),
+                                            model: p.model,
+                                            variant: p.variant,
+                                            index: p.index,
+                                            total: p.total,
+                                        };
+                                    }
+                                    ImageGenEvent::Done(r) => img_outcome = Some(r),
+                                }
+                            }
+                        }
+                        match img_outcome.expect("drive_image_gen yields exactly one Done") {
                             Ok(resp) if !resp.images.is_empty() => {
                                 let won_prompt = winning_image_prompt(
                                     resp.winning_variant,
@@ -2654,8 +2686,6 @@ pub fn run_stream(
                                         serde_json::to_value(&resp.attempts).unwrap_or_default();
                                 }
                                 let mime = data_url_mime(&resp.images[0]);
-                                let msg_ulid = Ulid::new();
-                                let msg_uuid: Uuid = msg_ulid.into();
                                 let row = eros_engine_store::chat::AssistantInsert {
                                     id: msg_uuid,
                                     content: String::new(),
@@ -2721,12 +2751,20 @@ pub fn run_stream(
                                     "stream(image): execute_image returned zero images \
                                      (unexpected); falling through to text"
                                 );
+                                yield ProtocolFrame::ImageFailed {
+                                    message_id: img_mid.clone(),
+                                    reason: ImageFailReason::ZeroImages,
+                                };
                             }
                             Err(eros_engine_llm::openrouter::ImageGenError::Config(m)) => {
                                 tracing::warn!(
                                     "stream(image): execute_image config error: {m}; \
                                      falling through to text"
                                 );
+                                yield ProtocolFrame::ImageFailed {
+                                    message_id: img_mid.clone(),
+                                    reason: ImageFailReason::ConfigError,
+                                };
                             }
                             Err(eros_engine_llm::openrouter::ImageGenError::ChainExhausted {
                                 attempts,
@@ -2745,6 +2783,10 @@ pub fn run_stream(
                                     face_used,
                                     &attempts,
                                 ));
+                                yield ProtocolFrame::ImageFailed {
+                                    message_id: img_mid.clone(),
+                                    reason: ImageFailReason::ChainExhausted,
+                                };
                             }
                         }
                     }

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -223,6 +223,51 @@ fn build_image_gen_request(
     }
 }
 
+/// Internal event from [`drive_image_gen`]: one `Attempt` per fallback-chain
+/// step (emitted as it begins), then exactly one terminal `Done`.
+enum ImageGenEvent {
+    Attempt(eros_engine_llm::openrouter::ImageAttemptProgress),
+    Done(
+        Result<
+            eros_engine_llm::openrouter::ImageGenResponse,
+            eros_engine_llm::openrouter::ImageGenError,
+        >,
+    ),
+}
+
+/// Drive `execute_image_inner` while surfacing each attempt live, so both image
+/// actions can stream `image_attempt` frames without duplicating the
+/// channel/`select!` plumbing. Owns the client `Arc` and polls the gen future
+/// in place; dropping the returned stream cancels the in-flight call. The
+/// channel is `tokio::sync::mpsc::unbounded` (futures-channel is not a workspace
+/// dependency).
+fn drive_image_gen(
+    client: std::sync::Arc<eros_engine_llm::openrouter::OpenRouterClient>,
+    req: eros_engine_llm::openrouter::ImageGenRequest,
+) -> impl futures_util::Stream<Item = ImageGenEvent> {
+    async_stream::stream! {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<
+            eros_engine_llm::openrouter::ImageAttemptProgress,
+        >();
+        let gen = client.execute_image_inner(req, move |p| {
+            let _ = tx.send(p);
+        });
+        tokio::pin!(gen);
+        let result = loop {
+            tokio::select! {
+                Some(p) = rx.recv() => yield ImageGenEvent::Attempt(p),
+                r = &mut gen => {
+                    while let Ok(p) = rx.try_recv() {
+                        yield ImageGenEvent::Attempt(p);
+                    }
+                    break r;
+                }
+            }
+        };
+        yield ImageGenEvent::Done(result);
+    }
+}
+
 /// The subject-level prompt that actually drew the image, given which variant
 /// won. `Original` → the pre-compose subject; `Composed`/`Single` → the composed
 /// `final_subject`. Used so persisted/emitted prompt reflects the retry winner.
@@ -2992,6 +3037,11 @@ pub fn run_stream(
                         (produced.last(), image_chain.clone())
                     {
                         let msg_uuid = last.message_id;
+                        // #131: an image is now being generated for this message.
+                        // Emitted before run_image_prompt_compose (itself an LLM
+                        // call) so it covers the whole gap after the text `done`.
+                        let img_mid = ulid_string(Ulid::from(msg_uuid));
+                        yield ProtocolFrame::ImagePending { message_id: img_mid.clone() };
                         let subject = plan
                             .image_prompt
                             .as_deref()
@@ -3051,7 +3101,29 @@ pub fn run_stream(
                         );
                         let ar = req.aspect_ratio.clone();
                         let res = req.resolution.clone();
-                        match state.openrouter.execute_image(req).await {
+                        // #131: drive image-gen, forwarding each attempt as an
+                        // image_attempt frame; capture the single terminal Done.
+                        let mut img_events =
+                            Box::pin(drive_image_gen(state.openrouter.clone(), req));
+                        let mut img_outcome = None;
+                        {
+                            use futures_util::StreamExt as _;
+                            while let Some(ev) = img_events.next().await {
+                                match ev {
+                                    ImageGenEvent::Attempt(p) => {
+                                        yield ProtocolFrame::ImageAttempt {
+                                            message_id: img_mid.clone(),
+                                            model: p.model,
+                                            variant: p.variant,
+                                            index: p.index,
+                                            total: p.total,
+                                        };
+                                    }
+                                    ImageGenEvent::Done(r) => img_outcome = Some(r),
+                                }
+                            }
+                        }
+                        match img_outcome.expect("drive_image_gen yields exactly one Done") {
                             Ok(resp) if !resp.images.is_empty() => {
                                 let won_prompt = winning_image_prompt(
                                     resp.winning_variant,
@@ -3111,12 +3183,20 @@ pub fn run_stream(
                                     "stream(text_image): execute_image returned zero images \
                                      (unexpected); no Image frame (text already delivered)"
                                 );
+                                yield ProtocolFrame::ImageFailed {
+                                    message_id: img_mid.clone(),
+                                    reason: ImageFailReason::ZeroImages,
+                                };
                             }
                             Err(eros_engine_llm::openrouter::ImageGenError::Config(m)) => {
                                 tracing::warn!(
                                     "stream(text_image): execute_image config error: {m}; \
                                      no Image frame (text already delivered)"
                                 );
+                                yield ProtocolFrame::ImageFailed {
+                                    message_id: img_mid.clone(),
+                                    reason: ImageFailReason::ConfigError,
+                                };
                             }
                             Err(eros_engine_llm::openrouter::ImageGenError::ChainExhausted {
                                 attempts,
@@ -3148,6 +3228,10 @@ pub fn run_stream(
                                         "stream(text_image): persist image_failed failed: {e}"
                                     );
                                 }
+                                yield ProtocolFrame::ImageFailed {
+                                    message_id: img_mid.clone(),
+                                    reason: ImageFailReason::ChainExhausted,
+                                };
                             }
                         }
                     }
@@ -8786,7 +8870,9 @@ data: [DONE]\n\n"
 
     #[test]
     fn image_pending_frame_serializes() {
-        let f = ProtocolFrame::ImagePending { message_id: ulid_string(Ulid::new()) };
+        let f = ProtocolFrame::ImagePending {
+            message_id: ulid_string(Ulid::new()),
+        };
         let v: serde_json::Value = serde_json::to_value(&f).unwrap();
         assert_eq!(v["type"], "image_pending");
         assert_eq!(v["message_id"].as_str().unwrap().len(), 26);
@@ -8823,5 +8909,46 @@ data: [DONE]\n\n"
         assert_eq!(chain["reason"], "chain_exhausted");
         assert_eq!(mk(ImageFailReason::ZeroImages)["reason"], "zero_images");
         assert_eq!(mk(ImageFailReason::ConfigError)["reason"], "config_error");
+    }
+
+    #[tokio::test]
+    async fn drive_image_gen_streams_attempts_then_done() {
+        use futures_util::StreamExt as _;
+        // Every request 500s ⇒ each candidate fails (Status) ⇒ ChainExhausted.
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::path("/api/v1/chat/completions"))
+            .respond_with(wiremock::ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+        let client = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                eros_engine_llm::openrouter::AppAttribution::default(),
+                format!("{}/api/v1/chat/completions", server.uri()),
+            ),
+        );
+        let req = eros_engine_llm::openrouter::ImageGenRequest {
+            model: "m1".into(),
+            fallback_model: vec!["m2".into()],
+            prompt: "a cat".into(),
+            max_tokens: 4096,
+            ..Default::default()
+        };
+        // 2 candidates, no prompt_original ⇒ Single variant ⇒ 2 planned attempts.
+        let events: Vec<ImageGenEvent> = drive_image_gen(client, req).collect().await;
+        let attempts = events
+            .iter()
+            .filter(|e| matches!(e, ImageGenEvent::Attempt(_)))
+            .count();
+        assert_eq!(attempts, 2, "one Attempt event per planned candidate");
+        assert!(
+            matches!(
+                events.last(),
+                Some(ImageGenEvent::Done(Err(
+                    eros_engine_llm::openrouter::ImageGenError::ChainExhausted { attempts }
+                ))) if attempts.len() == 2
+            ),
+            "last event is Done(Err(ChainExhausted)) with 2 attempts"
+        );
     }
 }

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -321,10 +321,52 @@ data: {"type":"image","message_id":"01J...","data_url":"data:image/png;base64,..
 | `model` | `String` \| `null` | Image model actually served. |
 | `generation_id` | `String` \| `null` | OpenRouter generation id. |
 
+**`image_pending` SSE frame** — emitted when the engine commits to generating an
+image for a message, before generation begins. Start a "generating…" indicator:
+
+```text
+data: {"type":"image_pending","message_id":"01J..."}
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `type` | `"image_pending"` | Frame type discriminator. |
+| `message_id` | `String` | The message the image is being generated for. For `reply_image` this is the *intended* image id; on failure the turn degrades to a different text message (see below). |
+
+**`image_attempt` SSE frame** — emitted as the model fallback chain walks, one
+per attempt as it begins:
+
+```text
+data: {"type":"image_attempt","message_id":"01J...","model":"google/gemini-2.5-flash-image","variant":"composed","index":1,"total":3}
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `type` | `"image_attempt"` | Frame type discriminator. |
+| `message_id` | `String` | Matches the `image_pending` frame's `message_id`. |
+| `model` | `String` | The model being tried for this attempt. |
+| `variant` | `"composed"` \| `"original"` \| `"single"` | Which prompt variant is being tried (`single` = no compose retry). |
+| `index` | `Number` | 1-based position in the attempt plan. |
+| `total` | `Number` | Total planned attempts. |
+
+**`image_failed` SSE frame** — emitted when image generation gives up. Clear the
+pending state and render a "couldn't generate" state:
+
+```text
+data: {"type":"image_failed","message_id":"01J...","reason":"chain_exhausted"}
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `type` | `"image_failed"` | Frame type discriminator. |
+| `message_id` | `String` | Matches the `image_pending` frame's `message_id`. |
+| `reason` | `"chain_exhausted"` \| `"zero_images"` \| `"config_error"` | `chain_exhausted` = every candidate model failed; `zero_images` = a success response carried no image (defensive); `config_error` = no key / no models. |
+
 **Full SSE frame sequences:**
 
-- `reply_text_image`: `meta(action_type=reply_text_image) → delta* → done → image → final`
-- `reply_image`: `meta(action_type=reply_image) → image → done → final`
+- `reply_text_image`: `meta(action_type=reply_text_image) → delta* → done → image_pending → image_attempt* → (image | image_failed) → final`
+- `reply_image` (success): `image_pending → image_attempt* → meta(action_type=reply_image) → image → done → final`
+- `reply_image` (image failed): `image_pending → image_attempt* → image_failed → meta(action_type=reply_text) → delta* → done → final` — the turn degrades to a normal text reply with a **new** `message_id` (see below).
 - `ghost`: `meta(action_type=ghost) → done → final` — no `delta`, no `model` in `meta`, `usage` and `generation_id` are `null` in `done`. The companion stayed silent this turn; no LLM was called.
 
 **Failed-image client contract** — no new error frame is emitted on image failure.
@@ -333,11 +375,14 @@ The `meta` frame's `action_type` declares the intended shape:
 - **`reply_text_image`** — the `image` frame arrives *after* `done`. If the stream
   reaches `final` with no `image` frame, the image generation failed (fail-open);
   the text was still delivered — render it.
-- **`reply_image`** — the `image` frame arrives *before* `done`. A `reply_image`
-  meta is only ever emitted when the image is already in-flight, so an `image`
-  frame will always follow. A failed image instead degrades the whole turn: the
-  client sees `meta.action_type=reply_text` (never `reply_image`) and a normal
-  text stream — the degrade is visible up front.
+- **`reply_image`** — `image_pending` and `image_attempt*` arrive first, carrying
+  the *intended* image id `X`. On success, `meta(action_type=reply_image) → image
+  → done` follow with that same `X`. On failure, an `image_failed` frame (also
+  `X`) is emitted and the turn degrades to a normal text reply whose `meta` /
+  `delta` / `done` carry a **different** `message_id` `Y` (`meta.action_type =
+  reply_text`). A consumer clears the pending state for `X` on `image_failed`,
+  then renders `Y` as an ordinary text message. (`X` is never persisted; the
+  failure diagnostic is persisted on `Y`'s row.)
 
 **Write-back endpoint** — after receiving the `image` frame, the client should
 upload the `data_url` to its own storage and post the resulting URL back:

--- a/docs/api-reference.zh.md
+++ b/docs/api-reference.zh.md
@@ -292,16 +292,58 @@ data: {"type":"image","message_id":"01J...","data_url":"data:image/png;base64,..
 | `model` | `String` \| `null` | 实际服务的图片模型。 |
 | `generation_id` | `String` \| `null` | OpenRouter 生成 id。 |
 
+**`image_pending` SSE 帧** — 引擎决定为某条消息生成图片时（生成开始前）发出。
+客户端可据此开始显示「生成中…」状态：
+
+```text
+data: {"type":"image_pending","message_id":"01J..."}
+```
+
+| 字段 | 类型 | 备注 |
+|---|---|---|
+| `type` | `"image_pending"` | 帧类型标识符。 |
+| `message_id` | `String` | 正在为其生成图片的消息。对 `reply_image` 而言这是*预期*的图片 id；若生成失败，整轮会降级为另一条文字消息（见下文）。 |
+
+**`image_attempt` SSE 帧** — 模型回退链每尝试一个候选模型时，在该次尝试开始时
+发出一帧：
+
+```text
+data: {"type":"image_attempt","message_id":"01J...","model":"google/gemini-2.5-flash-image","variant":"composed","index":1,"total":3}
+```
+
+| 字段 | 类型 | 备注 |
+|---|---|---|
+| `type` | `"image_attempt"` | 帧类型标识符。 |
+| `message_id` | `String` | 与 `image_pending` 帧的 `message_id` 相同。 |
+| `model` | `String` | 本次尝试所用的模型。 |
+| `variant` | `"composed"` \| `"original"` \| `"single"` | 本次尝试使用的提示词变体（`single` = 未启用 compose 重试）。 |
+| `index` | `Number` | 在尝试计划中的位置（从 1 开始）。 |
+| `total` | `Number` | 计划尝试的总次数。 |
+
+**`image_failed` SSE 帧** — 图片生成放弃时发出。客户端应清除 pending 状态，并渲染
+「生成失败」状态：
+
+```text
+data: {"type":"image_failed","message_id":"01J...","reason":"chain_exhausted"}
+```
+
+| 字段 | 类型 | 备注 |
+|---|---|---|
+| `type` | `"image_failed"` | 帧类型标识符。 |
+| `message_id` | `String` | 与 `image_pending` 帧的 `message_id` 相同。 |
+| `reason` | `"chain_exhausted"` \| `"zero_images"` \| `"config_error"` | `chain_exhausted` = 所有候选模型均失败；`zero_images` = 成功响应但未含图片（防御性）；`config_error` = 未配置 key 或模型。 |
+
 **完整 SSE 帧序列：**
 
-- `reply_text_image`：`meta(action_type=reply_text_image) → delta* → done → image → final`
-- `reply_image`：`meta(action_type=reply_image) → image → done → final`
+- `reply_text_image`：`meta(action_type=reply_text_image) → delta* → done → image_pending → image_attempt* → (image | image_failed) → final`
+- `reply_image`（成功）：`image_pending → image_attempt* → meta(action_type=reply_image) → image → done → final`
+- `reply_image`（图片失败）：`image_pending → image_attempt* → image_failed → meta(action_type=reply_text) → delta* → done → final` — 整轮降级为普通文字回复，并使用**新的** `message_id`（见下文）。
 - `ghost`：`meta(action_type=ghost) → done → final` — 无 `delta`，`meta` 中无 `model`，`done` 的 `usage` 和 `generation_id` 均为 `null`。该轮伴侣保持沉默，未调用任何 LLM。
 
 **图片失败客户端约定** — 图片失败时不会发出额外的 error 帧。客户端通过 `meta` 帧的 `action_type` 判断预期形状：
 
 - **`reply_text_image`** — `image` 帧在 `done` 之后到达。若流已到达 `final` 但仍未收到 `image` 帧，则图片生成失败（fail-open）；文字已正常投递，渲染即可。
-- **`reply_image`** — `image` 帧在 `done` 之前到达。`reply_image` 类型的 `meta` 只在图片确定可投递时才会下发，因此收到该 `meta` 后 `image` 帧必然随后出现。若图片失败，整轮会降级：客户端收到的是 `meta.action_type=reply_text`（而非 `reply_image`）加上普通文字流——降级从 `meta` 帧起即可见，不会出现空的 `reply_image`。
+- **`reply_image`** — `image_pending` 和 `image_attempt*` 先到达，携带*预期*的图片 id `X`。成功时，`meta(action_type=reply_image) → image → done` 随后到达，使用同一个 `X`。失败时，会发出一帧 `image_failed`（同样携带 `X`），整轮降级为普通文字回复，其 `meta` / `delta` / `done` 携带**另一个** `message_id` `Y`（`meta.action_type = reply_text`）。客户端在收到 `image_failed` 时清除 `X` 的 pending 状态，再把 `Y` 当作普通文字消息渲染。（`X` 不会被持久化；失败诊断信息持久化在 `Y` 所在行。）
 
 **写回端点** — 收到 `image` 帧后，客户端应将 `data_url` 上传到自有存储，然后把结果 URL 写回引擎：
 

--- a/docs/superpowers/specs/2026-06-30-image-lifecycle-frames-design.md
+++ b/docs/superpowers/specs/2026-06-30-image-lifecycle-frames-design.md
@@ -1,0 +1,359 @@
+# Image-generation lifecycle frames (image_pending / image_attempt / image_failed)
+
+**Date:** 2026-06-30
+**Issue:** #131 — chat stream: add image-generation lifecycle frames so SSE consumers can render a generating state
+**Scope:** one PR. New `ProtocolFrame` variants + emission wiring in `pipeline/stream.rs`, a streaming seam in `execute_image`, and docs. Additive on the wire.
+
+## Problem
+
+The chat SSE stream gives consumers no signal *during* image generation, and
+no signal at all when generation fails. The two image actions behave
+differently, and one of them has a multi-second blind window:
+
+- **`reply_image`** (`stream.rs:2492`) generates the image **first**, then emits
+  `meta → image → done` as a tight burst. The image is already present when the
+  bubble's first frame arrives. A consumer that shows a "generating" indicator
+  while the message is unsettled toggles it cleanly. But the wait happens
+  *before* `meta`, so it is invisible — the consumer can't show progress during
+  it — and on failure the whole turn silently degrades to a plain `reply_text`.
+
+- **`reply_text_image`** (`stream.rs:2964`) streams the text, emits the text
+  **`done`**, then **blocks on `execute_image(...).await`** (which also includes
+  an LLM `run_image_prompt_compose` call), then emits **`image`**, then `final`.
+  Between `done` and `image` there is a multi-second gap with **no frame at
+  all**. A consumer that gates its "generating image" indicator on the message
+  still being unsettled (on `done` not having fired) loses the signal at `done`,
+  while the image is still generating.
+
+- On **image-gen failure** for `reply_text_image` (chain exhausted / zero images
+  / config error), **no frame is emitted** — the image is silently dropped (only
+  a `ChainExhausted` diagnostic is persisted to row metadata). A consumer can't
+  clear its pending state or render a "couldn't generate" state; it waits until
+  `final`.
+
+The only robust "image is generating" signal a consumer has today is inferred
+from `action_type` + frame timing, and for `reply_text_image` that inference
+(`done` not yet fired) is *wrong*, because `done` fires before generation.
+
+## Goal
+
+Add explicit image-generation lifecycle frames so a consumer can drive a
+generating → done / failed state deterministically and consistently across both
+image actions:
+
+1. `image_pending` — the engine has committed to generating an image for a
+   message; start the spinner.
+2. `image_attempt` — live fallback-chain progress ("trying model X (i/N)").
+3. `image` — success terminal (existing frame; unchanged).
+4. `image_failed` — the fallback chain gave up; clear pending, render failed.
+
+## Background — the existing image paths
+
+- Both image arms live in one match arm of the `run_stream` generator
+  (`stream.rs:2469`, `ActionType::ReplyText | ReplyImage | ReplyTextImage`).
+- **`reply_image`**: generate first. On success a new `msg_ulid` is created
+  **after** the gen returns (`stream.rs:2586`), the row is persisted, and
+  `meta → image → done` is emitted (`stream.rs:2626`). On failure
+  (`ChainExhausted`) an `image_failed` diagnostic is stashed in
+  `image_failed_meta` and the arm falls through to the normal text path, which
+  produces a separate text row and attaches the diagnostic to it
+  (`stream.rs:2923`). `Config` / zero-image failures only `warn` and fall
+  through.
+- **`reply_text_image`**: the text burst runs first (`drive_chat_burst`,
+  `stream.rs:2887`) producing `meta → delta* → done` and a persisted assistant
+  row. Then, inside `if let (Some(last), Some((primary, fallback)))`
+  (`stream.rs:2965`), the image is generated and merged onto that **same** row
+  (`merge_assistant_image_meta`), and the `image` frame is yielded before
+  `final`. On failure: `ChainExhausted` persists `image_failed` onto the row;
+  `Config` / zero-image only `warn`. No frame is emitted in any failure case.
+- **`execute_image`** (`openrouter.rs:822`) walks `plan_attempts(candidates,
+  prompt, prompt_original)` — a precomputed list of `(model, variant, prompt)`
+  tuples (so the attempt **count is known up front**). Each iteration does one
+  HTTP post and pushes an `ImageAttempt { model, variant, outcome }`. First
+  attempt with ≥1 image returns `Ok(ImageGenResponse { .., attempts,
+  winning_variant })`; full exhaustion returns `Err(ChainExhausted {
+  attempts })`; pre-flight problems return `Err(Config(_))`. The per-attempt
+  detail therefore exists already — it is just only available **at the end**.
+- The SSE protocol is **not** modeled in `openapi.json` (confirmed: zero
+  matches). It is documented in `docs/api-reference.md`. So no OpenAPI
+  regeneration is needed for new frame types.
+- `execute_image` has exactly two callers, both in `stream.rs` — so its
+  signature can be extended freely.
+
+## Design
+
+### 1. New `ProtocolFrame` variants
+
+Added to the `ProtocolFrame` enum (`stream.rs:42`, `#[serde(tag = "type",
+rename_all = "snake_case")]`). Each frame has exactly one job, so payloads stay
+minimal.
+
+```rust
+ImagePending {
+    message_id: String,
+},
+ImageAttempt {
+    message_id: String,
+    model: String,
+    variant: PromptVariant,   // composed | original | single (existing enum)
+    index: u32,               // 1-based position in the attempt plan
+    total: u32,               // total planned attempts
+},
+ImageFailed {
+    message_id: String,
+    reason: ImageFailReason,
+},
+```
+
+New small enum (lives next to the frame types, snake_case Serialize):
+
+```rust
+pub enum ImageFailReason {
+    ChainExhausted,  // every candidate failed
+    ZeroImages,      // defensive: a success return carried zero images
+    ConfigError,     // no api key / no models configured
+}
+```
+
+These map 1:1 onto the three non-success arms of the existing `match
+execute_image(...)` blocks.
+
+**Payload rationale (deliberate minimalism):**
+
+- `image_pending` carries only `message_id`. Its single job is "an image is
+  coming for this message." The candidate model can differ from the served model
+  (fallback), so naming a model here would mislead; the model narrative belongs
+  to `image_attempt`, and the authoritative model/aspect/prompt arrive on the
+  terminal `image` frame.
+- `image_attempt` carries the per-attempt `model` + `variant` + `index`/`total`
+  — enough for "trying A (1/3)…", "trying A alt-prompt (2/3)…", "trying B
+  (3/3)…". This is **start-only**: one frame as each attempt begins. The
+  attempt's failure outcome is implied by the next `image_attempt` (or by the
+  terminal `image` / `image_failed`); the full per-attempt outcome
+  (transport / status+code / zero_images / decode) is still persisted to DB
+  metadata for diagnostics, unchanged.
+- `image_failed` carries `message_id` + a coarse `reason`. The per-model failure
+  story lives in the `image_attempt` frames and the persisted diagnostic, so the
+  frame itself stays small.
+
+`PromptVariant` is reused verbatim from `openrouter.rs:113` (already
+`Serialize`, snake_case). `ImageAttempt`/`AttemptOutcome` row diagnostics are
+unchanged.
+
+### 2. Streaming seam in `execute_image`
+
+To surface attempts live without a detached task, the existing fallback loop is
+extracted so a caller can observe each attempt as it starts:
+
+```rust
+// new progress payload (llm crate)
+pub struct ImageAttemptProgress {
+    pub model: String,
+    pub variant: PromptVariant,
+    pub index: u32,
+    pub total: u32,
+}
+
+// extracted core: existing loop, plus an on_attempt hook fired
+// immediately BEFORE each HTTP post.
+async fn execute_image_inner(
+    &self,
+    req: ImageGenRequest,
+    mut on_attempt: impl FnMut(ImageAttemptProgress),
+) -> Result<ImageGenResponse, ImageGenError> { /* today's loop */ }
+
+// unchanged public API: no-op hook, existing callers untouched
+pub async fn execute_image(&self, req: ImageGenRequest)
+    -> Result<ImageGenResponse, ImageGenError>
+{
+    self.execute_image_inner(req, |_| {}).await
+}
+```
+
+`total` is `plan.len()`; `index` is the 1-based loop position. The hook is a
+**sync** `FnMut` — it never `await`s — so it cannot reorder or block the gen
+loop.
+
+**Driving it once, via a `drive_image_gen` stream helper.** Rather than
+duplicate the channel/`select!` plumbing in both image arms, the server wraps it
+in a single free function (in `stream.rs`) returning a stream of events:
+
+```rust
+// server-internal
+enum ImageGenEvent {
+    Attempt(ImageAttemptProgress),
+    Done(Result<ImageGenResponse, ImageGenError>),
+}
+
+fn drive_image_gen(
+    client: Arc<OpenRouterClient>,
+    req: ImageGenRequest,
+) -> impl Stream<Item = ImageGenEvent> {
+    async_stream::stream! {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<ImageAttemptProgress>();
+        let gen = client.execute_image_inner(req, move |p| { let _ = tx.send(p); });
+        tokio::pin!(gen);
+        let result = loop {
+            tokio::select! {
+                Some(p) = rx.recv() => yield ImageGenEvent::Attempt(p),
+                r = &mut gen => {
+                    while let Ok(p) = rx.try_recv() { yield ImageGenEvent::Attempt(p); }
+                    break r;
+                }
+            }
+        };
+        yield ImageGenEvent::Done(result);
+    }
+}
+```
+
+Each image arm then forwards events with ~10 lines of glue — mapping `Attempt`
+→ an `image_attempt` frame stamped with that arm's own `message_id`, and
+capturing the single `Done`:
+
+```rust
+let mut events = Box::pin(drive_image_gen(state.openrouter.clone(), req));
+let mut outcome = None;
+while let Some(ev) = events.next().await {
+    match ev {
+        ImageGenEvent::Attempt(p) => yield ProtocolFrame::ImageAttempt {
+            message_id: img_mid.clone(),
+            model: p.model, variant: p.variant, index: p.index, total: p.total },
+        ImageGenEvent::Done(r) => outcome = Some(r),
+    }
+}
+match outcome.expect("drive_image_gen yields exactly one Done") { /* terminal arms */ }
+```
+
+The helper owns the `Arc<OpenRouterClient>` and polls `execute_image_inner` in
+place; while it `await`s each HTTP roundtrip, the `select!` drains queued
+progress into `Attempt` events. The channel is `tokio::sync::mpsc::unbounded`
+(`futures-channel` is not a workspace dependency). If the SSE client
+disconnects, the generator drops the boxed helper stream → the in-flight gen
+future drops → the HTTP call is cancelled. The concurrency lives in **one**
+place; only the ~10-line forwarding glue (differing solely by `message_id`)
+appears in each arm. The helper is independently unit-tested: collect its events
+against a wiremock that 500s every attempt → N `Attempt` events + one
+`Done(Err(ChainExhausted))`.
+
+### 3. Emission points & frame sequences
+
+**`reply_text_image`** (`stream.rs:2964` block). Emit `image_pending` at the
+**top** of the `if let (Some(last), Some(chain))` commit block — **before**
+`run_image_prompt_compose`, because compose is itself an LLM call inside the
+gap. `message_id` is the existing produced row id (`last.message_id`). Then run
+the streaming seam; on each terminal arm:
+
+| Arm | Action |
+|---|---|
+| `Ok(resp)` with ≥1 image | yield existing `image` frame (unchanged) |
+| `Err(ChainExhausted)` | persist `image_failed` meta (unchanged) **and** yield `image_failed { reason: chain_exhausted }` |
+| `Ok(_)` zero images | warn (unchanged) **and** yield `image_failed { reason: zero_images }` |
+| `Err(Config)` | warn (unchanged) **and** yield `image_failed { reason: config_error }` |
+
+Sequence:
+
+```
+meta → delta* → done → image_pending → image_attempt* → (image | image_failed) → final
+```
+
+If `image_chain` is `None` or the burst produced no row (`produced.last()` is
+`None`), the commit block is skipped entirely → **none** of the three new frames
+are emitted (there is nothing to attach an image to). Unchanged guard.
+
+**`reply_image`** (`stream.rs:2492` block). Pre-allocate `msg_ulid` **before**
+generation (today it is created after success). Emit `image_pending { message_id:
+X }` before compose/gen, run the streaming seam, then:
+
+- **Success:** keep `meta → image → done` using the **same** pre-allocated `X`
+  (the persisted row uses `X` too). Then `image_only_done` path emits `final`.
+
+  ```
+  image_pending(X) → image_attempt*(X) → meta(X) → image(X) → done(X) → final
+  ```
+
+- **Failure** (any of the three arms): yield `image_failed { message_id: X,
+  reason }`, then **fall through to the text path** exactly as today, which
+  produces a separate text row `Y` and emits a normal text reply. The
+  `ChainExhausted` diagnostic still persists onto `Y` (unchanged).
+
+  ```
+  image_pending(X) → image_attempt*(X) → image_failed(X) → meta(reply,Y) → delta* → done(Y) → final
+  ```
+
+  **Contract point: `X` ≠ `Y`.** `X` is the never-persisted *intended-image*
+  id that `image_pending`/`image_attempt`/`image_failed` reference; `Y` is the
+  real text message that the turn degrades to. A consumer clears the pending
+  state for `X` on `image_failed(X)`, then renders `Y` as an ordinary text
+  reply. (The persisted `image_failed` diagnostic lives on `Y`'s row — frames
+  describe the failed *attempt*; the DB record is for reconstruction.)
+
+### 4. Backward compatibility
+
+All three new frames are new `type` discriminants. Existing consumers already
+ignore unknown frame types (`docs/api-reference.md` §"Compatibility"), so they
+continue to see exactly today's streams:
+
+- `reply_image` success: `meta → image → done → final` (new frames interleaved
+  but ignored).
+- `reply_image` failure: `meta(reply) → delta* → done → final`.
+- `reply_text_image`: `meta → delta* → done → image → final` (success);
+  `… → done → final` with no `image` (failure).
+
+No existing frame's shape changes. This is purely additive.
+
+### 5. Error handling
+
+- The progress channel is best-effort: `unbounded_send` never blocks; send
+  errors are ignored and never fail the turn.
+- The streaming seam reuses the existing fallback/diagnostic logic verbatim —
+  the only new behavior is the `on_attempt` hook firing and the new `yield`s.
+  All DB persistence (`merge_assistant_image_meta`,
+  `merge_assistant_metadata_key`, the image-only row insert) is unchanged.
+- `config_error` / `zero_images` for `reply_text_image` previously emitted
+  nothing; they now also emit `image_failed`. This is the intended fix (the
+  "silently dropped" gap), not a regression.
+
+## Documentation
+
+- **`docs/api-reference.md`**: add frame tables for `image_pending`,
+  `image_attempt`, `image_failed` (+ the `reason` value list); update the "Full
+  SSE frame sequences" block for both actions; update the "Failed-image client
+  contract" section to describe the `reply_image` `X` ≠ `Y` flow.
+- **`docs/api-reference.zh.md`**: mirror the above; new sections written in
+  simplified Chinese (per repo doc-language convention).
+- No `openapi.json` change (SSE frames are not modeled there).
+
+## Testing
+
+The image client is a concrete `OpenRouterClient` (not a trait), so there is no
+mock seam for an end-to-end `run_stream` sequence test. The new concurrency,
+however, is isolated in `drive_image_gen`, which IS testable on its own with the
+`wiremock` harness both crates already use.
+
+1. **Frame serialization** (`stream.rs` `#[cfg(test)]` module): serialize each
+   new variant and assert the `type` tag + field shape, mirroring the existing
+   `meta` / `done` serialization tests. Cover `ImageFailReason` rendering
+   (`chain_exhausted` / `zero_images` / `config_error`) and `PromptVariant` in
+   an `image_attempt`.
+2. **`execute_image_inner` hook** (llm crate): a `wiremock` server that 500s
+   every request → each candidate fails (`Status`) → `ChainExhausted`. Assert
+   the `on_attempt` hook fires exactly `total` times with `index` 1..=`total`
+   and correct `total`, and that the call returns `ChainExhausted` with the same
+   number of attempts.
+3. **`drive_image_gen` helper** (server `stream.rs` tests): a `wiremock` server
+   that 500s every request; collect the event stream and assert N `Attempt`
+   events + exactly one terminal `Done(Err(ChainExhausted))` (N = candidate
+   count). This is the automated test for the streaming/cancellation seam.
+4. **Happy path** (`reply_text_image` / `reply_image` success → `image`, and the
+   `reply_image` `X` ≠ `Y` failure flow): manual verification against a live key,
+   as with the existing image features.
+
+## Out of scope
+
+- `image_attempt` outcome frames (start-only was chosen; per-attempt outcomes
+  remain in DB metadata only).
+- Modeling the SSE protocol in OpenAPI.
+- Any change to `execute_image`'s fallback/retry/compose logic — this PR only
+  observes it.
+```


### PR DESCRIPTION
## Summary

Adds explicit image-generation lifecycle SSE frames so chat consumers can render a deterministic **generating → done / failed** state for both image actions. Closes #131.

Today, `reply_text_image` blocks on image generation *after* the text `done` frame with **no frame in the gap** (so a consumer gating "generating" on the message being unsettled loses the signal), and image-gen failure emits nothing at all. This change makes the generating/done/failed states unambiguous and consistent across both image actions.

## New SSE frames (additive — existing consumers ignore unknown `type`s)

- **`image_pending`** `{ message_id }` — the engine has committed to generating an image; start the spinner.
- **`image_attempt`** `{ message_id, model, variant, index, total }` — live fallback-chain progress, one per attempt as it begins.
- **`image_failed`** `{ message_id, reason }` — gave up (`reason` ∈ `chain_exhausted` / `zero_images` / `config_error`); clear pending, render failed.

### Sequences
- `reply_text_image`: `meta → delta* → done → image_pending → image_attempt* → (image | image_failed) → final`
- `reply_image` (success): `image_pending → image_attempt* → meta → image → done → final`
- `reply_image` (failed): `image_pending(X) → image_attempt*(X) → image_failed(X) → meta(reply_text,Y) → delta* → done(Y) → final` — the turn degrades to a text reply with a **different** id `Y` (`X` is the never-persisted intended-image id that `image_failed` clears; the diagnostic persists on `Y`).

## How

- `execute_image` → refactored into `execute_image_inner(req, on_attempt)` (a sync hook fired before each HTTP post); `execute_image` retained as the stable public lib entry point.
- New `drive_image_gen(client, req) -> impl Stream<ImageGenEvent>` helper holds the channel/`select!` concurrency **once**; both image arms forward its events (gen future polled in place — dropping the stream cancels the in-flight call).

## Compatibility

Purely additive: no existing frame's shape changes; OpenAPI snapshot unchanged (SSE frames aren't modeled there). Docs updated in `api-reference.md` + `api-reference.zh.md`.

## Verification

- Full workspace (with DB): **693 tests pass, 0 failed** (core 63 / llm 169 / server 354 / store 107).
- `cargo fmt --check` clean · `cargo clippy --all-targets -D warnings` clean · OpenAPI snapshot unchanged.
- New automated tests: `execute_image_inner` attempt-hook (wiremock), `drive_image_gen` stream events (wiremock), frame serialization.
- Happy-path SSE wire-order is manual (no mock seam for the concrete client) — pending live-key check.

Design spec: `docs/superpowers/specs/2026-06-30-image-lifecycle-frames-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)