### PR TITLE
docs: describe the voice stream's lean frame set in OpenAPI

### DIFF
--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -751,7 +751,7 @@
         },
         "responses": {
           "200": {
-            "description": "SSE event stream (text/event-stream)",
+            "description": "SSE event stream (text/event-stream). Lean frame set: `delta`* then a terminal `done` (or a single `error`). Unlike the chat message stream, the voice turn emits no `meta` frame and no `action_type`.",
             "content": {
               "text/event-stream": {}
             }

--- a/crates/eros-engine-server/src/routes/voice.rs
+++ b/crates/eros-engine-server/src/routes/voice.rs
@@ -86,7 +86,9 @@ fn validate(req: &VoiceTurnRequest) -> Result<(), AppError> {
     params(("session_id" = Uuid, Path, description = "Chat session id")),
     request_body = VoiceTurnRequest,
     responses(
-        (status = 200, description = "SSE event stream (text/event-stream)", content_type = "text/event-stream"),
+        (status = 200, description = "SSE event stream (text/event-stream). Lean frame set: \
+            `delta`* then a terminal `done` (or a single `error`). Unlike the chat message \
+            stream, the voice turn emits no `meta` frame and no `action_type`.", content_type = "text/event-stream"),
         (status = 400, body = crate::routes::companion_stream::StreamPreErrorBody),
         (status = 401, description = "missing or invalid bearer"),
         (status = 403, body = crate::routes::companion_stream::StreamPreErrorBody),


### PR DESCRIPTION
## What

Follow-up to #145. That PR documented the chat message stream's `meta` frame `action_type` asymmetry. A reviewer suggested applying the *same* note to the voice endpoint for parity — but on inspection **the premise doesn't hold**: the voice turn stream never emits a `meta` frame at all.

`run_voice_turn` (`pipeline/voice.rs`) yields only `Delta` / `Done` / `Error`, and the route handler (`routes/voice.rs`) pipes them straight to SSE with no injected `Meta`. So the voice wire protocol is `[delta*, done]` or `[error]` — **no `meta` frame, no `action_type`** (consistent with #144's "lean" framing). Copying the action_type note there would have documented a field that doesn't exist.

## Change

Instead, describe what the voice endpoint *actually* emits. The 200 response description now reads:

> SSE event stream (text/event-stream). Lean frame set: `delta`* then a terminal `done` (or a single `error`). Unlike the chat message stream, the voice turn emits no `meta` frame and no `action_type`.

This is the accurate form of "documentation parity" — each streaming endpoint's description now states its own frame shape.

## Scope

OpenAPI description string only. No behavior change. `openapi.json` regenerated via `print-openapi` (single-line diff on the `/comp/voice/{session_id}/turn/stream` 200 response).

## Verification

- `cargo fmt` ✅
- `print-openapi` snapshot diff is the single intended line ✅
- `cargo clippy -p eros-engine-server --all-targets -- -D warnings` → exit 0 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)