### PR TITLE
perf(pipeline): cut two leg-3 Postgres roundtrips per turn

### DIFF
--- a/crates/eros-engine-server/src/pipeline/mod.rs
+++ b/crates/eros-engine-server/src/pipeline/mod.rs
@@ -59,24 +59,18 @@ pub async fn compute_signals_for_session(
     session_id: Uuid,
     affinity: &Affinity,
 ) -> Result<ConversationSignals, AppError> {
-    let message_count: i64 = sqlx::query_scalar(
-        "SELECT COUNT(*) FROM engine.chat_messages \
-         WHERE session_id = $1 AND role IN ('user', 'gift_user')",
+    // One aggregate roundtrip instead of two separate scans of the same rows.
+    // Fail-open matches the previous per-query behavior: any error collapses to
+    // count 0 / last_time None (→ 0.0 hours). `COUNT(*)` is never NULL;
+    // `MAX(sent_at)` is NULL for an empty session.
+    let (message_count, last_time): (i64, Option<chrono::DateTime<chrono::Utc>>) = sqlx::query_as(
+        "SELECT COUNT(*), MAX(sent_at) FROM engine.chat_messages \
+             WHERE session_id = $1 AND role IN ('user', 'gift_user')",
     )
     .bind(session_id)
     .fetch_one(pool)
     .await
-    .unwrap_or(0);
-
-    let last_time: Option<chrono::DateTime<chrono::Utc>> = sqlx::query_scalar(
-        "SELECT MAX(sent_at) FROM engine.chat_messages \
-         WHERE session_id = $1 AND role IN ('user', 'gift_user')",
-    )
-    .bind(session_id)
-    .fetch_optional(pool)
-    .await
-    .ok()
-    .flatten();
+    .unwrap_or((0, None));
 
     let hours_since_last_message = last_time
         .map(|t| (chrono::Utc::now() - t).num_minutes() as f64 / 60.0)
@@ -203,5 +197,55 @@ mod tests {
             .unwrap();
 
         assert_eq!(signals.message_count, 2, "two user rows must yield count 2");
+    }
+
+    /// Characterization: `hours_since_last_message` derives from the MAX(sent_at)
+    /// of the user/gift_user rows. Pins the MAX half of the signal before COUNT
+    /// and MAX are merged into a single aggregate query (the COUNT half is
+    /// already covered by `signals_count_*`).
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn signals_hours_since_reflects_latest_user_row(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let (_genome_id, instance_id, session_id) = seed_session(&pool, user_id).await;
+
+        // Two user rows; MAX(sent_at) = the newer one (~1h ago).
+        sqlx::query(
+            "INSERT INTO engine.chat_messages (session_id, role, content, sent_at) VALUES \
+                 ($1, 'user', 'older', now() - interval '3 hours'), \
+                 ($1, 'user', 'newer', now() - interval '1 hour')",
+        )
+        .bind(session_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let aff = fixture_affinity(session_id, user_id, instance_id);
+        let signals = compute_signals_for_session(&pool, session_id, &aff)
+            .await
+            .unwrap();
+
+        assert_eq!(signals.message_count, 2);
+        assert!(
+            (signals.hours_since_last_message - 1.0).abs() < 0.1,
+            "hours_since_last_message must track MAX(sent_at) (~1.0), got {}",
+            signals.hours_since_last_message
+        );
+    }
+
+    /// Characterization: an empty session yields count 0 and 0.0 hours (the
+    /// `MAX(sent_at) IS NULL` / no-rows fail-open path). Pins the empty-session
+    /// behavior before the COUNT+MAX merge.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn signals_empty_session_zero_count_zero_hours(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let (_genome_id, instance_id, session_id) = seed_session(&pool, user_id).await;
+
+        let aff = fixture_affinity(session_id, user_id, instance_id);
+        let signals = compute_signals_for_session(&pool, session_id, &aff)
+            .await
+            .unwrap();
+
+        assert_eq!(signals.message_count, 0);
+        assert_eq!(signals.hours_since_last_message, 0.0);
     }
 }

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -2502,23 +2502,31 @@ pub struct PersistedUserMessage {
 pub fn run_stream(
     state: Arc<AppState>,
     user_msg: PersistedUserMessage,
+    prefetched_persona: Option<eros_engine_core::persona::CompanionPersona>,
 ) -> impl futures_util::Stream<Item = ProtocolFrame> + Send + 'static {
     async_stream::stream! {
         let chat_repo = ChatRepo { pool: &state.pool };
         let persona_repo = PersonaRepo { pool: &state.pool };
         let affinity_repo = AffinityRepo { pool: &state.pool };
 
-        let persona = match persona_repo.load_companion(user_msg.instance_id).await {
-            Ok(Some(p)) => p,
-            _ => {
-                yield ProtocolFrame::Error {
-                    code: StreamErrorCode::Internal,
-                    retryable: false,
-                    message: "persona instance not found".into(),
-                    user_message: "服务出现问题，请稍后再试".into(),
-                };
-                return;
-            }
+        // Reuse the persona the entry handler already loaded for its
+        // existence/active check, so a turn hits `load_companion` once, not
+        // twice. Fall back to a DB load only when no prefetch was threaded
+        // through — the direct-`run_stream` test paths pass `None`.
+        let persona = match prefetched_persona {
+            Some(p) => p,
+            None => match persona_repo.load_companion(user_msg.instance_id).await {
+                Ok(Some(p)) => p,
+                _ => {
+                    yield ProtocolFrame::Error {
+                        code: StreamErrorCode::Internal,
+                        retryable: false,
+                        message: "persona instance not found".into(),
+                        user_message: "服务出现问题，请稍后再试".into(),
+                    };
+                    return;
+                }
+            },
         };
         let mut affinity = match affinity_repo
             .load_or_create(user_msg.session_id, user_msg.user_id, user_msg.instance_id)
@@ -3985,6 +3993,7 @@ mod tests {
                 image: None,
                 history_anchor: Default::default(),
             },
+            None,
         )
         .collect()
         .await;
@@ -4195,6 +4204,7 @@ data: [DONE]\n\n";
                 image: None,
                 history_anchor: Default::default(),
             },
+            None,
         )
         .collect()
         .await;
@@ -4293,6 +4303,7 @@ data: [DONE]\n\n";
                 image: None,
                 history_anchor: Default::default(),
             },
