### PR TITLE
feat(server): delegate image drawing to the client via image_request frame (E1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,6 +445,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
+ "base64",
  "chrono",
  "chrono-tz",
  "cron",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,4 @@ futures-util       = "0.3"
 tokio-stream       = "0.1"
 async-stream       = "0.3"
 ulid               = { version = "1", features = ["serde", "uuid"] }
+base64             = "0.22"

--- a/crates/eros-engine-core/src/types.rs
+++ b/crates/eros-engine-core/src/types.rs
@@ -96,9 +96,9 @@ pub enum HistoryAnchor {
 
 /// Which reference image an image turn should build on. `Face` = the static
 /// avatar / face reference; `Previous` = the previously generated image
-/// (iteration). Defaults to `Face`. Internal-only (mapped from the PDE verdict);
-/// not serialized to any DB/SSE wire path.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Deserialize)]
+/// (iteration). Defaults to `Face`. Serialized (snake_case) into the delegated
+/// `image_request` SSE frame; deserialized from the PDE verdict.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ImageRef {
     #[default]
@@ -248,6 +248,13 @@ mod tests {
             }
             _ => panic!("expected UserMessage"),
         }
+    }
+
+    #[test]
+    fn image_ref_serializes_snake_case() {
+        use crate::types::ImageRef;
+        assert_eq!(serde_json::to_value(ImageRef::Face).unwrap(), "face");
+        assert_eq!(serde_json::to_value(ImageRef::Previous).unwrap(), "previous");
     }
 
     #[test]

--- a/crates/eros-engine-core/src/types.rs
+++ b/crates/eros-engine-core/src/types.rs
@@ -254,7 +254,10 @@ mod tests {
     fn image_ref_serializes_snake_case() {
         use crate::types::ImageRef;
         assert_eq!(serde_json::to_value(ImageRef::Face).unwrap(), "face");
-        assert_eq!(serde_json::to_value(ImageRef::Previous).unwrap(), "previous");
+        assert_eq!(
+            serde_json::to_value(ImageRef::Previous).unwrap(),
+            "previous"
+        );
     }
 
     #[test]

--- a/crates/eros-engine-server/Cargo.toml
+++ b/crates/eros-engine-server/Cargo.toml
@@ -48,6 +48,7 @@ futures-util = { workspace = true }
 tokio-stream = { workspace = true }
 async-stream = { workspace = true }
 ulid         = { workspace = true }
+base64       = { workspace = true }
 rand = "0.8"
 # 6-field cron schedule parser (sec min hr dom mon dow). Pure parser; the
 # sweeper drives ticks via tokio::time::sleep. No runtime scheduler.

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -1249,6 +1249,10 @@
               "null"
             ]
           },
+          "delegate": {
+            "type": "boolean",
+            "description": "Delegate drawing to the downstream consumer. Default `false` keeps\ntoday's in-engine draw path unchanged. When `true`, the engine composes\nthe prompt and emits a single `image_request` frame (no provider call, no\nimage bytes, no draw-result persistence); the consumer draws, uploads,\nand records the outcome. `model`, `face_ref_url`, `prev_image_url`, and\n`resolution` are ignored when delegated (the composer needs only `style`)."
+          },
           "face_ref_url": {
             "type": [
               "string",

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -4638,6 +4638,357 @@ data: [DONE]\n\n";
         }
     }
 
