### PR TITLE
docs(readme): bump library-usage version refs to 0.7

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -66,9 +66,9 @@ cargo add eros-engine-core eros-engine-store eros-engine-llm
 
 ```toml
 [dependencies]
-eros-engine-core  = "0.6"
-eros-engine-store = "0.6"   # only if you want the Postgres + pgvector layer
-eros-engine-llm   = "0.6"   # only if you want the OpenRouter + Voyage clients
+eros-engine-core  = "0.7"
+eros-engine-store = "0.7"   # only if you want the Postgres + pgvector layer
+eros-engine-llm   = "0.7"   # only if you want the OpenRouter + Voyage clients
 ```
 
 `eros-engine-server` は意図的に crates.io では公開していません。Docker イメージとして実行してください（下記参照）。

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ cargo add eros-engine-core eros-engine-store eros-engine-llm
 
 ```toml
 [dependencies]
-eros-engine-core  = "0.6"
-eros-engine-store = "0.6"   # only if you want the Postgres + pgvector layer
-eros-engine-llm   = "0.6"   # only if you want the OpenRouter + Voyage clients
+eros-engine-core  = "0.7"
+eros-engine-store = "0.7"   # only if you want the Postgres + pgvector layer
+eros-engine-llm   = "0.7"   # only if you want the OpenRouter + Voyage clients
 ```
 
 `eros-engine-server` is intentionally not published to crates.io — run it as a Docker image (below).

--- a/README.zh.md
+++ b/README.zh.md
@@ -66,9 +66,9 @@ cargo add eros-engine-core eros-engine-store eros-engine-llm
 
 ```toml
 [dependencies]
-eros-engine-core  = "0.6"
-eros-engine-store = "0.6"   # only if you want the Postgres + pgvector layer
-eros-engine-llm   = "0.6"   # only if you want the OpenRouter + Voyage clients
+eros-engine-core  = "0.7"
+eros-engine-store = "0.7"   # only if you want the Postgres + pgvector layer
+eros-engine-llm   = "0.7"   # only if you want the OpenRouter + Voyage clients
 ```
 
 `eros-engine-server` 有意不发布到 crates.io——请使用 Docker 镜像运行（见下文）。


### PR DESCRIPTION
The `Use as a library` snippet in all three READMEs still pinned `eros-engine-{core,store,llm} = "0.6"`, missed when the crates moved to the `0.7.x` line (now `0.7.3` on crates.io). A reader running the snippet's `cargo add` / copy-paste would resolve `0.6.x` instead of the current release.

Bump the minor-only range refs `0.6` → `0.7` in README.md / README.zh.md / README.ja.md. Kept as minor-only ranges (not `0.7.3`) — these intentionally track the minor, not the patch. The docker-pull tags and crate badges are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)