+            None,
         )
         .collect()
         .await;
@@ -4430,6 +4441,7 @@ data: [DONE]\n\n";
                 image: None,
                 history_anchor: Default::default(),
             },
+            None,
         )
         .collect()
         .await;
@@ -4576,6 +4588,7 @@ data: [DONE]\n\n";
                 image: None,
                 history_anchor: Default::default(),
             },
+            None,
         )
         .collect()
         .await;
@@ -4687,6 +4700,7 @@ data: [DONE]\n\n";
                 image: None,
                 history_anchor: Default::default(),
             },
+            None,
         )
         .collect()
         .await;
@@ -4789,6 +4803,7 @@ data: [DONE]\n\n";
                 image: None,
                 history_anchor: Default::default(),
             },
+            None,
         )
         .collect()
         .await;
@@ -4902,6 +4917,7 @@ data: [DONE]\n\n";
                 }),
                 history_anchor: Default::default(),
             },
+            None,
         )
         .collect()
         .await;
@@ -5082,6 +5098,7 @@ data: [DONE]\n\n";
                 }),
                 history_anchor: Default::default(),
             },
+            None,
         )
         .collect()
         .await;
@@ -5241,6 +5258,7 @@ data: [DONE]\n\n";
                 image: None,
                 history_anchor: Default::default(),
             },
+            None,
         )
         .collect()
         .await;
@@ -5558,6 +5576,7 @@ data: [DONE]\n\n";
                 image: None,
                 history_anchor: Default::default(),
             },
+            None,
         )
         .collect()
         .await;
@@ -5683,6 +5702,7 @@ data: [DONE]\n\n";
                 image: None,
                 history_anchor: Default::default(),
             },
+            None,
         )
         .collect()
         .await;
@@ -5821,6 +5841,7 @@ data: [DONE]\n\n";
                 image: None,
                 history_anchor: Default::default(),
             },
+            None,
         )
         .collect()
         .await;
@@ -5974,6 +5995,7 @@ data: [DONE]\n\n";
                 image: None,
                 history_anchor: Default::default(),
             },
+            None,
         )
         .collect()
         .await;
@@ -6089,6 +6111,7 @@ data: [DONE]\n\n";
                 image: None,
                 history_anchor: Default::default(),
             },
+            None,
         )
         .collect()
         .await;
@@ -6185,6 +6208,7 @@ data: [DONE]\n\n";
                 image: None,
                 history_anchor: Default::default(),
             },
+            None,
         )
         .collect()
         .await;
@@ -6293,6 +6317,7 @@ data: [DONE]\n\n";
                 image: None,
                 history_anchor: Default::default(),
             },
+            None,
         )
         .collect()
         .await;
@@ -6403,6 +6428,7 @@ data: [DONE]\n\n";
                 image: None,
                 history_anchor: Default::default(),
             },
+            None,
         )
         .collect()
         .await;
