### PR TITLE
feat(stream): empty reply_text → ghost fallback

### DIFF
--- a/crates/eros-engine-server/src/pipeline/post_process.rs
+++ b/crates/eros-engine-server/src/pipeline/post_process.rs
@@ -1542,4 +1542,132 @@ mod tests {
         ];
         assert!(should_write_user_turn("hello", &produced));
     }
+
+    /// Locks the *accepted* partial affinity-neutrality contract for a
+    /// fallback-ghost turn (design spec
+    /// `docs/superpowers/specs/2026-07-06-empty-reply-ghost-fallback-design.md`
+    /// §6). `post_process::run` has no visibility into
+    /// `BurstOutcome.ghost_fallback` — from here a fallback-ghost turn (regex-
+    /// strip-to-empty or empty-completion) is indistinguishable from any other
+    /// `ReplyText` turn that happens to carry empty `produced` text. The
+    /// maintainer explicitly accepted that this path is NOT fully affinity-
+    /// neutral: `persist_affinity` still writes an `event_type = "message"`
+    /// event and applies the user-derived rule delta (`predict_reply_deltas`),
+    /// even though the LLM eval / memory / insight writes are all skipped. If
+    /// a future change makes this fully neutral (or silently regresses further,
+    /// e.g. by resurrecting a `ghost` event here), this test must fail and
+    /// force an explicit decision rather than drifting quietly.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn fallback_ghost_turn_writes_message_event_with_eval_skipped(pool: sqlx::PgPool) {
+        let state = crate::routes::companion::test_state(pool.clone());
+
+        let user_id = Uuid::new_v4();
+        let instance_id = Uuid::new_v4();
+        let session_id = sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(user_id)
+        .bind(instance_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        // "hi" is short enough to trip both the PDE's short-message rule delta
+        // (a patience penalty) AND `eval_skip_reason`'s `short_user_msg` gate,
+        // so the LLM affinity eval never fires while the rule delta still does.
+        let event = Event::UserMessage {
+            content: "hi".into(),
+            message_id: Uuid::new_v4(),
+            prompt_traits: Vec::new(),
+            audit: None,
+            tier: None,
+            memory_scope: Default::default(),
+            affinity_scope: Default::default(),
+            tips_amount_usd: None,
+            history_anchor: Default::default(),
+        };
+
+        // Mirrors what `pde::decide` would compute for a short user message
+        // (`predict_reply_deltas`'s short-message patience penalty) — built
+        // directly here since `run` takes an already-decided `ActionPlan`.
+        let plan = ActionPlan {
+            action_type: ActionType::ReplyText,
+            reply_style: eros_engine_core::types::ReplyStyle::Neutral,
+            affinity_deltas: eros_engine_core::affinity::AffinityDeltas {
+                patience: -0.02,
+                ..Default::default()
+            },
+            energy_cost: 0.0,
+            context_hints: Vec::new(),
+            image_prompt: None,
+            image_ref: eros_engine_core::types::ImageRef::Face,
+            aspect_ratio: None,
+        };
+
+        // EMPTY text — this is exactly what a fallback-ghost turn produces when
+        // it is served through the `ReplyText` arm.
+        let produced = vec![ProducedMessage {
+            message_id: Uuid::new_v4(),
+            full_text: String::new(),
+            action: ActionType::ReplyText,
+        }];
+
+        run(
+            state,
+            session_id,
+            user_id,
+            instance_id,
+            event,
+            plan,
+            produced,
+        )
+        .await;
+
+        let rows: Vec<(String, serde_json::Value)> = sqlx::query_as(
+            "SELECT e.event_type, e.context \
+             FROM engine.companion_affinity_events e \
+             JOIN engine.companion_affinity a ON a.id = e.affinity_id \
+             WHERE a.session_id = $1",
+        )
+        .bind(session_id)
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            rows.len(),
+            1,
+            "a fallback-ghost turn still writes exactly one affinity event \
+             (accepted, NOT neutral); got {rows:?}"
+        );
+        assert_eq!(
+            rows[0].0, "message",
+            "NOT 'ghost' — post_process::run can't see BurstOutcome.ghost_fallback, \
+             so a fallback-ghost turn is indistinguishable from a real empty reply \
+             and takes the same event_type=\"message\" path"
+        );
+        assert_eq!(
+            rows[0].1.get("eval_skip_reason").and_then(|v| v.as_str()),
+            Some("short_user_msg"),
+            "the LLM affinity eval must still be skipped (the guaranteed-neutral \
+             half of the contract); context: {:?}",
+            rows[0].1
+        );
+
+        // The rule-based delta (user-derived, not from the empty reply) still
+        // moved the vector: default patience 0.5 - 0.02 = 0.48 (test_state's
+        // ema_inertia = 0.0 → applied 1:1, no smoothing).
+        let patience: f64 = sqlx::query_scalar(
+            "SELECT patience FROM engine.companion_affinity WHERE session_id = $1",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert!(
+            (patience - 0.48).abs() < 1e-9,
+            "rule delta (-0.02 patience) still applied even though the reply \
+             was empty; got {patience}"
+        );
+    }
 }

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -826,6 +826,19 @@ fn drive_chat_burst(
                         let mut o = outcome.lock().unwrap();
                         o.ghost_fallback = true;
                         o.retries_chat = (chain.len() as u32).saturating_sub(1);
+                        // Keep an (empty) produced row so a ReplyTextImage turn's
+                        // trailing image_request still fires — the caller gates it
+                        // on `produced.last()`. The live and regex-strip ghost
+                        // paths both retain their row; without this, filtered-mode
+                        // text+image turns would silently drop the image half. The
+                        // empty full_text keeps the turn memory/insight/eval-neutral
+                        // downstream (persist_affinity's rule delta is unchanged).
+                        o.produced
+                            .push(crate::pipeline::post_process::ProducedMessage {
+                                message_id: msg_uuid,
+                                full_text: String::new(),
+                                action: plan_action,
+                            });
                     }
                     yield ProtocolFrame::Meta {
                         message_id: ulid_string(msg_ulid),
@@ -8148,6 +8161,124 @@ data: [DONE]\n\n";
             "only the accepted fallback remains in produced; got {produced:?}"
         );
         assert_eq!(produced[0].full_text, "hi there");
+    }
+
+    /// Codex P2 (PR #141, round 3): the FILTERED empty-completion ghost fallback
+    /// must retain an (empty) produced row like the live/regex-strip paths —
+    /// otherwise a ReplyTextImage turn's trailing image_request (gated on
+    /// `produced.last()`) silently drops the image half in filtered mode only.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn filtered_empty_completion_ghost_retains_produced_row(pool: PgPool) {
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+        use futures_util::StreamExt;
+        use wiremock::matchers::path as wm_path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        let body = "data: {\"choices\":[{\"delta\":{}}],\"id\":\"gen-e\",\"model\":\"primary\"}\n\ndata: [DONE]\n\n";
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+
+        let user_id = Uuid::new_v4();
+        let (_g, _instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                eros_engine_llm::openrouter::AppAttribution::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+        // Never-matching regex targeting "primary" forces FILTERED mode.
+        let regex_cfg = eros_engine_llm::model_config::ModelConfig::from_toml_str(
+            r#"
+            [tasks.chat_companion]
+            model = "primary"
+
+            [[tasks.chat_companion.output_regex]]
+            models = ["primary"]
+            pattern = '^THIS_PATTERN_NEVER_MATCHES_ANYTHING$'
+            "#,
+        )
+        .unwrap();
+        state.output_regex =
+            std::sync::Arc::new(regex_cfg.compile_output_regex().expect("compiles"));
+        let state = std::sync::Arc::new(state);
+
+        let chat_repo = ChatRepo { pool: &pool };
+        let umid = match chat_repo
+            .upsert_user_message_idempotent(
+                session_id,
+                "hi",
+                "01JFILTEREDIMG0000000000A",
+                "user",
+                None,
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
+
+        let req = eros_engine_llm::openrouter::ChatRequest {
+            model: "primary".into(),
+            fallback_model: vec![],
+            messages: vec![eros_engine_llm::openrouter::ChatMessage {
+                role: "user".into(),
+                content: "hi".into(),
+            }],
+            temperature: 0.0,
+            max_tokens: 64,
+            ..Default::default()
+        };
+        let outcome = std::sync::Arc::new(std::sync::Mutex::new(BurstOutcome::default()));
+        let burst = drive_chat_burst(
+            state.clone(),
+            session_id,
+            umid,
+            FrameActionType::ReplyTextImage,
+            "reply",
+            ActionType::ReplyTextImage,
+            req,
+            None,
+            None,
+            vec![],
+            None,
+            Default::default(),
+            Default::default(),
+            None,
+            outcome.clone(),
+        );
+        let frames: Vec<ProtocolFrame> = Box::pin(burst).collect().await;
+
+        assert!(
+            frames.iter().any(|f| matches!(
+                f,
+                ProtocolFrame::Done {
+                    ghost_fallback: true,
+                    ..
+                }
+            )),
+            "filtered empty completion must ghost: {frames:?}"
+        );
+        let produced = &outcome.lock().unwrap().produced;
+        assert_eq!(
+            produced.len(),
+            1,
+            "filtered empty-completion ghost must retain a produced row so ReplyTextImage's \
+             image_request still fires; got {produced:?}"
+        );
+        assert_eq!(
+            produced[0].full_text, "",
+            "the retained produced row is empty (memory/insight/eval-neutral)"
+        );
     }
 
     /// Codex P2 (round 6): a COMPLETE garbled primary followed by a failing fallback

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -3458,7 +3458,10 @@ mod tests {
             ghost_fallback: true,
         };
         let s = serde_json::to_string(&f).unwrap();
-        assert!(s.contains("\"ghost_fallback\":true"), "true must serialize: {s}");
+        assert!(
+            s.contains("\"ghost_fallback\":true"),
+            "true must serialize: {s}"
+        );
     }
 
     #[test]

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -779,7 +779,15 @@ fn drive_chat_burst(
                     {
                         tracing::warn!("stream(filtered): ghost-fallback persist failed: {e}");
                     }
-                    outcome.lock().unwrap().ghost_fallback = true;
+                    {
+                        // Mirror the sibling truncated branch: report the
+                        // fallback attempts consumed so the Final frame's
+                        // retries_chat isn't under-reported when only the LAST
+                        // chain model returns an empty completion.
+                        let mut o = outcome.lock().unwrap();
+                        o.ghost_fallback = true;
+                        o.retries_chat = (chain.len() as u32).saturating_sub(1);
+                    }
                     yield ProtocolFrame::Meta {
                         message_id: ulid_string(msg_ulid),
                         action_type: frame_action,

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -716,6 +716,7 @@ fn drive_chat_burst(
             let mut last_usage: Option<eros_engine_llm::openrouter::UsageBlock> = None;
             let mut last_gen_id: Option<String> = None;
             let mut truncated = false;
+            let mut empty_completion = false;
 
             let mut per_model_req = req.clone();
             per_model_req.model = model_id.clone();
@@ -734,7 +735,7 @@ fn drive_chat_burst(
                             Err(e) => { tracing::warn!("stream(filtered): chunk err: {e}"); truncated = true; break; }
                         }
                     }
-                    if !truncated && acc.is_empty() { truncated = true; }
+                    if !truncated && acc.is_empty() { empty_completion = true; }
                 }
                 Err(e) => { tracing::warn!("stream(filtered): open err: {e}"); truncated = true; }
             }
