### PR TITLE
feat(server): richer companion_insights extraction + jsonwebtoken CVE fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,6 +149,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,6 +320,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,6 +339,33 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -391,12 +436,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -535,6 +639,22 @@ dependencies = [
  "nom",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -681,6 +801,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -708,6 +829,17 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -1112,17 +1244,26 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.3.1"
+version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
  "base64",
+ "ed25519-dalek",
+ "getrandom 0.2.17",
+ "hmac",
  "js-sys",
+ "p256",
+ "p384",
  "pem",
- "ring",
+ "rand 0.8.6",
+ "rsa",
  "serde",
  "serde_json",
+ "sha2",
+ "signature",
  "simple_asn1",
+ "zeroize",
 ]
 
 [[package]]
@@ -1338,6 +1479,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1467,6 +1632,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -1696,6 +1870,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1734,6 +1918,15 @@ name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustls"
@@ -1787,6 +1980,26 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -3264,6 +3477,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerovec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,10 @@ async-trait = "0.1"
 utoipa = { version = "5", features = ["axum_extras", "uuid", "chrono"] }
 utoipa-axum = "0.2"
 utoipa-scalar = { version = "0.3", features = ["axum"] }
-jsonwebtoken = "9"
+# v10 makes the crypto backend a selectable feature (default enables none, which
+# panics at first decode). rust_crypto = pure-Rust provider, so OSS self-hosters
+# building for musl/Alpine/cross targets don't need the aws-lc-sys C toolchain.
+jsonwebtoken = { version = "10.3", features = ["rust_crypto"] }
 tower = "0.5"
 tower-http = { version = "0.6", features = ["trace", "cors"] }
 eventsource-stream = "0.2"

