### PR TITLE
docs(readme): bump dev docker-pull examples to 0.7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ eros-engine-llm   = "0.6"   # only if you want the OpenRouter + Voyage clients
 `linux/amd64` images for `eros-engine-server` are published to GitHub Container Registry for every `v*` tag (need arm64? Build it yourself from `docker/Dockerfile`):
 
 ```bash
-docker pull ghcr.io/etherfunlab/eros-engine:0.7.2
+docker pull ghcr.io/etherfunlab/eros-engine:0.7.3
 # or track the latest tagged release
 docker pull ghcr.io/etherfunlab/eros-engine:latest
 ```
@@ -87,7 +87,7 @@ Minimal run (you bring Postgres + your own `.env`):
 
 ```bash
 docker run --rm -p 8080:8080 --env-file .env \
-  ghcr.io/etherfunlab/eros-engine:0.7.2 serve
+  ghcr.io/etherfunlab/eros-engine:0.7.3 serve
 ```
 
 The `docker/Dockerfile` is the same artifact used to build this image. Deploy it on any container host. See [Deploying](docs/deploying.md).


### PR DESCRIPTION
The dev/main `-s ours` sync reconnected ancestry without carrying main's content, so dev's README still showed `ghcr.io/etherfunlab/eros-engine:0.7.2`. Bump the two docker-pull examples to the just-released `0.7.3` (matches main; `:latest` line unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)