### PR TITLE
feat: channel-scoped chat sessions (text/voice)

### DIFF
--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -1583,9 +1583,14 @@
           "session_id",
           "lead_score",
           "is_converted",
-          "last_active_at"
+          "last_active_at",
+          "channel"
         ],
         "properties": {
+          "channel": {
+            "type": "string",
+            "description": "Conversation channel ('text' or 'voice'); start/resume is channel-scoped."
+          },
           "instance_id": {
             "type": [
               "string",

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -1221,6 +1221,13 @@
       "BffStartRequest": {
         "type": "object",
         "properties": {
+          "channel": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Conversation channel ('text' default, or 'voice'). Passed through to\nthe canonical start; see `StartChatRequest::channel`."
+          },
           "genome_id": {
             "type": [
               "string",
@@ -1606,6 +1613,13 @@
       "StartChatRequest": {
         "type": "object",
         "properties": {
+          "channel": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Conversation channel for the session: `\"text\"` (default) or `\"voice\"`.\nStart/resume is channel-scoped — a voice-channel start never resumes a\ntext session and vice versa, so the two conversations stay isolated."
+          },
           "genome_id": {
             "type": [
               "string",

--- a/crates/eros-engine-server/src/routes/bff/companion.rs
+++ b/crates/eros-engine-server/src/routes/bff/companion.rs
@@ -65,6 +65,10 @@ pub struct BffStartRequest {
     /// BFF-only field; not present in the canonical /comp/chat/start body.
     #[serde(default)]
     pub history_limit: Option<i64>,
+    /// Conversation channel ('text' default, or 'voice'). Passed through to
+    /// the canonical start; see `StartChatRequest::channel`.
+    #[serde(default)]
+    pub channel: Option<String>,
 }
 
 impl From<&BffStartRequest> for StartChatRequest {
@@ -73,6 +77,7 @@ impl From<&BffStartRequest> for StartChatRequest {
             instance_id: b.instance_id,
             genome_id: b.genome_id,
             is_demo: b.is_demo,
+            channel: b.channel.clone(),
         }
     }
 }
@@ -694,5 +699,74 @@ mod tests {
         assert_eq!(status, StatusCode::OK);
         assert_eq!(bff["session_id"].as_str().unwrap(), canonical_session_id);
         assert!(!bff["is_new"].as_bool().unwrap()); // canonical already created it
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn bff_start_voice_channel_is_isolated_from_text(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let state = test_state(pool.clone());
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        // 1. Text start creates the text session.
+        let (status, text1) = send_request(
+            &mut app,
+            bff_start_request(&token, json!({ "genome_id": genome_id })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "body={text1}");
+        assert!(text1["is_new"].as_bool().unwrap());
+
+        // 2. Voice start must NOT resume it — it creates a separate session.
+        let (status, voice1) = send_request(
+            &mut app,
+            bff_start_request(
+                &token,
+                json!({ "genome_id": genome_id, "channel": "voice" }),
+            ),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "body={voice1}");
+        assert!(voice1["is_new"].as_bool().unwrap());
+        assert_ne!(voice1["session_id"], text1["session_id"]);
+
+        // 3. A second voice start resumes the SAME voice session.
+        let (_status, voice2) = send_request(
+            &mut app,
+            bff_start_request(
+                &token,
+                json!({ "genome_id": genome_id, "channel": "voice" }),
+            ),
+        )
+        .await;
+        assert!(!voice2["is_new"].as_bool().unwrap());
+        assert_eq!(voice2["session_id"], voice1["session_id"]);
+
+        // 4. Text start still resumes the TEXT session, even though the voice
+        //    session is more recent.
+        let (_status, text2) = send_request(
+            &mut app,
+            bff_start_request(&token, json!({ "genome_id": genome_id })),
+        )
+        .await;
+        assert!(!text2["is_new"].as_bool().unwrap());
+        assert_eq!(text2["session_id"], text1["session_id"]);
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn bff_start_rejects_invalid_channel(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let state = test_state(pool.clone());
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        let (status, _body) = send_request(
+            &mut app,
+            bff_start_request(&token, json!({ "genome_id": genome_id, "channel": "sms" })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
     }
 }

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -122,6 +122,8 @@ pub struct SessionListEntry {
     pub lead_score: f64,
     pub is_converted: bool,
     pub last_active_at: DateTime<Utc>,
+    /// Conversation channel ('text' or 'voice'); start/resume is channel-scoped.
+    pub channel: String,
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
@@ -612,6 +614,7 @@ async fn list_sessions(
             lead_score: s.lead_score,
             is_converted: s.is_converted,
             last_active_at: s.last_active_at,
+            channel: s.channel,
         })
         .collect();
     Ok(Json(ListSessionsResponse {
@@ -917,6 +920,52 @@ mod tests {
             .unwrap();
         let (status, _body) = send_request(&mut app, req).await;
         assert_eq!(status, StatusCode::FORBIDDEN);
+    }
+
+    // ─── Test 4b: GET /sessions exposes channel for text vs voice ───
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn get_sessions_exposes_channel_text_and_voice(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Nyx").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+
+        // seed_session creates a plain (text-channel-default) session.
+        let text_session = seed_session(&pool, user_id, instance_id).await;
+        let voice_session: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_sessions (user_id, instance_id, channel) \
+             VALUES ($1, $2, 'voice') RETURNING id",
+        )
+        .bind(user_id)
+        .bind(instance_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        let state = test_state(pool.clone());
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        let req = Request::builder()
+            .uri(format!("/comp/chat/{user_id}/sessions"))
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .body(Body::empty())
+            .unwrap();
+        let (status, body) = send_request(&mut app, req).await;
+        assert_eq!(status, StatusCode::OK, "got body: {body}");
+
+        let sessions = body["sessions"].as_array().expect("sessions array");
+        assert_eq!(sessions.len(), 2);
+
+        let channel_of = |id: Uuid| -> Option<String> {
+            sessions
+                .iter()
+                .find(|s| s["session_id"].as_str() == Some(id.to_string().as_str()))
+                .and_then(|s| s["channel"].as_str())
+                .map(str::to_string)
+        };
+        assert_eq!(channel_of(text_session), Some("text".to_string()));
+        assert_eq!(channel_of(voice_session), Some("voice".to_string()));
     }
 
     // ─── Bonus: debug affinity endpoint round-trips when enabled ────

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -78,6 +78,11 @@ pub struct StartChatRequest {
     /// Ignored when resuming an existing session.
     #[serde(default)]
     pub is_demo: Option<bool>,
+    /// Conversation channel for the session: `"text"` (default) or `"voice"`.
+    /// Start/resume is channel-scoped — a voice-channel start never resumes a
+    /// text session and vice versa, so the two conversations stay isolated.
+    #[serde(default)]
+    pub channel: Option<String>,
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
@@ -411,6 +416,12 @@ pub(crate) async fn resolve_or_create_session(
     let persona_repo = PersonaRepo { pool: &state.pool };
     let chat_repo = ChatRepo { pool: &state.pool };
 
+    let channel = match req.channel.as_deref() {
+        None | Some("text") => "text",
+        Some("voice") => "voice",
+        Some(other) => return Err(AppError::BadRequest(format!("invalid channel: {other}"))),
+    };
+
     let (instance_id, persona_name) = match req.instance_id {
         Some(iid) => {
             // Explicit instance: one JOIN read gives owner + genome name
@@ -456,7 +467,7 @@ pub(crate) async fn resolve_or_create_session(
     // Resume the latest session (bumping last_active_at in one statement), or
     // create a fresh one. Only `id` is consumed downstream.
     let (session_id, is_new) = match chat_repo
-        .resume_latest_session(user_id, instance_id)
+        .resume_latest_session(user_id, instance_id, channel)
         .await?
     {
         Some(s) => (s.id, false),
@@ -467,7 +478,7 @@ pub(crate) async fn resolve_or_create_session(
                 serde_json::json!({})
             };
             let s = chat_repo
-                .create_session_with_metadata(user_id, instance_id, metadata)
+                .create_session_with_metadata(user_id, instance_id, metadata, channel)
                 .await?;
             (s.id, true)
         }
@@ -1333,6 +1344,7 @@ mod tests {
             instance_id: None,
             genome_id: Some(genome_id),
             is_demo: None,
+            channel: None,
         };
         let resolved = resolve_or_create_session(&state, user_id, &req)
             .await
@@ -1368,6 +1380,7 @@ mod tests {
             instance_id: None,
             genome_id: Some(genome_id),
             is_demo: None,
+            channel: None,
         };
         let resolved = resolve_or_create_session(&state, user_id, &req)
             .await
@@ -1398,6 +1411,7 @@ mod tests {
             instance_id: Some(instance_id),
             genome_id: None,
             is_demo: None,
+            channel: None,
         };
         let err = resolve_or_create_session(&state, intruder, &req)
             .await
@@ -1426,6 +1440,7 @@ mod tests {
             instance_id: Some(instance_id),
             genome_id: None,
             is_demo: None,
+            channel: None,
         };
         let err = resolve_or_create_session(&state, user_id, &req)
             .await

--- a/crates/eros-engine-server/src/routes/voice.rs
+++ b/crates/eros-engine-server/src/routes/voice.rs
@@ -125,6 +125,19 @@ pub async fn voice_turn_stream(
             "无权访问该会话",
         ));
     }
+    // Channel-scoped enforcement: the voice endpoint writes `channel = 'voice'`
+    // messages, so it must only operate on a voice-channel session. Reject a
+    // text (or otherwise non-voice) session here — before persisting any turn —
+    // so voice messages never leak into a text conversation's history. Voice
+    // clients obtain a voice session via `chat/start` with `channel: "voice"`.
+    if session.channel != "voice" {
+        return Err(pre(
+            StatusCode::CONFLICT,
+            "wrong_channel",
+            "session is not a voice-channel session",
+            "该会话不是语音会话",
+        ));
+    }
     let instance_id = session.instance_id.ok_or_else(|| {
         pre(
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -243,7 +256,14 @@ mod tests {
         axum.with_state(state)
     }
 
+    /// Seed a voice-channel session (the voice endpoint's valid input).
     async fn seed(pool: &PgPool, user_id: Uuid) -> Uuid {
+        seed_channel(pool, user_id, "voice").await
+    }
+
+    /// Seed a session on an explicit `channel` for the voice endpoint's
+    /// channel-scoping tests.
+    async fn seed_channel(pool: &PgPool, user_id: Uuid, channel: &str) -> Uuid {
         let genome_id: Uuid = sqlx::query_scalar(
             "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata) \
              VALUES ('V','p','{}'::jsonb) RETURNING id",
@@ -255,10 +275,11 @@ mod tests {
             "INSERT INTO engine.persona_instances (genome_id, owner_uid) VALUES ($1,$2) RETURNING id",
         ).bind(genome_id).bind(user_id).fetch_one(pool).await.unwrap();
         sqlx::query_scalar(
-            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1,$2) RETURNING id",
+            "INSERT INTO engine.chat_sessions (user_id, instance_id, channel) VALUES ($1,$2,$3) RETURNING id",
         )
         .bind(user_id)
         .bind(instance_id)
+        .bind(channel)
         .fetch_one(pool)
         .await
         .unwrap()
@@ -369,6 +390,37 @@ mod tests {
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn voice_409_when_session_not_voice_channel(pool: PgPool) {
+        // The voice endpoint must only operate on voice-channel sessions.
+        // `seed` creates a default (text-channel) session; posting a voice turn
+        // to it must be rejected pre-stream (409) WITHOUT persisting a user row,
+        // so voice turns never leak into a text conversation.
+        let user_id = Uuid::new_v4();
+        let session_id = seed_channel(&pool, user_id, "text").await;
+        let mut app = build_router(with_voice(crate::routes::companion::test_state(
+            pool.clone(),
+        )));
+        let jwt = mint_jwt(user_id);
+        let resp = post_voice(
+            &mut app,
+            session_id,
+            &jwt,
+            json!({"content":"hi","client_msg_id":"01J2222222222222222222222A"}),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+
+        // No user row persisted — the rejection happened before the insert.
+        let count: i64 =
+            sqlx::query_scalar("SELECT count(*) FROM engine.chat_messages WHERE session_id = $1")
+                .bind(session_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(count, 0, "wrong-channel rejection must not persist a turn");
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
     async fn voice_404_when_persona_instance_missing(pool: PgPool) {
         // A session whose persona instance is missing/inactive must be rejected
         // pre-stream (404) WITHOUT persisting a user row. chat_sessions.instance_id
@@ -377,7 +429,8 @@ mod tests {
         let user_id = Uuid::new_v4();
         let missing_instance = Uuid::new_v4(); // no matching persona_instances row
         let session_id: Uuid = sqlx::query_scalar(
-            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
+            "INSERT INTO engine.chat_sessions (user_id, instance_id, channel) \
+             VALUES ($1, $2, 'voice') RETURNING id",
         )
         .bind(user_id)
         .bind(missing_instance)

--- a/crates/eros-engine-store/migrations/0031_chat_sessions_channel.sql
+++ b/crates/eros-engine-store/migrations/0031_chat_sessions_channel.sql
@@ -1,0 +1,20 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+--
+-- engine.chat_sessions gains a `channel` column separating voice-call sessions
+-- from default text-chat sessions. Extends 0030's chat_messages.channel to the
+-- session level: start/resume becomes channel-scoped, so a voice client and a
+-- text client hold independent conversations for the same user × instance.
+--
+-- Unlike the message column (NULL = text), this is NOT NULL DEFAULT 'text':
+-- every pre-existing session IS a text session, and a required value keeps the
+-- resume filter a plain equality. CHECK mirrors 0030 and is trivially extended
+-- when new channels appear.
+
+ALTER TABLE engine.chat_sessions
+    ADD COLUMN channel TEXT NOT NULL DEFAULT 'text'
+        CHECK (channel IN ('text', 'voice'));
+
+-- Covers the channel-scoped resume lookup (latest session per user × instance
+-- × channel, ordered by recency).
+CREATE INDEX idx_chat_sessions_user_instance_channel
+    ON engine.chat_sessions (user_id, instance_id, channel, last_active_at DESC);

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -15,6 +15,8 @@ pub struct ChatSession {
     pub is_converted: bool,
     pub last_active_at: DateTime<Utc>,
     pub metadata: serde_json::Value,
+    /// Conversation channel ('text' or 'voice'); start/resume is channel-scoped.
+    pub channel: String,
     /// Set by the dreaming-lite sweeper after a classification pass.
     /// `None` means the session is still eligible for the next sweep tick.
     pub classified_at: Option<DateTime<Utc>>,
@@ -138,6 +140,10 @@ impl<'a> ChatRepo<'a> {
     }
 
     /// Resume the most recent session for a user×instance pair, or create a new one.
+    ///
+    /// WARNING: channel-unaware — resumes the latest session on ANY channel.
+    /// Test-only convenience; production paths use `resume_latest_session`
+    /// with an explicit channel.
     pub async fn create_or_resume(
         &self,
         user_id: Uuid,
@@ -1023,12 +1029,24 @@ mod tests {
         let i3 = Uuid::new_v4();
 
         repo.create_session(user_id, i1).await.unwrap();
-        repo.create_session(user_id, i2).await.unwrap();
+        repo.create_session_with_metadata(user_id, i2, serde_json::json!({}), "voice")
+            .await
+            .unwrap();
         repo.create_session(other_user, i3).await.unwrap();
 
         let sessions = repo.list_sessions(user_id).await.unwrap();
         assert_eq!(sessions.len(), 2);
         assert!(sessions.iter().all(|s| s.user_id == user_id));
+        // channel is exposed on the projection and distinguishes the two
+        // sessions (the text default vs. the explicit voice session above).
+        let channels: std::collections::HashSet<&str> =
+            sessions.iter().map(|s| s.channel.as_str()).collect();
+        assert_eq!(
+            channels,
+            ["text", "voice"]
+                .into_iter()
+                .collect::<std::collections::HashSet<_>>()
+        );
     }
 
     #[sqlx::test(migrations = "./migrations")]

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -94,33 +94,37 @@ pub struct ChatRepo<'a> {
 }
 
 impl<'a> ChatRepo<'a> {
-    /// Create a new chat session for `user_id` × `instance_id`.
+    /// Create a new (text-channel) chat session for `user_id` × `instance_id`.
     pub async fn create_session(
         &self,
         user_id: Uuid,
         instance_id: Uuid,
     ) -> Result<ChatSession, sqlx::Error> {
-        self.create_session_with_metadata(user_id, instance_id, serde_json::json!({}))
+        self.create_session_with_metadata(user_id, instance_id, serde_json::json!({}), "text")
             .await
     }
 
     /// Create a session and seed `metadata` as the JSONB column. Used by
     /// callers that need session-scoped flags (e.g. `is_demo`) the
-    /// pipeline reads later.
+    /// pipeline reads later. `channel` scopes the session ('text'/'voice');
+    /// resume is channel-scoped so the two never cross (see
+    /// `resume_latest_session`).
     pub async fn create_session_with_metadata(
         &self,
         user_id: Uuid,
         instance_id: Uuid,
         metadata: serde_json::Value,
+        channel: &str,
     ) -> Result<ChatSession, sqlx::Error> {
         sqlx::query_as::<_, ChatSession>(
-            "INSERT INTO engine.chat_sessions (user_id, instance_id, metadata) \
-             VALUES ($1, $2, $3) \
+            "INSERT INTO engine.chat_sessions (user_id, instance_id, metadata, channel) \
+             VALUES ($1, $2, $3, $4) \
              RETURNING *",
         )
         .bind(user_id)
         .bind(instance_id)
         .bind(metadata)
+        .bind(channel)
         .fetch_one(self.pool)
         .await
     }
@@ -163,16 +167,18 @@ impl<'a> ChatRepo<'a> {
     /// exists (caller then creates). Folds the former SELECT-latest +
     /// separate UPDATE into one round-trip. Callers consume only `id`
     /// (immutable), so returning the post-bump row is immaterial.
+    /// Channel-scoped: only sessions on `channel` are candidates.
     pub async fn resume_latest_session(
         &self,
         user_id: Uuid,
         instance_id: Uuid,
+        channel: &str,
     ) -> Result<Option<ChatSession>, sqlx::Error> {
         sqlx::query_as::<_, ChatSession>(
             "UPDATE engine.chat_sessions SET last_active_at = now() \
              WHERE id = ( \
                  SELECT id FROM engine.chat_sessions \
-                 WHERE user_id = $1 AND instance_id = $2 \
+                 WHERE user_id = $1 AND instance_id = $2 AND channel = $3 \
                  ORDER BY last_active_at DESC \
                  LIMIT 1 \
              ) \
@@ -180,6 +186,7 @@ impl<'a> ChatRepo<'a> {
         )
         .bind(user_id)
         .bind(instance_id)
+        .bind(channel)
         .fetch_optional(self.pool)
         .await
     }
@@ -1221,7 +1228,7 @@ mod tests {
 
         // no session yet → None
         assert!(repo
-            .resume_latest_session(user_id, instance_id)
+            .resume_latest_session(user_id, instance_id, "text")
             .await
             .unwrap()
             .is_none());
@@ -1254,7 +1261,7 @@ mod tests {
                 .unwrap();
 
         let resumed = repo
-            .resume_latest_session(user_id, instance_id)
+            .resume_latest_session(user_id, instance_id, "text")
             .await
             .unwrap()
             .expect("resume the most-recent session");
@@ -2874,5 +2881,41 @@ mod tests {
             matches!(out, VoiceUserInsert::Duplicate(_)),
             "voice insert colliding with a gift_user row must be Duplicate, got {out:?}"
         );
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn sessions_are_channel_scoped(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let (user_id, instance_id) = (Uuid::new_v4(), Uuid::new_v4());
+
+        let text = repo.create_session(user_id, instance_id).await.unwrap();
+
+        // No voice session yet → nothing to resume on the voice channel.
+        assert!(repo
+            .resume_latest_session(user_id, instance_id, "voice")
+            .await
+            .unwrap()
+            .is_none());
+
+        let voice = repo
+            .create_session_with_metadata(user_id, instance_id, serde_json::json!({}), "voice")
+            .await
+            .unwrap();
+
+        // Each channel resumes ITS OWN latest session, even though the other
+        // channel's session is more recent.
+        let resumed_text = repo
+            .resume_latest_session(user_id, instance_id, "text")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(resumed_text.id, text.id);
+
+        let resumed_voice = repo
+            .resume_latest_session(user_id, instance_id, "voice")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(resumed_voice.id, voice.id);
     }
 }


### PR DESCRIPTION
## Summary
- `engine.chat_sessions` gains a `channel` column ('text' default / 'voice', migration 0031)
- `chat/start` (canonical + BFF) accepts an optional `channel` field; resume-or-create is now channel-scoped, so a voice client's session never collides with the text conversation for the same user × instance
- `GET /comp/chat/{user_id}/sessions` entries now expose `channel` so consumers can distinguish/filter voice sessions
- Extends 0030's `chat_messages.channel` to the session level

## Why
A voice client needs its own conversation context per companion. Today `chat/start` resumes the single latest session, so voice turns and text turns pollute each other's context.

## Compatibility
`channel` is optional and defaults to 'text' — existing clients are unaffected. Existing sessions backfill as 'text' via the column default. `SessionListEntry.channel` is additive. Note: the binary now requires migration 0031 (standard migrations-first deploy).

## Testing
- Store: `sessions_are_channel_scoped`, `list_sessions_for_user` (extended)
- Routes: `bff_start_voice_channel_is_isolated_from_text` (4-step isolation contract), `bff_start_rejects_invalid_channel` (400), `get_sessions_exposes_channel_text_and_voice`
- `cargo test --workspace` green; fmt + clippy -D warnings clean; openapi snapshot regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)