@@ -6532,6 +6558,7 @@ data: [DONE]\n\n";
                 image: None,
                 history_anchor: Default::default(),
             },
+            None,
         )
         .collect()
         .await;
@@ -6734,6 +6761,7 @@ data: [DONE]\n\n";
                 image: None,
                 history_anchor: Default::default(),
             },
+            None,
         )
         .collect()
         .await;
@@ -6879,6 +6907,7 @@ data: [DONE]\n\n";
                 image: None,
                 history_anchor: Default::default(),
             },
+            None,
         )
         .collect()
         .await;
@@ -6990,6 +7019,7 @@ data: [DONE]\n\n";
                 image: None,
                 history_anchor: Default::default(),
             },
+            None,
         )
         .collect()
         .await;
@@ -7166,6 +7196,7 @@ data: [DONE]\n\n";
                 image: None,
                 history_anchor: Default::default(),
             },
+            None,
         )
         .collect()
         .await;
@@ -7326,6 +7357,7 @@ data: [DONE]\n\n";
                 image: None,
                 history_anchor: Default::default(),
             },
+            None,
         )
         .collect()
         .await;
@@ -7469,6 +7501,7 @@ data: [DONE]\n\n";
                 image: None,
                 history_anchor: Default::default(),
             },
+            None,
         )
         .collect()
         .await;
@@ -7592,6 +7625,7 @@ data: [DONE]\n\n";
                 image: None,
                 history_anchor: Default::default(),
             },
+            None,
         )
         .collect()
         .await;
@@ -7729,6 +7763,7 @@ data: [DONE]\n\n";
                 image: None,
                 history_anchor: Default::default(),
             },
+            None,
         )
         .collect()
         .await;
@@ -7880,6 +7915,7 @@ data: [DONE]\n\n";
                 image: None,
                 history_anchor: Default::default(),
             },
+            None,
         )
         .collect()
         .await;
@@ -8767,6 +8803,7 @@ data: [DONE]\n\n";
                 image: None,
                 history_anchor: Default::default(),
             },
+            None,
         )
         .collect()
         .await;

--- a/crates/eros-engine-server/src/routes/companion_stream.rs
+++ b/crates/eros-engine-server/src/routes/companion_stream.rs
@@ -454,8 +454,10 @@ pub async fn send_message_stream(
     })?;
     // Verify the instance still exists and is active (404 otherwise) before
     // opening the stream. (Previously this load also fed the NFT-ownership gate.)
+    // The loaded persona is threaded into `run_stream` below so the turn does
+    // not re-issue the same `load_companion` query inside the generator.
     let persona_repo = PersonaRepo { pool: &state.pool };
-    persona_repo
+    let persona = persona_repo
         .load_companion(instance_id)
         .await?
         .ok_or_else(|| AppError::NotFound("instance not found".into()))?;
@@ -589,7 +591,7 @@ pub async fn send_message_stream(
                     image: req.image.clone(),
                     history_anchor,
                 };
-                Box::pin(run_stream(state_arc, user_msg))
+                Box::pin(run_stream(state_arc, user_msg, Some(persona)))
             }
             UpsertUserOutcome::DuplicateInProgress { user_message_id } => {
                 return Err(AppError::StreamPre(StreamPreError {


### PR DESCRIPTION
## What

Trims two redundant engine→Supabase roundtrips on the chat-stream critical path (both **before first token**), following the RTT-ledger dev-log's leg 3. Scope was deliberately kept to these two — the larger merges (recall UNION, history-window hoist, write-txn folds) were left out.

### 1. Remove the redundant `load_companion`
The entry handler (`companion_stream.rs`) loads the companion for its existence/active check, then `run_stream` loaded the **identical** row again. Now the entry threads its loaded persona into `run_stream` via a new `prefetched_persona` arg, so a turn hits `load_companion` **once**.

- Behavior-preserving: the entry keeps its pre-stream 404 + no-stray-write check.
- `run_stream` falls back to a DB load when `prefetched_persona` is `None` — the 29 direct-`run_stream` tests pass `None` and keep loading from the seeded DB.

### 2. Merge signals `COUNT` + `MAX`
`compute_signals_for_session` scanned the same `chat_messages` rows twice (one `COUNT(*)`, one `MAX(sent_at)`). Collapsed into one aggregate query. Fail-open semantics preserved exactly (`unwrap_or((0, None))` → count 0 / 0.0 hours). Pinned by two new characterization tests (MAX-derived hours; empty session) that were green against the old code before the merge.

## Verification
- `cargo fmt` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- tests: server **384 passed / 0 failed**, store **109 passed / 0 failed**
- openapi regen + diff — **no drift** (HTTP surface untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)