--- a/crates/eros-engine-server/src/prompt.rs
+++ b/crates/eros-engine-server/src/prompt.rs
@@ -579,28 +579,32 @@ pub fn build_prompt(
 /// the JSONB shape that `InsightRepo::merge` accepts, with each field's
 /// `compute_training_level` weight implicitly determined by presence.
 pub const COMPANION_INSIGHTS_SCHEMA: &str = r#"
-companion_insights schema (all fields optional, only include if confident):
+companion_insights schema（真人用户画像；所有字段可选；只输出下列字段，不要新增/编造字段名）：
 {
-  "city": "string — 常住城市（用户长期居住的城市）",
-  "location": "string — 目前所在地（用户此刻所在的城市/地点，如出差、旅游）",
-  "hometown": "string — 老家（用户的籍贯 / 出生成长地）",
-  "nationality": "string — 国籍",
-  "occupation": "string — job/career",
-  "mbti_guess": "string — e.g. INFP",
-  "love_values": "string — attitude toward love & relationships",
-  "interests": ["list", "of", "hobbies"],
-  "emotional_needs": "string — what emotional support they need",
-  "life_rhythm": "string — e.g. 夜猫子, 早睡早起",
+  "city": "string — 常住城市（用户长期居住/生活的地方）。写出具体地点，如事实支持可加居住时长等细节，不要只写省份或泛称。例：深圳南山，工作生活五年多",
+  "location": "string — 此刻/近期所在地（出差、旅行、临时停留），仅当明显不同于常住城市才填。例：这周在东京出差",
+  "hometown": "string — 老家 / 籍贯 / 出生成长地，仅当用户明确提到才填，不要用当前居住城市替代。例：湖南长沙人，大学才离开",
+  "nationality": "string — 国籍/地区身份。例：中国香港",
+  "occupation": "string — 职业与工作状态，写出行业/职级/公司类型/日常细节，不要只写职位名词（不要只写「工程师」）。例：在深圳一家中厂做后端工程师，常年加班，最近想跳槽",
+  "mbti_guess": "string — MBTI。用户自报的类型直接填；没有自报时，只有当事实里反复出现同一类典型行为/表达模式，才可基于此谨慎推断，并在值里带上推测措辞（如「像/偏」），不要凭一两句话臆断。例：用户自述 INFP；或 偏 INFP，多次表现出重意义、不爱社交",
+  "love_values": "string — 对爱情/亲密关系的态度与期待，写成一两句具体总结。例：渴望被理解胜过浪漫仪式，慢热，怕被抛弃所以习惯先推开人",
+  "interests": ["array of strings — 兴趣爱好，每项 4~12 个汉字的具体短语，带一个实际细节，不要是孤立的单字/双字标签（如「爬山」「音乐」）。例：周末常去爬山 / 沉迷手冲咖啡 / 养了只橘猫"],
+  "emotional_needs": "string — 需要什么样的情感支持，写成一两句。例：下班后想有人先听他吐槽、被肯定，不喜欢被讲道理",
+  "life_rhythm": "string — 作息与生活节奏，写出具体模式，不要只写单一标签（不要只写「夜猫子」）。例：典型夜猫子，凌晨两三点睡、中午起，靠咖啡和外卖过日子",
   "matching_preferences": {
-    "preferred_gender": "string",
+    "preferred_gender": "string — 偏好对象性别",
     "age_range": [min_int, max_int],
-    "deal_breakers": ["list"]
+    "deal_breakers": ["array of strings — 无法接受的点，每项一个具体短语。例：长期冷暴力"]
   },
-  "personality_traits": ["list", "of", "traits"]
+  "personality_traits": ["array of strings — 性格特质，每项 4~12 个汉字的具体短语，带依据/情境，不要是孤立单字（如「内向」「幽默」）。例：嘴硬心软 / 难过也说没事 / 对朋友很讲义气"]
 }
-地理字段示例：一个在深圳工作的香港新界人到台北旅游 → city=深圳, location=台北, hometown=新界, nationality=中国香港
-Return ONLY a JSON object with the fields you are confident about.
-Do not invent or guess anything not clearly supported by the facts.
+地理字段示例：一个在深圳工作的香港新界人到台北旅游 → city=深圳, location=台北, hometown=新界, nationality=中国香港。
+填写规范：
+- 只填【用户事实】清楚支持的字段；对已支持的内容尽量写足细节与情境，用完整短语或句子，不要用单个词/标签凑数。
+- 绝不虚构、外推或编造事实中没有的信息；mbti_guess 的推断规则见上，且仍需基于事实中反复出现的信号，不要凭单次只言片语臆断。
+- 更新 matching_preferences 等嵌套对象时，把仍然成立的旧字段一起带上返回完整对象，不要只给单个子字段（否则旧值会被覆盖丢失）。
+- 只输出上表列出的字段名，不要新增、不要改名。
+- 仅输出一个 JSON 对象，不要 markdown、不要解释。
 "#;
 
 /// Build the *user* message for the facts-extraction call: just the turn,
@@ -639,7 +643,8 @@ pub fn extract_structured_insights_prompt(
     format!(
         "以下是从对话中提取的【用户】事实：\n\
          {facts_str}\n\n\
-         现有的用户画像（companion_insights，供参考，不要重复已知信息）：\n\
+         现有的用户画像（companion_insights，供参考；如新事实能让某个已有字段更完整或更准确，\
+         请输出更新后的完整版本覆盖旧值，不要因为字段已存在就跳过或原样重复）：\n\
          {existing_str}\n\n\
          请根据上方的【用户事实】，填充以下 schema 中你有信心的字段。\
          schema 描述的是【真人用户】本人——occupation、city、location 等都指用户，绝不是 AI 伴侣：\n\


### PR DESCRIPTION
Two changes, folded together per request.

## 1. Enrich `companion_insights` extraction schema (`prompt.rs`)

**Problem (data-grounded, 29 prod rows):** the stage-2 insight-extraction schema examples were too thin, so extracted user profiles were shallow. avg **2.38** keys/row; fields with one-token examples came back as one token (`life_rhythm` avg **4.5** chars, `occupation` **8.2**), while the two fields with *prose* descriptions came back as full sentences (`love_values` **62**, `emotional_needs` **53**). The model mirrors the example's granularity.

**Fix (three AI opinions — Opus/Codex/Grok — synthesized by a Sonnet reviewer):**
- Rewrote every field description with dense Chinese examples + explicit "full phrases, not single tokens" directives.
- Fenced schema drift ("only these fields" — kills the stray `name` key seen in prod).
- Gated `mbti_guess` inference behind a repeated-signal + inline-hedge rule (it was 0/29 because "don't guess" contradicted the field's purpose).
- Fixed the calling prompt's `不要重复已知信息` clause, which was *suppressing* enrichment of thin existing values.

No new top-level fields (the flat `human_insights` mirror + `WEIGHTS` key on a fixed set); field names and `matching_preferences` sub-shape unchanged. Purely improves the chat-facing profile bullets — does **not** move `training_level` (presence-based; noted as a separate follow-up).

## 2. Fix dependabot #1: `jsonwebtoken` 9 → 10.3 (CVE-2026-25537)

`jsonwebtoken < 10.3.0` has a type-confusion flaw → potential auth bypass (GHSA-h395-gr6q-cpjc). The whole 9.x line is vulnerable, so the only fix is the major bump.

v10 makes the crypto backend a selectable feature whose default enables none → first `decode()` panics. Enabled the pure-Rust **`rust_crypto`** provider (over `aws_lc_rs`) so OSS self-hosters building for musl/Alpine/cross targets don't need the `aws-lc-sys` C toolchain. Our code already binds key type to algorithm (HS256→`from_secret`, asymmetric→`from_jwk`), so the hardening needed **no code changes** — `auth/supabase.rs` is untouched.

**Reviewer note:** only the HS256 legacy path has unit tests. They passing does confirm the CryptoProvider is correctly installed end-to-end (the panic was global). The asymmetric JWKS path (ES256/RS256/EdDSA) has no test — `rust_crypto` supports all three, but a wiremock-JWKS round-trip test would be the way to cover it if we want it.

## Verification
- `cargo fmt --all --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` — **696 passed, 0 failed** ✓
- HTTP surface unchanged → no openapi regen needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)