### PR TITLE
feat: voice-call parts — lean /comp/voice streaming endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,6 +594,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
+ "ulid",
  "uuid",
 ]
 

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -683,6 +683,24 @@ pub struct ResolvedVision {
     pub reasoning: Option<ReasoningConfig>,
 }
 
+/// Built-in, product-identity-free voice directive. Deployments override it via
+/// `[tasks.chat_voice].filter_prompt`. Kept terse: it is appended to the persona
+/// prompt on every voice turn.
+pub const DEFAULT_VOICE_DIRECTIVE: &str = "You are on a live voice call. Speak the way people talk out loud. Keep replies short — usually one or two sentences. Do not use markdown, lists, emoji, asterisks, or bracketed stage directions: everything you write is read aloud verbatim by a text-to-speech voice, so write only words meant to be spoken.";
+
+/// Resolved `[tasks.chat_voice]` (voice channel). `directive` is the effective
+/// voice instruction: the configured `filter_prompt`, or `DEFAULT_VOICE_DIRECTIVE`
+/// when blank/omitted.
+#[derive(Debug, Clone)]
+pub struct ResolvedVoice {
+    pub model: String,
+    pub fallback_model: Vec<String>,
+    pub temperature: f64,
+    pub max_tokens: u32,
+    pub reasoning: Option<ReasoningConfig>,
+    pub directive: String,
+}
+
 /// Generic, product-identity-free default prompt for the image-prompt composer.
 /// Used when the task is enabled but supplies no `filter_prompt`; deployments
 /// override it via `[tasks.chat_image_prompt_compose].filter_prompt`. Keep the
@@ -1044,6 +1062,47 @@ impl ModelConfig {
             retry_depth,
             reasoning: task_cfg.reasoning.clone(),
         })
+    }
+
+    /// Resolve the voice task. `None` ⇒ feature off (no `[tasks.chat_voice]`).
+    /// Unlike vision, a blank `filter_prompt` does NOT disable the feature — it
+    /// falls back to the built-in `DEFAULT_VOICE_DIRECTIVE`.
+    pub fn resolve_voice(&self) -> Option<ResolvedVoice> {
+        const VOICE_TASK: &str = "chat_voice";
+        let task_cfg = self.tasks.get(VOICE_TASK)?;
+        let directive = task_cfg
+            .filter_prompt
+            .clone()
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or_else(|| DEFAULT_VOICE_DIRECTIVE.to_string());
+        let m = self.resolve(VOICE_TASK, None);
+        Some(ResolvedVoice {
+            model: m.model,
+            fallback_model: m.fallback_model,
+            temperature: m.temperature,
+            max_tokens: m.max_tokens,
+            reasoning: m.reasoning,
+            directive,
+        })
+    }
+
+    /// Boot gate: if `[tasks.chat_voice]` is present, its `model` MUST be a single
+    /// fixed, non-empty id (no round-robin array, no weighted table). Absent task
+    /// is fine (feature off).
+    pub fn validate_voice_model(&self) -> Result<(), String> {
+        const VOICE_TASK: &str = "chat_voice";
+        match self.tasks.get(VOICE_TASK) {
+            None => Ok(()),
+            Some(t) => match &t.model {
+                ModelSpec::Fixed(s) if !s.trim().is_empty() => Ok(()),
+                ModelSpec::Fixed(_) => {
+                    Err("[tasks.chat_voice].model must be set to a single model id".to_string())
+                }
+                _ => Err("[tasks.chat_voice].model must be a single fixed id \
+                          (no round-robin array or weighted table)"
+                    .to_string()),
+            },
+        }
     }
 
     /// Resolve the PDE decision task. `None` (feature off → rule engine) when
@@ -2777,6 +2836,71 @@ retry_depth = 0
         let r = cfg.resolve_vision().expect("vision resolves");
         assert_eq!(r.retry_depth, 0);
         assert!(r.fallback_model.is_empty());
+    }
+
+    #[test]
+    fn resolve_voice_none_when_task_absent() {
+        let cfg = ModelConfig::from_toml_str("").unwrap();
+        assert!(cfg.resolve_voice().is_none());
+    }
+
+    #[test]
+    fn resolve_voice_uses_default_directive_and_model() {
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.chat_voice]\nmodel = \"vendor/fast\"\nmax_tokens = 200\ntemperature = 0.7\n",
+        )
+        .unwrap();
+        let v = cfg.resolve_voice().expect("voice resolved");
+        assert_eq!(v.model, "vendor/fast");
+        assert_eq!(v.max_tokens, 200);
+        assert_eq!(v.directive, DEFAULT_VOICE_DIRECTIVE);
+    }
+
+    #[test]
+    fn resolve_voice_directive_override() {
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.chat_voice]\nmodel = \"vendor/fast\"\nfilter_prompt = \"speak like a pirate\"\n",
+        )
+        .unwrap();
+        let v = cfg.resolve_voice().unwrap();
+        assert_eq!(v.directive, "speak like a pirate");
+    }
+
+    #[test]
+    fn validate_voice_model_rejects_non_fixed_and_empty() {
+        // Absent task: ok.
+        assert!(ModelConfig::from_toml_str("")
+            .unwrap()
+            .validate_voice_model()
+            .is_ok());
+        // Fixed non-empty: ok.
+        assert!(
+            ModelConfig::from_toml_str("[tasks.chat_voice]\nmodel = \"a/b\"\n")
+                .unwrap()
+                .validate_voice_model()
+                .is_ok()
+        );
+        // Round-robin array: rejected.
+        assert!(
+            ModelConfig::from_toml_str("[tasks.chat_voice]\nmodel = [\"a/b\", \"c/d\"]\n")
+                .unwrap()
+                .validate_voice_model()
+                .is_err()
+        );
+        // Weighted table: rejected.
+        assert!(
+            ModelConfig::from_toml_str("[tasks.chat_voice]\nmodel = { \"a/b\" = 1.0 }\n")
+                .unwrap()
+                .validate_voice_model()
+                .is_err()
+        );
+        // Missing model (empty Fixed default): rejected.
+        assert!(
+            ModelConfig::from_toml_str("[tasks.chat_voice]\ntemperature = 0.7\n")
+                .unwrap()
+                .validate_voice_model()
+                .is_err()
+        );
     }
 
     #[test]

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -721,6 +721,112 @@
         ]
       }
     },
+    "/comp/voice/{session_id}/turn/stream": {
+      "post": {
+        "tags": [
+          "companion"
+        ],
+        "operationId": "voice_turn_stream",
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "description": "Chat session id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VoiceTurnRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "SSE event stream (text/event-stream)",
+            "content": {
+              "text/event-stream": {}
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StreamPreErrorBody"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "missing or invalid bearer"
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StreamPreErrorBody"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StreamPreErrorBody"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StreamPreErrorBody"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StreamPreErrorBody"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StreamPreErrorBody"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
     "/healthz": {
       "get": {
         "tags": [
@@ -1676,6 +1782,21 @@
                 "$ref": "#/components/schemas/LabelTransitionDto"
               }
             ]
+          }
+        }
+      },
+      "VoiceTurnRequest": {
+        "type": "object",
+        "required": [
+          "content",
+          "client_msg_id"
+        ],
+        "properties": {
+          "client_msg_id": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
           }
         }
       }

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -789,6 +789,16 @@
               }
             }
           },
+          "409": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StreamPreErrorBody"
+                }
+              }
+            }
+          },
           "422": {
             "description": "",
             "content": {

--- a/crates/eros-engine-server/src/main.rs
+++ b/crates/eros-engine-server/src/main.rs
@@ -291,6 +291,10 @@ async fn run_server() -> Result<()> {
         anyhow::bail!(msg);
     }
 
+    if let Err(msg) = model_config.validate_voice_model() {
+        anyhow::bail!(msg);
+    }
+
     let output_regex = match model_config.compile_output_regex() {
         Ok(rules) => Arc::new(rules),
         Err(msg) => anyhow::bail!(msg),

--- a/crates/eros-engine-server/src/pipeline/dreaming.rs
+++ b/crates/eros-engine-server/src/pipeline/dreaming.rs
@@ -151,6 +151,7 @@ async fn classify_session(
     let rows: Vec<(String, String)> = sqlx::query_as(
         "SELECT role, content FROM engine.chat_messages \
          WHERE session_id = $1 AND role IN ('user', 'assistant') \
+           AND channel IS DISTINCT FROM 'voice' \
          ORDER BY sent_at",
     )
     .bind(session_id)
@@ -470,5 +471,73 @@ mod tests {
         assert_eq!(written, 0, "empty memories → no rows");
         // mock.expect(1) is verified on MockServer drop: the request carried the
         // configured system prompt sentinel.
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn classify_session_excludes_voice_rows(pool: sqlx::PgPool) {
+        use wiremock::matchers::path as wm_path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "choices": [{ "message": { "content": "{\"memories\":[]}" } }],
+                "id": "gen-x", "model": "primary"
+            })))
+            .mount(&mock)
+            .await;
+
+        // Seed session with one TEXT assistant turn and one VOICE assistant turn.
+        let user_id = Uuid::new_v4();
+        let genome_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata) VALUES ('V','p','{}'::jsonb) RETURNING id",
+        ).fetch_one(&pool).await.unwrap();
+        let instance_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_instances (genome_id, owner_uid) VALUES ($1,$2) RETURNING id",
+        ).bind(genome_id).bind(user_id).fetch_one(&pool).await.unwrap();
+        let session_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1,$2) RETURNING id",
+        )
+        .bind(user_id)
+        .bind(instance_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        sqlx::query("INSERT INTO engine.chat_messages (session_id, role, content) VALUES ($1,'user','TEXTLINE')")
+            .bind(session_id).execute(&pool).await.unwrap();
+        sqlx::query("INSERT INTO engine.chat_messages (session_id, role, content, channel) VALUES ($1,'assistant','VOICELINE','voice')")
+            .bind(session_id).execute(&pool).await.unwrap();
+
+        // State with a memory_extraction task + mock OpenRouter.
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = std::sync::Arc::new(
+            eros_engine_llm::model_config::ModelConfig::from_toml_str(
+                "[tasks.memory_extraction]\nmodel = \"primary\"\nfilter_prompt = \"extract\"\n",
+            )
+            .unwrap(),
+        );
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                eros_engine_llm::openrouter::AppAttribution::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+
+        // Drive the private classify_session (same module).
+        let _ = super::classify_session(&state, session_id, user_id, Some(instance_id)).await;
+
+        // The request the extractor sent must contain the text turn, not the voice turn.
+        let reqs = mock.received_requests().await.unwrap();
+        let joined: String = reqs
+            .iter()
+            .map(|r| String::from_utf8_lossy(&r.body).to_string())
+            .collect();
+        assert!(joined.contains("TEXTLINE"), "text turn must be extracted");
+        assert!(
+            !joined.contains("VOICELINE"),
+            "voice turn must be excluded from memory extraction"
+        );
     }
 }

--- a/crates/eros-engine-server/src/pipeline/mod.rs
+++ b/crates/eros-engine-server/src/pipeline/mod.rs
@@ -8,6 +8,7 @@ pub mod handlers;
 pub mod post_process;
 pub mod snapshot;
 pub mod stream;
+pub mod voice;
 
 use uuid::Uuid;
 

--- a/crates/eros-engine-server/src/pipeline/voice.rs
+++ b/crates/eros-engine-server/src/pipeline/voice.rs
@@ -150,6 +150,12 @@ pub fn run_voice_turn(
         let mut truncated = false;
 
         'candidates: for model_id in candidates {
+            // Per-attempt metadata: reset so an abandoned candidate's usage / gen_id /
+            // model / truncated never leaks onto a later fallback's reply.
+            last_usage = None;
+            last_gen_id = None;
+            served_model = None;
+            truncated = false;
             let req = ChatRequest {
                 model: model_id.clone(),
                 messages: messages.clone(),
@@ -212,9 +218,11 @@ pub fn run_voice_turn(
             return;
         }
 
-        // Persist the assistant turn only when it carries text.
+        // Persist the assistant turn only when it carries text. The DB always
+        // gets the FULL unfiltered usage; the wire `Done` frame below gets a
+        // separate, hidden-keys-filtered copy (mirrors the text/replay paths).
+        let usage_full = last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok());
         if !acc.is_empty() {
-            let usage_json = last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok());
             if let Err(e) = chat_repo
                 .insert_voice_assistant_message(
                     turn.session_id,
@@ -222,7 +230,7 @@ pub fn run_voice_turn(
                     assistant_uuid,
                     &acc,
                     served_model.as_deref(),
-                    usage_json.as_ref(),
+                    usage_full.as_ref(),
                     last_gen_id.as_deref(),
                     truncated,
                 )
@@ -232,10 +240,16 @@ pub fn run_voice_turn(
             }
         }
 
+        let mut usage_wire = usage_full;
+        crate::routes::companion::filter_usage_keys(
+            &mut usage_wire,
+            &state.config.openrouter_usage_hidden_keys,
+        );
+
         yield ProtocolFrame::Done {
             message_id,
             truncated,
-            usage: last_usage.and_then(|u| serde_json::to_value(u).ok()),
+            usage: usage_wire,
             generation_id: last_gen_id,
             ghost_fallback: false,
         };
@@ -792,5 +806,280 @@ data: [DONE]\n\n";
                 "request body must not contain an empty-content message; body={req_body}",
             );
         }