+    // ── Delegated image drawing (image.delegate) — the two arms end-to-end ──
+    // These drive `run_stream` with `delegate:true` and a `force`d image action
+    // (mode selects the arm), asserting the delegated frame sequence, that NO
+    // in-engine draw happens, and that only the minimal `metadata.image` marker
+    // is persisted. The model config enables the image executor
+    // (`chat_image_generation`) but omits the judge (`pde_decision`) and the
+    // composer (`chat_image_prompt_compose`), so the image-only turn makes zero
+    // LLM calls and the outcome is deterministic.
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn delegated_reply_image_emits_image_request_and_marker_no_draw(pool: PgPool) {
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+        use futures_util::StreamExt;
+        use wiremock::matchers::path as wm_path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        // Any OpenRouter call 500s — so an ERRONEOUS draw would surface as an
+        // `image_failed` frame (asserted absent). The correct delegated
+        // image-only path makes no provider call at all.
+        let mock = MockServer::start().await;
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&mock)
+            .await;
+
+        let user_id = Uuid::new_v4();
+        let (_g, instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = std::sync::Arc::new(
+            eros_engine_llm::model_config::ModelConfig::from_toml_str(
+                "[tasks.chat_image_generation]\nmodel = \"img-a\"\n",
+            )
+            .unwrap(),
+        );
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                eros_engine_llm::openrouter::AppAttribution::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+
+        let chat_repo = ChatRepo { pool: &pool };
+        let user_message_id = match chat_repo
+            .upsert_user_message_idempotent(
+                session_id,
+                "draw me",
+                "01J9000000000000000000000A",
+                "user",
+                None,
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
+
+        let frames: Vec<ProtocolFrame> = run_stream(
+            std::sync::Arc::new(state),
+            PersistedUserMessage {
+                user_message_id,
+                session_id,
+                user_id,
+                instance_id,
+                content: "draw me".into(),
+                prompt_traits: vec![],
+                audit: None,
+                tier: None,
+                memory_scope: Default::default(),
+                affinity_scope: Default::default(),
+                tips_amount_usd: None,
+                image_url: None,
+                image: Some(crate::routes::companion_stream::ImageReplyParams {
+                    force: true,
+                    delegate: true,
+                    mode: crate::routes::companion_stream::ImageMode::ImageOnly,
+                    image_prompt: Some("a beach at sunset".into()),
+                    ..Default::default()
+                }),
+                history_anchor: Default::default(),
+            },
+        )
+        .collect()
+        .await;
+
+        // Exact delegated image-only sequence: meta → done → image_request → final.
+        let types: Vec<String> = frames
+            .iter()
+            .map(|f| {
+                serde_json::to_value(f).unwrap()["type"]
+                    .as_str()
+                    .unwrap()
+                    .to_string()
+            })
+            .collect();
+        assert_eq!(
+            types,
+            ["meta", "done", "image_request", "final"],
+            "delegated image-only sequence, got {frames:?}"
+        );
+        // No in-engine draw-lifecycle frame may appear in the delegated path.
+        assert!(
+            !frames.iter().any(|f| matches!(
+                f,
+                ProtocolFrame::ImagePending { .. }
+                    | ProtocolFrame::ImageAttempt { .. }
+                    | ProtocolFrame::Image { .. }
+                    | ProtocolFrame::ImageFailed { .. }
+            )),
+            "no draw frame may appear: {frames:?}"
+        );
+        // meta carries reply_image and no model (the consumer chooses the model).
+        let (action, model) = frames
+            .iter()
+            .find_map(|f| match f {
+                ProtocolFrame::Meta {
+                    action_type, model, ..
+                } => Some((*action_type, model.clone())),
+                _ => None,
+            })
+            .expect("meta present");
+        assert_eq!(action, FrameActionType::ReplyImage);
+        assert!(model.is_none(), "delegated meta carries no model");
+        // image_request: face ref + base64 composed wire prompt containing the subject.
+        let (composed_b64, image_ref) = frames
+            .iter()
+            .find_map(|f| match f {
+                ProtocolFrame::ImageRequest {
+                    composed_prompt,
+                    image_ref,
+                    ..
+                } => Some((composed_prompt.clone(), *image_ref)),
+                _ => None,
+            })
+            .expect("image_request present");
+        assert_eq!(image_ref, eros_engine_core::types::ImageRef::Face);
+        let composed = {
+            use base64::Engine as _;
+            String::from_utf8(
+                base64::engine::general_purpose::STANDARD
+                    .decode(&composed_b64)
+                    .unwrap(),
+            )
+            .unwrap()
+        };
+        assert!(
+            composed.contains("a beach at sunset"),
+            "composed wire prompt should contain the subject: {composed}"
+        );
+
+        // Persistence: minimal marker only (seed subject under `prompt`), and NOT
+        // the composed wire prompt / model / generation_id / url.
+        let meta_row: Option<serde_json::Value> = sqlx::query_scalar(
+            "SELECT metadata FROM engine.chat_messages \
+             WHERE session_id = $1 AND role = 'assistant' \
+             ORDER BY sent_at DESC LIMIT 1",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let img = meta_row.expect("assistant row has metadata")["image"].clone();
+        assert_eq!(
+            img["prompt"], "a beach at sunset",
+            "marker keeps the seed subject"
+        );
+        assert!(img.get("model").is_none(), "marker must not store a model");
+        assert!(
+            img.get("generation_id").is_none(),
+            "marker must not store a generation id"
+        );
+        assert!(img.get("url").is_none(), "marker must not store a url");
+        assert_ne!(
+            img["prompt"],
+            serde_json::json!(composed),
+            "the composed wire prompt must not be persisted (only the seed subject)"
+        );
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn delegated_reply_text_image_appends_image_request_and_marker(pool: PgPool) {
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+        use futures_util::StreamExt;
+        use wiremock::matchers::path as wm_path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        // The text reply streams from this mock (≥ MIN_FILTERED_OUTPUT_CHARS so it
+        // is not degraded as too-short). The delegated image path makes NO extra
+        // (draw) call; a draw would reuse this endpoint but we assert no
+        // image_failed / image frame appears.
+        let mock = MockServer::start().await;
+        let body = "\
+data: {\"choices\":[{\"delta\":{\"content\":\"I would absolutely love that for you, \"}}]}\n\n\
+data: {\"choices\":[{\"delta\":{\"content\":\"let me slip into something far more comfortable and show you every bit of it\"}}],\"usage\":{\"prompt_tokens\":2,\"completion_tokens\":9,\"total_tokens\":11},\"id\":\"gen-r\",\"model\":\"primary\"}\n\n\
+data: [DONE]\n\n";
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+
+        let user_id = Uuid::new_v4();
+        let (_g, instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = std::sync::Arc::new(
+            eros_engine_llm::model_config::ModelConfig::from_toml_str(
+                "[tasks.chat_image_generation]\nmodel = \"img-a\"\n",
+            )
+            .unwrap(),
+        );
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                eros_engine_llm::openrouter::AppAttribution::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+
+        let chat_repo = ChatRepo { pool: &pool };
+        let user_message_id = match chat_repo
+            .upsert_user_message_idempotent(
+                session_id,
+                "hi",
+                "01J9111111111111111111111A",
+                "user",
+                None,
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
+
+        let frames: Vec<ProtocolFrame> = run_stream(
+            std::sync::Arc::new(state),
+            PersistedUserMessage {
+                user_message_id,
+                session_id,
+                user_id,
+                instance_id,
+                content: "hi".into(),
+                prompt_traits: vec![],
+                audit: None,
+                tier: None,
+                memory_scope: Default::default(),
+                affinity_scope: Default::default(),
+                tips_amount_usd: None,
+                image_url: None,
+                image: Some(crate::routes::companion_stream::ImageReplyParams {
+                    force: true,
+                    delegate: true,
+                    // default mode = TextImage ⇒ ReplyTextImage
+                    image_prompt: Some("in a red dress".into()),
+                    ..Default::default()
+                }),
+                history_anchor: Default::default(),
+            },
+        )
+        .collect()
+        .await;
+
+        let types: Vec<String> = frames
+            .iter()
+            .map(|f| {
+                serde_json::to_value(f).unwrap()["type"]
+                    .as_str()
+                    .unwrap()
+                    .to_string()
+            })
+            .collect();
+        // meta(reply_text_image) → delta* → done → image_request → final.
+        assert_eq!(types.first().map(String::as_str), Some("meta"), "{types:?}");
+        assert_eq!(types.last().map(String::as_str), Some("final"), "{types:?}");
+        assert!(
+            types.iter().any(|t| t == "delta"),
+            "text burst delta present: {types:?}"
+        );
+        let ir_pos = types
+            .iter()
+            .position(|t| t == "image_request")
+            .expect("image_request present");
+        let done_pos = types
+            .iter()
+            .position(|t| t == "done")
+            .expect("done present");
+        assert!(
+            done_pos < ir_pos,
+            "image_request comes after done: {types:?}"
+        );
+        assert_eq!(
+            types[ir_pos + 1],
+            "final",
+            "image_request immediately before final"
+        );
+        assert_eq!(
+            types
+                .iter()
+                .filter(|t| t.as_str() == "image_request")
+                .count(),
+            1,
+            "exactly one image_request"
+        );
+        // No draw-lifecycle frames.
+        assert!(
+            !frames.iter().any(|f| matches!(
+                f,
+                ProtocolFrame::ImagePending { .. }
+                    | ProtocolFrame::ImageAttempt { .. }
+                    | ProtocolFrame::Image { .. }
+                    | ProtocolFrame::ImageFailed { .. }
+            )),
+            "no draw frame may appear: {types:?}"
+        );
+        let action = frames
+            .iter()
+            .find_map(|f| match f {
+                ProtocolFrame::Meta { action_type, .. } => Some(*action_type),
+                _ => None,
+            })
+            .expect("meta present");
+        assert_eq!(action, FrameActionType::ReplyTextImage);
+
+        // The minimal marker was MERGED onto the assistant TEXT row (content
+        // non-empty), carrying only the seed subject.
+        let row: (String, Option<serde_json::Value>) = sqlx::query_as(
+            "SELECT content, metadata FROM engine.chat_messages \
+             WHERE session_id = $1 AND role = 'assistant' \
+             ORDER BY sent_at DESC LIMIT 1",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert!(!row.0.is_empty(), "the text reply row has content");
+        let img = row.1.expect("row has metadata")["image"].clone();
+        assert_eq!(img["prompt"], "in a red dress");
+        assert!(img.get("model").is_none(), "marker must not store a model");
+        assert!(
+            img.get("generation_id").is_none(),
+            "marker must not store a generation id"
+        );
+        assert!(img.get("url").is_none(), "marker must not store a url");
+    }
+
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
     async fn live_burst_meta_omits_model_when_override_false(pool: PgPool) {
         use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -3211,7 +3211,10 @@ pub fn run_stream(
                         // Emitted before run_image_prompt_compose (itself an LLM
                         // call) so it covers the whole gap after the text `done`.
                         let img_mid = ulid_string(Ulid::from(msg_uuid));
-                        yield ProtocolFrame::ImagePending { message_id: img_mid.clone() };
+                        let delegate = req_image.is_some_and(|i| i.delegate);
+                        if !delegate {
+                            yield ProtocolFrame::ImagePending { message_id: img_mid.clone() };
+                        }
                         let subject = plan
                             .image_prompt
                             .as_deref()
@@ -3271,137 +3274,160 @@ pub fn run_stream(
                         );
                         let ar = req.aspect_ratio.clone();
                         let res = req.resolution.clone();
-                        // #131: drive image-gen, forwarding each attempt as an
-                        // image_attempt frame; capture the single terminal Done.
-                        let mut img_events =
-                            Box::pin(drive_image_gen(state.openrouter.clone(), req));
-                        let mut img_outcome = None;
-                        {
-                            use futures_util::StreamExt as _;
-                            while let Some(ev) = img_events.next().await {
-                                match ev {
-                                    ImageGenEvent::Attempt(p) => {
-                                        yield ProtocolFrame::ImageAttempt {
-                                            message_id: img_mid.clone(),
-                                            model: p.model,
-                                            variant: p.variant,
-                                            index: p.index,
-                                            total: p.total,
-                                        };
+                        if delegate {
+                            // Delegated text+image: no provider call. Merge ONLY
+                            // the minimal marker (seed subject + aspect) onto the
+                            // already-persisted text row so the PDE stays
+                            // image-aware (§5); emit one image_request. The text
+                            // already reached the client via meta → delta* → done;
+                            // `final` follows below.
+                            let marker = build_delegated_image_marker(&subject, ar.as_deref());
+                            if let Err(e) = chat_repo
+                                .merge_assistant_image_meta(user_msg.session_id, msg_uuid, &marker)
+                                .await
+                            {
+                                tracing::warn!(
+                                    "stream(text_image,delegate): merge marker failed: {e}"
+                                );
+                            }
+                            yield build_image_request_frame(
+                                img_mid.clone(),
+                                &req,
+                                plan.image_ref,
+                            );
+                        } else {
+                            // #131: drive image-gen, forwarding each attempt as an
+                            // image_attempt frame; capture the single terminal Done.
+                            let mut img_events =
+                                Box::pin(drive_image_gen(state.openrouter.clone(), req));
+                            let mut img_outcome = None;
+                            {
+                                use futures_util::StreamExt as _;
+                                while let Some(ev) = img_events.next().await {
+                                    match ev {
+                                        ImageGenEvent::Attempt(p) => {
+                                            yield ProtocolFrame::ImageAttempt {
+                                                message_id: img_mid.clone(),
+                                                model: p.model,
+                                                variant: p.variant,
+                                                index: p.index,
+                                                total: p.total,
+                                            };
+                                        }
+                                        ImageGenEvent::Done(r) => img_outcome = Some(r),
                                     }
-                                    ImageGenEvent::Done(r) => img_outcome = Some(r),
                                 }
                             }
-                        }
-                        match img_outcome.expect("drive_image_gen yields exactly one Done") {
-                            Ok(resp) if !resp.images.is_empty() => {
-                                let won_prompt = winning_image_prompt(
-                                    resp.winning_variant,
-                                    &final_subject,
-                                    &subject,
-                                );
-                                let cr = eros_engine_llm::openrouter::ChatResponse {
-                                    reply: String::new(),
-                                    generation_id: resp.generation_id.clone(),
-                                    model: resp.model.clone(),
-                                    usage: resp.usage.clone(),
-                                    finish_reason: resp.finish_reason.clone(),
-                                };
-                                // Mirror the other in-stream task log sites
-                                // (vision / filters / pde): session_id = None.
-                                super::log_openrouter_usage("chat_image_generation", None, &cr);
-                                let mut image_meta = serde_json::json!({
-                                    "prompt": won_prompt,
-                                    "style": style_str,
-                                    "model": resp.model,
-                                    "aspect_ratio": ar,
-                                    "resolution": res,
-                                    "generation_id": resp.generation_id,
-                                    "face_ref_used": face_used,
-                                    "image_ref": ref_kind,
-                                });
-                                if !resp.attempts.is_empty() {
-                                    image_meta["attempts"] =
-                                        serde_json::to_value(&resp.attempts).unwrap_or_default();
-                                }
-                                let mime = data_url_mime(&resp.images[0]);
-                                // merge_assistant_image_meta wraps under {"image":..}
-                                // itself — pass the raw image_meta.
-                                if let Err(e) = chat_repo
-                                    .merge_assistant_image_meta(
-                                        user_msg.session_id,
-                                        msg_uuid,
-                                        &image_meta,
-                                    )
-                                    .await
-                                {
-                                    tracing::warn!(
-                                        "stream(text_image): merge image meta failed: {e}"
+                            match img_outcome.expect("drive_image_gen yields exactly one Done") {
+                                Ok(resp) if !resp.images.is_empty() => {
+                                    let won_prompt = winning_image_prompt(
+                                        resp.winning_variant,
+                                        &final_subject,
+                                        &subject,
                                     );
+                                    let cr = eros_engine_llm::openrouter::ChatResponse {
+                                        reply: String::new(),
+                                        generation_id: resp.generation_id.clone(),
+                                        model: resp.model.clone(),
+                                        usage: resp.usage.clone(),
+                                        finish_reason: resp.finish_reason.clone(),
+                                    };
+                                    // Mirror the other in-stream task log sites
+                                    // (vision / filters / pde): session_id = None.
+                                    super::log_openrouter_usage("chat_image_generation", None, &cr);
+                                    let mut image_meta = serde_json::json!({
+                                        "prompt": won_prompt,
+                                        "style": style_str,
+                                        "model": resp.model,
+                                        "aspect_ratio": ar,
+                                        "resolution": res,
+                                        "generation_id": resp.generation_id,
+                                        "face_ref_used": face_used,
+                                        "image_ref": ref_kind,
+                                    });
+                                    if !resp.attempts.is_empty() {
+                                        image_meta["attempts"] =
+                                            serde_json::to_value(&resp.attempts).unwrap_or_default();
+                                    }
+                                    let mime = data_url_mime(&resp.images[0]);
+                                    // merge_assistant_image_meta wraps under {"image":..}
+                                    // itself — pass the raw image_meta.
+                                    if let Err(e) = chat_repo
+                                        .merge_assistant_image_meta(
+                                            user_msg.session_id,
+                                            msg_uuid,
+                                            &image_meta,
+                                        )
+                                        .await
+                                    {
+                                        tracing::warn!(
+                                            "stream(text_image): merge image meta failed: {e}"
+                                        );
+                                    }
+                                    yield ProtocolFrame::Image {
+                                        message_id: ulid_string(Ulid::from(msg_uuid)),
+                                        data_url: resp.images[0].clone(),
+                                        mime,
+                                        image_prompt: Some(won_prompt.clone()),
+                                        model: resp.model.clone(),
+                                        generation_id: resp.generation_id.clone(),
+                                    };
                                 }
-                                yield ProtocolFrame::Image {
-                                    message_id: ulid_string(Ulid::from(msg_uuid)),
-                                    data_url: resp.images[0].clone(),
-                                    mime,
-                                    image_prompt: Some(won_prompt.clone()),
-                                    model: resp.model.clone(),
-                                    generation_id: resp.generation_id.clone(),
-                                };
-                            }
-                            Ok(_) => {
-                                tracing::warn!(
-                                    "stream(text_image): execute_image returned zero images \
-                                     (unexpected); no Image frame (text already delivered)"
-                                );
-                                yield ProtocolFrame::ImageFailed {
-                                    message_id: img_mid.clone(),
-                                    reason: ImageFailReason::ZeroImages,
-                                };
-                            }
-                            Err(eros_engine_llm::openrouter::ImageGenError::Config(m)) => {
-                                tracing::warn!(
-                                    "stream(text_image): execute_image config error: {m}; \
-                                     no Image frame (text already delivered)"
-                                );
-                                yield ProtocolFrame::ImageFailed {
-                                    message_id: img_mid.clone(),
-                                    reason: ImageFailReason::ConfigError,
-                                };
-                            }
-                            Err(eros_engine_llm::openrouter::ImageGenError::ChainExhausted {
-                                attempts,
-                            }) => {
-                                tracing::warn!(
-                                    attempts = attempts.len(),
-                                    "stream(text_image): image chain exhausted; persisting \
-                                     image_failed onto the text row"
-                                );
-                                let meta = build_image_failed_meta(
-                                    &final_subject,
-                                    &style_str,
-                                    ar.as_deref(),
-                                    res.as_deref(),
-                                    ref_kind,
-                                    face_used,
-                                    &attempts,
-                                );
-                                if let Err(e) = chat_repo
-                                    .merge_assistant_metadata_key(
-                                        user_msg.session_id,
-                                        msg_uuid,
-                                        "image_failed",
-                                        &meta,
-                                    )
-                                    .await
-                                {
+                                Ok(_) => {
                                     tracing::warn!(
-                                        "stream(text_image): persist image_failed failed: {e}"
+                                        "stream(text_image): execute_image returned zero images \
+                                         (unexpected); no Image frame (text already delivered)"
                                     );
+                                    yield ProtocolFrame::ImageFailed {
+                                        message_id: img_mid.clone(),
+                                        reason: ImageFailReason::ZeroImages,
+                                    };
                                 }
-                                yield ProtocolFrame::ImageFailed {
-                                    message_id: img_mid.clone(),
-                                    reason: ImageFailReason::ChainExhausted,
-                                };
+                                Err(eros_engine_llm::openrouter::ImageGenError::Config(m)) => {
+                                    tracing::warn!(
+                                        "stream(text_image): execute_image config error: {m}; \
+                                         no Image frame (text already delivered)"
+                                    );
+                                    yield ProtocolFrame::ImageFailed {
+                                        message_id: img_mid.clone(),
+                                        reason: ImageFailReason::ConfigError,
+                                    };
+                                }
+                                Err(eros_engine_llm::openrouter::ImageGenError::ChainExhausted {
+                                    attempts,
+                                }) => {
+                                    tracing::warn!(
+                                        attempts = attempts.len(),
+                                        "stream(text_image): image chain exhausted; persisting \
+                                         image_failed onto the text row"
+                                    );
+                                    let meta = build_image_failed_meta(
+                                        &final_subject,
+                                        &style_str,
+                                        ar.as_deref(),
+                                        res.as_deref(),
+                                        ref_kind,
+                                        face_used,
+                                        &attempts,
+                                    );
+                                    if let Err(e) = chat_repo
+                                        .merge_assistant_metadata_key(
+                                            user_msg.session_id,
+                                            msg_uuid,
+                                            "image_failed",
+                                            &meta,
+                                        )
+                                        .await
+                                    {
+                                        tracing::warn!(
+                                            "stream(text_image): persist image_failed failed: {e}"
+                                        );
+                                    }
+                                    yield ProtocolFrame::ImageFailed {
+                                        message_id: img_mid.clone(),
+                                        reason: ImageFailReason::ChainExhausted,
+                                    };
+                                }
                             }
                         }
                     }

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -120,8 +120,6 @@ pub enum ProtocolFrame {
     /// Delegated image turn: the engine composed the prompt and hands drawing to
     /// the consumer. Replaces the whole `image_pending`/`image_attempt`/`image`/
     /// `image_failed` sequence for this turn — the engine draws nothing.
-    // non-test callers land later on this branch (delegated image branch); allow removed then.
-    #[allow(dead_code)]
     ImageRequest {
         message_id: String,
         /// base64(STANDARD, unwrapped) of the UTF-8 final wire prompt — exactly
@@ -288,8 +286,6 @@ fn drive_image_gen(
 /// appearance + enriched subject) — exactly what the provider would receive.
 /// base64(STANDARD, unwrapped) of its UTF-8 bytes keeps the explicit/CJK text
 /// out of SSE transport and intermediary logs. Pure.
-// non-test callers land later on this branch (delegated image branch); allow removed then.
-#[allow(dead_code)]
 fn build_image_request_frame(
     message_id: String,
     req: &eros_engine_llm::openrouter::ImageGenRequest,
@@ -309,8 +305,6 @@ fn build_image_request_frame(
 /// and the aspect ratio — deliberately NOT the composed wire prompt, model,
 /// generation id, url, or success/failure. Preserves the PDE image-awareness
 /// transcript (§5) while leaving the draw result with the consumer. Pure.
-// non-test callers land later on this branch (delegated image branch); allow removed then.
-#[allow(dead_code)]
 fn build_delegated_image_marker(
     seed_subject: &str,
     aspect_ratio: Option<&str>,
@@ -320,6 +314,32 @@ fn build_delegated_image_marker(
         m["aspect_ratio"] = serde_json::Value::String(ar.to_string());
     }
     m
+}
+
+/// The three ordered frames of a delegated image-only turn:
+/// `meta → done → image_request`. No `image_pending`/`image_attempt`/`image`/
+/// `image_failed`, no image bytes. Meta carries no model (the consumer selects
+/// it). Pure, so the order is unit-testable without the stream generator.
+fn delegated_image_only_frames(
+    message_id: String,
+    req: &eros_engine_llm::openrouter::ImageGenRequest,
+    image_ref: eros_engine_core::types::ImageRef,
+) -> Vec<ProtocolFrame> {
+    vec![
+        ProtocolFrame::Meta {
+            message_id: message_id.clone(),
+            action_type: FrameActionType::ReplyImage,
+            model: None,
+            continues_from: None,
+        },
+        ProtocolFrame::Done {
+            message_id: message_id.clone(),
+            truncated: false,
+            usage: None,
+            generation_id: None,
+        },
+        build_image_request_frame(message_id, req, image_ref),
+    ]
 }
 
 /// The subject-level prompt that actually drew the image, given which variant
@@ -2625,7 +2645,10 @@ pub fn run_stream(
                         let msg_ulid = Ulid::new();
                         let msg_uuid: Uuid = msg_ulid.into();
                         let img_mid = ulid_string(msg_ulid);
-                        yield ProtocolFrame::ImagePending { message_id: img_mid.clone() };
+                        let delegate = req_image.is_some_and(|i| i.delegate);
+                        if !delegate {
+                            yield ProtocolFrame::ImagePending { message_id: img_mid.clone() };
+                        }
                         let subject = plan
                             .image_prompt
                             .as_deref()
@@ -2685,162 +2708,213 @@ pub fn run_stream(
                         );
                         let ar = req.aspect_ratio.clone();
                         let res = req.resolution.clone();
-                        // #131: drive image-gen, forwarding each attempt as an
-                        // image_attempt frame; capture the single terminal Done.
-                        let mut img_events =
-                            Box::pin(drive_image_gen(state.openrouter.clone(), req));
-                        let mut img_outcome = None;
-                        {
-                            use futures_util::StreamExt as _;
-                            while let Some(ev) = img_events.next().await {
-                                match ev {
-                                    ImageGenEvent::Attempt(p) => {
-                                        yield ProtocolFrame::ImageAttempt {
-                                            message_id: img_mid.clone(),
-                                            model: p.model,
-                                            variant: p.variant,
-                                            index: p.index,
-                                            total: p.total,
-                                        };
+                        if delegate {
+                            // Delegated image-only: no provider call. Persist an
+                            // empty-content row carrying ONLY the minimal marker
+                            // (seed subject + aspect) so the PDE stays image-aware
+                            // (§5); the composed prompt + draw result live with the
+                            // consumer. Then meta → done → image_request, and fall
+                            // into the shared image-only completion below (final +
+                            // post-process, text path skipped).
+                            let marker = build_delegated_image_marker(&subject, ar.as_deref());
+                            let row = eros_engine_store::chat::AssistantInsert {
+                                id: msg_uuid,
+                                content: String::new(),
+                                assistant_action_type: "reply".into(),
+                                continues_from_message_id: None,
+                                truncated: false,
+                                model: None,
+                                usage: None,
+                                generation_id: None,
+                                filter_audit: None,
+                                metadata: Some(serde_json::json!({ "image": marker })),
+                            };
+                            if let Err(e) = chat_repo
+                                .insert_assistant_batch(
+                                    user_msg.session_id,
+                                    user_msg.user_message_id,
+                                    std::slice::from_ref(&row),
+                                )
+                                .await
+                            {
+                                tracing::warn!("stream(image,delegate): persist failed: {e}");
+                            }
+                            // full_text="" so insight/memory extraction skips this
+                            // row; affinity uses plan.image_prompt as the proxy,
+                            // mirroring the non-delegated image-only path.
+                            image_only_produced.push(
+                                crate::pipeline::post_process::ProducedMessage {
+                                    message_id: msg_uuid,
+                                    full_text: String::new(),
+                                    action: ActionType::ReplyImage,
+                                },
+                            );
+                            for frame in delegated_image_only_frames(
+                                img_mid.clone(),
+                                &req,
+                                plan.image_ref,
+                            ) {
+                                yield frame;
+                            }
+                            image_only_done = true;
+                        } else {
+                            // #131: drive image-gen, forwarding each attempt as an
+                            // image_attempt frame; capture the single terminal Done.
+                            let mut img_events =
+                                Box::pin(drive_image_gen(state.openrouter.clone(), req));
+                            let mut img_outcome = None;
+                            {
+                                use futures_util::StreamExt as _;
+                                while let Some(ev) = img_events.next().await {
+                                    match ev {
+                                        ImageGenEvent::Attempt(p) => {
+                                            yield ProtocolFrame::ImageAttempt {
+                                                message_id: img_mid.clone(),
+                                                model: p.model,
+                                                variant: p.variant,
+                                                index: p.index,
+                                                total: p.total,
+                                            };
+                                        }
+                                        ImageGenEvent::Done(r) => img_outcome = Some(r),
                                     }
-                                    ImageGenEvent::Done(r) => img_outcome = Some(r),
                                 }
                             }
-                        }
-                        match img_outcome.expect("drive_image_gen yields exactly one Done") {
-                            Ok(resp) if !resp.images.is_empty() => {
-                                let won_prompt = winning_image_prompt(
-                                    resp.winning_variant,
-                                    &final_subject,
-                                    &subject,
-                                );
-                                // Usage logging via the ChatResponse adapter.
-                                let cr = eros_engine_llm::openrouter::ChatResponse {
-                                    reply: String::new(),
-                                    generation_id: resp.generation_id.clone(),
-                                    model: resp.model.clone(),
-                                    usage: resp.usage.clone(),
-                                    finish_reason: resp.finish_reason.clone(),
-                                };
-                                // Mirror the other in-stream task log sites
-                                // (vision / filters / pde): session_id = None.
-                                super::log_openrouter_usage("chat_image_generation", None, &cr);
-                                let mut image_meta = serde_json::json!({
-                                    "prompt": won_prompt,
-                                    "style": style_str,
-                                    "model": resp.model,
-                                    "aspect_ratio": ar,
-                                    "resolution": res,
-                                    "generation_id": resp.generation_id,
-                                    "face_ref_used": face_used,
-                                    "image_ref": ref_kind,
-                                });
-                                if !resp.attempts.is_empty() {
-                                    image_meta["attempts"] =
-                                        serde_json::to_value(&resp.attempts).unwrap_or_default();
+                            match img_outcome.expect("drive_image_gen yields exactly one Done") {
+                                Ok(resp) if !resp.images.is_empty() => {
+                                    let won_prompt = winning_image_prompt(
+                                        resp.winning_variant,
+                                        &final_subject,
+                                        &subject,
+                                    );
+                                    // Usage logging via the ChatResponse adapter.
+                                    let cr = eros_engine_llm::openrouter::ChatResponse {
+                                        reply: String::new(),
+                                        generation_id: resp.generation_id.clone(),
+                                        model: resp.model.clone(),
+                                        usage: resp.usage.clone(),
+                                        finish_reason: resp.finish_reason.clone(),
+                                    };
+                                    // Mirror the other in-stream task log sites
+                                    // (vision / filters / pde): session_id = None.
+                                    super::log_openrouter_usage("chat_image_generation", None, &cr);
+                                    let mut image_meta = serde_json::json!({
+                                        "prompt": won_prompt,
+                                        "style": style_str,
+                                        "model": resp.model,
+                                        "aspect_ratio": ar,
+                                        "resolution": res,
+                                        "generation_id": resp.generation_id,
+                                        "face_ref_used": face_used,
+                                        "image_ref": ref_kind,
+                                    });
+                                    if !resp.attempts.is_empty() {
+                                        image_meta["attempts"] =
+                                            serde_json::to_value(&resp.attempts).unwrap_or_default();
+                                    }
+                                    let mime = data_url_mime(&resp.images[0]);
+                                    let row = eros_engine_store::chat::AssistantInsert {
+                                        id: msg_uuid,
+                                        content: String::new(),
+                                        assistant_action_type: "reply".into(),
+                                        continues_from_message_id: None,
+                                        truncated: false,
+                                        model: resp.model.clone(),
+                                        usage: resp.usage.clone(),
+                                        generation_id: resp.generation_id.clone(),
+                                        filter_audit: None,
+                                        metadata: Some(serde_json::json!({ "image": image_meta })),
+                                    };
+                                    if let Err(e) = chat_repo
+                                        .insert_assistant_batch(
+                                            user_msg.session_id,
+                                            user_msg.user_message_id,
+                                            std::slice::from_ref(&row),
+                                        )
+                                        .await
+                                    {
+                                        tracing::warn!("stream(image): persist failed: {e}");
+                                    }
+                                    // full_text="" so insight/memory extraction skips
+                                    // this row; affinity uses plan.image_prompt as the
+                                    // proxy (Task 12).
+                                    image_only_produced.push(
+                                        crate::pipeline::post_process::ProducedMessage {
+                                            message_id: msg_uuid,
+                                            full_text: String::new(),
+                                            action: ActionType::ReplyImage,
+                                        },
+                                    );
+                                    let mut wire_usage = resp.usage.clone();
+                                    filter_usage_keys(
+                                        &mut wire_usage,
+                                        &state.config.openrouter_usage_hidden_keys,
+                                    );
+                                    // Frame order: meta → image → done → final.
+                                    yield ProtocolFrame::Meta {
+                                        message_id: ulid_string(msg_ulid),
+                                        action_type: FrameActionType::ReplyImage,
+                                        model: resp.model.clone(),
+                                        continues_from: None,
+                                    };
+                                    yield ProtocolFrame::Image {
+                                        message_id: ulid_string(msg_ulid),
+                                        data_url: resp.images[0].clone(),
+                                        mime,
+                                        image_prompt: Some(won_prompt.clone()),
+                                        model: resp.model.clone(),
+                                        generation_id: resp.generation_id.clone(),
+                                    };
+                                    yield ProtocolFrame::Done {
+                                        message_id: ulid_string(msg_ulid),
+                                        truncated: false,
+                                        usage: wire_usage,
+                                        generation_id: resp.generation_id.clone(),
+                                    };
+                                    image_only_done = true;
                                 }
-                                let mime = data_url_mime(&resp.images[0]);
-                                let row = eros_engine_store::chat::AssistantInsert {
-                                    id: msg_uuid,
-                                    content: String::new(),
-                                    assistant_action_type: "reply".into(),
-                                    continues_from_message_id: None,
-                                    truncated: false,
-                                    model: resp.model.clone(),
-                                    usage: resp.usage.clone(),
-                                    generation_id: resp.generation_id.clone(),
-                                    filter_audit: None,
-                                    metadata: Some(serde_json::json!({ "image": image_meta })),
-                                };
-                                if let Err(e) = chat_repo
-                                    .insert_assistant_batch(
-                                        user_msg.session_id,
-                                        user_msg.user_message_id,
-                                        std::slice::from_ref(&row),
-                                    )
-                                    .await
-                                {
-                                    tracing::warn!("stream(image): persist failed: {e}");
+                                Ok(_) => {
+                                    tracing::warn!(
+                                        "stream(image): execute_image returned zero images \
+                                         (unexpected); falling through to text"
+                                    );
+                                    yield ProtocolFrame::ImageFailed {
+                                        message_id: img_mid.clone(),
+                                        reason: ImageFailReason::ZeroImages,
+                                    };
                                 }
-                                // full_text="" so insight/memory extraction skips
-                                // this row; affinity uses plan.image_prompt as the
-                                // proxy (Task 12).
-                                image_only_produced.push(
-                                    crate::pipeline::post_process::ProducedMessage {
-                                        message_id: msg_uuid,
-                                        full_text: String::new(),
-                                        action: ActionType::ReplyImage,
-                                    },
-                                );
-                                let mut wire_usage = resp.usage.clone();
-                                filter_usage_keys(
-                                    &mut wire_usage,
-                                    &state.config.openrouter_usage_hidden_keys,
-                                );
-                                // Frame order: meta → image → done → final.
-                                yield ProtocolFrame::Meta {
-                                    message_id: ulid_string(msg_ulid),
-                                    action_type: FrameActionType::ReplyImage,
-                                    model: resp.model.clone(),
-                                    continues_from: None,
-                                };
-                                yield ProtocolFrame::Image {
-                                    message_id: ulid_string(msg_ulid),
-                                    data_url: resp.images[0].clone(),
-                                    mime,
-                                    image_prompt: Some(won_prompt.clone()),
-                                    model: resp.model.clone(),
-                                    generation_id: resp.generation_id.clone(),
-                                };
-                                yield ProtocolFrame::Done {
-                                    message_id: ulid_string(msg_ulid),
-                                    truncated: false,
-                                    usage: wire_usage,
-                                    generation_id: resp.generation_id.clone(),
-                                };
-                                image_only_done = true;
-                            }
-                            Ok(_) => {
-                                tracing::warn!(
-                                    "stream(image): execute_image returned zero images \
-                                     (unexpected); falling through to text"
-                                );
-                                yield ProtocolFrame::ImageFailed {
-                                    message_id: img_mid.clone(),
-                                    reason: ImageFailReason::ZeroImages,
-                                };
-                            }
-                            Err(eros_engine_llm::openrouter::ImageGenError::Config(m)) => {
-                                tracing::warn!(
-                                    "stream(image): execute_image config error: {m}; \
-                                     falling through to text"
-                                );
-                                yield ProtocolFrame::ImageFailed {
-                                    message_id: img_mid.clone(),
-                                    reason: ImageFailReason::ConfigError,
-                                };
-                            }
-                            Err(eros_engine_llm::openrouter::ImageGenError::ChainExhausted {
-                                attempts,
-                            }) => {
-                                tracing::warn!(
-                                    attempts = attempts.len(),
-                                    "stream(image): image chain exhausted; persisting \
-                                     image_failed onto the fallthrough text row"
-                                );
-                                image_failed_meta = Some(build_image_failed_meta(
-                                    &final_subject,
-                                    &style_str,
-                                    ar.as_deref(),
-                                    res.as_deref(),
-                                    ref_kind,
-                                    face_used,
-                                    &attempts,
-                                ));
-                                yield ProtocolFrame::ImageFailed {
-                                    message_id: img_mid.clone(),
-                                    reason: ImageFailReason::ChainExhausted,
-                                };
+                                Err(eros_engine_llm::openrouter::ImageGenError::Config(m)) => {
+                                    tracing::warn!(
+                                        "stream(image): execute_image config error: {m}; \
+                                         falling through to text"
+                                    );
+                                    yield ProtocolFrame::ImageFailed {
+                                        message_id: img_mid.clone(),
+                                        reason: ImageFailReason::ConfigError,
+                                    };
+                                }
+                                Err(eros_engine_llm::openrouter::ImageGenError::ChainExhausted {
+                                    attempts,
+                                }) => {
+                                    tracing::warn!(
+                                        attempts = attempts.len(),
+                                        "stream(image): image chain exhausted; persisting \
+                                         image_failed onto the fallthrough text row"
+                                    );
+                                    image_failed_meta = Some(build_image_failed_meta(
+                                        &final_subject,
+                                        &style_str,
+                                        ar.as_deref(),
+                                        res.as_deref(),
+                                        ref_kind,
+                                        face_used,
+                                        &attempts,
+                                    ));
+                                    yield ProtocolFrame::ImageFailed {
+                                        message_id: img_mid.clone(),
+                                        reason: ImageFailReason::ChainExhausted,
+                                    };
+                                }
                             }
                         }
                     }
@@ -9062,6 +9136,42 @@ data: [DONE]\n\n"
         assert_eq!(m2.as_object().unwrap().len(), 1);
         let w2 = serde_json::json!({ "image": m2 });
         assert!(assistant_transcript_line("", Some(&w2)).contains("a portrait"));
+    }
+
+    #[test]
+    fn delegated_image_only_frames_are_meta_done_image_request() {
+        let req = eros_engine_llm::openrouter::ImageGenRequest {
+            model: "m1".into(),
+            fallback_model: vec![],
+            prompt: "a wire prompt".into(),
+            prompt_original: None,
+            face_ref_url: None,
+            aspect_ratio: Some("1:1".into()),
+            resolution: None,
+            max_tokens: 4096,
+        };
+        let frames = delegated_image_only_frames(
+            "01XYZ".into(),
+            &req,
+            eros_engine_core::types::ImageRef::Face,
+        );
+        let types: Vec<String> = frames
+            .iter()
+            .map(|f| {
+                serde_json::to_value(f).unwrap()["type"]
+                    .as_str()
+                    .unwrap()
+                    .to_string()
+            })
+            .collect();
+        assert_eq!(types, ["meta", "done", "image_request"]);
+        // meta has no model (the consumer chooses it); no image_pending/attempt/failed.
+        let meta = serde_json::to_value(&frames[0]).unwrap();
+        assert_eq!(meta["action_type"], "reply_image");
+        assert!(
+            meta.get("model").is_none(),
+            "delegated meta carries no model"
+        );
     }
 
     #[tokio::test]

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -117,6 +117,21 @@ pub enum ProtocolFrame {
         message_id: String,
         reason: ImageFailReason,
     },
+    /// Delegated image turn: the engine composed the prompt and hands drawing to
+    /// the consumer. Replaces the whole `image_pending`/`image_attempt`/`image`/
+    /// `image_failed` sequence for this turn — the engine draws nothing.
+    // non-test callers land later on this branch (delegated image branch); allow removed then.
+    #[allow(dead_code)]
+    ImageRequest {
+        message_id: String,
+        /// base64(STANDARD, unwrapped) of the UTF-8 final wire prompt — exactly
+        /// what the provider would have received. Opaque in transport; the
+        /// consumer decodes it at the last hop and uses it verbatim.
+        composed_prompt: String,
+        image_ref: eros_engine_core::types::ImageRef,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        aspect_ratio: Option<String>,
+    },
 }
 
 /// Render a 128-bit id as a Crockford Base32 ULID string (26 chars).
@@ -266,6 +281,45 @@ fn drive_image_gen(
         };
         yield ImageGenEvent::Done(result);
     }
+}
+
+/// Build the delegated `image_request` frame from the already-composed image
+/// request. `req.prompt` is the final wire prompt (style preset + persona
+/// appearance + enriched subject) — exactly what the provider would receive.
+/// base64(STANDARD, unwrapped) of its UTF-8 bytes keeps the explicit/CJK text
+/// out of SSE transport and intermediary logs. Pure.
+// non-test callers land later on this branch (delegated image branch); allow removed then.
+#[allow(dead_code)]
+fn build_image_request_frame(
+    message_id: String,
+    req: &eros_engine_llm::openrouter::ImageGenRequest,
+    image_ref: eros_engine_core::types::ImageRef,
+) -> ProtocolFrame {
+    use base64::Engine as _;
+    ProtocolFrame::ImageRequest {
+        message_id,
+        composed_prompt: base64::engine::general_purpose::STANDARD.encode(req.prompt.as_bytes()),
+        image_ref,
+        aspect_ratio: req.aspect_ratio.clone(),
+    }
+}
+
+/// Minimal `metadata.image` marker for a delegated image turn. Stores ONLY the
+/// PDE seed subject (under `prompt`, the key `assistant_transcript_line` reads)
+/// and the aspect ratio — deliberately NOT the composed wire prompt, model,
+/// generation id, url, or success/failure. Preserves the PDE image-awareness
+/// transcript (§5) while leaving the draw result with the consumer. Pure.
+// non-test callers land later on this branch (delegated image branch); allow removed then.
+#[allow(dead_code)]
+fn build_delegated_image_marker(
+    seed_subject: &str,
+    aspect_ratio: Option<&str>,
+) -> serde_json::Value {
+    let mut m = serde_json::json!({ "prompt": seed_subject });
+    if let Some(ar) = aspect_ratio.filter(|s| !s.is_empty()) {
+        m["aspect_ratio"] = serde_json::Value::String(ar.to_string());
+    }
+    m
 }
 
 /// The subject-level prompt that actually drew the image, given which variant
@@ -8951,6 +9005,63 @@ data: [DONE]\n\n"
         assert_eq!(chain["reason"], "chain_exhausted");
         assert_eq!(mk(ImageFailReason::ZeroImages)["reason"], "zero_images");
         assert_eq!(mk(ImageFailReason::ConfigError)["reason"], "config_error");
+    }
+
+    #[test]
+    fn image_request_frame_serializes_with_base64_and_snake_ref() {
+        use base64::Engine as _;
+        let prompt = "写实风格，海边少女，画幅 3:4"; // CJK + explicit-ish, exercises base64 of UTF-8
+        let req = eros_engine_llm::openrouter::ImageGenRequest {
+            model: "m1".into(),
+            fallback_model: vec![],
+            prompt: prompt.to_string(),
+            prompt_original: None,
+            face_ref_url: None,
+            aspect_ratio: Some("3:4".into()),
+            resolution: None,
+            max_tokens: 4096,
+        };
+        let f = build_image_request_frame(
+            "01ABC".into(),
+            &req,
+            eros_engine_core::types::ImageRef::Previous,
+        );
+        let v: serde_json::Value = serde_json::to_value(&f).unwrap();
+        assert_eq!(v["type"], "image_request");
+        assert_eq!(v["message_id"], "01ABC");
+        assert_eq!(v["image_ref"], "previous");
+        assert_eq!(v["aspect_ratio"], "3:4");
+        // composed_prompt round-trips base64 -> the exact UTF-8 wire prompt
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(v["composed_prompt"].as_str().unwrap())
+            .unwrap();
+        assert_eq!(String::from_utf8(decoded).unwrap(), prompt);
+    }
+
+    #[test]
+    fn delegated_marker_preserves_image_awareness() {
+        // Seed subject under `prompt` (the key assistant_transcript_line reads),
+        // plus aspect — and NOTHING else (no composed prompt / model / gen id).
+        let marker = build_delegated_image_marker("beach at sunset", Some("3:4"));
+        assert_eq!(marker["prompt"], "beach at sunset");
+        assert_eq!(marker["aspect_ratio"], "3:4");
+        assert_eq!(
+            marker.as_object().unwrap().len(),
+            2,
+            "marker must be minimal"
+        );
+        // The §5 regression guard: transcript still annotates it as a prior image.
+        let wrapped = serde_json::json!({ "image": marker });
+        let line = assistant_transcript_line("", Some(&wrapped));
+        assert!(line.contains("beach at sunset"), "subject surfaced: {line}");
+        assert!(line.contains("3:4"), "aspect surfaced: {line}");
+        assert_ne!(line.trim(), "", "image turn must not be a blank line");
+
+        // No aspect => still a valid one-key marker that annotates.
+        let m2 = build_delegated_image_marker("a portrait", None);
+        assert_eq!(m2.as_object().unwrap().len(), 1);
+        let w2 = serde_json::json!({ "image": m2 });
+        assert!(assistant_transcript_line("", Some(&w2)).contains("a portrait"));
     }
 
     #[tokio::test]

--- a/crates/eros-engine-server/src/routes/companion_stream.rs
+++ b/crates/eros-engine-server/src/routes/companion_stream.rs
@@ -110,9 +110,6 @@ pub struct ImageReplyParams {
     /// image bytes, no draw-result persistence); the consumer draws, uploads,
     /// and records the outcome. `model`, `face_ref_url`, `prev_image_url`, and
     /// `resolution` are ignored when delegated (the composer needs only `style`).
-    // Read by the delegated image-reply branch added later on this branch; the
-    // allow is removed once that reader lands.
-    #[allow(dead_code)]
     #[serde(default)]
     pub delegate: bool,
 }

--- a/crates/eros-engine-server/src/routes/companion_stream.rs
+++ b/crates/eros-engine-server/src/routes/companion_stream.rs
@@ -104,6 +104,17 @@ pub struct ImageReplyParams {
     /// clients backed by a private store should pass a short-lived signed URL.
     #[serde(default)]
     pub prev_image_url: Option<String>,
+    /// Delegate drawing to the downstream consumer. Default `false` keeps
+    /// today's in-engine draw path unchanged. When `true`, the engine composes
+    /// the prompt and emits a single `image_request` frame (no provider call, no
+    /// image bytes, no draw-result persistence); the consumer draws, uploads,
+    /// and records the outcome. `model`, `face_ref_url`, `prev_image_url`, and
+    /// `resolution` are ignored when delegated (the composer needs only `style`).
+    // Read by the delegated image-reply branch added later on this branch; the
+    // allow is removed once that reader lands.
+    #[allow(dead_code)]
+    #[serde(default)]
+    pub delegate: bool,
 }
 
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
@@ -1340,5 +1351,13 @@ mod validate_payload_tests {
             ..Default::default()
         });
         assert!(validate_payload(&ok).is_ok());
+    }
+
+    #[test]
+    fn image_reply_params_delegate_defaults_false() {
+        let none: ImageReplyParams = serde_json::from_str("{}").unwrap();
+        assert!(!none.delegate, "absent delegate must default to false");
+        let on: ImageReplyParams = serde_json::from_str(r#"{"delegate":true}"#).unwrap();
+        assert!(on.delegate);
     }
 }

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -293,6 +293,7 @@ curl -N -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/js
 | `resolution` | `String` | task `default_resolution` | Model-specific hint (e.g. `"1024x1365"`). Shape-validated only — opaque beyond that. |
 | `face_ref_url` | `String` | absent | image2image face/appearance reference (absolute `http(s)`, ≤ 2048 chars). Returns `422` if malformed. |
 | `prev_image_url` | `String` | absent | The previously generated image, for iteration (absolute `http(s)`, ≤ 2048 chars; validated like `face_ref_url`). Used only when the PDE picks `image_ref = "previous"` (see below); otherwise ignored. Clients backed by a private object store should pass a short-lived signed URL — the engine does not fetch it; it embeds the URL in the OpenRouter body and the image provider fetches it at generation time. Returns `422` if malformed. |
+| `delegate` | `bool` | `false` | When `true`, the engine composes the prompt and emits a single `image_request` frame instead of drawing inline; it makes no provider call, streams no image bytes, and persists no draw result. The consumer draws the composed prompt, uploads, and records the outcome. `model`, `face_ref_url`, `prev_image_url`, and `resolution` are ignored when delegated (only `style` is used). Default `false` preserves the in-engine draw path. |
 
 **Reference selection (`image_ref`).** The PDE verdict carries `image_ref`
 (`"face"` | `"previous"`, default `"face"`). At draw time the engine picks the
@@ -361,6 +362,30 @@ data: {"type":"image_failed","message_id":"01J...","reason":"chain_exhausted"}
 | `type` | `"image_failed"` | Frame type discriminator. |
 | `message_id` | `String` | Matches the `image_pending` frame's `message_id`. |
 | `reason` | `"chain_exhausted"` \| `"zero_images"` \| `"config_error"` | `chain_exhausted` = every candidate model failed; `zero_images` = a success response carried no image (defensive); `config_error` = no key / no models. |
+
+**`image_request` SSE frame** — emitted for a *delegated* image turn
+(`image.delegate: true`) in place of the whole
+`image_pending`/`image_attempt`/`image`/`image_failed` sequence. The engine
+composed the prompt; the consumer draws it. The engine draws nothing, streams no
+image bytes, and persists no draw result.
+
+```
+data: {"type":"image_request","message_id":"01J...","composed_prompt":"5YaZ5a6e...","image_ref":"face","aspect_ratio":"3:4"}
+```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `type` | `"image_request"` | Frame type discriminator. |
+| `message_id` | `String` | The real assistant `message_id`; key the draw and storage to it. |
+| `composed_prompt` | `String` | base64(`STANDARD`, unwrapped) of the UTF-8 final wire prompt. Decode at the last hop and use verbatim as the provider text prompt — reconstruct no prompt logic. |
+| `image_ref` | `"face"` \| `"previous"` | Which reference image the plan chose; the consumer resolves the actual URL. |
+| `aspect_ratio` | `String` \| absent | The semantic aspect (`1:1`,`3:4`,`4:3`,`9:16`,`16:9`) or absent. The consumer owns aspect→resolution mapping; no width/height is sent. |
+
+**Delegated sequences.** Image-only:
+`meta(reply_image) → done → image_request → final`.
+Text + image: `meta(reply_text_image) → delta* → done → image_request → final`.
+No `image_pending`/`image_attempt`/`image`/`image_failed` is emitted on the chat
+stream in the delegated path; total-failure handling is the consumer's.
 
 **Full SSE frame sequences:**
 

--- a/docs/api-reference.zh.md
+++ b/docs/api-reference.zh.md
@@ -271,6 +271,7 @@ curl -N -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/js
 | `resolution` | `String` | 任务 `default_resolution` | 模型相关的分辨率提示（如 `"1024x1365"`）。仅做形状校验，透传给模型。 |
 | `face_ref_url` | `String` | 缺失 | 图生图面部参考图（绝对 `http(s)` URL，≤ 2048 字符）。格式非法时返回 `422`。 |
 | `prev_image_url` | `String` | 缺失 | 上一张生成的图片，用于迭代续图（绝对 `http(s)` URL，≤ 2048 字符；校验同 `face_ref_url`）。仅当 PDE 选择 `image_ref = "previous"`（见下）时使用，否则忽略。私有对象存储的调用方应传一个短时效签名 URL——引擎不会去拉取它，而是把 URL 嵌进 OpenRouter 请求体，由画图供应商在生成时拉取。格式非法时返回 `422`。 |
+| `delegate` | `bool` | `false` | 为 `true` 时，引擎只组装提示词并发送单个 `image_request` 帧，不再内联绘图：不调用图像服务、不回传图像字节、不持久化绘图结果。由下游消费方绘制组装后的提示词、上传并记录结果。委托模式下忽略 `model`、`face_ref_url`、`prev_image_url`、`resolution`（仅使用 `style`）。默认 `false`，保持引擎内绘图路径不变。|
 
 **参考图选择（`image_ref`）。** PDE verdict 带有 `image_ref`（`"face"` \| `"previous"`，默认 `"face"`）。出图时引擎据此选参考图：`previous` 且带有 `prev_image_url` ⇒ 在上一张图上迭代；否则回退到 `face_ref_url`（头像）。所选类型记录在 `metadata.image` 中。
 
@@ -332,6 +333,27 @@ data: {"type":"image_failed","message_id":"01J...","reason":"chain_exhausted"}
 | `type` | `"image_failed"` | 帧类型标识符。 |
 | `message_id` | `String` | 与 `image_pending` 帧的 `message_id` 相同。 |
 | `reason` | `"chain_exhausted"` \| `"zero_images"` \| `"config_error"` | `chain_exhausted` = 所有候选模型均失败；`zero_images` = 成功响应但未含图片（防御性）；`config_error` = 未配置 key 或模型。 |
+
+**`image_request` SSE 帧** —— 委托绘图时（`image.delegate: true`）替代整套
+`image_pending`/`image_attempt`/`image`/`image_failed` 序列。引擎负责组装提示词，
+消费方负责绘制。引擎不绘图、不回传图像字节、不持久化绘图结果。
+
+```
+data: {"type":"image_request","message_id":"01J...","composed_prompt":"5YaZ5a6e...","image_ref":"face","aspect_ratio":"3:4"}
+```
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `type` | `"image_request"` | 帧类型标识。|
+| `message_id` | `String` | 真实的 assistant `message_id`；绘图与存储都以它为键。|
+| `composed_prompt` | `String` | 最终发给图像服务的提示词的 UTF-8 字节的 base64（`STANDARD`，无换行）。在最后一跳解码后原样用作图像服务的文本提示词，不要再重建任何提示词逻辑。|
+| `image_ref` | `"face"` \| `"previous"` | 计划选择的参考图；实际 URL 由消费方解析。|
+| `aspect_ratio` | `String` \| 不存在 | 语义画幅（`1:1`,`3:4`,`4:3`,`9:16`,`16:9`）或不存在。画幅→分辨率映射由消费方负责，引擎不发送宽高。|
+
+**委托序列。** 纯图片：`meta(reply_image) → done → image_request → final`。
+图文：`meta(reply_text_image) → delta* → done → image_request → final`。
+委托路径下聊天流不再发送 `image_pending`/`image_attempt`/`image`/`image_failed`；
+整体失败的处理归消费方。
 
 **完整 SSE 帧序列：**
 

--- a/docs/superpowers/specs/2026-07-05-delegate-image-drawing-to-client-design.md
+++ b/docs/superpowers/specs/2026-07-05-delegate-image-drawing-to-client-design.md
@@ -1,0 +1,318 @@
+# Delegate image drawing to the client (`image_request` frame)
+
+**Date:** 2026-07-05
+**Scope:** engine (this repo). Additive, flag-gated. A new `ProtocolFrame::ImageRequest`
+variant + a delegated branch in the two image arms of `pipeline/stream.rs`, a
+per-request `image.delegate` opt-in, and docs. No image is drawn on the engine
+when delegated; the composed prompt is handed to the downstream consumer, which
+draws it. The old in-engine drawing path is **retained unchanged** behind the
+default-off flag and removed in a later cleanup phase (E2) once no consumer sends
+`delegate:false`.
+
+> This is a public repository. Keep the spec and all code/commits
+> product-identity-free — refer to "the client" / "the downstream consumer",
+> never a specific product, brand, or URL.
+
+## Problem
+
+Today the engine performs the entire image lifecycle inline on the chat SSE
+stream. For a `reply_image` / `reply_text_image` turn the engine:
+
+1. Runs an LLM composer (`run_image_prompt_compose`, task
+   `chat_image_prompt_compose`) to expand the PDE seed into a detailed subject.
+2. Calls the image provider itself (`OpenRouterClient::execute_image_inner`,
+   `crates/eros-engine-llm/src/openrouter.rs:849-954`), walking the full
+   model×variant retry chain (`plan_attempts`, `openrouter.rs:313-329`:
+   `model1·composed → model1·original → model2·composed → model2·original`).
+3. Streams the finished image back as base64 in the `image` frame, and
+   persists `metadata.image{...}` / `metadata.image_failed{...}` onto the
+   assistant row in `engine.chat_messages`.
+
+The consequence is that **a single chat request stays open for the entire draw**.
+One successful generation takes ≥15s; a chain that retries up to four times can
+approach a minute, all inside the one stream. A client that cannot afford to
+block that long gets a very poor turn, and a fully-failed chain degrades to a
+plain text reply after ~60s of waiting. The engine also carries the whole image
+lifecycle: provider retries, base64 transport, a write-back endpoint for the
+durable URL, and result persistence — I/O and RTT that do not need to live here.
+
+## Goal
+
+Invert the responsibility: **the engine decides and composes; the consumer
+draws.** For a delegated image turn the engine emits a single new frame carrying
+the composed prompt and the reference choice, then ends the stream. It performs
+no provider call, streams no image bytes, and persists no draw result. This:
+
+- Removes the 15–60s draw (and its retries) from the chat stream — the turn
+  returns as soon as the composer finishes (one LLM call, fail-open).
+- Stops the engine from parsing/forwarding reference-image URLs and base64
+  images — less RTT and I/O.
+- Moves the image lifecycle (retries, upload, success/failure record) to the
+  consumer, which already owns its own storage.
+
+The composer stays in the engine (it needs persona `art_metadata`, the scene
+transcript, and the deployment's tuned `filter_prompt`, all engine-side).
+
+## Background — the current image path
+
+- **Action enum** `ActionType` — `crates/eros-engine-core/src/types.rs:112-119`
+  (`ReplyText`, `Ghost`, `ReplyImage`, `ReplyTextImage`, `Proactive`). The PDE
+  bundle `ActionPlan` (`types.rs:143-160`) carries `image_prompt`,
+  `image_ref: ImageRef` (`Face`/`Previous`, `types.rs:101-107`), `aspect_ratio`.
+- **Decision** — the LLM judge (task `pde_decision`) yields a `PdeVerdict`
+  (`stream.rs:1227-1239`); `guard_action` (`stream.rs:1463-1488`) maps it to an
+  `ActionType`, gating image actions on `image_executor_available`
+  (`stream.rs:2376-2384`), which is true iff the request carries an `image`
+  block. `pde::plan_for` (`pde.rs:125-158`) builds the plan.
+- **Composer** — `run_image_prompt_compose` (`stream.rs:1977-2040`) feeds the
+  model `[人物外观]{appearance}` (from persona `art_metadata`),
+  `[最近场景]{recent_scene}`, `[画面主题种子]{seed}`, `[风格]{style}`,
+  `[画幅]{aspect_ratio}` (`compose_user_payload`, `stream.rs:1961-1971`). Its
+  output is the enriched **subject**, not yet the wire prompt. It fails open to
+  the seed subject.
+- **Wire prompt** — `build_image_gen_request` (`stream.rs:166-224`) calls
+  `compose_image_prompt(style, persona, subject)`
+  (`crates/eros-engine-server/src/pipeline/handlers.rs:265-282`), which layers
+  `style_preset(style)` + persona appearance + subject into the final text sent
+  to the provider. The reference URL (`face`/`previous`) is chosen by
+  `select_image_ref` (`stream.rs:141-158`) and attached to the provider body
+  (`build_image_body`, `openrouter.rs:269-307`), **not** to the composer.
+- **SSE frames** — `ProtocolFrame` (`stream.rs:52-120`, `#[serde(tag="type",
+  rename_all="snake_case")]`): image-related variants `ImagePending`,
+  `ImageAttempt`, `ImageFailed`, `Image` (`stream.rs:95-119`), plus
+  `ImageFailReason` (`stream.rs:40-49`). Serialized as unnamed `data:` lines in
+  `routes/companion_stream.rs:586-589`.
+- **Emission** — the two arms: `reply_image` (`stream.rs:2563-2793`) and
+  `reply_text_image` (`stream.rs:3077-3280`). Both call `drive_image_gen`
+  (`stream.rs:244-269`) around `execute_image_inner`.
+- **Persistence** — assistant row in `engine.chat_messages` (`metadata JSONB`
+  added in migration `0019`); image data merged via `merge_assistant_image_meta`
+  / `set_assistant_image_url` / `merge_assistant_metadata_key`
+  (`crates/eros-engine-store/src/chat.rs:714-787`). The **PDE image-awareness
+  transcript** annotates prior assistant turns that carry `metadata.image` (the
+  `assistant_transcript_line` helper feeding `build_input_filter_transcript`) —
+  see Design §5, this is the one non-obvious dependency.
+- **Decision audit** — a separate table `engine.companion_decision_events`
+  (migration `0028`) records the judge verdict incl. the seed `image_prompt`
+  (`VerdictAudit`, `stream.rs:1620-1647`). Unaffected by this change.
+- **Request DTO** — `StreamSendRequest` (`companion_stream.rs:109-135`) with
+  optional `image: ImageReplyParams` (`companion_stream.rs:81-107`).
+- **Version** — workspace `Cargo.toml:8` (`0.7.1-dev`). Config path via
+  `MODEL_CONFIG_PATH` (`main.rs:275-281`).
+
+## Design
+
+### 1. Per-request opt-in — `image.delegate`
+
+Add `delegate: bool` (`#[serde(default)]`) to `ImageReplyParams`
+(`companion_stream.rs:81-107`). Default `false` → today's in-engine drawing path,
+byte-for-byte. `true` → the delegated path below. The `image` block's *presence*
+still drives `image_executor_available` (so the judge may pick image actions);
+`delegate` only routes **how** an image action is fulfilled. No change to
+`guard_action` or the availability gate.
+
+When `delegate` is `true` the consumer no longer needs to send `model`,
+`face_ref_url`, `prev_image_url`, or `resolution` (the engine neither draws nor
+resolves the reference URL). The only field the composer still needs is `style`.
+These fields remain accepted (ignored when delegated) for compatibility.
+
+### 2. New frame — `ProtocolFrame::ImageRequest`
+
+Added to `ProtocolFrame` (`stream.rs:52-120`), snake_case:
+
+```rust
+ImageRequest {
+    message_id: String,
+    composed_prompt: String,   // base64(STANDARD) of the UTF-8 final wire prompt
+    image_ref: ImageRef,       // "face" | "previous"
+    aspect_ratio: Option<String>,
+},
+```
+
+- **`composed_prompt` is the *final wire prompt*** — exactly the text the engine
+  would have sent to the provider today, i.e. the output of
+  `compose_image_prompt(style, persona, composer_subject)` (style preset +
+  appearance + enriched subject). The consumer decodes it and uses it verbatim as
+  the provider text prompt; it reconstructs no prompt logic. Style presets and
+  persona appearance stay engine-owned.
+- **Base64.** The composed prompt is often explicit and frequently CJK. Encoding
+  it (STANDARD, unwrapped, of the UTF-8 bytes) keeps the plaintext out of SSE
+  transport, intermediary logs, and consumer network inspectors. The plaintext
+  exists only inside the engine (before encoding) and inside the consumer's
+  server (after decoding). Requires `ImageRef` to derive `Serialize`
+  (snake_case) if it does not already.
+- **`image_ref`** names the reference *image* choice (`face` vs `previous`) the
+  plan made. The consumer holds both candidate images and resolves the actual
+  URL at draw time. The engine emits only the choice — no URL.
+- **`aspect_ratio`** is the PDE's semantic choice (`{1:1,3:4,4:3,9:16,16:9}` or
+  absent). The consumer owns the aspect→resolution mapping (it is now a drawing
+  concern). The engine does **not** emit width/height.
+
+The engine emits `image_request`, no image bytes, and none of `image_pending`,
+`image_attempt`, `image`, or `image_failed` in the delegated path — those become
+the consumer's own draw-stream frames.
+
+### 3. Delegated branch in the two image arms
+
+A shared helper produces the frame from the already-computed composer output:
+run the same compose path (`run_image_prompt_compose` → `compose_image_prompt`)
+to get the final wire prompt, base64-encode it, and yield `ImageRequest` with the
+plan's `image_ref` and `aspect_ratio`. Skip `drive_image_gen` /
+`execute_image_inner` entirely.
+
+**Uniform sequence — `image_request` sits between `done` and `final` in both
+actions:**
+
+- `reply_image` (image-only) delegated — persist the assistant row with empty
+  `content` (as today), then:
+
+  ```
+  meta(reply_image, X) → done(X) → image_request(X) → final
+  ```
+
+- `reply_text_image` delegated — the text burst streams first (unchanged), then:
+
+  ```
+  meta(reply_text_image, X) → delta* → done(X) → image_request(X) → final
+  ```
+
+`X` is the real, persisted assistant `message_id`; the consumer keys its draw and
+its own storage to `X`. (Contrast the non-delegated `reply_image` failure flow,
+where the intended-image id `X` differs from a degraded text id `Y`
+(`2026-06-30-image-lifecycle-frames-design.md` §3). Delegated `reply_image` has
+**no** engine-side failure degrade — the engine cannot know the consumer's draw
+outcome — so there is a single id and no `X`≠`Y` split. Total-failure handling is
+the consumer's, by design.)
+
+### 4. No draw-result persistence
+
+In the delegated path the engine writes **no** `metadata.image` /
+`metadata.image_failed` draw result, does not call the write-back endpoint path
+(`set_generated_image_url`, `companion_stream.rs:605-671`), and does not persist
+the composed wire prompt. The composed prompt, model, generation id, and
+success/failure record are the consumer's to store. `companion_decision_events`
+is unchanged (it already holds the seed `image_prompt` for engine-side
+diagnostics; the composed wire prompt was never in it).
+
+### 5. Preserve PDE image-awareness (the one subtle dependency)
+
+The PDE's image-awareness transcript (`build_input_filter_transcript` via
+`assistant_transcript_line`) annotates prior assistant turns **by the presence of
+`metadata.image` on the chat row**. If the delegated path writes nothing, the PDE
+can no longer tell it previously sent an image, breaking the iterate-vs-fresh
+`image_ref` choice and the "don't repeat / stop drawing" guidance — and for
+image-only turns the transcript line goes blank again (empty `content`).
+
+Therefore the delegated path MUST still write a **minimal marker** on the
+assistant row, sufficient for `assistant_transcript_line` to keep working, but
+**not** the draw result. Recommended: store the short PDE **seed subject** (the
+value already persisted plaintext in `companion_decision_events`) under a minimal
+`metadata.image` marker — e.g. `{"image": {"subject": "<seed>"}}` — deliberately
+omitting the composed wire prompt, model, generation id, attempts, url, and
+success/failure. This keeps the PDE fully aware while honoring "the draw metadata
+lives with the consumer" and keeping the explicit composed prompt out of engine
+storage.
+
+> Implementation note: confirm exactly what `assistant_transcript_line` reads
+> (boolean presence vs. a subject string) and write the smallest marker that
+> reproduces today's annotation. Do not regress the "avoid repeating the same
+> composition" behavior.
+
+### 6. What the engine keeps doing
+
+- Judge (`pde_decision`) and composer (`chat_image_prompt_compose`) run exactly
+  as today. The composer is the source of the composed prompt.
+- The assistant row is still inserted (text for `reply_text_image`, empty for
+  `reply_image`) so `message_id` `X` is stable and returned in `meta`.
+- `companion_decision_events` audit unchanged.
+
+## Backward compatibility
+
+Purely additive and flag-gated:
+
+- `image.delegate` defaults `false` → the entire existing draw path
+  (`execute_image_inner`, `plan_attempts`, `drive_image_gen`, `image_pending` /
+  `image_attempt` / `image` / `image_failed`, `metadata.image` persistence, the
+  write-back endpoint) is unchanged. Existing consumers see today's streams.
+- `image_request` is a new `type` discriminant; consumers already ignore unknown
+  frames.
+- No existing frame's shape changes.
+
+**This matters because the engine deployment is shared across environments.** A
+single engine build serves consumers that have and have not migrated. Shipping E1
+with the flag off means unmigrated consumers keep drawing via the engine while a
+migrated consumer opts in per-request with `delegate:true`. Both paths coexist
+for the whole migration window.
+
+## Error handling
+
+- Composer fail-open is unchanged: on compose failure/timeout/empty the engine
+  falls back to the seed subject, then wraps it through `compose_image_prompt` and
+  emits `image_request` with that. A delegated turn never fails to emit a frame
+  for a compose problem.
+- The engine has no draw outcome to report in the delegated path; there is no
+  `image_failed` from the chat stream. Draw failure is entirely downstream.
+- `image_ref` / `aspect_ratio` follow the existing defaults when the PDE omits
+  them (`face`, config default) before the frame is built.
+
+## Documentation
+
+- `docs/api-reference.md`: add the `image_request` frame table (fields +
+  base64 note + `image_ref` values); document the delegated sequences for both
+  actions; note `image.delegate` on the request DTO; state that the delegated
+  path emits none of the `image_pending`/`image_attempt`/`image`/`image_failed`
+  frames and persists no draw result. Keep product-identity-free.
+- `docs/api-reference.zh.md`: mirror in simplified Chinese (repo convention).
+- No `openapi.json` change (SSE frames are not modeled there).
+
+## Testing
+
+- **Frame serialization** (`stream.rs` `#[cfg(test)]`): serialize `ImageRequest`
+  and assert `type:"image_request"` + field shape, incl. `image_ref` snake_case
+  and that `composed_prompt` round-trips base64→UTF-8.
+- **Delegated arm sequences**: with a fake/stubbed compose (or a wiremock compose
+  endpoint), drive both arms with `delegate:true` and assert the frame order —
+  `meta → done → image_request → final` (image-only) and
+  `meta → delta* → done → image_request → final` (text+image) — and assert **no**
+  `image_pending`/`image_attempt`/`image`/`image_failed` and **no** provider call.
+- **Marker persistence**: assert the delegated assistant row carries the minimal
+  `metadata.image` marker (subject only) and that a subsequent turn's PDE
+  transcript annotates it as a prior image (the §5 regression guard).
+- **Non-delegated regression**: `delegate:false` (and absent) still produces
+  today's streams and persistence unchanged.
+
+## Rollout / sequencing
+
+- **E1 (this spec) — additive, flag-gated. Implemented and shipped first.** Add
+  `image.delegate`, `ImageRequest`, the delegated branch + minimal marker, docs,
+  tests. Deploy the engine; with the flag off, all environments behave exactly as
+  today. This is the "engine first" work.
+- Then the consumer migrates (its own repo/spec): opts in with `delegate:true`,
+  draws the composed prompt itself, owns storage + settlement. Verified in a test
+  environment, then promoted.
+- **E2 — cleanup (later, after the consumer is fully migrated and verified in
+  production).** Remove the dead in-engine drawing path: `execute_image_inner`,
+  `plan_attempts`, `drive_image_gen`, the `image_pending`/`image_attempt`/`image`/
+  `image_failed` emission, the write-back endpoint, and the `chat_image_generation`
+  model-config task. Do **not** do this in E1 — it would break unmigrated
+  consumers on the shared deployment.
+
+## Out of scope
+
+- Removing the old drawing path (deferred to E2).
+- Moving the composer out of the engine — it stays (persona/scene/config live
+  here); the stream still waits on the single composer LLM call, which is the
+  small part of the latency.
+- Re-adding an `original` prompt variant — the consumer's retry uses the composed
+  prompt only (its decision); the engine emits one composed prompt.
+- Modeling the SSE protocol in OpenAPI.
+
+## Open items for the implementation plan
+
+1. Confirm `ImageRef` derives `Serialize` (snake_case); add if missing.
+2. Confirm the exact read shape of `assistant_transcript_line` and design the
+   smallest `metadata.image` marker that preserves its annotation (§5).
+3. Pick the base64 helper already in the workspace (the image-data path uses one)
+   and apply STANDARD/unwrapped to the UTF-8 wire prompt.
+4. Decide whether the delegated branch shares one helper across both arms (it
+   should) and where it slots relative to the existing `drive_image_gen` call.


### PR DESCRIPTION
## Summary

**E1** of a two-repo change that inverts image generation: behind a default-off per-request `image.delegate` opt-in, the engine composes the image prompt and emits a new `image_request` SSE frame (base64 composed wire prompt + reference choice + aspect) instead of drawing inline, then ends the stream — moving the 15–60s draw + retries to the downstream consumer. Additive and backward-compatible; the in-engine drawing path is retained **unchanged** behind the flag and removed only in a later E2 cleanup (out of scope here).

Spec: `docs/superpowers/specs/2026-07-05-delegate-image-drawing-to-client-design.md`

## What changed
- `ImageRef` derives `Serialize` (snake_case → `face`/`previous`).
- `image.delegate: bool` (`#[serde(default)]`) added to `ImageReplyParams`; OpenAPI snapshot regenerated.
- New `ProtocolFrame::ImageRequest { message_id, composed_prompt(base64), image_ref, aspect_ratio? }` + pure helpers `build_image_request_frame` / `build_delegated_image_marker`; new `base64` dependency.
- Delegated branch in both image arms (`reply_image`, `reply_text_image`). The non-delegated path is byte-for-byte unchanged (only `image_pending` gated on `!delegate` and the existing draw block wrapped in an `else`). `composed_prompt` is exactly the provider wire prompt (`ImageGenRequest.prompt`), guaranteed by reusing the shared compose path before the fork.
- Delegated turns persist only a **minimal** `metadata.image` marker (seed subject under `prompt` + aspect) — never the composed prompt / model / generation id / url — preserving the PDE image-awareness transcript (spec §5) while leaving the draw result with the consumer.
- Docs (`api-reference.md` + `.zh.md`) for the frame, the delegated sequences, and `image.delegate`.

## Delegated sequences
- image-only: `meta(reply_image) → done → image_request → final`
- text+image: `meta(reply_text_image) → delta* → done → image_request → final`

No `image_pending`/`image_attempt`/`image`/`image_failed`, no provider call, no draw-result persistence in the delegated path.

## Testing
- 5 unit tests (frame base64/snake_case roundtrip incl. CJK; `delegate` default; marker→transcript §5 regression guard; `delegated_image_only_frames` order; `ImageRef` serialize).
- 2 end-to-end integration tests driving `run_stream` with `delegate:true` through both arms — asserting the frame sequence, no draw-lifecycle frames, no provider draw call, and minimal-marker persistence (insert for image-only, merge for text+image).
- Full workspace: **699+ passed, 0 failed**; `clippy -D warnings` clean; `fmt --check` clean; OpenAPI snapshot in sync.

## Rollout
E1 ships flag-off → all environments behave exactly as today until a consumer opts in with `delegate:true`. The consumer migrates in its own repo; E2 (removing the dead in-engine draw path) follows later, after the consumer is verified in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)