@@ -748,6 +749,53 @@ fn drive_chat_burst(
                 // fallback — doing so would discard a recoverable complete garble if
                 // the later attempt failed. An INCOMPLETE garble is already
                 // `truncated` (length / transport) and handled by the block below.
+            }
+
+            if empty_completion {
+                if idx + 1 == chain.len() {
+                    // Last attempt served a 200 OK with an empty body: ghost
+                    // fallback (affinity-neutral), NOT the pseudo-ghost/Error
+                    // path below — that's reserved for length/transport
+                    // truncation. Mirrors the regex-strip-to-empty case (a)
+                    // above (`ghost_fallback_metadata`), tagged distinctly as
+                    // "empty_completion" so ops can tell the two apart.
+                    let msg_ulid = Ulid::new();
+                    let msg_uuid: Uuid = msg_ulid.into();
+                    let row = eros_engine_store::chat::AssistantInsert {
+                        id: msg_uuid,
+                        content: String::new(),
+                        assistant_action_type: persist_action.into(),
+                        continues_from_message_id: None,
+                        truncated: false,
+                        model: Some(model_id.clone()),
+                        usage: last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok()),
+                        generation_id: last_gen_id.clone(),
+                        filter_audit: None,
+                        metadata: ghost_fallback_metadata(build_metadata(None), "empty_completion"),
+                    };
+                    if let Err(e) = chat_repo
+                        .insert_assistant_batch(session_id, user_message_id, &[row])
+                        .await
+                    {
+                        tracing::warn!("stream(filtered): ghost-fallback persist failed: {e}");
+                    }
+                    outcome.lock().unwrap().ghost_fallback = true;
+                    yield ProtocolFrame::Meta {
+                        message_id: ulid_string(msg_ulid),
+                        action_type: frame_action,
+                        model: display_override.as_ref().and_then(|d| d.display(model_id)),
+                        continues_from: None,
+                    };
+                    yield ProtocolFrame::Done {
+                        message_id: ulid_string(msg_ulid),
+                        truncated: false,
+                        usage: None,
+                        generation_id: last_gen_id,
+                        ghost_fallback: true,
+                    };
+                    return;
+                }
+                continue; // non-last empty completion: try the next model
             }
 
             if truncated {
@@ -4248,6 +4296,141 @@ data: [DONE]\n\n";
         .await
         .unwrap();
         assert_eq!(gs, 2, "ghost fallback must not reset ghost_streak");
+    }
+
+    /// Filtered mode, case (b): the served model returns a 200 OK stream
+    /// whose delta never carries a `content` field, so `acc` stays empty and
+    /// `finish_reason` is never `"length"` — an empty completion, distinct
+    /// from case (a)'s regex-strip-to-empty above. On the LAST chain attempt
+    /// (single-model chain here, so this is also the first) that must
+    /// surface as `Done{ghost_fallback:true}` tagged
+    /// `metadata.fallback_reason = "empty_completion"`, NOT the
+    /// pseudo-ghost/Error truncation path. The `output_regex` rule below
+    /// targets the chain model ("primary") purely so `regex_targets_chain`
+    /// forces FILTERED mode — an unpinned/untargeted rule would silently
+    /// fall through to LIVE mode instead (see
+    /// `regex_strip_to_empty_becomes_ghost_fallback` above) — but its
+    /// pattern never matches anything, so it's a pure mode-selection no-op
+    /// and the empty-completion branch (which returns before the regex is
+    /// ever applied) never touches it.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn empty_completion_last_attempt_becomes_ghost_fallback(pool: PgPool) {
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+        use futures_util::StreamExt;
+        use wiremock::matchers::path as wm_path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        // 200 stream with a delta that carries no `content` at all → empty completion.
+        let body = "data: {\"choices\":[{\"delta\":{}}],\"id\":\"gen-e\",\"model\":\"primary\"}\n\ndata: [DONE]\n\n";
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+
+        let user_id = Uuid::new_v4();
+        let (_g, instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                eros_engine_llm::openrouter::AppAttribution::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+        // Pin the chain model to "primary" (matching the mock) and target it
+        // with a never-matching output_regex rule: forces FILTERED mode via
+        // `regex_targets_chain` without ever altering the (already empty)
+        // reply. Built via `ModelConfig::from_toml_str` +
+        // `compile_output_regex()` — not `regex::Regex::new` by hand — since
+        // `regex` isn't a direct dependency of eros-engine-server.
+        let regex_cfg = eros_engine_llm::model_config::ModelConfig::from_toml_str(
+            r#"
+            [tasks.chat_companion]
+            model = "primary"
+
+            [[tasks.chat_companion.output_regex]]
+            models = ["primary"]
+            pattern = '^THIS_PATTERN_NEVER_MATCHES_ANYTHING$'
+            "#,
+        )
+        .unwrap();
+        state.model_config = std::sync::Arc::new(regex_cfg.clone());
+        state.output_regex = std::sync::Arc::new(
+            regex_cfg
+                .compile_output_regex()
+                .expect("never-matching pattern compiles"),
+        );
+
+        let chat_repo = ChatRepo { pool: &pool };
+        let umid = match chat_repo
+            .upsert_user_message_idempotent(
+                session_id,
+                "hi",
+                "01J4444444444444444444444A",
+                "user",
+                None,
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
+
+        let frames: Vec<ProtocolFrame> = run_stream(
+            std::sync::Arc::new(state),
+            PersistedUserMessage {
+                user_message_id: umid,
+                session_id,
+                user_id,
+                instance_id,
+                content: "hi".into(),
+                prompt_traits: vec![],
+                audit: None,
+                tier: None,
+                memory_scope: Default::default(),
+                affinity_scope: Default::default(),
+                tips_amount_usd: None,
+                image_url: None,
+                image: None,
+                history_anchor: Default::default(),
+            },
+        )
+        .collect()
+        .await;
+
+        assert!(
+            frames.iter().any(|f| matches!(
+                f,
+                ProtocolFrame::Done {
+                    ghost_fallback: true,
+                    ..
+                }
+            )),
+            "expected Done{{ghost_fallback:true}}, got {frames:?}"
+        );
+        assert!(
+            !frames
+                .iter()
+                .any(|f| matches!(f, ProtocolFrame::Error { .. })),
+            "empty completion must not error"
+        );
+        let reason: Option<String> = sqlx::query_scalar(
+            "SELECT metadata->>'fallback_reason' FROM engine.chat_messages \
+             WHERE user_message_id = $1 AND role = 'assistant'",
+        )
+        .bind(umid)
+        .fetch_optional(&pool)
+        .await
+        .unwrap()
+        .flatten();
+        assert_eq!(reason.as_deref(), Some("empty_completion"));
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -574,6 +574,14 @@ fn drive_chat_burst(
                 // LAST chain attempt returning empty is a ghost fallback,
                 // distinct from length/transport truncation (pseudo-ghost).
                 let is_ghost_fallback = empty_completion && idx + 1 == chain.len();
+                // A non-last empty completion is a superseded attempt, not a
+                // successful turn: mark it `truncated` so the persisted row and
+                // its Done frame carry the "replace me" signal (as before this
+                // feature) and the client / replay never see a spurious empty
+                // reply bubble. Only the LAST empty attempt is the ghost.
+                if empty_completion && !is_ghost_fallback {
+                    truncated = true;
+                }
 
                 // Persist BEFORE yielding Done (spec §2.3 risk R7).
                 let row = eros_engine_store::chat::AssistantInsert {
@@ -633,10 +641,9 @@ fn drive_chat_burst(
                     o.produced.retain(|m| m.message_id == msg_uuid);
                     return;
                 }
-                if empty_completion {
-                    // Non-last empty completion: advance to the next model.
-                    continue;
-                }
+                // (A non-last empty completion is now marked `truncated` above,
+                // so it falls through to the existing chain-advance path below —
+                // no separate branch needed.)
 
                 if !truncated {
                     let mut o = outcome.lock().unwrap();

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -833,10 +833,17 @@ fn drive_chat_burst(
                         model: display_override.as_ref().and_then(|d| d.display(model_id)),
                         continues_from: None,
                     };
+                    // Forward the served usage (a provider can emit a usage block
+                    // on an otherwise-empty completion) — same wire contract as the
+                    // other served Done frames; the DB row above already persisted
+                    // the full unfiltered usage.
+                    let mut wire_usage =
+                        last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok());
+                    filter_usage_keys(&mut wire_usage, &state.config.openrouter_usage_hidden_keys);
                     yield ProtocolFrame::Done {
                         message_id: ulid_string(msg_ulid),
                         truncated: false,
-                        usage: None,
+                        usage: wire_usage,
                         generation_id: last_gen_id,
                         ghost_fallback: true,
                     };
@@ -3317,7 +3324,20 @@ pub fn replay_stream(
                     truncated: row.truncated,
                     usage,
                     generation_id: row.generation_id.clone(),
-                    ghost_fallback: false,
+                    // Re-emit the ghost-fallback flag so an idempotent replay of an
+                    // empty-reply fallback turn is wire-identical to the original
+                    // live stream (a real ghost likewise re-emits its ghost frames
+                    // on replay). Match ONLY the ghost-fallback reasons — the
+                    // pseudo-ghost ("stream_failure") and garble-repaired
+                    // ("garble_repaired") rows also carry a fallback_reason but are
+                    // non-empty canned/ salvaged replies, not ghosts.
+                    ghost_fallback: matches!(
+                        row.metadata
+                            .as_ref()
+                            .and_then(|m| m.get("fallback_reason"))
+                            .and_then(|v| v.as_str()),
+                        Some("regex_strip") | Some("empty_completion")
+                    ),
                 };
             }
             // If every persisted assistant row was truncated, emit the same
@@ -4002,6 +4022,80 @@ mod tests {
         );
         assert_eq!(usage["prompt_tokens"], 1290);
         assert_eq!(usage["total_tokens"], 1307);
+    }
+
+    /// Codex P2 (PR #141): an idempotent replay of an empty-reply ghost-fallback
+    /// row must re-emit Done{ghost_fallback:true} — wire-identical to the original
+    /// live stream (a real ghost likewise re-emits its ghost frames on replay). A
+    /// pseudo-ghost / garble row also carries a fallback_reason but is a non-empty
+    /// canned/salvaged reply, so it must replay as ghost_fallback:false.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn replay_reemits_ghost_fallback_only_for_empty_reply_fallbacks(pool: PgPool) {
+        use futures_util::StreamExt;
+
+        let user_id = Uuid::new_v4();
+        let (_g, _instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+        let state = std::sync::Arc::new(crate::routes::companion::test_state(pool.clone()));
+
+        let mk = |content: &str, reason: &str| eros_engine_store::chat::ChatMessage {
+            id: Uuid::new_v4(),
+            session_id,
+            role: "assistant".into(),
+            content: content.into(),
+            sent_at: chrono::Utc::now(),
+            client_msg_id: None,
+            ghost_decision: false,
+            user_message_id: None,
+            continues_from_message_id: None,
+            truncated: false,
+            model: Some("m/x".into()),
+            usage: None,
+            generation_id: Some("gen-x".into()),
+            assistant_action_type: Some("reply".into()),
+            pre_filter_content: None,
+            metadata: Some(serde_json::json!({ "fallback_reason": reason })),
+        };
+
+        let done_flag = |frames: &[ProtocolFrame]| -> bool {
+            frames
+                .iter()
+                .find_map(|f| match f {
+                    ProtocolFrame::Done { ghost_fallback, .. } => Some(*ghost_fallback),
+                    _ => None,
+                })
+                .expect("a Done frame")
+        };
+
+        // Empty-reply ghost fallback → replay re-emits ghost_fallback:true.
+        let ghost: Vec<ProtocolFrame> = replay_stream(
+            state.clone(),
+            session_id,
+            user_id,
+            false,
+            vec![mk("", "empty_completion")],
+        )
+        .collect()
+        .await;
+        assert!(
+            done_flag(&ghost),
+            "empty_completion fallback row must replay as ghost_fallback:true"
+        );
+
+        // Pseudo-ghost: a fallback_reason is present but the content is a real
+        // canned reply → must NOT replay as a ghost.
+        let pseudo: Vec<ProtocolFrame> = replay_stream(
+            state,
+            session_id,
+            user_id,
+            false,
+            vec![mk("稍后再聊", "stream_failure")],
+        )
+        .collect()
+        .await;
+        assert!(
+            !done_flag(&pseudo),
+            "pseudo-ghost row (non-empty, stream_failure) must replay as ghost_fallback:false"
+        );
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
@@ -7906,6 +8000,154 @@ data: [DONE]\n\n";
             produced[0].full_text, "hi there",
             "produced must carry the clean fallback, not the superseded garbled attempt",
         );
+    }
+
+    /// Codex P2 (PR #141): a NON-last empty completion in LIVE mode is a
+    /// superseded (truncated) attempt that advances the chain — NOT a spurious
+    /// successful empty turn, and NOT a ghost. Only the LAST empty attempt is the
+    /// ghost fallback; here a later model replies, so there is no ghost at all.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn live_nonlast_empty_completion_advances_as_truncated(pool: PgPool) {
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+        use futures_util::StreamExt;
+        use wiremock::matchers::{body_partial_json, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        // Primary "e/x" returns a 200 stream with NO content (empty completion);
+        // fallback "f/x" streams clean text.
+        let empty = "data: {\"choices\":[{\"delta\":{}}],\"id\":\"gen-e\",\"model\":\"e/x\"}\n\ndata: [DONE]\n\n";
+        let clean = concat!(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"hi there\"}}],",
+            "\"id\":\"gen-f\",\"model\":\"f/x\"}\n\n",
+            "data: [DONE]\n\n"
+        );
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .and(body_partial_json(serde_json::json!({"model": "e/x"})))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(empty, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .and(body_partial_json(serde_json::json!({"model": "f/x"})))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(clean, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+
+        let user_id = Uuid::new_v4();
+        let (_g, _instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                eros_engine_llm::openrouter::AppAttribution::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+        let state = std::sync::Arc::new(state);
+
+        let chat_repo = ChatRepo { pool: &pool };
+        let user_message_id = match chat_repo
+            .upsert_user_message_idempotent(
+                session_id,
+                "hi",
+                "01JEMPTYADVANCE000000000A",
+                "user",
+                None,
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
+
+        let req = eros_engine_llm::openrouter::ChatRequest {
+            model: "e/x".into(),
+            fallback_model: vec!["f/x".into()],
+            messages: vec![eros_engine_llm::openrouter::ChatMessage {
+                role: "user".into(),
+                content: "hi".into(),
+            }],
+            temperature: 0.0,
+            max_tokens: 64,
+            ..Default::default()
+        };
+        let outcome = std::sync::Arc::new(std::sync::Mutex::new(BurstOutcome::default()));
+        let burst = drive_chat_burst(
+            state.clone(),
+            session_id,
+            user_message_id,
+            FrameActionType::Reply,
+            "reply",
+            ActionType::ReplyText,
+            req,
+            None,
+            None,
+            vec![],
+            None,
+            Default::default(),
+            Default::default(),
+            None,
+            outcome.clone(),
+        );
+        let frames: Vec<ProtocolFrame> = Box::pin(burst).collect().await;
+
+        // One Done per attempt: the non-last empty attempt is truncated (a
+        // superseded "replace me" signal), NOT a ghost; the clean fallback is a
+        // normal accepted reply.
+        let dones: Vec<(bool, bool)> = frames
+            .iter()
+            .filter_map(|f| match f {
+                ProtocolFrame::Done {
+                    truncated,
+                    ghost_fallback,
+                    ..
+                } => Some((*truncated, *ghost_fallback)),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(dones.len(), 2, "one Done per attempt: {frames:?}");
+        assert_eq!(
+            dones[0],
+            (true, false),
+            "non-last empty attempt must be truncated, never a spurious success or ghost: {frames:?}"
+        );
+        assert_eq!(
+            dones[1],
+            (false, false),
+            "the clean fallback is a normal accepted reply: {frames:?}"
+        );
+        assert!(
+            !frames.iter().any(|f| matches!(
+                f,
+                ProtocolFrame::Done {
+                    ghost_fallback: true,
+                    ..
+                }
+            )),
+            "no ghost fallback when a later model replies: {frames:?}"
+        );
+        assert!(
+            frames.iter().any(
+                |f| matches!(f, ProtocolFrame::Delta { content, .. } if content == "hi there")
+            ),
+            "the clean fallback text must be delivered: {frames:?}"
+        );
+        let produced = &outcome.lock().unwrap().produced;
+        assert_eq!(
+            produced.len(),
+            1,
+            "only the accepted fallback remains in produced; got {produced:?}"
+        );
+        assert_eq!(produced[0].full_text, "hi there");
     }
 
     /// Codex P2 (round 6): a COMPLETE garbled primary followed by a failing fallback

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -1014,7 +1014,11 @@ fn drive_chat_burst(
             // Empty visible text (regex-strip-to-empty, case a) means nothing
             // was served: the assistant row is a ghost fallback, not a normal
             // reply — tag it in metadata and keep affinity's ghost_streak
-            // untouched (see BurstOutcome.ghost_fallback gating).
+            // untouched (see BurstOutcome.ghost_fallback gating). Tagging it
+            // `"regex_strip"` is always correct here: `visible` can only be
+            // empty via the regex-strip-to-empty branch above, since the LLM
+            // output filter fails open to the (non-empty) `cleaned` text and
+            // never emptifies an otherwise non-empty reply.
             let is_ghost = visible.is_empty();
 
             if !visible.is_empty() {

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -495,6 +495,7 @@ fn drive_chat_burst(
                 let mut last_usage: Option<eros_engine_llm::openrouter::UsageBlock> = None;
                 let mut last_gen_id: Option<String> = None;
                 let mut truncated = false;
+                let mut empty_completion = false;
 
                 yield ProtocolFrame::Meta {
                     message_id: ulid_string(msg_ulid),
@@ -534,7 +535,7 @@ fn drive_chat_burst(
                             }
                         }
                         if !truncated && acc.is_empty() {
-                            truncated = true;
+                            empty_completion = true;
                         }
                     }
                     Err(e) => {
@@ -568,6 +569,12 @@ fn drive_chat_burst(
                     }
                 }
 
+                // Disposition, computed once up front (spec §5.3): a non-last
+                // empty completion advances to the next model below; only the
+                // LAST chain attempt returning empty is a ghost fallback,
+                // distinct from length/transport truncation (pseudo-ghost).
+                let is_ghost_fallback = empty_completion && idx + 1 == chain.len();
+
                 // Persist BEFORE yielding Done (spec §2.3 risk R7).
                 let row = eros_engine_store::chat::AssistantInsert {
                     id: msg_uuid,
@@ -579,7 +586,11 @@ fn drive_chat_burst(
                     usage: last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok()),
                     generation_id: last_gen_id.clone(),
                     filter_audit: None,
-                    metadata: build_metadata(None),
+                    metadata: if is_ghost_fallback {
+                        ghost_fallback_metadata(build_metadata(None), "empty_completion")
+                    } else {
+                        build_metadata(None)
+                    },
                 };
                 if let Err(e) = chat_repo
                     .insert_assistant_batch(session_id, user_message_id, &[row])
@@ -603,8 +614,29 @@ fn drive_chat_burst(
                     truncated,
                     usage: wire_usage,
                     generation_id: last_gen_id,
-                    ghost_fallback: false,
+                    ghost_fallback: is_ghost_fallback,
                 };
+
+                if is_ghost_fallback {
+                    let mut o = outcome.lock().unwrap();
+                    o.ghost_fallback = true;
+                    // retries_chat = fallback count consumed (0-based, matches
+                    // the sibling chain-exhausted-truncated branch below) so
+                    // the Final frame doesn't under-report fallback attempts
+                    // when only the LAST chain model returns empty.
+                    o.retries_chat = (chain.len() as u32).saturating_sub(1);
+                    // Drop any earlier (superseded) truncated attempts pushed
+                    // in prior loop iterations — mirrors the accept path just
+                    // below so post_process (memory/insight/affinity) only
+                    // ever sees this ghost's empty full_text, never a partial
+                    // truncated attempt from earlier in the chain.
+                    o.produced.retain(|m| m.message_id == msg_uuid);
+                    return;
+                }
+                if empty_completion {
+                    // Non-last empty completion: advance to the next model.
+                    continue;
+                }
 
                 if !truncated {
                     let mut o = outcome.lock().unwrap();
@@ -4381,6 +4413,117 @@ data: [DONE]\n\n";
                 session_id,
                 "hi",
                 "01J4444444444444444444444A",
+                "user",
+                None,
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
+
+        let frames: Vec<ProtocolFrame> = run_stream(
+            std::sync::Arc::new(state),
+            PersistedUserMessage {
+                user_message_id: umid,
+                session_id,
+                user_id,
+                instance_id,
+                content: "hi".into(),
+                prompt_traits: vec![],
+                audit: None,
+                tier: None,
+                memory_scope: Default::default(),
+                affinity_scope: Default::default(),
+                tips_amount_usd: None,
+                image_url: None,
+                image: None,
+                history_anchor: Default::default(),
+            },
+        )
+        .collect()
+        .await;
+
+        assert!(
+            frames.iter().any(|f| matches!(
+                f,
+                ProtocolFrame::Done {
+                    ghost_fallback: true,
+                    ..
+                }
+            )),
+            "expected Done{{ghost_fallback:true}}, got {frames:?}"
+        );
+        assert!(
+            !frames
+                .iter()
+                .any(|f| matches!(f, ProtocolFrame::Error { .. })),
+            "empty completion must not error"
+        );
+        let reason: Option<String> = sqlx::query_scalar(
+            "SELECT metadata->>'fallback_reason' FROM engine.chat_messages \
+             WHERE user_message_id = $1 AND role = 'assistant'",
+        )
+        .bind(umid)
+        .fetch_optional(&pool)
+        .await
+        .unwrap()
+        .flatten();
+        assert_eq!(reason.as_deref(), Some("empty_completion"));
+    }
+
+    /// LIVE mode (primary-risk), case (b): the served model returns a 200 OK
+    /// stream whose delta never carries a `content` field, so `acc` stays
+    /// empty and `finish_reason` is never `"length"` — an empty completion on
+    /// the LAST (here, only) chain attempt in the un-buffered path, which
+    /// interleaves persist → Done → accept/advance per attempt. Unlike the
+    /// filtered-mode sibling above, this test carries NO `output_regex` rule
+    /// and no LLM `filter` — `test_state`'s bare defaults leave both
+    /// `regex_targets_chain` and `llm_filter_arms` false, so `filtered_mode`
+    /// is false and the turn runs the LIVE branch under test. Must surface as
+    /// `Done{ghost_fallback:true}` tagged `metadata.fallback_reason =
+    /// "empty_completion"`, NOT the pseudo-ghost/Error truncation path that
+    /// the sibling `run_stream_reply_terminates_cleanly_with_mock_openrouter`
+    /// / multi-attempt tests exercise.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn empty_completion_live_last_attempt_becomes_ghost_fallback(pool: PgPool) {
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+        use futures_util::StreamExt;
+        use wiremock::matchers::path as wm_path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        // 200 stream with a delta that carries no `content` at all → empty completion.
+        let body = "data: {\"choices\":[{\"delta\":{}}],\"id\":\"gen-el\",\"model\":\"primary\"}\n\ndata: [DONE]\n\n";
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+
+        let user_id = Uuid::new_v4();
+        let (_g, instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                eros_engine_llm::openrouter::AppAttribution::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+        // No output_regex, no filter → live mode.
+
+        let chat_repo = ChatRepo { pool: &pool };
+        let umid = match chat_repo
+            .upsert_user_message_idempotent(
+                session_id,
+                "hi",
+                "01J5555555555555555555555B",
                 "user",
                 None,
             )

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -73,6 +73,10 @@ pub enum ProtocolFrame {
         /// full unfiltered usage separately.
         usage: Option<serde_json::Value>,
         generation_id: Option<String>,
+        /// True when this served reply_text resolved empty and is surfaced as a
+        /// ghost. The cause lives in the persisted row's metadata.fallback_reason.
+        #[serde(default, skip_serializing_if = "is_false")]
+        ghost_fallback: bool,
     },
     Final {
         lead_score: f64,
@@ -130,6 +134,10 @@ pub enum ProtocolFrame {
         #[serde(skip_serializing_if = "Option::is_none")]
         aspect_ratio: Option<String>,
     },
+}
+
+fn is_false(b: &bool) -> bool {
+    !*b
 }
 
 /// Render a 128-bit id as a Crockford Base32 ULID string (26 chars).
@@ -334,6 +342,7 @@ fn delegated_image_only_frames(
             truncated: false,
             usage: None,
             generation_id: None,
+            ghost_fallback: false,
         },
         build_image_request_frame(message_id, composed_prompt, image_ref, aspect_ratio),
     ]
@@ -591,6 +600,7 @@ fn drive_chat_burst(
                     truncated,
                     usage: wire_usage,
                     generation_id: last_gen_id,
+                    ghost_fallback: false,
                 };
 
                 if !truncated {
@@ -950,6 +960,7 @@ fn drive_chat_burst(
                 truncated: false,
                 usage: wire_usage,
                 generation_id: last_gen_id,
+                ghost_fallback: false,
             };
             return;
         }
@@ -2183,6 +2194,7 @@ async fn build_stream_failure_pseudo_ghost(
             truncated: false,
             usage: None,
             generation_id: None,
+            ghost_fallback: false,
         },
     ];
     let produced = crate::pipeline::post_process::ProducedMessage {
@@ -2284,6 +2296,7 @@ async fn build_garble_repaired_replacement(
             truncated: false,
             usage: None,
             generation_id: None,
+            ghost_fallback: false,
         },
     ];
     let produced = crate::pipeline::post_process::ProducedMessage {
@@ -2555,6 +2568,7 @@ pub fn run_stream(
                     truncated: false,
                     usage: None,
                     generation_id: None,
+                    ghost_fallback: false,
                 };
                 let final_frame = compute_final_frame(&state, user_msg.session_id, user_msg.user_id, false, None, user_msg.tier.clone(), 0, 0).await;
                 yield final_frame;
@@ -3136,6 +3150,7 @@ pub fn replay_stream(
                 truncated: false,
                 usage: None,
                 generation_id: None,
+                ghost_fallback: false,
             };
         } else {
             for row in &rows {
@@ -3171,6 +3186,7 @@ pub fn replay_stream(
                     truncated: row.truncated,
                     usage,
                     generation_id: row.generation_id.clone(),
+                    ghost_fallback: false,
                 };
             }
             // If every persisted assistant row was truncated, emit the same
@@ -3338,6 +3354,7 @@ mod tests {
                 "total_tokens": 14,
             })),
             generation_id: Some("gen-1".into()),
+            ghost_fallback: false,
         };
         let v: serde_json::Value = serde_json::to_value(&f).unwrap();
         assert_eq!(v["type"], "done");
@@ -3403,11 +3420,38 @@ mod tests {
             truncated: false,
             usage: None,
             generation_id: None,
+            ghost_fallback: false,
         };
         let v: serde_json::Value = serde_json::to_value(&f).unwrap();
         // Spec §1.5 done schema permits `usage: null` — do NOT omit.
         assert!(v.get("usage").is_some());
         assert!(v["usage"].is_null());
+    }
+
+    #[test]
+    fn done_frame_omits_ghost_fallback_when_false() {
+        let f = ProtocolFrame::Done {
+            message_id: "m".into(),
+            truncated: false,
+            usage: None,
+            generation_id: None,
+            ghost_fallback: false,
+        };
+        let s = serde_json::to_string(&f).unwrap();
+        assert!(!s.contains("ghost_fallback"), "false must be omitted: {s}");
+    }
+
+    #[test]
+    fn done_frame_serializes_ghost_fallback_when_true() {
+        let f = ProtocolFrame::Done {
+            message_id: "m".into(),
+            truncated: false,
+            usage: None,
+            generation_id: None,
+            ghost_fallback: true,
+        };
+        let s = serde_json::to_string(&f).unwrap();
+        assert!(s.contains("\"ghost_fallback\":true"), "true must serialize: {s}");
     }
 
     #[test]

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -923,6 +923,11 @@ fn drive_chat_burst(
                 None => (cleaned.clone(), regex_audit(&acc), None), // regex-only turn
                 }
             };
+            // Empty visible text (regex-strip-to-empty, case a) means nothing
+            // was served: the assistant row is a ghost fallback, not a normal
+            // reply — tag it in metadata and keep affinity's ghost_streak
+            // untouched (see BurstOutcome.ghost_fallback gating).
+            let is_ghost = visible.is_empty();
 
             if !visible.is_empty() {
                 yield ProtocolFrame::Delta {
@@ -941,7 +946,11 @@ fn drive_chat_burst(
                 usage: last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok()),
                 generation_id: last_gen_id.clone(),
                 filter_audit,
-                metadata: build_metadata(filter_failure.as_ref()),
+                metadata: if is_ghost {
+                    ghost_fallback_metadata(build_metadata(filter_failure.as_ref()), "regex_strip")
+                } else {
+                    build_metadata(filter_failure.as_ref())
+                },
             };
             if let Err(e) = chat_repo.insert_assistant_batch(session_id, user_message_id, &[row]).await {
                 tracing::warn!("stream(filtered): persist failed: {e}");
@@ -958,16 +967,32 @@ fn drive_chat_burst(
 
             let mut wire_usage = last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok());
             filter_usage_keys(&mut wire_usage, &state.config.openrouter_usage_hidden_keys);
+            if is_ghost {
+                outcome.lock().unwrap().ghost_fallback = true;
+            }
             yield ProtocolFrame::Done {
                 message_id: ulid_string(msg_ulid),
                 truncated: false,
                 usage: wire_usage,
                 generation_id: last_gen_id,
-                ghost_fallback: false,
+                ghost_fallback: is_ghost,
             };
             return;
         }
     }
+}
+
+/// Assistant-row metadata for an empty-reply ghost fallback: the base metadata
+/// bag (may be None) plus a `fallback_reason` tag.
+fn ghost_fallback_metadata(
+    base: Option<serde_json::Value>,
+    reason: &str,
+) -> Option<serde_json::Value> {
+    let mut obj = base
+        .and_then(|v| v.as_object().cloned())
+        .unwrap_or_default();
+    obj.insert("fallback_reason".into(), serde_json::json!(reason));
+    Some(serde_json::Value::Object(obj))
 }
 
 /// Pick the text post_process extracts from: original (after) vs visible (before).
@@ -4057,6 +4082,172 @@ data: [DONE]\n\n";
         .await
         .unwrap();
         assert_eq!(gs, 0, "a real reply must reset ghost_streak");
+    }
+
+    /// Filtered mode, case (a): a reply that's entirely a bracketed artifact
+    /// strips to "" via `output_regex`, so nothing is served. That must
+    /// surface as `Done{ghost_fallback:true}` (no `Delta` at all), tag the
+    /// persisted assistant row with `metadata.fallback_reason = "regex_strip"`,
+    /// and — per the design's "既不加也不清零" — leave `ghost_streak` untouched
+    /// (gated in `run_stream` via `BurstOutcome.ghost_fallback`, asserted
+    /// separately by `normal_reply_resets_ghost_streak` for the real-reply
+    /// case). `[tasks.chat_companion].model = "primary"` is set explicitly so
+    /// the `output_regex` rule's `models` list actually targets the model
+    /// `state.model_config.resolve` picks — the default `ModelConfig` (no
+    /// `[tasks.chat_companion]` block) falls through to the compiled-in
+    /// `x-ai/grok-4-mini`, which wouldn't match a rule scoped to "primary" and
+    /// would silently fall back to LIVE mode instead of filtered.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn regex_strip_to_empty_becomes_ghost_fallback(pool: PgPool) {
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+        use futures_util::StreamExt;
+        use wiremock::matchers::path as wm_path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        // Reply is entirely a bracketed artifact.
+        let body = "data: {\"choices\":[{\"delta\":{\"content\":\"[你给对方发送了一张照片]\"}}],\"id\":\"gen-a\",\"model\":\"primary\"}\n\ndata: [DONE]\n\n";
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+
+        let user_id = Uuid::new_v4();
+        let (_g, instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+        // Seed ghost_streak = 2 on the affinity row (upsert, not a bare UPDATE:
+        // the row doesn't exist yet — created lazily by run_stream's
+        // `AffinityRepo::load_or_create` — same rationale as
+        // `normal_reply_resets_ghost_streak` above). This also happens to sit
+        // at the ghost anti-streak veto's threshold (`ghost_streak >= 2` in
+        // `eros_engine_core::ghost::ghost_permitted`), but that veto is moot
+        // here anyway: a brand-new session's `message_count < 10` already
+        // forces `pde::decide` to `ActionType::ReplyText` deterministically.
+        sqlx::query(
+            "INSERT INTO engine.companion_affinity (session_id, user_id, instance_id, ghost_streak) \
+             VALUES ($1, $2, $3, 2) \
+             ON CONFLICT (session_id) DO UPDATE SET ghost_streak = 2",
+        )
+        .bind(session_id)
+        .bind(user_id)
+        .bind(instance_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                eros_engine_llm::openrouter::AppAttribution::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+        // One config carries both the resolved chat model ("primary") and the
+        // output_regex rule scoped to it — built via `ModelConfig::from_toml_str`
+        // + `compile_output_regex()` rather than constructing `CompiledRegexRule`
+        // by hand, so the test doesn't need `regex` as a direct dependency of
+        // eros-engine-server (mirrors the `regex_target_buffers_without_...`
+        // / `regex_strips_artifact_from_client_and_memory` tests above). The
+        // pattern matches a WHOLE reply that's just one bracketed artifact
+        // (TOML literal string — `'...'` — so the backslashes reach `regex`
+        // unescaped).
+        let regex_cfg = eros_engine_llm::model_config::ModelConfig::from_toml_str(
+            r#"
+            [tasks.chat_companion]
+            model = "primary"
+
+            [[tasks.chat_companion.output_regex]]
+            models = ["primary"]
+            pattern = '^\s*\[[^\]]*\]\s*$'
+            "#,
+        )
+        .unwrap();
+        state.model_config = std::sync::Arc::new(regex_cfg.clone());
+        state.output_regex = std::sync::Arc::new(
+            regex_cfg
+                .compile_output_regex()
+                .expect("bracket-only pattern compiles"),
+        );
+
+        let chat_repo = ChatRepo { pool: &pool };
+        let umid = match chat_repo
+            .upsert_user_message_idempotent(
+                session_id,
+                "hi",
+                "01J3333333333333333333333A",
+                "user",
+                None,
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
+
+        let frames: Vec<ProtocolFrame> = run_stream(
+            std::sync::Arc::new(state),
+            PersistedUserMessage {
+                user_message_id: umid,
+                session_id,
+                user_id,
+                instance_id,
+                content: "hi".into(),
+                prompt_traits: vec![],
+                audit: None,
+                tier: None,
+                memory_scope: Default::default(),
+                affinity_scope: Default::default(),
+                tips_amount_usd: None,
+                image_url: None,
+                image: None,
+                history_anchor: Default::default(),
+            },
+        )
+        .collect()
+        .await;
+
+        // Done carries ghost_fallback; no Delta was emitted.
+        assert!(
+            frames.iter().any(|f| matches!(
+                f,
+                ProtocolFrame::Done {
+                    ghost_fallback: true,
+                    ..
+                }
+            )),
+            "expected Done{{ghost_fallback:true}}, got {frames:?}"
+        );
+        assert!(
+            !frames
+                .iter()
+                .any(|f| matches!(f, ProtocolFrame::Delta { .. })),
+            "no Delta for an empty reply"
+        );
+        // Audit row: empty content + fallback_reason.
+        let (content, reason): (String, Option<String>) = sqlx::query_as(
+            "SELECT content, metadata->>'fallback_reason' FROM engine.chat_messages \
+             WHERE user_message_id = $1 AND role = 'assistant'",
+        )
+        .bind(umid)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(content, "");
+        assert_eq!(reason.as_deref(), Some("regex_strip"));
+        // Affinity-neutral: ghost_streak untouched.
+        let gs: i32 = sqlx::query_scalar(
+            "SELECT ghost_streak FROM engine.companion_affinity WHERE session_id = $1",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(gs, 2, "ghost fallback must not reset ghost_streak");
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -384,6 +384,9 @@ pub struct BurstOutcome {
     pub filtered: bool,
     pub retries_chat: u32,   // successful chat-attempt index (0 = primary)
     pub retries_filter: u32, // served filter-model index (0 when none/primary)
+    /// True when this burst ended as an empty-reply ghost fallback. The caller
+    /// skips affinity side-effects (the ghost_streak reset) when set.
+    pub ghost_fallback: bool,
 }
 
 /// Per-burst driver: walks the model fallback chain, emits Meta/Delta/Done
@@ -2922,21 +2925,25 @@ pub fn run_stream(
                         yield frame;
                     }
                 }
-                let (produced, did_filter, retries_chat, retries_filter) = {
+                let (produced, did_filter, retries_chat, retries_filter, ghost_fallback) = {
                     let g = outcome.lock().unwrap();
-                    (g.produced.clone(), g.filtered, g.retries_chat, g.retries_filter)
+                    (g.produced.clone(), g.filtered, g.retries_chat, g.retries_filter, g.ghost_fallback)
                 };
 
-                // Reset ghost streak (mirrors sync pipeline policy).
-                if let Err(e) = sqlx::query(
-                    "UPDATE engine.companion_affinity SET ghost_streak = 0, updated_at = now() \
-                     WHERE session_id = $1 AND ghost_streak <> 0",
-                )
-                .bind(user_msg.session_id)
-                .execute(&state.pool)
-                .await
-                {
-                    tracing::warn!("stream: ghost streak reset failed: {e}");
+                // Reset ghost streak (mirrors sync pipeline policy). A ghost
+                // fallback (empty served reply) is affinity-neutral — do NOT
+                // reset, per the design's "既不加也不清零".
+                if !ghost_fallback {
+                    if let Err(e) = sqlx::query(
+                        "UPDATE engine.companion_affinity SET ghost_streak = 0, updated_at = now() \
+                         WHERE session_id = $1 AND ghost_streak <> 0",
+                    )
+                    .bind(user_msg.session_id)
+                    .execute(&state.pool)
+                    .await
+                    {
+                        tracing::warn!("stream: ghost streak reset failed: {e}");
+                    }
                 }
 
                 // ── ReplyTextImage: append the generated image AFTER the text ──
@@ -3951,6 +3958,102 @@ data: [DONE]\n\n";
             "no error frame expected, got {frames:?}",
         );
         assert!(matches!(frames.last(), Some(ProtocolFrame::Final { .. })));
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn normal_reply_resets_ghost_streak(pool: PgPool) {
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+        use futures_util::StreamExt;
+        use wiremock::matchers::path as wm_path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        let body = "data: {\"choices\":[{\"delta\":{\"content\":\"hey\"}}],\"id\":\"gen-r\",\"model\":\"primary\"}\n\ndata: [DONE]\n\n";
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+
+        let user_id = Uuid::new_v4();
+        let (_g, instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+        // Seed a non-zero ghost streak on the session's affinity row. The row
+        // doesn't exist yet at this point (created lazily by run_stream's
+        // `AffinityRepo::load_or_create`), so upsert rather than UPDATE —
+        // a bare UPDATE here would silently affect 0 rows and the later
+        // load_or_create would just insert a fresh ghost_streak=0 row,
+        // making the assertion below pass trivially regardless of the
+        // reset/gate logic under test.
+        sqlx::query(
+            "INSERT INTO engine.companion_affinity (session_id, user_id, instance_id, ghost_streak) \
+             VALUES ($1, $2, $3, 3) \
+             ON CONFLICT (session_id) DO UPDATE SET ghost_streak = 3",
+        )
+        .bind(session_id)
+        .bind(user_id)
+        .bind(instance_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                eros_engine_llm::openrouter::AppAttribution::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+
+        let chat_repo = ChatRepo { pool: &pool };
+        let umid = match chat_repo
+            .upsert_user_message_idempotent(
+                session_id,
+                "hi",
+                "01J2222222222222222222222A",
+                "user",
+                None,
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
+
+        let _frames: Vec<ProtocolFrame> = run_stream(
+            std::sync::Arc::new(state),
+            PersistedUserMessage {
+                user_message_id: umid,
+                session_id,
+                user_id,
+                instance_id,
+                content: "hi".into(),
+                prompt_traits: vec![],
+                audit: None,
+                tier: None,
+                memory_scope: Default::default(),
+                affinity_scope: Default::default(),
+                tips_amount_usd: None,
+                image_url: None,
+                image: None,
+                history_anchor: Default::default(),
+            },
+        )
+        .collect()
+        .await;
+
+        let gs: i32 = sqlx::query_scalar(
+            "SELECT ghost_streak FROM engine.companion_affinity WHERE session_id = $1",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(gs, 0, "a real reply must reset ghost_streak");
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/docs/superpowers/specs/2026-07-06-empty-reply-ghost-fallback-design.md
+++ b/docs/superpowers/specs/2026-07-06-empty-reply-ghost-fallback-design.md
@@ -160,27 +160,44 @@ mode only handles case (b).
 > live-mode chain-exhaustion control flow. It is the main area for careful tests
 > (§8) and review.
 
-## 6. Affinity neutrality
+## 6. Affinity effect — *partial* neutrality (consciously scoped)
 
-A fallback-ghost turn must have **zero** affinity effect:
+A fallback-ghost turn is **partially** affinity-neutral. The final whole-branch
+review (2026-07-06) found that strict "zero affinity effect" is not achieved by
+construction, and the maintainer chose to accept the status quo rather than
+expand scope. The actual, guaranteed contract:
 
-- No `record_ghost` (we are not in the ghost branch — satisfied by construction).
-- **Skip the post-burst `ghost_streak = 0` reset** (`run_stream`,
-  `stream.rs:2916-2926`) for a fallback-ghost outcome — the reply-path normally
-  resets it, but a technical empty reply is not "engagement." The burst outcome
-  must carry a `ghost_fallback` signal that `run_stream` checks before resetting.
-- **No per-turn affinity delta.** The empty `produced.full_text` already causes
-  memory/insight writes to be skipped (`post_process.rs:291-293`, insight loop
-  `74-82`); the per-turn affinity eval must likewise not run on an empty reply.
-  The implementation propagates the fallback signal (or reuses the empty-text
-  guard) so post-process treats the turn as a no-op.
+**Neutral (guaranteed):**
+- No `record_ghost` — we are not in the ghost branch. So **no `ghost` affinity
+  event** is written.
+- **`ghost_streak` reset skipped** — `run_stream` gates the post-burst
+  `ghost_streak = 0` reset on `BurstOutcome.ghost_fallback`. A technical empty
+  reply does not clear a real-ghost streak (neither increments nor resets it).
+- **LLM affinity eval skipped** — the empty `produced.full_text` makes the
+  evaluator's `eval_text` empty, so `eval_skip_reason` marks the turn skipped and
+  no LLM-scored delta is computed.
+- **Memory + insight skipped** — empty produced text is filtered by
+  `should_write_user_turn` (`post_process.rs:291-293`) and the insight loop
+  (`74-87`).
 
-> **Open confirmation for review:** decisions here refine "affinity-neutral" from
-> the brainstorm. Case (a) already flows through the reply path today (so its
-> current affinity behavior is the status quo); this spec tightens it to be
-> strictly neutral. Confirm that the `ghost_streak` reset skip and the
-> no-affinity-delta rule are wanted (they match the stated "既不加也不清零"
-> intent).
+**NOT neutral (accepted status quo):**
+- `post_process::run` still runs for the `ReplyText` arm (it is not gated on
+  `ghost_fallback`). Inside it, `persist_affinity` still writes an
+  `event_type="message"` affinity event and applies the **rule-based** delta
+  `predict_reply_deltas` (`pde.rs`), which is derived from the *user* message's
+  length / staleness — **not** from the empty reply — and `refresh_lead_score`
+  runs. So affinity meters can still move by the small user-side rule delta.
+
+**Rationale.** For case (a) (regex-strip-to-empty) this is exactly the
+pre-existing behavior — **not a regression**. Making it strictly neutral would
+require threading `ghost_fallback` into `post_process::run` and gating
+`persist_affinity` / lead refresh there — a change to `post_process.rs` beyond
+this feature's scope, for a small effect (the rule delta is user-derived and
+typically tiny). The guaranteed-neutral pieces above are what keep *ghost*
+analytics clean (no ghost event, no streak change, no LLM eval, no
+memory/insight); the residual `message` event + rule delta are identical to any
+other reply turn. A test (§10) locks this accepted contract against silent
+drift. Revisiting strict neutrality is a possible follow-up, not a blocker.
 
 ## 7. Persistence, replay, reload
 

--- a/docs/superpowers/specs/2026-07-06-empty-reply-ghost-fallback-design.md
+++ b/docs/superpowers/specs/2026-07-06-empty-reply-ghost-fallback-design.md
@@ -145,13 +145,18 @@ persist/`Done`, then:
 
 - Persist the row with `metadata.fallback_reason = "empty_completion"` when
   `is_ghost_fallback`.
-- Emit `Done{ ghost_fallback: is_ghost_fallback, truncated: <length/transport
-  only> }`.
-- Adjust the tail so a non-last empty completion **advances** (not accepted as a
-  reply), a last empty completion **returns via ghost-fallback** (not
-  pseudo-ghost), and a genuine truncation keeps its current path. Note: because
-  `empty_completion` is now split from `truncated`, the "accept reply" gate
-  (`596`) must become `if !truncated && !empty_completion`.
+- Emit `Done{ ghost_fallback: is_ghost_fallback }`.
+- **A non-last empty completion is marked `truncated = true`** (before the
+  persist/`Done`) so it flows through the *existing* superseded-attempt
+  advance path unchanged — the persisted row and its `Done{truncated:true}`
+  carry the "replace me" signal, exactly as before this feature, so the client
+  and replay never see a spurious *successful* empty turn. (An earlier draft
+  routed it through a separate `if empty_completion { continue }` branch that
+  left `truncated:false` and emitted a phantom completed empty turn — a bug
+  caught in codex review; marking it truncated is the fix.) Only the **last**
+  empty attempt (`is_ghost_fallback`) returns via the ghost path; genuine
+  length/transport truncation keeps its current pseudo-ghost/`Error` path. The
+  "accept reply" gate (`if !truncated`) is therefore **unchanged**.
 
 Case (a) does not occur in live mode (regex only runs when buffering), so live
 mode only handles case (b).

--- a/docs/superpowers/specs/2026-07-06-empty-reply-ghost-fallback-design.md
+++ b/docs/superpowers/specs/2026-07-06-empty-reply-ghost-fallback-design.md
@@ -219,10 +219,17 @@ drift. Revisiting strict neutrality is a possible follow-up, not a blocker.
   audit row is dropped by the web's `isEmptyAssistantTurn` → nothing shown,
   identical to a real ghost's reload and to today. No history/BFF change.
 - **Replay (idempotent re-request).** `upsert_user_message_idempotent`
-  (`chat.rs:581-608`) returns the assistant row as a normal reply; with empty
-  content the web drops it → nothing shown. The live-only hint is not
-  reconstructed on replay — consistent with real-ghost reload. **No replay
-  change.**
+  (`chat.rs:581-608`) returns the persisted assistant row and `replay_stream`
+  re-emits its frames. `replay_stream` **re-emits `Done{ghost_fallback:true}`**
+  for a fallback row (matched precisely on `metadata.fallback_reason ∈
+  {regex_strip, empty_completion}` — the pseudo-ghost `stream_failure` and
+  `garble_repaired` rows carry a `fallback_reason` too but are non-empty replies,
+  so they stay `false`). This makes an idempotent retry wire-identical to the
+  original live stream, exactly as a **real** ghost re-emits its `Meta{Ghost}`
+  frames on replay. (Corrected after codex review — an earlier draft hard-coded
+  `ghost_fallback:false` on replay, which made a reconnecting client render the
+  fallback as a plain empty done instead of a ghost.) **Reload** still shows
+  nothing (slim history has no flag), matching a real ghost's reload.
 
 ## 8. Consumer (eros-engine-web) change
 

--- a/docs/superpowers/specs/2026-07-06-empty-reply-ghost-fallback-design.md
+++ b/docs/superpowers/specs/2026-07-06-empty-reply-ghost-fallback-design.md
@@ -1,0 +1,250 @@
+# Empty `reply_text` → ghost fallback — design
+
+**Date:** 2026-07-06
+**Status:** design (approved shape, pending spec review)
+**Area:** `crates/eros-engine-server/src/pipeline/stream.rs` (streaming reply path), the SSE wire (`ProtocolFrame::Done`), and a one-condition change in the downstream consumer (`eros-engine-web`).
+
+## 1. Problem
+
+On the streaming chat path a `reply_text` turn can end up with an **empty**
+final reply, from two distinct causes:
+
+- **(a) regex strip empties it.** The per-model output-regex filter
+  (`apply_output_regex`) strips an artifact-only reply down to `""`
+  (`drive_chat_burst`, filtered mode, `stream.rs:847-853`). Since the fail-safe
+  was removed (commit `4bee255`, 2026-06-29) this is intentional. Today the
+  engine persists an empty assistant row (`content=""`, with `pre_filter_content`
+  / `generation_id` / `filter_triggers` audit), emits `Meta{Reply}` + **no**
+  `Delta` + `Done`, and the web silently drops the empty bubble.
+- **(b) the model returns an empty completion.** A served attempt yields no
+  content (a 2xx response with an empty body — not a length truncation, not a
+  transport error). Today this is folded into `truncated` (`stream.rs:524-526`
+  live / `724` filtered), advances the model chain, and on chain exhaustion
+  produces either the canned "pseudo-ghost" phrase
+  (`build_stream_failure_pseudo_ghost`) or a hard `Error` frame.
+
+In both cases the user sees **nothing** — no reply, and no signal that the
+companion chose not to answer. We want an empty `reply_text` to render as a
+**ghost** ("AI 伴侣没回复"), the same affordance the real ghost path produces,
+while keeping a server-side audit trail (`generation_id`, `pre_filter_content`)
+so a "real ghost" and a "fell-back-to-ghost" are distinguishable after the fact.
+
+## 2. Goal & non-goals
+
+**Goal.** When a *successfully served* `reply_text` turn produces an empty final
+reply, surface it to the consumer as a ghost (live), record why in the audit
+trail, and stay affinity-neutral.
+
+**In scope**
+
+- (a) regex-strip-to-empty (filtered mode).
+- (b) empty completion (200-ish response, empty body), in **both** live and
+  filtered modes. The model chain still advances on an empty completion; only the
+  **last** attempt being empty falls back to ghost.
+
+**Out of scope (unchanged behavior)**
+
+- Genuine transport errors / stream-open failures / length truncation → keep the
+  existing `truncated` → chain-advance → `build_stream_failure_pseudo_ghost` /
+  `Error` behavior.
+- The real ghost path (PDE `Ghost` decision, `stream.rs:2537-2561`) — untouched.
+- The canned pseudo-ghost phrase fallback — untouched (a distinct feature; see
+  naming note §9).
+- Any change to `training_level`, memory, or insight extraction.
+
+## 3. Locked design decisions
+
+1. **Signal via a `Done` flag, not `Meta{Ghost}`.** `Meta{Reply}` is emitted
+   before the empty state is known (live: `stream.rs:487`, upfront; filtered:
+   `792`), so it cannot cleanly become `Meta{Ghost}`. `Done` is emitted in both
+   modes *after* the completion is known (live: `589`, filtered: `948`), so a
+   flag on `Done` has no ordering hazard and works uniformly in both modes.
+2. **Keep the audit assistant row.** The empty row is the natural home for the
+   audit (`content=""`, `pre_filter_content`, `generation_id`, `filter_triggers`
+   already persisted for case (a)). Add `metadata.fallback_reason`.
+3. **Wire flag is a generic `bool`; the reason lives in the DB.** `Done` carries
+   `ghost_fallback: bool`; `chat_messages.metadata.fallback_reason` distinguishes
+   `"regex_strip"` vs `"empty_completion"`.
+4. **Affinity-neutral.** A fallback-ghost turn must NOT run `record_ghost`, must
+   NOT bump/reset `ghost_streak`, and must NOT emit a per-turn affinity delta —
+   it is a technical empty reply, not the companion choosing to go silent, and
+   must not pollute ghost gating or affinity analytics.
+5. **The ghost hint is live-only.** We do NOT stamp the user row's
+   `ghost_decision` and do NOT emit `Meta{Ghost}`. On reload/replay the empty
+   audit row is dropped by the web's existing `isEmptyAssistantTurn` → nothing is
+   shown, byte-identical to how a real ghost and today's empty rows reload. So no
+   replay-path change is required.
+6. **One condition on the web.** The consumer marks a finalized assistant message
+   as ghost when its `Done` carried `ghost_fallback`, reusing the existing ghost
+   rendering, instead of dropping the empty bubble.
+
+## 4. Wire protocol change
+
+`ProtocolFrame::Done` (`stream.rs:67-76`) gains one field:
+
+```rust
+Done {
+    message_id: String,
+    truncated: bool,
+    usage: Option<serde_json::Value>,
+    generation_id: Option<String>,
+    /// True when this turn's reply_text was served but resolved empty and is
+    /// being surfaced as a ghost ("AI didn't reply"). The specific cause lives
+    /// in the persisted row's `metadata.fallback_reason`, not on the wire.
+    #[serde(default, skip_serializing_if = "is_false")]
+    ghost_fallback: bool,
+},
+```
+
+`skip_serializing_if` keeps the frame byte-identical for the overwhelming
+majority (non-fallback) case, so only fallback turns carry the new field.
+
+## 5. Engine data flow
+
+A shared requirement across all three trigger sites: emit
+`Done{ ghost_fallback: true, generation_id: <last_gen_id>, truncated: false,
+usage: <served usage or None> }`, persist (or keep) an empty assistant audit row
+with `metadata.fallback_reason` set, do **not** advance the chain or fall through
+to pseudo-ghost/Error, and mark the turn as affinity-neutral (§6).
+
+### 5.1 Filtered mode — case (a) regex-strip-to-empty
+
+`drive_chat_burst`, filtered served path (`stream.rs:809-953`). `visible` is
+empty **iff** the regex-strip-to-empty branch (`847`) fired (the LLM output
+filter never emptifies a non-empty `cleaned` — it fails open to `cleaned`). So at
+the existing `Done` emit (`948`):
+
+- Set `ghost_fallback: visible.is_empty()`.
+- When empty, add `fallback_reason = "regex_strip"` to the row `metadata` built
+  at `931` (the row + regex audit at `921-935` are otherwise unchanged).
+
+No new persist and no control-flow change — this is a flag + a metadata key.
+
+### 5.2 Filtered mode — case (b) empty completion
+
+Split empty-completion out of `truncated`. Today `stream.rs:724` does
+`if !truncated && acc.is_empty() { truncated = true }`. Introduce
+`empty_completion` tracked separately (empty body, not length, not transport):
+
+- Non-last attempt empty → advance the chain (as today).
+- **Last** attempt empty → emit the shared ghost-fallback outcome (§5), persisting
+  a fresh empty audit row (`content=""`, `generation_id`, `fallback_reason =
+  "empty_completion"`), instead of `build_stream_failure_pseudo_ghost` / `Error`
+  (`stream.rs:740-789`).
+
+Transport errors and length truncation continue to set `truncated` and keep the
+existing path.
+
+### 5.3 Live mode — case (b) empty completion
+
+`drive_chat_burst`, live path (`stream.rs:479-684`). Same split. Live mode emits
+`Meta{Reply}` upfront (`487`), persists the row (`560`), then emits `Done` (`589`)
+— all before the last-attempt decision (`607`). Compute
+`is_ghost_fallback = empty_completion && idx + 1 == chain.len()` before the
+persist/`Done`, then:
+
+- Persist the row with `metadata.fallback_reason = "empty_completion"` when
+  `is_ghost_fallback`.
+- Emit `Done{ ghost_fallback: is_ghost_fallback, truncated: <length/transport
+  only> }`.
+- Adjust the tail so a non-last empty completion **advances** (not accepted as a
+  reply), a last empty completion **returns via ghost-fallback** (not
+  pseudo-ghost), and a genuine truncation keeps its current path. Note: because
+  `empty_completion` is now split from `truncated`, the "accept reply" gate
+  (`596`) must become `if !truncated && !empty_completion`.
+
+Case (a) does not occur in live mode (regex only runs when buffering), so live
+mode only handles case (b).
+
+> **Risk (primary).** §5.3 is the most delicate part — it restructures the
+> live-mode chain-exhaustion control flow. It is the main area for careful tests
+> (§8) and review.
+
+## 6. Affinity neutrality
+
+A fallback-ghost turn must have **zero** affinity effect:
+
+- No `record_ghost` (we are not in the ghost branch — satisfied by construction).
+- **Skip the post-burst `ghost_streak = 0` reset** (`run_stream`,
+  `stream.rs:2916-2926`) for a fallback-ghost outcome — the reply-path normally
+  resets it, but a technical empty reply is not "engagement." The burst outcome
+  must carry a `ghost_fallback` signal that `run_stream` checks before resetting.
+- **No per-turn affinity delta.** The empty `produced.full_text` already causes
+  memory/insight writes to be skipped (`post_process.rs:291-293`, insight loop
+  `74-82`); the per-turn affinity eval must likewise not run on an empty reply.
+  The implementation propagates the fallback signal (or reuses the empty-text
+  guard) so post-process treats the turn as a no-op.
+
+> **Open confirmation for review:** decisions here refine "affinity-neutral" from
+> the brainstorm. Case (a) already flows through the reply path today (so its
+> current affinity behavior is the status quo); this spec tightens it to be
+> strictly neutral. Confirm that the `ghost_streak` reset skip and the
+> no-affinity-delta rule are wanted (they match the stated "既不加也不清零"
+> intent).
+
+## 7. Persistence, replay, reload
+
+- **Audit row.** `chat_messages`: `content=""`, `assistant_action_type="reply"`
+  (unchanged), `pre_filter_content` = raw pre-strip reply (case a) / empty
+  (case b), `generation_id` = served generation, `filter_triggers` = regex audit
+  (case a) / null (case b), `metadata.fallback_reason ∈ {regex_strip,
+  empty_completion}`. No schema migration — `metadata` is existing JSONB.
+- **Distinguisher.** Real ghost = `ghost_decision=true` on the user row + **no**
+  assistant row. Fallback-ghost = an empty assistant row whose
+  `metadata.fallback_reason` is set (+ no `ghost_decision`).
+- **Reload (`GET …/history`).** The slim-history endpoint returns only
+  `{id, role, content, sent_at, client_msg_id}` (no ghost signal). The empty
+  audit row is dropped by the web's `isEmptyAssistantTurn` → nothing shown,
+  identical to a real ghost's reload and to today. No history/BFF change.
+- **Replay (idempotent re-request).** `upsert_user_message_idempotent`
+  (`chat.rs:581-608`) returns the assistant row as a normal reply; with empty
+  content the web drops it → nothing shown. The live-only hint is not
+  reconstructed on replay — consistent with real-ghost reload. **No replay
+  change.**
+
+## 8. Consumer (eros-engine-web) change
+
+Confirmed against `etherfunlab/eros-engine-web@main`. One condition:
+
+- `erosClient.ts`: add `ghost_fallback?: boolean` to the `done` `StreamFrame`
+  variant (`~137`).
+- `stores/chat.ts` finalize / `onDone`: when a finalized assistant message has
+  `ghost_fallback` (empty content + flag), set `ghosted = true` (the same flag
+  `Meta{action_type:'ghost'}` sets at `chat.ts:393,406`) instead of letting it be
+  dropped. `chatVisibility.ts`'s `isEmptyAssistantTurn` already **keeps** `m.ghosted`
+  rows, so the existing ghost rendering is reused — no new component.
+
+No change to history mapping, `chatVisibility.ts`, or the affinity store.
+
+## 9. Naming
+
+The codebase already has `build_stream_failure_pseudo_ghost` (a **canned-phrase**
+reply persisted as a real reply row) — a different concept. This feature uses
+**`ghost_fallback`** on the wire and `fallback_reason ∈ {regex_strip,
+empty_completion}` in the DB. Do not reuse "pseudo_ghost".
+
+## 10. Testing
+
+- **Filtered case (a):** a served reply that a regex rule strips to empty →
+  `Done{ghost_fallback:true}`, audit row `content=""` +
+  `fallback_reason="regex_strip"` + `pre_filter_content` = raw, no `Delta`.
+- **Filtered case (b):** last-attempt empty completion → `Done{ghost_fallback:true}`,
+  `fallback_reason="empty_completion"`, no pseudo-ghost/Error; a non-last empty
+  completion still advances to the next model.
+- **Live case (b):** same as filtered case (b) on the live path; non-last empty
+  advances; a real transport error / length truncation on the last attempt still
+  produces pseudo-ghost/Error (regression guard).
+- **Neutrality:** a fallback-ghost turn leaves `ghost_streak` unchanged (no reset)
+  and writes no affinity delta / memory / insight.
+- **Non-fallback regression:** a normal non-empty reply emits `Done` **without**
+  the `ghost_fallback` field (wire byte-identical), and `record_ghost` /
+  `ghost_streak` reset behavior for real replies and real ghosts is unchanged.
+- **Wire back-compat:** `Done` serialization for a non-fallback turn is
+  byte-identical to before (skip_serializing_if).
+
+## 11. Rollout
+
+Engine and web ship independently and are forward/backward compatible: the engine
+only ever *adds* `ghost_fallback:true` on fallback turns; an un-updated web
+ignores the unknown field (renders as today — empty bubble dropped). Land the
+engine change first; the web condition can follow. No migration, no config.


### PR DESCRIPTION
Surfaces a **successfully served but empty** `reply_text` turn as a ghost ("AI 伴侣没回复"), with a server-side audit trail — instead of the current silent empty bubble.

Spec: `docs/superpowers/specs/2026-07-06-empty-reply-ghost-fallback-design.md`

## What & why
Two empty sources, both → ghost:
- **(a) regex strip → empty** (`drive_chat_burst` filtered path): the per-model output-regex filter strips an artifact-only reply to `""`.
- **(b) empty completion** (200-OK, empty body — not length truncation, not transport error), in **both** live and filtered modes: the chain still advances on an empty completion; only the **last** attempt being empty ghosts (genuine truncation/transport keeps the existing pseudo-ghost/`Error` path).

Both emit `Done{ ghost_fallback: true }` + persist an empty assistant audit row tagged `metadata.fallback_reason ∈ {regex_strip, empty_completion}` (reusing the existing `pre_filter_content`/`generation_id`/`filter_triggers` columns — **no migration**). Distinguisher vs a real ghost: real ghost = `ghost_decision` on the user row + no assistant row; fallback = empty audit row + `fallback_reason`.

## Design decisions
- **Signal via a `Done` flag, not `Meta{Ghost}`** — `Meta` is emitted before the empty state is known; `Done` is emitted after (both modes), so the flag has no ordering hazard. `#[serde(skip_serializing_if)]` keeps non-fallback `Done` frames byte-identical.
- **Live-only hint / no reload-or-replay change** — no `ghost_decision` stamp, no `Meta{Ghost}`, so on history reload & idempotent replay the empty row is dropped (nothing shown), identical to a real ghost. No history/replay code touched.
- **Affinity — *partial* neutrality (consciously accepted, spec §6):** neutral on the ghost event, the `ghost_streak` reset, the LLM affinity eval, memory, and insight. NOT neutral: `post_process` still applies the user-derived rule delta + writes a `message` affinity event (status quo for case a; an empty completion is ghost-equivalent to a problematic user turn, so this is arguably correct). A dedicated test locks this contract.

## Consumer (separate, in lockstep)
The downstream web consumer (`eros-engine-web`) needs one condition to render the hint from `Done.ghost_fallback` — filed as an issue for its maintainer (see spec §8). Engine and web are forward/backward compatible (an un-updated web ignores the new field → renders as today).

## Testing
Built task-by-task with TDD (subagent-driven), each task spec+quality reviewed, plus a final whole-branch review.
- `cargo fmt --all --check` ✓ · `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` — **703 passed, 0 failed** ✓ (incl. per-case ghost-fallback tests in live + filtered mode, a ghost_streak-neutrality test, and the affinity partial-neutrality contract test)
- HTTP surface unchanged → openapi in sync (SSE `ProtocolFrame` isn't in the schema).

🤖 Generated with [Claude Code](https://claude.com/claude-code)