### PR TITLE
docs: clarify meta-frame action_type wire asymmetry (reply_text → reply)

### DIFF
--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -557,7 +557,7 @@
         },
         "responses": {
           "200": {
-            "description": "SSE event stream (text/event-stream)",
+            "description": "SSE event stream (text/event-stream). The `meta` frame's `action_type` is one of `reply` | `ghost` | `reply_image` | `reply_text_image`. Note the asymmetry: a plain-text `reply_text` turn is reported as `reply` (there is no `reply_text` on the wire), while the text+image variant keeps its full `reply_text_image` name.",
             "content": {
               "text/event-stream": {}
             }

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -31,7 +31,7 @@ pub enum StreamErrorCode {
 /// Serializes snake_case: `reply` | `ghost` | `reply_image` | `reply_text_image`.
 ///
 /// Asymmetry worth calling out: this is the *wire* action, coarser than the
-/// internal PDE [`ActionType`](eros_engine_core::types::ActionType). A plain-text
+/// internal PDE [`ActionType`]. A plain-text
 /// turn (`ActionType::ReplyText`, audited as `reply_text`) is reported here as
 /// **`reply`** — there is no `reply_text` on the wire. The text+image variant, by
 /// contrast, keeps its full name **`reply_text_image`**. So `reply_text_image`

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -26,7 +26,16 @@ pub enum StreamErrorCode {
     Timeout,
 }
 
-/// Action type tag used in `meta` frames.
+/// Action type tag carried by the `meta` frame's `action_type` field.
+///
+/// Serializes snake_case: `reply` | `ghost` | `reply_image` | `reply_text_image`.
+///
+/// Asymmetry worth calling out: this is the *wire* action, coarser than the
+/// internal PDE [`ActionType`](eros_engine_core::types::ActionType). A plain-text
+/// turn (`ActionType::ReplyText`, audited as `reply_text`) is reported here as
+/// **`reply`** — there is no `reply_text` on the wire. The text+image variant, by
+/// contrast, keeps its full name **`reply_text_image`**. So `reply_text_image`
+/// appears but `reply_text` never does. See [`frame_action_for`] for the mapping.
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum FrameActionType {
@@ -54,6 +63,10 @@ pub enum ImageFailReason {
 pub enum ProtocolFrame {
     Meta {
         message_id: String,
+        /// Coarse wire action: `reply` | `ghost` | `reply_image` |
+        /// `reply_text_image`. A plain-text `reply_text` turn is reported as
+        /// `reply` (there is no `reply_text` on the wire); only the text+image
+        /// variant keeps its full `reply_text_image` name. See [`FrameActionType`].
         action_type: FrameActionType,
         #[serde(skip_serializing_if = "Option::is_none")]
         model: Option<String>,
@@ -145,8 +158,12 @@ pub fn ulid_string(u: Ulid) -> String {
     u.to_string()
 }
 
-/// Map an `ActionType` to the `FrameActionType` used in SSE Meta/Image frames.
-/// Consumed by the image execution arm (Task 10).
+/// Map the internal PDE `ActionType` to the coarser `FrameActionType` sent on the
+/// wire in SSE Meta/Image frames. Consumed by the image execution arm (Task 10).
+///
+/// Note the asymmetry: `ReplyText` collapses to `Reply` (wire `reply`), so a plain
+/// text turn is never reported as `reply_text`; only `ReplyTextImage` keeps its
+/// full name (`reply_text_image`). See [`FrameActionType`].
 fn frame_action_for(a: eros_engine_core::types::ActionType) -> FrameActionType {
     match a {
         eros_engine_core::types::ActionType::ReplyImage => FrameActionType::ReplyImage,

--- a/crates/eros-engine-server/src/routes/companion_stream.rs
+++ b/crates/eros-engine-server/src/routes/companion_stream.rs
@@ -381,7 +381,11 @@ fn validate_draw_request(req: &DrawImageRequest) -> Result<(), AppError> {
     params(("session_id" = Uuid, Path, description = "Chat session id")),
     request_body = StreamSendRequest,
     responses(
-        (status = 200, description = "SSE event stream (text/event-stream)", content_type = "text/event-stream"),
+        (status = 200, description = "SSE event stream (text/event-stream). The `meta` frame's \
+            `action_type` is one of `reply` | `ghost` | `reply_image` | `reply_text_image`. \
+            Note the asymmetry: a plain-text `reply_text` turn is reported as `reply` (there is no \
+            `reply_text` on the wire), while the text+image variant keeps its full \
+            `reply_text_image` name.", content_type = "text/event-stream"),
         (status = 400, body = StreamPreErrorBody),
         (status = 401, description = "missing or invalid bearer"),
         (status = 403, body = StreamPreErrorBody),


### PR DESCRIPTION
## What

Documents the asymmetry in the SSE `meta` frame's `action_type` field: the **wire** action is coarser than the internal PDE `ActionType`.

- A plain-text turn (`ActionType::ReplyText`, audited as `reply_text`) is reported on the wire as **`reply`** — there is no `reply_text` action_type on the stream.
- The text+image variant, by contrast, keeps its full name **`reply_text_image`**.

So `reply_text_image` appears on the wire but `reply_text` never does. This has been true since the first SSE streaming commit (v0.2.0, `a3f86ea`) — `FrameActionType::Reply` was never `reply_text` — but nothing spelled the asymmetry out, which is an easy trap when reading the wire.

## Where documented

| Location | What |
|---|---|
| `FrameActionType` enum doc | wire values + asymmetry vs internal `ActionType` |
| `ProtocolFrame::Meta.action_type` field doc | the four values + the `reply_text` → `reply` collapse |
| `frame_action_for` doc | explicit `ReplyText → Reply` collapse, `ReplyTextImage` keeps its name |
| streaming endpoint OpenAPI 200 response | same note, surfaced in `openapi.json` |

## Scope

Doc-comment + one OpenAPI description string only. No behavior change. `openapi.json` regenerated via `print-openapi` (single description line diff).

## Verification

- `cargo fmt` ✅
- `cargo run -p eros-engine-server -- print-openapi` → snapshot diff is the single intended line ✅
- `cargo clippy -p eros-engine-server --all-targets -- -D warnings` → exit 0 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)