+    }
+
+    /// Codex P2 (r5): the `Done` frame's usage must have deployment-hidden keys
+    /// (e.g. `cost`) stripped, while the persisted assistant row keeps the FULL
+    /// unfiltered usage — mirrors the text/replay paths' `filter_usage_keys` use.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn run_voice_turn_done_filters_hidden_usage_keys(pool: sqlx::PgPool) {
+        use eros_engine_llm::model_config::ModelConfig;
+        use futures_util::StreamExt;
+        use wiremock::matchers::path as wm_path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        let body = "\
+data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n\
+data: {\"choices\":[{\"delta\":{\"content\":\" there\"}}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":2,\"total_tokens\":3,\"cost\":0.01},\"id\":\"gen-v\",\"model\":\"primary\"}\n\n\
+data: [DONE]\n\n";
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+
+        // Seed persona + instance + session.
+        let user_id = Uuid::new_v4();
+        let genome_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata) \
+             VALUES ('V', 'You are V.', '{}'::jsonb) RETURNING id",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let instance_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_instances (genome_id, owner_uid) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(genome_id).bind(user_id).fetch_one(&pool).await.unwrap();
+        let session_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(user_id)
+        .bind(instance_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        // Persist the user turn as the route would.
+        let repo = ChatRepo { pool: &pool };
+        let umid = match repo
+            .insert_voice_user_message(session_id, "hello", "01J9000000000000000000VOIC5")
+            .await
+            .unwrap()
+        {
+            eros_engine_store::chat::VoiceUserInsert::Inserted(id) => id,
+            other => panic!("expected Inserted, got {other:?}"),
+        };
+
+        // State with a chat_voice task + mock OpenRouter, and `cost` configured
+        // as a deployment-hidden usage key.
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = Arc::new(
+            ModelConfig::from_toml_str(
+                "[tasks.chat_voice]\nmodel = \"primary\"\nmax_tokens = 100\n",
+            )
+            .unwrap(),
+        );
+        state.openrouter = Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                eros_engine_llm::openrouter::AppAttribution::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+        state.config.openrouter_usage_hidden_keys =
+            std::collections::HashSet::from(["cost".to_string()]);
+
+        let resolved = state.model_config.resolve_voice().unwrap();
+        let frames: Vec<ProtocolFrame> = run_voice_turn(
+            Arc::new(state),
+            VoiceTurn {
+                session_id,
+                instance_id,
+                user_message_id: umid,
+            },
+            resolved,
+        )
+        .collect()
+        .await;
+
+        let usage = frames
+            .iter()
+            .find_map(|f| match f {
+                ProtocolFrame::Done { usage, .. } => Some(usage.clone()),
+                _ => None,
+            })
+            .expect("a Done frame")
+            .expect("usage present");
+        assert!(
+            usage.get("cost").is_none(),
+            "cost must be stripped from the wire Done frame; got {usage}"
+        );
+        assert_eq!(usage["prompt_tokens"], 1);
+        assert_eq!(usage["total_tokens"], 3);
+
+        // The persisted row keeps the FULL unfiltered usage, incl. `cost`.
+        let persisted_usage: Option<serde_json::Value> = sqlx::query_scalar(
+            "SELECT usage FROM engine.chat_messages \
+             WHERE session_id = $1 AND role = 'assistant'",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let persisted_usage = persisted_usage.expect("usage persisted");
+        assert_eq!(
+            persisted_usage["cost"], 0.01,
+            "DB row must keep the FULL unfiltered usage; got {persisted_usage}"
+        );
+    }
+
+    /// Codex P2 (r5): when a primary candidate emits terminal metadata (usage /
+    /// generation_id / a `length` finish) but NO content and the loop falls
+    /// through to a fallback, that abandoned metadata must never leak onto the
+    /// fallback's successful reply.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn run_voice_turn_fallback_does_not_inherit_primary_metadata(pool: sqlx::PgPool) {
+        use eros_engine_llm::model_config::ModelConfig;
+        use futures_util::StreamExt;
+        use wiremock::matchers::path as wm_path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+
+        // First request (PRIMARY) — metadata-only, a `length` finish, usage +
+        // generation_id, but NO content: an empty completion that also happens
+        // to carry terminal metadata. Limited to one match so the SECOND
+        // request (the fallback candidate) falls through to the content mock.
+        let primary_body = "\
+data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"length\"}],\"usage\":{\"prompt_tokens\":9,\"completion_tokens\":0,\"total_tokens\":9},\"id\":\"gen-primary\",\"model\":\"primary\"}\n\n\
+data: [DONE]\n\n";
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(primary_body, "text/event-stream"),
+            )
+            .up_to_n_times(1)
+            .mount(&mock)
+            .await;
+
+        // Second request onward (the fallback candidate) — plain content, no
+        // usage/id/model of its own.
+        let fallback_body = "\
+data: {\"choices\":[{\"delta\":{\"content\":\"recovered\"}}]}\n\n\
+data: [DONE]\n\n";
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(fallback_body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+
+        // Seed persona + instance + session.
+        let user_id = Uuid::new_v4();
+        let genome_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata) \
+             VALUES ('V', 'You are V.', '{}'::jsonb) RETURNING id",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let instance_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_instances (genome_id, owner_uid) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(genome_id).bind(user_id).fetch_one(&pool).await.unwrap();
+        let session_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(user_id)
+        .bind(instance_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        // Persist the user turn as the route would.
+        let repo = ChatRepo { pool: &pool };
+        let umid = match repo
+            .insert_voice_user_message(session_id, "hello", "01J9000000000000000000VOIC6")
+            .await
+            .unwrap()
+        {
+            eros_engine_store::chat::VoiceUserInsert::Inserted(id) => id,
+            other => panic!("expected Inserted, got {other:?}"),
+        };
+
+        // State with a chat_voice task configured with a fallback model, +
+        // mock OpenRouter.
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = Arc::new(
+            ModelConfig::from_toml_str(
+                "[tasks.chat_voice]\nmodel = \"primary\"\nfallback = [\"backup\"]\nmax_tokens = 100\n",
+            )
+            .unwrap(),
+        );
+        state.openrouter = Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                eros_engine_llm::openrouter::AppAttribution::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+
+        let resolved = state.model_config.resolve_voice().unwrap();
+        assert_eq!(resolved.fallback_model, vec!["backup".to_string()]);
+        let frames: Vec<ProtocolFrame> = run_voice_turn(
+            Arc::new(state),
+            VoiceTurn {
+                session_id,
+                instance_id,
+                user_message_id: umid,
+            },
+            resolved,
+        )
+        .collect()
+        .await;
+
+        let text: String = frames
+            .iter()
+            .filter_map(|f| match f {
+                ProtocolFrame::Delta { content, .. } => Some(content.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(text, "recovered");
+
+        let done = frames
+            .iter()
+            .find_map(|f| match f {
+                ProtocolFrame::Done {
+                    truncated,
+                    generation_id,
+                    ..
+                } => Some((*truncated, generation_id.clone())),
+                _ => None,
+            })
+            .expect("a Done frame");
+        assert!(
+            !done.0,
+            "truncated must not inherit the abandoned primary's `length` finish"
+        );
+        assert_ne!(
+            done.1,
+            Some("gen-primary".to_string()),
+            "generation_id must not inherit the abandoned primary's id"
+        );
+        assert_eq!(
+            done.1, None,
+            "the successful fallback carried no generation_id of its own"
+        );
+
+        // The persisted row carries the fallback's content — proof the earlier
+        // primary's abandoned metadata never reached persistence either.
+        let content: String = sqlx::query_scalar(
+            "SELECT content FROM engine.chat_messages \
+             WHERE session_id = $1 AND role = 'assistant'",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(content, "recovered");
     }
 }

--- a/crates/eros-engine-server/src/pipeline/voice.rs
+++ b/crates/eros-engine-server/src/pipeline/voice.rs
@@ -174,7 +174,15 @@ pub fn run_voice_turn(
                         truncated = true;
                         break 'candidates;
                     }
-                    None => break 'candidates, // clean [DONE]
+                    None => {
+                        // Clean stream end. If this candidate streamed nothing, treat it as an
+                        // empty/failed candidate and try the next one (fallbacks apply to empty
+                        // completions too); otherwise we have a reply — stop.
+                        if acc.is_empty() {
+                            continue 'candidates;
+                        }
+                        break 'candidates;
+                    }
                 }
             }
         }
@@ -504,6 +512,144 @@ data: [DONE]\n\n";
             n, 0,
             "no assistant row should be persisted on empty completion"
         );
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn run_voice_turn_falls_back_to_content_on_empty_primary(pool: sqlx::PgPool) {
+        use eros_engine_llm::model_config::ModelConfig;
+        use futures_util::StreamExt;
+        use wiremock::matchers::path as wm_path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+
+        // First request (PRIMARY) — metadata-only + clean [DONE]: an empty
+        // completion. Limited to one match so the SECOND request (the
+        // fallback candidate) falls through to the content mock below.
+        let empty_body = "\
+data: {\"choices\":[{\"delta\":{}}],\"id\":\"gen-empty\",\"model\":\"primary\"}\n\n\
+data: [DONE]\n\n";
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(empty_body, "text/event-stream"),
+            )
+            .up_to_n_times(1)
+            .mount(&mock)
+            .await;
+
+        // Second request onward (the fallback candidate) — normal content.
+        let content_body = "\
+data: {\"choices\":[{\"delta\":{\"content\":\"recovered\"}}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":2,\"total_tokens\":3},\"id\":\"gen-backup\",\"model\":\"backup\"}\n\n\
+data: [DONE]\n\n";
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(content_body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+
+        // Seed persona + instance + session.
+        let user_id = Uuid::new_v4();
+        let genome_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata) \
+             VALUES ('V', 'You are V.', '{}'::jsonb) RETURNING id",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let instance_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_instances (genome_id, owner_uid) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(genome_id).bind(user_id).fetch_one(&pool).await.unwrap();
+        let session_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(user_id)
+        .bind(instance_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        // Persist the user turn as the route would.
+        let repo = ChatRepo { pool: &pool };
+        let umid = match repo
+            .insert_voice_user_message(session_id, "hello", "01J9000000000000000000VOIC4")
+            .await
+            .unwrap()
+        {
+            eros_engine_store::chat::VoiceUserInsert::Inserted(id) => id,
+            other => panic!("expected Inserted, got {other:?}"),
+        };
+
+        // State with a chat_voice task configured with a fallback model, +
+        // mock OpenRouter.
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = Arc::new(
+            ModelConfig::from_toml_str(
+                "[tasks.chat_voice]\nmodel = \"primary\"\nfallback = [\"backup\"]\nmax_tokens = 100\n",
+            )
+            .unwrap(),
+        );
+        state.openrouter = Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                eros_engine_llm::openrouter::AppAttribution::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+
+        let resolved = state.model_config.resolve_voice().unwrap();
+        assert_eq!(resolved.fallback_model, vec!["backup".to_string()]);
+        let frames: Vec<ProtocolFrame> = run_voice_turn(
+            Arc::new(state),
+            VoiceTurn {
+                session_id,
+                instance_id,
+                user_message_id: umid,
+            },
+            resolved,
+        )
+        .collect()
+        .await;
+
+        // The empty PRIMARY must not surface as an error — the fallback
+        // candidate's content wins: a Delta carrying "recovered", a terminal
+        // Done, and no Error frame.
+        let text: String = frames
+            .iter()
+            .filter_map(|f| match f {
+                ProtocolFrame::Delta { content, .. } => Some(content.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(text, "recovered");
+        assert!(matches!(frames.last(), Some(ProtocolFrame::Done { .. })));
+        assert!(!frames
+            .iter()
+            .any(|f| matches!(f, ProtocolFrame::Error { .. })));
+
+        // Assistant row persisted with the fallback's content.
+        let (content, channel): (String, Option<String>) = sqlx::query_as(
+            "SELECT content, channel FROM engine.chat_messages \
+             WHERE session_id = $1 AND role = 'assistant'",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(content, "recovered");
+        assert_eq!(channel.as_deref(), Some("voice"));
+
+        // Sanity: both candidates were actually hit (one empty, one content).
+        let received = mock
+            .received_requests()
+            .await
+            .expect("recording enabled by default");
+        assert_eq!(received.len(), 2, "expected primary + fallback requests");
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/crates/eros-engine-server/src/pipeline/voice.rs
+++ b/crates/eros-engine-server/src/pipeline/voice.rs
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! Voice channel — thin per-turn generator and prompt.
+//!
+//! Spec: docs/superpowers/specs/2026-07-07-voice-call-parts-design.md
+
+use eros_engine_core::affinity::{Affinity, RelationshipLabel};
+use eros_engine_core::persona::PersonaGenome;
+
+/// Assemble the thin voice system prompt: persona + voice directive + one
+/// optional relationship line. Deliberately excludes recall, memories, traits,
+/// scopes, and every heavy block the text path's `build_prompt` composes.
+pub fn build_voice_prompt(
+    genome: &PersonaGenome,
+    directive: &str,
+    affinity: Option<&Affinity>,
+) -> String {
+    let mut s = String::with_capacity(genome.system_prompt.len() + directive.len() + 96);
+    s.push_str(&genome.system_prompt);
+    s.push_str("\n\n");
+    s.push_str(directive);
+    if let Some(line) = affinity.and_then(relationship_line) {
+        s.push_str("\n\n");
+        s.push_str(&line);
+    }
+    s
+}
+
+/// One short relationship-tone line from the cached `relationship_label`.
+/// `None` (fresh affinity, no label yet) ⇒ no line.
+fn relationship_line(affinity: &Affinity) -> Option<String> {
+    let phrase = match &affinity.relationship_label {
+        Some(RelationshipLabel::Stranger) => {
+            "You two are still getting to know each other; keep it light."
+        }
+        Some(RelationshipLabel::Friend) => "You two are close friends; be warm and familiar.",
+        Some(RelationshipLabel::Romantic) => "You share a romantic bond; be affectionate.",
+        Some(RelationshipLabel::Frenemy) => "Your dynamic is playful and a little combative.",
+        Some(RelationshipLabel::SlowBurn) => "There's a slow-building closeness between you.",
+        None => return None,
+    };
+    Some(phrase.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use uuid::Uuid;
+
+    fn genome() -> PersonaGenome {
+        PersonaGenome {
+            id: Uuid::new_v4(),
+            name: "Mia".into(),
+            system_prompt: "You are Mia.".into(),
+            tip_personality: None,
+            art_metadata: serde_json::json!({}),
+        }
+    }
+
+    fn affinity_with(label: Option<RelationshipLabel>) -> Affinity {
+        let now = Utc::now();
+        Affinity {
+            id: Uuid::new_v4(),
+            session_id: Uuid::new_v4(),
+            user_id: Uuid::new_v4(),
+            instance_id: Uuid::new_v4(),
+            warmth: 0.0,
+            trust: 0.0,
+            intrigue: 0.0,
+            intimacy: 0.0,
+            patience: 0.0,
+            tension: 0.0,
+            ghost_streak: 0,
+            last_ghost_at: None,
+            total_ghosts: 0,
+            relationship_label: label,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    #[test]
+    fn includes_persona_and_directive() {
+        let p = build_voice_prompt(&genome(), "DIRECTIVE", None);
+        assert!(p.contains("You are Mia."));
+        assert!(p.contains("DIRECTIVE"));
+        // No affinity ⇒ no relationship line.
+        assert!(!p.contains("romantic"));
+    }
+
+    #[test]
+    fn appends_relationship_line_when_labelled() {
+        let a = affinity_with(Some(RelationshipLabel::Romantic));
+        let p = build_voice_prompt(&genome(), "DIRECTIVE", Some(&a));
+        assert!(p.contains("romantic bond"));
+    }
+
+    #[test]
+    fn no_relationship_line_when_label_none() {
+        let a = affinity_with(None);
+        let p = build_voice_prompt(&genome(), "DIRECTIVE", Some(&a));
+        assert_eq!(p, "You are Mia.\n\nDIRECTIVE");
+    }
+}

--- a/crates/eros-engine-server/src/pipeline/voice.rs
+++ b/crates/eros-engine-server/src/pipeline/voice.rs
@@ -3,8 +3,20 @@
 //!
 //! Spec: docs/superpowers/specs/2026-07-07-voice-call-parts-design.md
 
+use std::sync::Arc;
+use ulid::Ulid;
+use uuid::Uuid;
+
 use eros_engine_core::affinity::{Affinity, RelationshipLabel};
 use eros_engine_core::persona::PersonaGenome;
+use eros_engine_llm::model_config::ResolvedVoice;
+use eros_engine_llm::openrouter::{ChatMessage as WireMessage, ChatRequest, UsageBlock};
+use eros_engine_store::affinity::AffinityRepo;
+use eros_engine_store::chat::ChatRepo;
+use eros_engine_store::persona::PersonaRepo;
+
+use crate::pipeline::stream::{ulid_string, ProtocolFrame, StreamErrorCode};
+use crate::state::AppState;
 
 /// Assemble the thin voice system prompt: persona + voice directive + one
 /// optional relationship line. Deliberately excludes recall, memories, traits,
@@ -39,6 +51,168 @@ fn relationship_line(affinity: &Affinity) -> Option<String> {
         None => return None,
     };
     Some(phrase.to_string())
+}
+
+/// Inputs for one voice turn. The user utterance is already persisted (by the
+/// route) as the latest history row, so the generator reads it from history —
+/// it is not passed again here.
+pub struct VoiceTurn {
+    pub session_id: Uuid,
+    pub instance_id: Uuid,
+    pub user_message_id: Uuid,
+}
+
+/// Recent turns fed to the model on a voice turn. Shorter than the text path to
+/// keep latency/tokens down.
+pub const VOICE_HISTORY_WINDOW: i64 = 12;
+
+/// Drive one voice turn: load persona + (optional) affinity + recent history,
+/// assemble the thin prompt, stream a single-model completion (walking the
+/// outage fallback chain ourselves, since `execute_stream` is single-model),
+/// emit `delta`* then `done`, and persist the assistant turn. `error` only when
+/// no candidate produced anything.
+pub fn run_voice_turn(
+    state: Arc<AppState>,
+    turn: VoiceTurn,
+    resolved: ResolvedVoice,
+) -> impl futures_util::Stream<Item = ProtocolFrame> + Send + 'static {
+    async_stream::stream! {
+        let chat_repo = ChatRepo { pool: &state.pool };
+        let persona_repo = PersonaRepo { pool: &state.pool };
+        let affinity_repo = AffinityRepo { pool: &state.pool };
+
+        let persona = match persona_repo.load_companion(turn.instance_id).await {
+            Ok(Some(p)) => p,
+            _ => {
+                yield ProtocolFrame::Error {
+                    code: StreamErrorCode::Internal,
+                    retryable: false,
+                    message: "persona instance not found".into(),
+                    user_message: "服务出现问题，请稍后再试".into(),
+                };
+                return;
+            }
+        };
+
+        // Read-only affinity load (never creates a row on the voice path).
+        let affinity = affinity_repo.load(turn.session_id).await.unwrap_or(None);
+
+        // Chronological history, includes the just-persisted user turn.
+        let history = chat_repo
+            .history(turn.session_id, VOICE_HISTORY_WINDOW, 0)
+            .await
+            .unwrap_or_default();
+
+        let system_prompt =
+            build_voice_prompt(&persona.genome, &resolved.directive, affinity.as_ref());
+
+        let mut messages = Vec::with_capacity(history.len() + 1);
+        messages.push(WireMessage { role: "system".into(), content: system_prompt });
+        for m in history {
+            let role = match m.role.as_str() {
+                "assistant" => "assistant",
+                "user" | "gift_user" => "user",
+                _ => continue,
+            };
+            messages.push(WireMessage { role: role.into(), content: m.content });
+        }
+
+        // Candidate chain: primary + outage fallbacks (single-model each).
+        let mut candidates = Vec::with_capacity(1 + resolved.fallback_model.len());
+        candidates.push(resolved.model.clone());
+        candidates.extend(resolved.fallback_model.iter().cloned());
+
+        let mid = Ulid::new();
+        let message_id = ulid_string(mid);
+        let assistant_uuid: Uuid = mid.into();
+
+        let mut acc = String::new();
+        let mut last_usage: Option<UsageBlock> = None;
+        let mut last_gen_id: Option<String> = None;
+        let mut served_model: Option<String> = None;
+        let mut truncated = false;
+
+        'candidates: for model_id in candidates {
+            let req = ChatRequest {
+                model: model_id.clone(),
+                messages: messages.clone(),
+                temperature: resolved.temperature as f32,
+                max_tokens: resolved.max_tokens,
+                reasoning: resolved.reasoning.clone(),
+                ..Default::default()
+            };
+            let stream = match state.openrouter.execute_stream(req).await {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!(model = %model_id, error = %e, "voice: open stream failed");
+                    if acc.is_empty() { continue 'candidates; }
+                    truncated = true;
+                    break 'candidates;
+                }
+            };
+            futures_util::pin_mut!(stream);
+            loop {
+                match futures_util::StreamExt::next(&mut stream).await {
+                    Some(Ok(chunk)) => {
+                        if chunk.usage.is_some() { last_usage = chunk.usage.clone(); }
+                        if chunk.generation_id.is_some() { last_gen_id = chunk.generation_id.clone(); }
+                        if chunk.model.is_some() { served_model = chunk.model.clone(); }
+                        if let Some(text) = chunk.content {
+                            acc.push_str(&text);
+                            yield ProtocolFrame::Delta { message_id: message_id.clone(), content: text };
+                        }
+                        if chunk.finish_reason.as_deref() == Some("length") { truncated = true; }
+                    }
+                    Some(Err(e)) => {
+                        tracing::warn!(model = %model_id, error = %e, "voice: mid-stream error");
+                        if acc.is_empty() { continue 'candidates; }
+                        truncated = true;
+                        break 'candidates;
+                    }
+                    None => break 'candidates, // clean [DONE]
+                }
+            }
+        }
+
+        // Nothing ever streamed and no successful open ⇒ upstream error.
+        if acc.is_empty() && served_model.is_none() && last_gen_id.is_none() {
+            yield ProtocolFrame::Error {
+                code: StreamErrorCode::UpstreamUnavailable,
+                retryable: true,
+                message: "voice generation failed on all candidates".into(),
+                user_message: "对方暂时说不出话，请稍后再试".into(),
+            };
+            return;
+        }
+
+        // Persist the assistant turn only when it carries text.
+        if !acc.is_empty() {
+            let usage_json = last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok());
+            if let Err(e) = chat_repo
+                .insert_voice_assistant_message(
+                    turn.session_id,
+                    turn.user_message_id,
+                    assistant_uuid,
+                    &acc,
+                    served_model.as_deref(),
+                    usage_json.as_ref(),
+                    last_gen_id.as_deref(),
+                    truncated,
+                )
+                .await
+            {
+                tracing::warn!(error = %e, "voice: assistant persist failed");
+            }
+        }
+
+        yield ProtocolFrame::Done {
+            message_id,
+            truncated,
+            usage: last_usage.and_then(|u| serde_json::to_value(u).ok()),
+            generation_id: last_gen_id,
+            ghost_fallback: false,
+        };
+    }
 }
 
 #[cfg(test)]
@@ -100,5 +274,111 @@ mod tests {
         let a = affinity_with(None);
         let p = build_voice_prompt(&genome(), "DIRECTIVE", Some(&a));
         assert_eq!(p, "You are Mia.\n\nDIRECTIVE");
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn run_voice_turn_streams_delta_then_done_and_persists(pool: sqlx::PgPool) {
+        use eros_engine_llm::model_config::ModelConfig;
+        use futures_util::StreamExt;
+        use wiremock::matchers::path as wm_path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        let body = "\
+data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n\
+data: {\"choices\":[{\"delta\":{\"content\":\" there\"}}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":2,\"total_tokens\":3},\"id\":\"gen-v\",\"model\":\"primary\"}\n\n\
+data: [DONE]\n\n";
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+
+        // Seed persona + instance + session.
+        let user_id = Uuid::new_v4();
+        let genome_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata) \
+             VALUES ('V', 'You are V.', '{}'::jsonb) RETURNING id",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let instance_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_instances (genome_id, owner_uid) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(genome_id).bind(user_id).fetch_one(&pool).await.unwrap();
+        let session_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(user_id)
+        .bind(instance_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        // Persist the user turn as the route would.
+        let repo = ChatRepo { pool: &pool };
+        let umid = repo
+            .insert_voice_user_message(session_id, "hello", "01J9000000000000000000VOICE")
+            .await
+            .unwrap();
+
+        // State with a chat_voice task + mock OpenRouter.
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = Arc::new(
+            ModelConfig::from_toml_str(
+                "[tasks.chat_voice]\nmodel = \"primary\"\nmax_tokens = 100\n",
+            )
+            .unwrap(),
+        );
+        state.openrouter = Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                eros_engine_llm::openrouter::AppAttribution::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+
+        let resolved = state.model_config.resolve_voice().unwrap();
+        let frames: Vec<ProtocolFrame> = run_voice_turn(
+            Arc::new(state),
+            VoiceTurn {
+                session_id,
+                instance_id,
+                user_message_id: umid,
+            },
+            resolved,
+        )
+        .collect()
+        .await;
+
+        // delta(s) carry the text; terminal frame is Done; no Error.
+        let text: String = frames
+            .iter()
+            .filter_map(|f| match f {
+                ProtocolFrame::Delta { content, .. } => Some(content.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(text, "hi there");
+        assert!(matches!(frames.last(), Some(ProtocolFrame::Done { .. })));
+        assert!(!frames
+            .iter()
+            .any(|f| matches!(f, ProtocolFrame::Error { .. })));
+
+        // Assistant row persisted on the voice channel.
+        let (content, channel): (String, Option<String>) = sqlx::query_as(
+            "SELECT content, channel FROM engine.chat_messages \
+             WHERE session_id = $1 AND role = 'assistant'",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(content, "hi there");
+        assert_eq!(channel.as_deref(), Some("voice"));
     }
 }

--- a/crates/eros-engine-server/src/pipeline/voice.rs
+++ b/crates/eros-engine-server/src/pipeline/voice.rs
@@ -98,10 +98,22 @@ pub fn run_voice_turn(
         let affinity = affinity_repo.load(turn.session_id).await.unwrap_or(None);
 
         // Chronological history, includes the just-persisted user turn.
-        let history = chat_repo
+        let history = match chat_repo
             .history(turn.session_id, VOICE_HISTORY_WINDOW, 0)
             .await
-            .unwrap_or_default();
+        {
+            Ok(h) => h,
+            Err(e) => {
+                tracing::warn!(error = %e, "voice: history read failed");
+                yield ProtocolFrame::Error {
+                    code: StreamErrorCode::Internal,
+                    retryable: true,
+                    message: "history read failed".into(),
+                    user_message: "服务出现问题，请稍后再试".into(),
+                };
+                return;
+            }
+        };
 
         let system_prompt =
             build_voice_prompt(&persona.genome, &resolved.directive, affinity.as_ref());

--- a/crates/eros-engine-server/src/pipeline/voice.rs
+++ b/crates/eros-engine-server/src/pipeline/voice.rs
@@ -179,8 +179,10 @@ pub fn run_voice_turn(
             }
         }
 
-        // Nothing ever streamed and no successful open ⇒ upstream error.
-        if acc.is_empty() && served_model.is_none() && last_gen_id.is_none() {
+        // Any empty accumulation — no successful open, or a stream that sent
+        // only metadata (id/model) and then errored or ended without content
+        // — is an upstream failure. Never emit an empty `done`.
+        if acc.is_empty() {
             yield ProtocolFrame::Error {
                 code: StreamErrorCode::UpstreamUnavailable,
                 retryable: true,
@@ -326,10 +328,14 @@ data: [DONE]\n\n";
 
         // Persist the user turn as the route would.
         let repo = ChatRepo { pool: &pool };
-        let umid = repo
+        let umid = match repo
             .insert_voice_user_message(session_id, "hello", "01J9000000000000000000VOICE")
             .await
-            .unwrap();
+            .unwrap()
+        {
+            eros_engine_store::chat::VoiceUserInsert::Inserted(id) => id,
+            other => panic!("expected Inserted, got {other:?}"),
+        };
 
         // State with a chat_voice task + mock OpenRouter.
         let mut state = crate::routes::companion::test_state(pool.clone());
@@ -385,6 +391,119 @@ data: [DONE]\n\n";
         .unwrap();
         assert_eq!(content, "hi there");
         assert_eq!(channel.as_deref(), Some("voice"));
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn run_voice_turn_empty_completion_is_error(pool: sqlx::PgPool) {
+        use eros_engine_llm::model_config::ModelConfig;
+        use futures_util::StreamExt;
+        use wiremock::matchers::path as wm_path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        // Metadata-only frame (no content delta) then a clean [DONE] — the
+        // stream ends without ever producing text.
+        let body = "\
+data: {\"choices\":[{\"delta\":{}}],\"id\":\"gen-e\",\"model\":\"primary\"}\n\n\
+data: [DONE]\n\n";
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+
+        // Seed persona + instance + session.
+        let user_id = Uuid::new_v4();
+        let genome_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata) \
+             VALUES ('V', 'You are V.', '{}'::jsonb) RETURNING id",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let instance_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_instances (genome_id, owner_uid) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(genome_id).bind(user_id).fetch_one(&pool).await.unwrap();
+        let session_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(user_id)
+        .bind(instance_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        // Persist the user turn as the route would.
+        let repo = ChatRepo { pool: &pool };
+        let umid = match repo
+            .insert_voice_user_message(session_id, "hello", "01J9000000000000000000VOIC3")
+            .await
+            .unwrap()
+        {
+            eros_engine_store::chat::VoiceUserInsert::Inserted(id) => id,
+            other => panic!("expected Inserted, got {other:?}"),
+        };
+
+        // State with a chat_voice task + mock OpenRouter.
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = Arc::new(
+            ModelConfig::from_toml_str(
+                "[tasks.chat_voice]\nmodel = \"primary\"\nmax_tokens = 100\n",
+            )
+            .unwrap(),
+        );
+        state.openrouter = Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                eros_engine_llm::openrouter::AppAttribution::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+
+        let resolved = state.model_config.resolve_voice().unwrap();
+        let frames: Vec<ProtocolFrame> = run_voice_turn(
+            Arc::new(state),
+            VoiceTurn {
+                session_id,
+                instance_id,
+                user_message_id: umid,
+            },
+            resolved,
+        )
+        .collect()
+        .await;
+
+        // An empty completion must yield an Error frame, never a Done.
+        assert!(
+            frames
+                .iter()
+                .any(|f| matches!(f, ProtocolFrame::Error { .. })),
+            "expected an Error frame, got {frames:?}"
+        );
+        assert!(
+            !frames
+                .iter()
+                .any(|f| matches!(f, ProtocolFrame::Done { .. })),
+            "must not emit Done on an empty completion; got {frames:?}"
+        );
+
+        // No assistant row persisted.
+        let n: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM engine.chat_messages \
+             WHERE session_id = $1 AND role = 'assistant'",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            n, 0,
+            "no assistant row should be persisted on empty completion"
+        );
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
@@ -444,10 +563,14 @@ data: [DONE]\n\n";
 
         // Persist the user turn as the route would.
         let repo = ChatRepo { pool: &pool };
-        let umid = repo
+        let umid = match repo
             .insert_voice_user_message(session_id, "hello", "01J9000000000000000000VOIC2")
             .await
-            .unwrap();
+            .unwrap()
+        {
+            eros_engine_store::chat::VoiceUserInsert::Inserted(id) => id,
+            other => panic!("expected Inserted, got {other:?}"),
+        };
 
         // State with a chat_voice task + mock OpenRouter.
         let mut state = crate::routes::companion::test_state(pool.clone());

--- a/crates/eros-engine-server/src/pipeline/voice.rs
+++ b/crates/eros-engine-server/src/pipeline/voice.rs
@@ -109,6 +109,11 @@ pub fn run_voice_turn(
         let mut messages = Vec::with_capacity(history.len() + 1);
         messages.push(WireMessage { role: "system".into(), content: system_prompt });
         for m in history {
+            if m.content.is_empty() {
+                continue; // defensive: never emit an empty-content wire message
+                          // (e.g. a caption-less image turn from a mixed session) —
+                          // some providers reject empty messages.
+            }
             let role = match m.role.as_str() {
                 "assistant" => "assistant",
                 "user" | "gift_user" => "user",
@@ -380,5 +385,131 @@ data: [DONE]\n\n";
         .unwrap();
         assert_eq!(content, "hi there");
         assert_eq!(channel.as_deref(), Some("voice"));
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn run_voice_turn_skips_empty_content_history_rows(pool: sqlx::PgPool) {
+        use eros_engine_llm::model_config::ModelConfig;
+        use futures_util::StreamExt;
+        use wiremock::matchers::path as wm_path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        let body = "\
+data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n\
+data: {\"choices\":[{\"delta\":{\"content\":\" there\"}}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":2,\"total_tokens\":3},\"id\":\"gen-v\",\"model\":\"primary\"}\n\n\
+data: [DONE]\n\n";
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+
+        // Seed persona + instance + session.
+        let user_id = Uuid::new_v4();
+        let genome_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata) \
+             VALUES ('V', 'You are V.', '{}'::jsonb) RETURNING id",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let instance_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_instances (genome_id, owner_uid) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(genome_id).bind(user_id).fetch_one(&pool).await.unwrap();
+        let session_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(user_id)
+        .bind(instance_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        // A stray empty-content assistant row (e.g. a caption-less image turn
+        // from a mixed session) landing BEFORE the voice user turn. It must be
+        // skipped in the wire-message mapping, never sent upstream.
+        sqlx::query(
+            "INSERT INTO engine.chat_messages (session_id, role, content) \
+             VALUES ($1, 'assistant', '')",
+        )
+        .bind(session_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // Persist the user turn as the route would.
+        let repo = ChatRepo { pool: &pool };
+        let umid = repo
+            .insert_voice_user_message(session_id, "hello", "01J9000000000000000000VOIC2")
+            .await
+            .unwrap();
+
+        // State with a chat_voice task + mock OpenRouter.
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = Arc::new(
+            ModelConfig::from_toml_str(
+                "[tasks.chat_voice]\nmodel = \"primary\"\nmax_tokens = 100\n",
+            )
+            .unwrap(),
+        );
+        state.openrouter = Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                eros_engine_llm::openrouter::AppAttribution::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+
+        let resolved = state.model_config.resolve_voice().unwrap();
+        let frames: Vec<ProtocolFrame> = run_voice_turn(
+            Arc::new(state),
+            VoiceTurn {
+                session_id,
+                instance_id,
+                user_message_id: umid,
+            },
+            resolved,
+        )
+        .collect()
+        .await;
+
+        // Stream still completes cleanly: delta(s) carry the text, terminal
+        // frame is Done, no Error — the empty history row must not break the
+        // turn.
+        let text: String = frames
+            .iter()
+            .filter_map(|f| match f {
+                ProtocolFrame::Delta { content, .. } => Some(content.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(text, "hi there");
+        assert!(matches!(frames.last(), Some(ProtocolFrame::Done { .. })));
+        assert!(!frames
+            .iter()
+            .any(|f| matches!(f, ProtocolFrame::Error { .. })));
+
+        // The outgoing request body must NOT contain the empty-content row —
+        // proof the skip guard actually dropped it from the wire mapping.
+        let received = mock
+            .received_requests()
+            .await
+            .expect("recording enabled by default");
+        assert!(
+            !received.is_empty(),
+            "expected at least one upstream request"
+        );
+        for req in &received {
+            let req_body = String::from_utf8_lossy(&req.body);
+            assert!(
+                !req_body.contains("\"content\":\"\""),
+                "request body must not contain an empty-content message; body={req_body}",
+            );
+        }
     }
 }

--- a/crates/eros-engine-server/src/routes/mod.rs
+++ b/crates/eros-engine-server/src/routes/mod.rs
@@ -21,6 +21,7 @@ pub mod companion_stream;
 pub mod debug;
 pub mod dto;
 pub mod health;
+pub mod voice;
 
 /// Compose the full app router with auth layers attached.
 ///
@@ -33,6 +34,7 @@ pub fn router(state: AppState) -> OpenApiRouter<AppState> {
     let comp = OpenApiRouter::new()
         .merge(companion::router())
         .merge(companion_stream::router())
+        .merge(voice::router())
         .merge(debug::router(state.config.expose_affinity_debug))
         .merge(bff::router())
         .layer(from_fn_with_state(state.clone(), require_auth));
@@ -49,6 +51,7 @@ pub fn router_for_openapi(expose_affinity_debug: bool) -> OpenApiRouter<AppState
         .merge(health::router())
         .merge(companion::router())
         .merge(companion_stream::router())
+        .merge(voice::router())
         .merge(debug::router(expose_affinity_debug))
         .merge(bff::router())
 }

--- a/crates/eros-engine-server/src/routes/voice.rs
+++ b/crates/eros-engine-server/src/routes/voice.rs
@@ -106,7 +106,12 @@ pub async fn voice_turn_stream(
 
     let chat_repo = ChatRepo { pool: &state.pool };
     let session = chat_repo.get_session(session_id).await?.ok_or_else(|| {
-        pre(StatusCode::NOT_FOUND, "session_not_found", "session not found", "会话不存在")
+        pre(
+            StatusCode::NOT_FOUND,
+            "session_not_found",
+            "session not found",
+            "会话不存在",
+        )
     })?;
     if session.user_id != user_id {
         return Err(pre(
@@ -152,7 +157,11 @@ pub async fn voice_turn_stream(
         .insert_voice_user_message(session_id, &req.content, &req.client_msg_id)
         .await?;
 
-    let turn = VoiceTurn { session_id, instance_id, user_message_id };
+    let turn = VoiceTurn {
+        session_id,
+        instance_id,
+        user_message_id,
+    };
     let proto = run_voice_turn(Arc::new(state.clone()), turn, resolved);
 
     let sse = futures_util::StreamExt::map(
@@ -164,8 +173,8 @@ pub async fn voice_turn_stream(
             }
         },
         |frame: ProtocolFrame| {
-            let json = serde_json::to_string(&frame)
-                .expect("ProtocolFrame serialization is infallible");
+            let json =
+                serde_json::to_string(&frame).expect("ProtocolFrame serialization is infallible");
             Ok::<_, Infallible>(Event::default().data(json))
         },
     );
@@ -212,13 +221,21 @@ mod tests {
         let genome_id: Uuid = sqlx::query_scalar(
             "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata) \
              VALUES ('V','p','{}'::jsonb) RETURNING id",
-        ).fetch_one(pool).await.unwrap();
+        )
+        .fetch_one(pool)
+        .await
+        .unwrap();
         let instance_id: Uuid = sqlx::query_scalar(
             "INSERT INTO engine.persona_instances (genome_id, owner_uid) VALUES ($1,$2) RETURNING id",
         ).bind(genome_id).bind(user_id).fetch_one(pool).await.unwrap();
         sqlx::query_scalar(
             "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1,$2) RETURNING id",
-        ).bind(user_id).bind(instance_id).fetch_one(pool).await.unwrap()
+        )
+        .bind(user_id)
+        .bind(instance_id)
+        .fetch_one(pool)
+        .await
+        .unwrap()
     }
 
     fn with_voice(mut state: AppState) -> AppState {
@@ -228,9 +245,12 @@ mod tests {
         state
     }
 
-    async fn post_voice(app: &mut Router, session_id: Uuid, jwt: &str, body: serde_json::Value)
-        -> axum::http::Response<Body>
-    {
+    async fn post_voice(
+        app: &mut Router,
+        session_id: Uuid,
+        jwt: &str,
+        body: serde_json::Value,
+    ) -> axum::http::Response<Body> {
         let req = Request::builder()
             .method("POST")
             .uri(format!("/comp/voice/{session_id}/turn/stream"))
@@ -247,8 +267,13 @@ mod tests {
         let session_id = seed(&pool, user_id).await;
         let mut app = build_router(with_voice(crate::routes::companion::test_state(pool)));
         let jwt = mint_jwt(user_id);
-        let resp = post_voice(&mut app, session_id, &jwt,
-            json!({"content":"","client_msg_id":"01J2222222222222222222222A"})).await;
+        let resp = post_voice(
+            &mut app,
+            session_id,
+            &jwt,
+            json!({"content":"","client_msg_id":"01J2222222222222222222222A"}),
+        )
+        .await;
         assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
     }
 
@@ -259,8 +284,13 @@ mod tests {
         // Default test_state has no chat_voice task.
         let mut app = build_router(crate::routes::companion::test_state(pool));
         let jwt = mint_jwt(user_id);
-        let resp = post_voice(&mut app, session_id, &jwt,
-            json!({"content":"hi","client_msg_id":"01J2222222222222222222222A"})).await;
+        let resp = post_voice(
+            &mut app,
+            session_id,
+            &jwt,
+            json!({"content":"hi","client_msg_id":"01J2222222222222222222222A"}),
+        )
+        .await;
         assert_eq!(resp.status(), StatusCode::NOT_IMPLEMENTED);
     }
 
@@ -270,8 +300,13 @@ mod tests {
         let session_id = seed(&pool, owner).await;
         let mut app = build_router(with_voice(crate::routes::companion::test_state(pool)));
         let other = mint_jwt(Uuid::new_v4());
-        let resp = post_voice(&mut app, session_id, &other,
-            json!({"content":"hi","client_msg_id":"01J2222222222222222222222A"})).await;
+        let resp = post_voice(
+            &mut app,
+            session_id,
+            &other,
+            json!({"content":"hi","client_msg_id":"01J2222222222222222222222A"}),
+        )
+        .await;
         assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     }
 }

--- a/crates/eros-engine-server/src/routes/voice.rs
+++ b/crates/eros-engine-server/src/routes/voice.rs
@@ -90,6 +90,7 @@ fn validate(req: &VoiceTurnRequest) -> Result<(), AppError> {
         (status = 401, description = "missing or invalid bearer"),
         (status = 403, body = crate::routes::companion_stream::StreamPreErrorBody),
         (status = 404, body = crate::routes::companion_stream::StreamPreErrorBody),
+        (status = 409, body = crate::routes::companion_stream::StreamPreErrorBody),
         (status = 422, body = crate::routes::companion_stream::StreamPreErrorBody),
         (status = 429, body = crate::routes::companion_stream::StreamPreErrorBody),
         (status = 501, body = crate::routes::companion_stream::StreamPreErrorBody),

--- a/crates/eros-engine-server/src/routes/voice.rs
+++ b/crates/eros-engine-server/src/routes/voice.rs
@@ -16,6 +16,7 @@ use utoipa_axum::{router::OpenApiRouter, routes};
 use uuid::Uuid;
 
 use eros_engine_store::chat::{ChatRepo, VoiceUserInsert};
+use eros_engine_store::persona::PersonaRepo;
 
 use crate::auth::middleware::AuthUser;
 use crate::error::{AppError, StreamPreError};
@@ -140,6 +141,15 @@ pub async fn voice_turn_stream(
             "该服务未启用语音",
         )
     })?;
+
+    // Reject a session whose persona instance is missing/inactive BEFORE
+    // acquiring a slot or persisting the user turn — mirrors the text stream so
+    // a recoverable precondition failure never leaves an orphaned user row.
+    let persona_repo = PersonaRepo { pool: &state.pool };
+    persona_repo
+        .load_companion(instance_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("instance not found".into()))?;
 
     let guard = state
         .stream_slots
@@ -354,5 +364,50 @@ mod tests {
         )
         .await;
         assert_eq!(resp.status(), StatusCode::CONFLICT);
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn voice_404_when_persona_instance_missing(pool: PgPool) {
+        // A session whose persona instance is missing/inactive must be rejected
+        // pre-stream (404) WITHOUT persisting a user row. chat_sessions.instance_id
+        // has no FK, so a dangling instance_id is possible; load_companion also
+        // filters status='active', so an archived instance takes the same path.
+        let user_id = Uuid::new_v4();
+        let missing_instance = Uuid::new_v4(); // no matching persona_instances row
+        let session_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(user_id)
+        .bind(missing_instance)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        let mut app = build_router(with_voice(crate::routes::companion::test_state(
+            pool.clone(),
+        )));
+        let jwt = mint_jwt(user_id);
+        let cmid = "01J3333333333333333333333A";
+        let resp = post_voice(
+            &mut app,
+            session_id,
+            &jwt,
+            json!({"content":"hi","client_msg_id": cmid}),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+        // The pre-stream 404 must not have persisted a user row.
+        let n: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM engine.chat_messages WHERE client_msg_id = $1",
+        )
+        .bind(cmid)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            n, 0,
+            "no user row should be persisted when the instance is missing"
+        );
     }
 }

--- a/crates/eros-engine-server/src/routes/voice.rs
+++ b/crates/eros-engine-server/src/routes/voice.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 use utoipa_axum::{router::OpenApiRouter, routes};
 use uuid::Uuid;
 
-use eros_engine_store::chat::ChatRepo;
+use eros_engine_store::chat::{ChatRepo, VoiceUserInsert};
 
 use crate::auth::middleware::AuthUser;
 use crate::error::{AppError, StreamPreError};
@@ -152,10 +152,23 @@ pub async fn voice_turn_stream(
             )
         })?;
 
-    // Persist the user turn (idempotent on (session_id, client_msg_id)).
-    let user_message_id = chat_repo
+    // Persist the user turn (idempotent on (session_id, client_msg_id)). A
+    // duplicate client_msg_id must NOT trigger a second assistant reply /
+    // second upstream LLM call — return 409 instead of regenerating.
+    let user_message_id = match chat_repo
         .insert_voice_user_message(session_id, &req.content, &req.client_msg_id)
-        .await?;
+        .await?
+    {
+        VoiceUserInsert::Inserted(id) => id,
+        VoiceUserInsert::Duplicate(_) => {
+            return Err(pre(
+                StatusCode::CONFLICT,
+                "duplicate",
+                "duplicate client_msg_id for this session",
+                "这条消息已在处理",
+            ));
+        }
+    };
 
     let turn = VoiceTurn {
         session_id,
@@ -308,5 +321,37 @@ mod tests {
         )
         .await;
         assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn voice_409_on_duplicate_client_msg_id(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let session_id = seed(&pool, user_id).await;
+        let client_msg_id = "01J2222222222222222222222A";
+
+        // Pre-seed a user voice row with this client_msg_id, as if a first
+        // request already landed it.
+        let chat_repo = ChatRepo { pool: &pool };
+        match chat_repo
+            .insert_voice_user_message(session_id, "hi", client_msg_id)
+            .await
+            .unwrap()
+        {
+            VoiceUserInsert::Inserted(_) => {}
+            other => panic!("expected Inserted, got {other:?}"),
+        }
+
+        let mut app = build_router(with_voice(crate::routes::companion::test_state(pool)));
+        let jwt = mint_jwt(user_id);
+        // No mock OpenRouter configured — the 409 must happen before any
+        // generation is attempted.
+        let resp = post_voice(
+            &mut app,
+            session_id,
+            &jwt,
+            json!({"content":"hi","client_msg_id": client_msg_id}),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
     }
 }

--- a/crates/eros-engine-server/src/routes/voice.rs
+++ b/crates/eros-engine-server/src/routes/voice.rs
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! POST /comp/voice/{session_id}/turn/stream — lean voice-channel turn.
+//!
+//! Spec: docs/superpowers/specs/2026-07-07-voice-call-parts-design.md
+
+use axum::extract::{Extension, Path, State};
+use axum::http::StatusCode;
+use axum::response::sse::{Event, KeepAlive, Sse};
+use axum::Json;
+use futures_util::Stream;
+use serde::Deserialize;
+use std::convert::Infallible;
+use std::sync::Arc;
+use std::time::Duration;
+use utoipa_axum::{router::OpenApiRouter, routes};
+use uuid::Uuid;
+
+use eros_engine_store::chat::ChatRepo;
+
+use crate::auth::middleware::AuthUser;
+use crate::error::{AppError, StreamPreError};
+use crate::pipeline::stream::ProtocolFrame;
+use crate::pipeline::voice::{run_voice_turn, VoiceTurn};
+use crate::state::AppState;
+
+const MAX_CONTENT_CHARS: usize = 4096;
+const MIN_CLIENT_MSG_ID_LEN: usize = 26;
+const MAX_CLIENT_MSG_ID_LEN: usize = 36;
+const CONCURRENT_STREAMS_PER_USER: u32 = 3;
+const SSE_KEEPALIVE_SECS: u64 = 15;
+
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
+pub struct VoiceTurnRequest {
+    pub content: String,
+    pub client_msg_id: String,
+}
+
+fn pre(status: StatusCode, code: &'static str, message: &str, user_message: &str) -> AppError {
+    AppError::StreamPre(StreamPreError {
+        status,
+        code,
+        message: message.into(),
+        user_message: user_message.into(),
+        original_user_message_id: None,
+    })
+}
+
+fn validate(req: &VoiceTurnRequest) -> Result<(), AppError> {
+    if req.content.is_empty() {
+        return Err(pre(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "unprocessable",
+            "content must not be empty",
+            "请输入一条消息",
+        ));
+    }
+    if req.content.chars().count() > MAX_CONTENT_CHARS {
+        return Err(pre(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "unprocessable",
+            "content too long",
+            "消息过长，请缩短后重试",
+        ));
+    }
+    let n = req.client_msg_id.len();
+    let bad_chars = req
+        .client_msg_id
+        .chars()
+        .any(|c| c.is_whitespace() || !c.is_ascii() || !c.is_ascii_graphic());
+    if !(MIN_CLIENT_MSG_ID_LEN..=MAX_CLIENT_MSG_ID_LEN).contains(&n) || bad_chars {
+        return Err(pre(
+            StatusCode::BAD_REQUEST,
+            "invalid_payload",
+            "client_msg_id invalid",
+            "请求无效",
+        ));
+    }
+    Ok(())
+}
+
+#[utoipa::path(
+    post,
+    path = "/comp/voice/{session_id}/turn/stream",
+    tag = "companion",
+    params(("session_id" = Uuid, Path, description = "Chat session id")),
+    request_body = VoiceTurnRequest,
+    responses(
+        (status = 200, description = "SSE event stream (text/event-stream)", content_type = "text/event-stream"),
+        (status = 400, body = crate::routes::companion_stream::StreamPreErrorBody),
+        (status = 401, description = "missing or invalid bearer"),
+        (status = 403, body = crate::routes::companion_stream::StreamPreErrorBody),
+        (status = 404, body = crate::routes::companion_stream::StreamPreErrorBody),
+        (status = 422, body = crate::routes::companion_stream::StreamPreErrorBody),
+        (status = 429, body = crate::routes::companion_stream::StreamPreErrorBody),
+        (status = 501, body = crate::routes::companion_stream::StreamPreErrorBody),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn voice_turn_stream(
+    State(state): State<AppState>,
+    Path(session_id): Path<Uuid>,
+    Extension(AuthUser(user_id)): Extension<AuthUser>,
+    Json(req): Json<VoiceTurnRequest>,
+) -> Result<Sse<impl Stream<Item = Result<Event, Infallible>>>, AppError> {
+    validate(&req)?;
+
+    let chat_repo = ChatRepo { pool: &state.pool };
+    let session = chat_repo.get_session(session_id).await?.ok_or_else(|| {
+        pre(StatusCode::NOT_FOUND, "session_not_found", "session not found", "会话不存在")
+    })?;
+    if session.user_id != user_id {
+        return Err(pre(
+            StatusCode::FORBIDDEN,
+            "session_forbidden",
+            "session not owned by JWT user",
+            "无权访问该会话",
+        ));
+    }
+    let instance_id = session.instance_id.ok_or_else(|| {
+        pre(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "internal",
+            "session has no instance_id",
+            "服务出现问题，请稍后再试",
+        )
+    })?;
+
+    // Voice is opt-in: no [tasks.chat_voice] ⇒ 501.
+    let resolved = state.model_config.resolve_voice().ok_or_else(|| {
+        pre(
+            StatusCode::NOT_IMPLEMENTED,
+            "voice_disabled",
+            "voice is not configured on this deployment",
+            "该服务未启用语音",
+        )
+    })?;
+
+    let guard = state
+        .stream_slots
+        .try_acquire(user_id, CONCURRENT_STREAMS_PER_USER)
+        .ok_or_else(|| {
+            pre(
+                StatusCode::TOO_MANY_REQUESTS,
+                "rate_limited",
+                "per-user stream cap reached",
+                "请求过多，请稍后再试",
+            )
+        })?;
+
+    // Persist the user turn (idempotent on (session_id, client_msg_id)).
+    let user_message_id = chat_repo
+        .insert_voice_user_message(session_id, &req.content, &req.client_msg_id)
+        .await?;
+
+    let turn = VoiceTurn { session_id, instance_id, user_message_id };
+    let proto = run_voice_turn(Arc::new(state.clone()), turn, resolved);
+
+    let sse = futures_util::StreamExt::map(
+        async_stream::stream! {
+            let _guard = guard;
+            futures_util::pin_mut!(proto);
+            while let Some(frame) = futures_util::StreamExt::next(&mut proto).await {
+                yield frame;
+            }
+        },
+        |frame: ProtocolFrame| {
+            let json = serde_json::to_string(&frame)
+                .expect("ProtocolFrame serialization is infallible");
+            Ok::<_, Infallible>(Event::default().data(json))
+        },
+    );
+
+    Ok(Sse::new(sse).keep_alive(
+        KeepAlive::new()
+            .interval(Duration::from_secs(SSE_KEEPALIVE_SECS))
+            .text("ping"),
+    ))
+}
+
+pub fn router() -> OpenApiRouter<AppState> {
+    OpenApiRouter::new().routes(routes!(voice_turn_stream))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::{header, Request};
+    use axum::Router;
+    use eros_engine_llm::model_config::ModelConfig;
+    use jsonwebtoken::{encode, EncodingKey, Header};
+    use serde_json::json;
+    use sqlx::PgPool;
+    use tower::Service;
+
+    fn mint_jwt(uid: Uuid) -> String {
+        let exp = (chrono::Utc::now() + chrono::Duration::hours(1)).timestamp();
+        encode(
+            &Header::default(),
+            &json!({ "sub": uid.to_string(), "exp": exp }),
+            &EncodingKey::from_secret(crate::routes::companion::TEST_SECRET.as_ref()),
+        )
+        .unwrap()
+    }
+
+    fn build_router(state: AppState) -> Router {
+        let (axum, _api) = crate::routes::router(state.clone()).split_for_parts();
+        axum.with_state(state)
+    }
+
+    async fn seed(pool: &PgPool, user_id: Uuid) -> Uuid {
+        let genome_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata) \
+             VALUES ('V','p','{}'::jsonb) RETURNING id",
+        ).fetch_one(pool).await.unwrap();
+        let instance_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_instances (genome_id, owner_uid) VALUES ($1,$2) RETURNING id",
+        ).bind(genome_id).bind(user_id).fetch_one(pool).await.unwrap();
+        sqlx::query_scalar(
+            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1,$2) RETURNING id",
+        ).bind(user_id).bind(instance_id).fetch_one(pool).await.unwrap()
+    }
+
+    fn with_voice(mut state: AppState) -> AppState {
+        state.model_config = Arc::new(
+            ModelConfig::from_toml_str("[tasks.chat_voice]\nmodel = \"primary\"\n").unwrap(),
+        );
+        state
+    }
+
+    async fn post_voice(app: &mut Router, session_id: Uuid, jwt: &str, body: serde_json::Value)
+        -> axum::http::Response<Body>
+    {
+        let req = Request::builder()
+            .method("POST")
+            .uri(format!("/comp/voice/{session_id}/turn/stream"))
+            .header(header::AUTHORIZATION, format!("Bearer {jwt}"))
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        app.call(req).await.unwrap()
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn voice_422_when_content_empty(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let session_id = seed(&pool, user_id).await;
+        let mut app = build_router(with_voice(crate::routes::companion::test_state(pool)));
+        let jwt = mint_jwt(user_id);
+        let resp = post_voice(&mut app, session_id, &jwt,
+            json!({"content":"","client_msg_id":"01J2222222222222222222222A"})).await;
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn voice_501_when_task_absent(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let session_id = seed(&pool, user_id).await;
+        // Default test_state has no chat_voice task.
+        let mut app = build_router(crate::routes::companion::test_state(pool));
+        let jwt = mint_jwt(user_id);
+        let resp = post_voice(&mut app, session_id, &jwt,
+            json!({"content":"hi","client_msg_id":"01J2222222222222222222222A"})).await;
+        assert_eq!(resp.status(), StatusCode::NOT_IMPLEMENTED);
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn voice_403_when_not_owner(pool: PgPool) {
+        let owner = Uuid::new_v4();
+        let session_id = seed(&pool, owner).await;
+        let mut app = build_router(with_voice(crate::routes::companion::test_state(pool)));
+        let other = mint_jwt(Uuid::new_v4());
+        let resp = post_voice(&mut app, session_id, &other,
+            json!({"content":"hi","client_msg_id":"01J2222222222222222222222A"})).await;
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+}

--- a/crates/eros-engine-store/Cargo.toml
+++ b/crates/eros-engine-store/Cargo.toml
@@ -26,3 +26,4 @@ rand = "0.8"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+ulid = { workspace = true }

--- a/crates/eros-engine-store/migrations/0030_chat_messages_channel.sql
+++ b/crates/eros-engine-store/migrations/0030_chat_messages_channel.sql
@@ -1,0 +1,16 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+--
+-- engine.chat_messages gains a `channel` column distinguishing the voice
+-- channel from the default text chat. Voice I/O is still text; only the entry
+-- endpoint differs. NULL = prior behaviour (text). 'voice' = voice channel.
+-- Symmetric across user and assistant rows, and the single key used to exclude
+-- voice turns from session-end memory extraction (dreaming).
+--
+-- Adding a nullable column is a metadata-only change (no table rewrite). The
+-- CHECK mirrors the codebase convention (cf. assistant_action_type in 0012) and
+-- is trivially extended when new channels appear. No index: the dreaming filter
+-- is already narrowed by session_id.
+
+ALTER TABLE engine.chat_messages
+    ADD COLUMN channel TEXT NULL
+        CHECK (channel IS NULL OR channel IN ('voice'));

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -844,28 +844,35 @@ impl<'a> ChatRepo<'a> {
         content: &str,
         client_msg_id: &str,
     ) -> Result<VoiceUserInsert, sqlx::Error> {
-        if let Some(id) = sqlx::query_scalar::<_, Uuid>(
-            "SELECT id FROM engine.chat_messages \
-             WHERE session_id = $1 AND client_msg_id = $2 AND role = 'user' \
-             LIMIT 1",
-        )
-        .bind(session_id)
-        .bind(client_msg_id)
-        .fetch_optional(self.pool)
-        .await?
-        {
-            return Ok(VoiceUserInsert::Duplicate(id));
-        }
-        let id: Uuid = sqlx::query_scalar(
+        // Atomic: on a (session_id, client_msg_id) conflict — the partial unique
+        // index chat_messages_client_msg_id_uidx (WHERE client_msg_id IS NOT NULL,
+        // migration 0012) — DO NOTHING and fall through to reading the existing id,
+        // so concurrent duplicates are classified reliably (the loser gets
+        // Duplicate, never a unique-violation 500).
+        let inserted: Option<Uuid> = sqlx::query_scalar(
             "INSERT INTO engine.chat_messages (session_id, role, content, client_msg_id, channel) \
-             VALUES ($1, 'user', $2, $3, 'voice') RETURNING id",
+             VALUES ($1, 'user', $2, $3, 'voice') \
+             ON CONFLICT (session_id, client_msg_id) WHERE client_msg_id IS NOT NULL DO NOTHING \
+             RETURNING id",
         )
         .bind(session_id)
         .bind(content)
         .bind(client_msg_id)
+        .fetch_optional(self.pool)
+        .await?;
+        if let Some(id) = inserted {
+            return Ok(VoiceUserInsert::Inserted(id));
+        }
+        // Conflict → the row already exists; fetch its id.
+        let existing: Uuid = sqlx::query_scalar(
+            "SELECT id FROM engine.chat_messages \
+             WHERE session_id = $1 AND client_msg_id = $2 AND role = 'user' LIMIT 1",
+        )
+        .bind(session_id)
+        .bind(client_msg_id)
         .fetch_one(self.pool)
         .await?;
-        Ok(VoiceUserInsert::Inserted(id))
+        Ok(VoiceUserInsert::Duplicate(existing))
     }
 
     /// Persist an assistant turn on the voice channel: `role='assistant'`,

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -863,10 +863,13 @@ impl<'a> ChatRepo<'a> {
         if let Some(id) = inserted {
             return Ok(VoiceUserInsert::Inserted(id));
         }
-        // Conflict → the row already exists; fetch its id.
+        // Conflict → a row with this (session_id, client_msg_id) already exists.
+        // The unique index is role-agnostic, so the conflicting row may be a
+        // `user` OR a `gift_user` (tip) row — do NOT filter by role, or a tip
+        // collision would miss and surface a 500 instead of the 409 duplicate.
         let existing: Uuid = sqlx::query_scalar(
             "SELECT id FROM engine.chat_messages \
-             WHERE session_id = $1 AND client_msg_id = $2 AND role = 'user' LIMIT 1",
+             WHERE session_id = $1 AND client_msg_id = $2 LIMIT 1",
         )
         .bind(session_id)
         .bind(client_msg_id)
@@ -2834,5 +2837,42 @@ mod tests {
         assert_eq!(h[0].role, "user");
         assert_eq!(h[1].role, "assistant");
         assert_eq!(h[1].content, "hi there");
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn voice_insert_duplicate_against_gift_user_row_is_not_500(pool: PgPool) {
+        // A voice request reusing a client_msg_id that already exists on a tip
+        // (`gift_user`) row must be classified as Duplicate (→ 409), not error
+        // out with RowNotFound (→ 500). The unique index is role-agnostic, so
+        // the conflict-recovery SELECT must not filter by role.
+        let session_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(Uuid::new_v4())
+        .bind(Uuid::new_v4())
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let cmid = "01J9000000000000000000GIFT1";
+        sqlx::query(
+            "INSERT INTO engine.chat_messages (session_id, role, content, client_msg_id) \
+             VALUES ($1, 'gift_user', '(tip)', $2)",
+        )
+        .bind(session_id)
+        .bind(cmid)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let repo = ChatRepo { pool: &pool };
+        // Must NOT panic (no RowNotFound → no 500); must be Duplicate.
+        let out = repo
+            .insert_voice_user_message(session_id, "hi", cmid)
+            .await
+            .unwrap();
+        assert!(
+            matches!(out, VoiceUserInsert::Duplicate(_)),
+            "voice insert colliding with a gift_user row must be Duplicate, got {out:?}"
+        );
     }
 }

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -2631,4 +2631,47 @@ mod tests {
             "cross-session write must be a no-op"
         );
     }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn channel_column_accepts_voice_and_null_rejects_other(pool: PgPool) {
+        // Minimal session to satisfy FKs.
+        let session_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(Uuid::new_v4())
+        .bind(Uuid::new_v4())
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        // NULL channel (default) — ok.
+        sqlx::query(
+            "INSERT INTO engine.chat_messages (session_id, role, content) VALUES ($1, 'user', 'a')",
+        )
+        .bind(session_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // 'voice' — ok.
+        sqlx::query(
+            "INSERT INTO engine.chat_messages (session_id, role, content, channel) VALUES ($1, 'user', 'b', 'voice')",
+        )
+        .bind(session_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // 'bogus' — rejected by CHECK.
+        let err = sqlx::query(
+            "INSERT INTO engine.chat_messages (session_id, role, content, channel) VALUES ($1, 'user', 'c', 'bogus')",
+        )
+        .bind(session_id)
+        .execute(&pool)
+        .await;
+        assert!(
+            err.is_err(),
+            "channel = 'bogus' must violate the CHECK constraint"
+        );
+    }
 }

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -544,6 +544,15 @@ pub enum UpsertUserOutcome {
     DuplicateInProgress { user_message_id: Uuid },
 }
 
+/// Outcome of `insert_voice_user_message`. The route uses this to distinguish
+/// a fresh user turn (proceed to generation) from a replayed `client_msg_id`
+/// (return 409, never regenerate a second assistant reply).
+#[derive(Debug, Clone, Copy)]
+pub enum VoiceUserInsert {
+    Inserted(Uuid),
+    Duplicate(Uuid),
+}
+
 impl<'a> ChatRepo<'a> {
     /// Insert a user message keyed by `client_msg_id` with permanent
     /// idempotency. The partial unique index on `(session_id, client_msg_id)`
@@ -825,14 +834,16 @@ impl<'a> ChatRepo<'a> {
 
     /// Idempotently persist a user turn on the voice channel. Mirrors the
     /// `(session_id, client_msg_id)` uniqueness of the text path but writes
-    /// `channel = 'voice'` and skips all replay/ghost machinery. Returns the row
-    /// id — the existing row's id when `client_msg_id` was already seen.
+    /// `channel = 'voice'` and skips all replay/ghost machinery. Returns
+    /// which case occurred — `Duplicate` when `client_msg_id` was already
+    /// seen (existing row's id), `Inserted` (fresh row's id) otherwise — so
+    /// callers can refuse to regenerate a reply for a duplicate.
     pub async fn insert_voice_user_message(
         &self,
         session_id: Uuid,
         content: &str,
         client_msg_id: &str,
-    ) -> Result<Uuid, sqlx::Error> {
+    ) -> Result<VoiceUserInsert, sqlx::Error> {
         if let Some(id) = sqlx::query_scalar::<_, Uuid>(
             "SELECT id FROM engine.chat_messages \
              WHERE session_id = $1 AND client_msg_id = $2 AND role = 'user' \
@@ -843,7 +854,7 @@ impl<'a> ChatRepo<'a> {
         .fetch_optional(self.pool)
         .await?
         {
-            return Ok(id);
+            return Ok(VoiceUserInsert::Duplicate(id));
         }
         let id: Uuid = sqlx::query_scalar(
             "INSERT INTO engine.chat_messages (session_id, role, content, client_msg_id, channel) \
@@ -854,7 +865,7 @@ impl<'a> ChatRepo<'a> {
         .bind(client_msg_id)
         .fetch_one(self.pool)
         .await?;
-        Ok(id)
+        Ok(VoiceUserInsert::Inserted(id))
     }
 
     /// Persist an assistant turn on the voice channel: `role='assistant'`,
@@ -2757,15 +2768,24 @@ mod tests {
 
         // User insert: idempotent on client_msg_id.
         let cmid = "01J9000000000000000000VOICE";
-        let u1 = repo
+        let u1 = match repo
             .insert_voice_user_message(session_id, "hello", cmid)
             .await
-            .unwrap();
-        let u2 = repo
+            .unwrap()
+        {
+            VoiceUserInsert::Inserted(id) => id,
+            other => panic!("expected Inserted, got {other:?}"),
+        };
+        match repo
             .insert_voice_user_message(session_id, "hello again", cmid)
             .await
-            .unwrap();
-        assert_eq!(u1, u2, "same client_msg_id must return the same row id");
+            .unwrap()
+        {
+            VoiceUserInsert::Duplicate(id) => {
+                assert_eq!(id, u1, "same client_msg_id must return the same row id");
+            }
+            other => panic!("expected Duplicate, got {other:?}"),
+        }
 
         let (role, channel): (String, Option<String>) =
             sqlx::query_as("SELECT role, channel FROM engine.chat_messages WHERE id = $1")

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -822,6 +822,74 @@ impl<'a> ChatRepo<'a> {
         tx.commit().await?;
         Ok(())
     }
+
+    /// Idempotently persist a user turn on the voice channel. Mirrors the
+    /// `(session_id, client_msg_id)` uniqueness of the text path but writes
+    /// `channel = 'voice'` and skips all replay/ghost machinery. Returns the row
+    /// id — the existing row's id when `client_msg_id` was already seen.
+    pub async fn insert_voice_user_message(
+        &self,
+        session_id: Uuid,
+        content: &str,
+        client_msg_id: &str,
+    ) -> Result<Uuid, sqlx::Error> {
+        if let Some(id) = sqlx::query_scalar::<_, Uuid>(
+            "SELECT id FROM engine.chat_messages \
+             WHERE session_id = $1 AND client_msg_id = $2 AND role = 'user' \
+             LIMIT 1",
+        )
+        .bind(session_id)
+        .bind(client_msg_id)
+        .fetch_optional(self.pool)
+        .await?
+        {
+            return Ok(id);
+        }
+        let id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_messages (session_id, role, content, client_msg_id, channel) \
+             VALUES ($1, 'user', $2, $3, 'voice') RETURNING id",
+        )
+        .bind(session_id)
+        .bind(content)
+        .bind(client_msg_id)
+        .fetch_one(self.pool)
+        .await?;
+        Ok(id)
+    }
+
+    /// Persist an assistant turn on the voice channel: `role='assistant'`,
+    /// `assistant_action_type='reply'`, `channel='voice'`. No filter audit, no
+    /// continues_from — voice replies are single, whole messages.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn insert_voice_assistant_message(
+        &self,
+        session_id: Uuid,
+        user_message_id: Uuid,
+        id: Uuid,
+        content: &str,
+        model: Option<&str>,
+        usage: Option<&serde_json::Value>,
+        generation_id: Option<&str>,
+        truncated: bool,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query(
+            "INSERT INTO engine.chat_messages \
+             (id, session_id, role, content, user_message_id, truncated, model, usage, \
+              generation_id, assistant_action_type, channel) \
+             VALUES ($1, $2, 'assistant', $3, $4, $5, $6, $7, $8, 'reply', 'voice')",
+        )
+        .bind(id)
+        .bind(session_id)
+        .bind(content)
+        .bind(user_message_id)
+        .bind(truncated)
+        .bind(model)
+        .bind(usage)
+        .bind(generation_id)
+        .execute(self.pool)
+        .await?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -2673,5 +2741,71 @@ mod tests {
             err.is_err(),
             "channel = 'bogus' must violate the CHECK constraint"
         );
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn voice_inserts_are_marked_and_idempotent(pool: PgPool) {
+        let session_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(Uuid::new_v4())
+        .bind(Uuid::new_v4())
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let repo = ChatRepo { pool: &pool };
+
+        // User insert: idempotent on client_msg_id.
+        let cmid = "01J9000000000000000000VOICE";
+        let u1 = repo
+            .insert_voice_user_message(session_id, "hello", cmid)
+            .await
+            .unwrap();
+        let u2 = repo
+            .insert_voice_user_message(session_id, "hello again", cmid)
+            .await
+            .unwrap();
+        assert_eq!(u1, u2, "same client_msg_id must return the same row id");
+
+        let (role, channel): (String, Option<String>) =
+            sqlx::query_as("SELECT role, channel FROM engine.chat_messages WHERE id = $1")
+                .bind(u1)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(role, "user");
+        assert_eq!(channel.as_deref(), Some("voice"));
+
+        // Assistant insert.
+        let aid: Uuid = ulid::Ulid::new().into();
+        repo.insert_voice_assistant_message(
+            session_id,
+            u1,
+            aid,
+            "hi there",
+            Some("primary"),
+            None,
+            Some("gen-1"),
+            false,
+        )
+        .await
+        .unwrap();
+        let (role, aat, channel): (String, Option<String>, Option<String>) = sqlx::query_as(
+            "SELECT role, assistant_action_type, channel FROM engine.chat_messages WHERE id = $1",
+        )
+        .bind(aid)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(role, "assistant");
+        assert_eq!(aat.as_deref(), Some("reply"));
+        assert_eq!(channel.as_deref(), Some("voice"));
+
+        // history() returns both, chronologically, and content survives.
+        let h = repo.history(session_id, 10, 0).await.unwrap();
+        assert_eq!(h.len(), 2);
+        assert_eq!(h[0].role, "user");
+        assert_eq!(h[1].role, "assistant");
+        assert_eq!(h[1].content, "hi there");
     }
 }

--- a/docs/superpowers/specs/2026-07-07-voice-call-parts-design.md
+++ b/docs/superpowers/specs/2026-07-07-voice-call-parts-design.md
@@ -1,0 +1,178 @@
+# Voice-call parts (engine side) — design
+
+- Date: 2026-07-07
+- Status: design agreed, implementation plan pending
+- Repo: `eros-engine`
+
+## Background & goals
+
+Add engine support for a **voice-call-style** companion interaction (prior art: Grok Ani — real-time spoken conversation, switchable with a text mode). A voice turn is the loop **STT → LLM → TTS**.
+
+Following the delegation philosophy established in v0.7.1 (the `image_request` frame: the engine only composes the prompt and hands drawing to the consumer), **the engine owns only the LLM segment and ships only the parts the consumer needs. STT and TTS belong entirely to the consumer; the engine never touches audio.** This keeps the engine lean, avoids needless I/O and round-trips, and keeps heavy frames off the chat SSE shape (which would perturb response shape and latency).
+
+`eros-engine` is OSS and ships parts, not a hosted product. This spec defines only the **engine contract**: one lean endpoint, one `model_config` task, light persistence, and a memory-exclusion tweak. Everything on the audio/orchestration side is the consumer's responsibility and is out of scope here.
+
+## Non-goals
+
+- No STT, no TTS, no audio provider selection — all consumer-side.
+- No PDE judge, no vector recall, no per-turn post-processing (affinity scoring / insight extraction).
+- No replay / full idempotent-replay machinery.
+- No changes to the `/comp/chat/{session_id}/message/stream` hot path (only its parts are reused).
+
+## Responsibility split
+
+| Concern | Owner |
+| --- | --- |
+| Mic capture, VAD, STT, TTS, call UI, turn-taking / barge-in | Consumer (out of scope) |
+| LLM text reply (text in → text out, streaming) | Engine |
+| Persona prompt, thin relationship state, single-model selection, persistence | Engine |
+
+## Architecture: per-turn stateless
+
+OpenRouter chat completions are **stateless** — there is no provider-side session holding context; every turn must resend the (trimmed) message array. So context is held by the engine **reusing the existing chat session**: each turn does one cheap `history()` read, with no vector recall.
+
+The engine's voice endpoint is therefore **per-turn stateless**: a whole call is a sequence of independent SSE requests. The consumer orchestrates the call; the engine per turn just does "receive one user utterance → read the last N turns of history → generate → stream text back → persist."
+
+## Single-turn data flow
+
+```
+consumer:  mic → VAD → STT → text
+consumer → engine:  POST /comp/voice/{session_id}/turn/stream  { content, client_msg_id }
+engine:
+   1. JWT auth + session-ownership check (same as message/stream)
+   2. acquire a per-user stream slot (reuse existing guard, cap 3)
+   3. persist user turn (role=user, channel="voice")
+   4. read last N turns of history (text turns + voice turns, interleaved)
+   5. load 1 affinity row (cheap single-row read)
+   6. assemble thin system_prompt (persona + voice directive + one relationship line)
+   7. single-model OpenRouter streaming call ([tasks.chat_voice])
+   8. SSE: delta* → final
+   9. persist assistant turn (role=assistant, assistant_action_type="reply", channel="voice")
+engine → consumer:  SSE  delta* / final ( / error )
+consumer:  text deltas → sentence-wise TTS → playback
+```
+
+On this path the engine does **not**: PDE judge, vector recall, insight/memory extraction, affinity scoring, image/traits/scopes/tips branches, replay.
+
+## Engine endpoint contract
+
+**Route** (name TBD): `POST /comp/voice/{session_id}/turn/stream`
+
+A dedicated thin handler that only shares the parts — OpenRouter client / `model_config` / `PersonaRepo` / `ChatRepo` / `AffinityRepo` — and never enters `run_stream`.
+
+**Request body** (minimal):
+
+```json
+{ "content": "the user's utterance text", "client_msg_id": "<26..36 ASCII printable>" }
+```
+
+- `content`: non-empty, `chars() <= MAX_CONTENT_CHARS` (reuse the existing validation style and `StreamPreError` shape).
+- `client_msg_id`: reuse the existing format constraints. Used for lightest-touch idempotency — `(session_id, client_msg_id)` is unique; on collision, do not double-insert. **No** replay stream.
+
+**Reused**: JWT + session-ownership gate, per-user stream slot guard (`CONCURRENT_STREAMS_PER_USER = 3`), the `StreamPreError` pre-stream error shape, `upsert_user_message_idempotent` for the user turn.
+
+**SSE frames (thin)**: only `delta` / `final` / `error` (reuse the corresponding `ProtocolFrame` variants); **no** `meta` / `image*` / `pending` heavy frames. Streaming is required so the consumer can TTS sentence-by-sentence for a real-time feel. Keep-alive reuses the existing 15s ping.
+
+**Errors**:
+- `[tasks.chat_voice]` not configured ⇒ `501` (same pattern as the image endpoint: the feature is opt-in).
+- Other 4xx (422/400/401/403/404/409/429) match `message/stream` semantics and error shape.
+
+## Thin prompt assembly
+
+```
+system_prompt =
+    genome.system_prompt                    # persona, from DB
+  + <voice directive>                        # [tasks.chat_voice].filter_prompt (built-in default, overridable)
+  + <one relationship line>                  # relationship_label + a tone hint, from the one affinity row
+```
+
+- The **voice directive** lives in the new task's `filter_prompt`, with a product-identity-free **built-in default** (same pattern as `chat_image_prompt_compose`: the deployment may override). Default intent: *you are on a voice call; keep replies short and spoken; no markdown / emoji / bracketed stage directions* (TTS reads everything literally, so symbols and asides must be suppressed).
+- **Relationship state**: inject `relationship_label` and a short tone hint so the call's tone tracks the text relationship's progress. **No** vector recall, no memory pull, no traits/scopes/emotional_context/avoid_repetition heavy blocks.
+
+**history → wire messages**: read the session's last N turns (a dedicated constant `VOICE_HISTORY_WINDOW`, shorter than the text path to cut latency/tokens). Text and voice turns are **interleaved**, so a call remembers the text chat and vice versa. Voice-turn `role` stays `user`/`assistant`, so mapping to wire role is free.
+
+## New model_config task
+
+```toml
+[tasks.chat_voice]          # name TBD
+model = "some/fast-model"   # single fixed id: no rotation (no round-robin / weighted)
+fallback = ["backup/model"] # allowed — but this is an outage retry chain, not rotation
+temperature = 0.8
+max_tokens = 300            # call replies are short
+reasoning = { enabled = false }
+# filter_prompt optional: overrides the built-in voice directive default
+```
+
+- Latency-sensitive; the deployment picks a fast model (time-to-first-token first).
+- Matches the constraint of a **single model**: `model` accepts only a single fixed id, not the round-robin/weighted array/table forms. `fallback` as an outage retry chain is allowed, same semantics as other tasks.
+- Task absent ⇒ endpoint 501 (opt-in feature).
+- Add a commented example block to `examples/model_config.toml`.
+
+## Persistence & the `channel` column
+
+Voice turns land in the existing `chat_messages` (reusing the session for continuity). A new dedicated column `channel` distinguishes them — cleaner and more SQL-friendly than a JSON flag, and **symmetric** across user and assistant rows (voice I/O is still text; only the entry endpoint differs).
+
+- `channel IS NULL` → prior behavior (text chat). Every existing INSERT leaves it NULL, so the hot path is untouched.
+- `channel = 'voice'` → voice channel.
+
+| Turn | role | assistant_action_type | channel |
+| --- | --- | --- | --- |
+| user voice turn | `user` (unchanged) | — | `voice` |
+| assistant voice turn | `assistant` (unchanged) | `reply` (unchanged) | `voice` |
+
+- `role` never changes, so every time-ordered history read naturally includes voice turns → two-way continuity, and existing role-filtered queries/analytics are undisturbed.
+- `assistant_action_type` stays `'reply'` → **no** change to its CHECK constraint, and no asymmetric "what do we call the user side" problem. The `channel` column marks both sides identically.
+- `channel` is the single exclusion/selection key for everything voice.
+
+**Migration `0030`** adds the column:
+
+```sql
+ALTER TABLE engine.chat_messages
+  ADD COLUMN channel TEXT NULL
+    CHECK (channel IS NULL OR channel IN ('voice'));
+```
+
+Adding a nullable column is a metadata-only change in Postgres (no table rewrite), so it is non-blocking. The CHECK follows the codebase convention (cf. `assistant_action_type` in `0012`) and is trivially extended when new channels appear. No new index is needed for the dreaming filter (already narrowed by `session_id`); a partial index `WHERE channel IS NOT NULL` can be added later if cross-session voice analytics ever needs it.
+
+**Store surface**: the voice endpoint's user/assistant inserts set `channel = 'voice'`; existing `ChatRepo` inserts leave it NULL. `AssistantInsert` and the user upsert gain an optional `channel` (defaulting NULL) so the text path is unchanged.
+
+## Memory exclusion (experimental — keep it out of memory for now)
+
+Voice is still experimental, so keep it **out** of long-term memory to avoid polluting the profile.
+
+- **per-turn**: the voice endpoint runs no insight/memory extraction (see non-goals), so it produces no memories.
+- **session-end dreaming sweeper**: `crates/eros-engine-server/src/pipeline/dreaming.rs` `classify_session` currently pulls the whole conversation with
+  `SELECT role, content FROM engine.chat_messages WHERE session_id = $1 ORDER BY ...`
+  and feeds it to `memory_extraction`. Add `AND channel IS DISTINCT FROM 'voice'` to that WHERE so voice turns are excluded from memory extraction. (`IS DISTINCT FROM` keeps NULL/text rows and drops only voice.)
+
+> To let calls contribute to memory later, drop this filter — a single, reversible switch.
+
+## Reuse / skip list
+
+**Reuse (parts)**: OpenRouter client, `model_config` (new task), `PersonaRepo::load_companion`, `ChatRepo` (history + upsert), `AffinityRepo` (single-row load), the JWT/ownership gate, the stream slot guard, `StreamPreError`, the delta/final/error `ProtocolFrame` variants, SSE keep-alive.
+
+**Skip (lean)**: PDE judge, `build_reply_request`'s vector recall + insight + recent_turns + emotional_context + avoid_repetition + heavy `build_prompt`, per-turn affinity eval, per-turn insight/memory extraction, image/traits/scopes/tips branches, replay / full idempotent replay.
+
+## Naming — open items (settle before implementation)
+
+- Endpoint path (`/comp/voice/{session_id}/turn/stream`?)
+- Task name (`chat_voice`?)
+- The `channel` value string (`'voice'`?) — the column name `channel` is settled.
+
+(Naming was explicitly deferred; this spec uses the placeholders above consistently.)
+
+## Testing
+
+- Endpoint: empty content → 422; malformed client_msg_id → 400; session not owned → 403; session missing → 404; `[tasks.chat_voice]` absent → 501; slot cap exceeded → 429.
+- Idempotency: repeating the same `(session_id, client_msg_id)` produces no duplicate row.
+- Persistence: user/assistant voice turns carry `channel='voice'`; `role` (`user`/`assistant`) and `assistant_action_type` (`reply`) unchanged; text turns keep `channel IS NULL`.
+- Migration: an assistant-side `channel` value outside the CHECK set is rejected; existing text INSERTs default `channel` to NULL.
+- Prompt: thin prompt contains persona + voice directive + relationship line; **excludes** recall/memory blocks.
+- SSE: only delta/final(/error) appear, no meta/image frames; deltas are incrementally consumable.
+- Interleaving: a voice turn reads prior text turns and vice versa.
+- Memory exclusion: with a mixed session, `classify_session` feeds only rows where `channel IS DISTINCT FROM 'voice'`; voice content never reaches `memory_extraction`.
+- Single-model constraint: an array/table form for `chat_voice.model` is rejected at load time.
+
+## Consumer-side contract (out of scope, for reference)
+
+The consumer captures and gates audio (VAD), runs STT, POSTs the recognized text per turn to the voice endpoint, consumes the SSE text deltas and runs TTS sentence-by-sentence, plays the audio, and orchestrates turn-taking / barge-in and the "in a call" session state. The engine is agnostic to all of it.

--- a/docs/superpowers/specs/2026-07-07-voice-call-parts-design.md
+++ b/docs/superpowers/specs/2026-07-07-voice-call-parts-design.md
@@ -42,13 +42,13 @@ engine:
    1. JWT auth + session-ownership check (same as message/stream)
    2. acquire a per-user stream slot (reuse existing guard, cap 3)
    3. persist user turn (role=user, channel="voice")
-   4. read last N turns of history (text turns + voice turns, interleaved)
+   4. read last N turns of THIS session's history (in-call conversation memory; no vector recall)
    5. load 1 affinity row (cheap single-row read)
    6. assemble thin system_prompt (persona + voice directive + one relationship line)
    7. single-model OpenRouter streaming call ([tasks.chat_voice])
-   8. SSE: delta* → final
+   8. SSE: delta* → done
    9. persist assistant turn (role=assistant, assistant_action_type="reply", channel="voice")
-engine → consumer:  SSE  delta* / final ( / error )
+engine → consumer:  SSE  delta* / done ( / error )
 consumer:  text deltas → sentence-wise TTS → playback
 ```
 
@@ -71,7 +71,7 @@ A dedicated thin handler that only shares the parts — OpenRouter client / `mod
 
 **Reused**: JWT + session-ownership gate, per-user stream slot guard (`CONCURRENT_STREAMS_PER_USER = 3`), the `StreamPreError` pre-stream error shape, `upsert_user_message_idempotent` for the user turn.
 
-**SSE frames (thin)**: only `delta` / `final` / `error` (reuse the corresponding `ProtocolFrame` variants); **no** `meta` / `image*` / `pending` heavy frames. Streaming is required so the consumer can TTS sentence-by-sentence for a real-time feel. Keep-alive reuses the existing 15s ping.
+**SSE frames (thin)**: only `delta` / `done` / `error` (reuse the corresponding `ProtocolFrame` variants — the per-message terminal is the existing `done` frame; the chat-only `final` frame is deliberately NOT emitted); **no** `meta` / `image*` / `pending` heavy frames. Streaming is required so the consumer can TTS sentence-by-sentence for a real-time feel. Keep-alive reuses the existing 15s ping.
 
 **Errors**:
 - `[tasks.chat_voice]` not configured ⇒ `501` (same pattern as the image endpoint: the feature is opt-in).
@@ -89,7 +89,13 @@ system_prompt =
 - The **voice directive** lives in the new task's `filter_prompt`, with a product-identity-free **built-in default** (same pattern as `chat_image_prompt_compose`: the deployment may override). Default intent: *you are on a voice call; keep replies short and spoken; no markdown / emoji / bracketed stage directions* (TTS reads everything literally, so symbols and asides must be suppressed).
 - **Relationship state**: inject `relationship_label` and a short tone hint so the call's tone tracks the text relationship's progress. **No** vector recall, no memory pull, no traits/scopes/emotional_context/avoid_repetition heavy blocks.
 
-**history → wire messages**: read the session's last N turns (a dedicated constant `VOICE_HISTORY_WINDOW`, shorter than the text path to cut latency/tokens). Text and voice turns are **interleaved**, so a call remembers the text chat and vice versa. Voice-turn `role` stays `user`/`assistant`, so mapping to wire role is free.
+**history → wire messages**: the engine reads THIS session's last N turns (a dedicated constant `VOICE_HISTORY_WINDOW`, shorter than the text path to cut latency/tokens) so the model has **in-call memory** — OpenRouter is stateless, so each turn must resend the recent conversation or the companion forgets what was just said. This is the conversation flow, distinct from the thin *system* prompt above. Voice-turn `role` stays `user`/`assistant`, so wire-role mapping is free. Empty-`content` history rows are **skipped** (defensive: a caption-less image turn — which stores empty `content` — would otherwise become an empty wire message some providers reject).
+
+## Session scope & known characteristics
+
+- **Voice uses its own session (downstream policy).** The engine is session-agnostic — it reads whatever `session_id` it is given. The intended usage is that a voice call opens a **separate** session, so voice and text turns never share one. The `channel='voice'` marking + the dreaming filter are belt-and-suspenders that keep voice out of long-term memory even if a consumer does mix them.
+- **`last_active_at` is intentionally not bumped by voice turns.** Voice is deliberately isolated from the text recency/memory machinery. Consequence: a voice-only session ranks by its creation time in `last_active_at`-ordered lists, and — only in a mixed session, which the intended usage avoids — a long call would not defer dreaming. Accepted for this experimental feature; revisit if voice and text are ever meant to share a session.
+- **Empty-`content` history rows are skipped** in the wire mapping (defensive; see the history note above).
 
 ## New model_config task
 
@@ -120,7 +126,7 @@ Voice turns land in the existing `chat_messages` (reusing the session for contin
 | user voice turn | `user` (unchanged) | — | `voice` |
 | assistant voice turn | `assistant` (unchanged) | `reply` (unchanged) | `voice` |
 
-- `role` never changes, so every time-ordered history read naturally includes voice turns → two-way continuity, and existing role-filtered queries/analytics are undisturbed.
+- `role` never changes, so wire-role mapping is free and existing role-filtered queries/analytics are undisturbed. (Whether voice and text share a session is a downstream policy — see "Session scope" below — so "continuity" here means in-call memory within the voice session, not cross-channel mixing.)
 - `assistant_action_type` stays `'reply'` → **no** change to its CHECK constraint, and no asymmetric "what do we call the user side" problem. The `channel` column marks both sides identically.
 - `channel` is the single exclusion/selection key for everything voice.
 

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -409,3 +409,24 @@ max_tokens = 400
 [tasks.embedding]
 model = "voyage-3-lite"
 dimensions = 512
+
+# ── Voice channel (chat_voice) ───────────────────────────────────────────────
+# OPT-IN. Feature is OFF unless this block exists. Powers the lean voice-call
+# endpoint POST /comp/voice/{session_id}/turn/stream (text in → streamed text
+# out). Latency-sensitive: pick a fast model (time-to-first-token first).
+#
+# `model` MUST be a single fixed id — NOT the round-robin array or weighted
+# table forms (the server refuses to boot otherwise). `fallback` is allowed as
+# an outage retry chain (tried sequentially; NOT rotation). `filter_prompt` is
+# OPTIONAL: it overrides the built-in, product-identity-free voice directive
+# (short, spoken, no markdown/emoji/stage-directions). Voice turns persist on a
+# `channel = 'voice'` column and are excluded from session-end memory extraction.
+#[tasks.chat_voice]
+#model        = "vendor/fast-voice-model"
+#fallback     = ["vendor/backup-model"]
+#temperature  = 0.8
+#max_tokens   = 300
+#reasoning    = { enabled = false }
+#filter_prompt = """
+#…optional override of the built-in voice directive…
+#"""


### PR DESCRIPTION
## Summary

Adds engine-side parts for a **voice-call-style** companion interaction (STT → LLM → TTS). The engine owns only the LLM turn — STT/TTS and audio are the consumer's. New lean, **per-turn-stateless** SSE endpoint `POST /comp/voice/{session_id}/turn/stream` (text in → streamed text out) that reuses the chat session but skips PDE, vector recall, and per-turn post-processing.

Design intent (confirmed with product): a voice call runs on its **own session** — voice and text never mix. In-call memory comes from reading that session's own recent history (OpenRouter is stateless — each turn resends the recent conversation); the "thin prompt" is the *system* prompt (persona + voice directive + one relationship line), with no recall/memory scaffolding.

## What's included

- **Migration 0030** — `channel` column on `chat_messages` (NULL = text, `'voice'` = voice; role-agnostic CHECK).
- **Store** — `insert_voice_user_message` (atomic idempotent → Inserted/Duplicate) + `insert_voice_assistant_message`.
- **model_config** — `[tasks.chat_voice]`: single fixed model (boot-gated, no rotation; `fallback` = outage chain), built-in overridable voice directive.
- **Generator** `run_voice_turn` — single-model `execute_stream` with a manual fallback walk; `delta` → `done` / `error`; usage filtered on the wire, full usage persisted.
- **Route** — `POST /comp/voice/{session_id}/turn/stream` (422/400/403/404/409/429/501), pre-stream persona gate, per-user slot guard.
- **Dreaming** — voice turns excluded from session-end memory extraction (voice is experimental; keep it out of long-term memory).
- Spec (`docs/superpowers/specs/2026-07-07-voice-call-parts-design.md`), example config, regenerated OpenAPI.

## Verification

- `cargo fmt` / `clippy --all-targets -D warnings` clean; `cargo test --workspace` — **728 passed / 0 failed**.
- `codex exec review --base dev`: **clean** after 6 fix rounds (idempotency/atomicity, empty→error, fallback-on-empty, history-read failure, usage-key filtering, per-candidate metadata attribution, pre-stream persona gate).

STT/TTS and the voice-call UI are downstream (out of scope; the engine is session-agnostic — it reads whatever session it's given).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
