### PR TITLE
chore(release): v0.7.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,7 +511,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "eros-engine-core"
-version = "0.7.3-dev"
+version = "0.7.4-dev"
 dependencies = [
  "chrono",
  "serde",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-llm"
-version = "0.7.3-dev"
+version = "0.7.4-dev"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-server"
-version = "0.7.3-dev"
+version = "0.7.4-dev"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -582,7 +582,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-store"
-version = "0.7.3-dev"
+version = "0.7.4-dev"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,7 +511,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "eros-engine-core"
-version = "0.7.4-dev"
+version = "0.7.4"
 dependencies = [
  "chrono",
  "serde",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-llm"
-version = "0.7.4-dev"
+version = "0.7.4"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-server"
-version = "0.7.4-dev"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -582,7 +582,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-store"
-version = "0.7.4-dev"
+version = "0.7.4"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.7.3-dev"
+version = "0.7.4-dev"
 edition = "2021"
 license = "AGPL-3.0-only"
 repository = "https://github.com/etherfunlab/eros-engine"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.7.4-dev"
+version = "0.7.4"
 edition = "2021"
 license = "AGPL-3.0-only"
 repository = "https://github.com/etherfunlab/eros-engine"

--- a/README.ja.md
+++ b/README.ja.md
@@ -66,9 +66,9 @@ cargo add eros-engine-core eros-engine-store eros-engine-llm
 
 ```toml
 [dependencies]
-eros-engine-core  = "0.6"
-eros-engine-store = "0.6"   # only if you want the Postgres + pgvector layer
-eros-engine-llm   = "0.6"   # only if you want the OpenRouter + Voyage clients
+eros-engine-core  = "0.7"
+eros-engine-store = "0.7"   # only if you want the Postgres + pgvector layer
+eros-engine-llm   = "0.7"   # only if you want the OpenRouter + Voyage clients
 ```
 
 `eros-engine-server` は意図的に crates.io では公開していません。Docker イメージとして実行してください（下記参照）。

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ cargo add eros-engine-core eros-engine-store eros-engine-llm
 
 ```toml
 [dependencies]
-eros-engine-core  = "0.6"
-eros-engine-store = "0.6"   # only if you want the Postgres + pgvector layer
-eros-engine-llm   = "0.6"   # only if you want the OpenRouter + Voyage clients
+eros-engine-core  = "0.7"
+eros-engine-store = "0.7"   # only if you want the Postgres + pgvector layer
+eros-engine-llm   = "0.7"   # only if you want the OpenRouter + Voyage clients
 ```
 
 `eros-engine-server` is intentionally not published to crates.io — run it as a Docker image (below).

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ eros-engine-llm   = "0.7"   # only if you want the OpenRouter + Voyage clients
 `linux/amd64` images for `eros-engine-server` are published to GitHub Container Registry for every `v*` tag (need arm64? Build it yourself from `docker/Dockerfile`):
 
 ```bash
-docker pull ghcr.io/etherfunlab/eros-engine:0.7.3
+docker pull ghcr.io/etherfunlab/eros-engine:0.7.4
 # or track the latest tagged release
 docker pull ghcr.io/etherfunlab/eros-engine:latest
 ```
@@ -87,7 +87,7 @@ Minimal run (you bring Postgres + your own `.env`):
 
 ```bash
 docker run --rm -p 8080:8080 --env-file .env \
-  ghcr.io/etherfunlab/eros-engine:0.7.3 serve
+  ghcr.io/etherfunlab/eros-engine:0.7.4 serve
 ```
 
 The `docker/Dockerfile` is the same artifact used to build this image. Deploy it on any container host. See [Deploying](docs/deploying.md).

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ eros-engine-llm   = "0.6"   # only if you want the OpenRouter + Voyage clients
 `linux/amd64` images for `eros-engine-server` are published to GitHub Container Registry for every `v*` tag (need arm64? Build it yourself from `docker/Dockerfile`):
 
 ```bash
-docker pull ghcr.io/etherfunlab/eros-engine:0.7.2
+docker pull ghcr.io/etherfunlab/eros-engine:0.7.3
 # or track the latest tagged release
 docker pull ghcr.io/etherfunlab/eros-engine:latest
 ```
@@ -87,7 +87,7 @@ Minimal run (you bring Postgres + your own `.env`):
 
 ```bash
 docker run --rm -p 8080:8080 --env-file .env \
-  ghcr.io/etherfunlab/eros-engine:0.7.2 serve
+  ghcr.io/etherfunlab/eros-engine:0.7.3 serve
 ```
 
 The `docker/Dockerfile` is the same artifact used to build this image. Deploy it on any container host. See [Deploying](docs/deploying.md).

--- a/README.zh.md
+++ b/README.zh.md
@@ -66,9 +66,9 @@ cargo add eros-engine-core eros-engine-store eros-engine-llm
 
 ```toml
 [dependencies]
-eros-engine-core  = "0.6"
-eros-engine-store = "0.6"   # only if you want the Postgres + pgvector layer
-eros-engine-llm   = "0.6"   # only if you want the OpenRouter + Voyage clients
+eros-engine-core  = "0.7"
+eros-engine-store = "0.7"   # only if you want the Postgres + pgvector layer
+eros-engine-llm   = "0.7"   # only if you want the OpenRouter + Voyage clients
 ```
 
 `eros-engine-server` 有意不发布到 crates.io——请使用 Docker 镜像运行（见下文）。

--- a/crates/eros-engine-llm/Cargo.toml
+++ b/crates/eros-engine-llm/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "openrouter", "voyage", "embeddings", "llm"]
 categories = ["api-bindings"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "0.7.4-dev" }
+eros-engine-core = { path = "../eros-engine-core", version = "0.7.4" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/eros-engine-llm/Cargo.toml
+++ b/crates/eros-engine-llm/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "openrouter", "voyage", "embeddings", "llm"]
 categories = ["api-bindings"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "0.7.3-dev" }
+eros-engine-core = { path = "../eros-engine-core", version = "0.7.4-dev" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/eros-engine-server/Cargo.toml
+++ b/crates/eros-engine-server/Cargo.toml
@@ -13,9 +13,9 @@ name = "eros-engine"
 path = "src/main.rs"
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "0.7.4-dev" }
-eros-engine-llm  = { path = "../eros-engine-llm", version = "0.7.4-dev" }
-eros-engine-store = { path = "../eros-engine-store", version = "0.7.4-dev" }
+eros-engine-core = { path = "../eros-engine-core", version = "0.7.4" }
+eros-engine-llm  = { path = "../eros-engine-llm", version = "0.7.4" }
+eros-engine-store = { path = "../eros-engine-store", version = "0.7.4" }
 axum = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/eros-engine-server/Cargo.toml
+++ b/crates/eros-engine-server/Cargo.toml
@@ -13,9 +13,9 @@ name = "eros-engine"
 path = "src/main.rs"
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "0.7.3-dev" }
-eros-engine-llm  = { path = "../eros-engine-llm", version = "0.7.3-dev" }
-eros-engine-store = { path = "../eros-engine-store", version = "0.7.3-dev" }
+eros-engine-core = { path = "../eros-engine-core", version = "0.7.4-dev" }
+eros-engine-llm  = { path = "../eros-engine-llm", version = "0.7.4-dev" }
+eros-engine-store = { path = "../eros-engine-store", version = "0.7.4-dev" }
 axum = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -1221,6 +1221,13 @@
       "BffStartRequest": {
         "type": "object",
         "properties": {
+          "channel": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Conversation channel ('text' default, or 'voice'). Passed through to\nthe canonical start; see `StartChatRequest::channel`."
+          },
           "genome_id": {
             "type": [
               "string",
@@ -1576,9 +1583,14 @@
           "session_id",
           "lead_score",
           "is_converted",
-          "last_active_at"
+          "last_active_at",
+          "channel"
         ],
         "properties": {
+          "channel": {
+            "type": "string",
+            "description": "Conversation channel ('text' or 'voice'); start/resume is channel-scoped."
+          },
           "instance_id": {
             "type": [
               "string",
@@ -1606,6 +1618,13 @@
       "StartChatRequest": {
         "type": "object",
         "properties": {
+          "channel": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Conversation channel for the session: `\"text\"` (default) or `\"voice\"`.\nStart/resume is channel-scoped — a voice-channel start never resumes a\ntext session and vice versa, so the two conversations stay isolated."
+          },
           "genome_id": {
             "type": [
               "string",

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0-only",
       "identifier": "AGPL-3.0-only"
     },
-    "version": "0.7.4-dev"
+    "version": "0.7.4"
   },
   "servers": [
     {

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0-only",
       "identifier": "AGPL-3.0-only"
     },
-    "version": "0.7.3-dev"
+    "version": "0.7.4-dev"
   },
   "servers": [
     {

--- a/crates/eros-engine-server/src/routes/bff/companion.rs
+++ b/crates/eros-engine-server/src/routes/bff/companion.rs
@@ -65,6 +65,10 @@ pub struct BffStartRequest {
     /// BFF-only field; not present in the canonical /comp/chat/start body.
     #[serde(default)]
     pub history_limit: Option<i64>,
+    /// Conversation channel ('text' default, or 'voice'). Passed through to
+    /// the canonical start; see `StartChatRequest::channel`.
+    #[serde(default)]
+    pub channel: Option<String>,
 }
 
 impl From<&BffStartRequest> for StartChatRequest {
@@ -73,6 +77,7 @@ impl From<&BffStartRequest> for StartChatRequest {
             instance_id: b.instance_id,
             genome_id: b.genome_id,
             is_demo: b.is_demo,
+            channel: b.channel.clone(),
         }
     }
 }
@@ -694,5 +699,74 @@ mod tests {
         assert_eq!(status, StatusCode::OK);
         assert_eq!(bff["session_id"].as_str().unwrap(), canonical_session_id);
         assert!(!bff["is_new"].as_bool().unwrap()); // canonical already created it
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn bff_start_voice_channel_is_isolated_from_text(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let state = test_state(pool.clone());
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        // 1. Text start creates the text session.
+        let (status, text1) = send_request(
+            &mut app,
+            bff_start_request(&token, json!({ "genome_id": genome_id })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "body={text1}");
+        assert!(text1["is_new"].as_bool().unwrap());
+
+        // 2. Voice start must NOT resume it — it creates a separate session.
+        let (status, voice1) = send_request(
+            &mut app,
+            bff_start_request(
+                &token,
+                json!({ "genome_id": genome_id, "channel": "voice" }),
+            ),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "body={voice1}");
+        assert!(voice1["is_new"].as_bool().unwrap());
+        assert_ne!(voice1["session_id"], text1["session_id"]);
+
+        // 3. A second voice start resumes the SAME voice session.
+        let (_status, voice2) = send_request(
+            &mut app,
+            bff_start_request(
+                &token,
+                json!({ "genome_id": genome_id, "channel": "voice" }),
+            ),
+        )
+        .await;
+        assert!(!voice2["is_new"].as_bool().unwrap());
+        assert_eq!(voice2["session_id"], voice1["session_id"]);
+
+        // 4. Text start still resumes the TEXT session, even though the voice
+        //    session is more recent.
+        let (_status, text2) = send_request(
+            &mut app,
+            bff_start_request(&token, json!({ "genome_id": genome_id })),
+        )
+        .await;
+        assert!(!text2["is_new"].as_bool().unwrap());
+        assert_eq!(text2["session_id"], text1["session_id"]);
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn bff_start_rejects_invalid_channel(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let state = test_state(pool.clone());
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        let (status, _body) = send_request(
+            &mut app,
+            bff_start_request(&token, json!({ "genome_id": genome_id, "channel": "sms" })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
     }
 }

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -78,6 +78,11 @@ pub struct StartChatRequest {
     /// Ignored when resuming an existing session.
     #[serde(default)]
     pub is_demo: Option<bool>,
+    /// Conversation channel for the session: `"text"` (default) or `"voice"`.
+    /// Start/resume is channel-scoped — a voice-channel start never resumes a
+    /// text session and vice versa, so the two conversations stay isolated.
+    #[serde(default)]
+    pub channel: Option<String>,
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
@@ -117,6 +122,8 @@ pub struct SessionListEntry {
     pub lead_score: f64,
     pub is_converted: bool,
     pub last_active_at: DateTime<Utc>,
+    /// Conversation channel ('text' or 'voice'); start/resume is channel-scoped.
+    pub channel: String,
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
@@ -411,6 +418,12 @@ pub(crate) async fn resolve_or_create_session(
     let persona_repo = PersonaRepo { pool: &state.pool };
     let chat_repo = ChatRepo { pool: &state.pool };
 
+    let channel = match req.channel.as_deref() {
+        None | Some("text") => "text",
+        Some("voice") => "voice",
+        Some(other) => return Err(AppError::BadRequest(format!("invalid channel: {other}"))),
+    };
+
     let (instance_id, persona_name) = match req.instance_id {
         Some(iid) => {
             // Explicit instance: one JOIN read gives owner + genome name
@@ -456,7 +469,7 @@ pub(crate) async fn resolve_or_create_session(
     // Resume the latest session (bumping last_active_at in one statement), or
     // create a fresh one. Only `id` is consumed downstream.
     let (session_id, is_new) = match chat_repo
-        .resume_latest_session(user_id, instance_id)
+        .resume_latest_session(user_id, instance_id, channel)
         .await?
     {
         Some(s) => (s.id, false),
@@ -467,7 +480,7 @@ pub(crate) async fn resolve_or_create_session(
                 serde_json::json!({})
             };
             let s = chat_repo
-                .create_session_with_metadata(user_id, instance_id, metadata)
+                .create_session_with_metadata(user_id, instance_id, metadata, channel)
                 .await?;
             (s.id, true)
         }
@@ -601,6 +614,7 @@ async fn list_sessions(
             lead_score: s.lead_score,
             is_converted: s.is_converted,
             last_active_at: s.last_active_at,
+            channel: s.channel,
         })
         .collect();
     Ok(Json(ListSessionsResponse {
@@ -906,6 +920,52 @@ mod tests {
             .unwrap();
         let (status, _body) = send_request(&mut app, req).await;
         assert_eq!(status, StatusCode::FORBIDDEN);
+    }
+
+    // ─── Test 4b: GET /sessions exposes channel for text vs voice ───
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn get_sessions_exposes_channel_text_and_voice(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Nyx").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+
+        // seed_session creates a plain (text-channel-default) session.
+        let text_session = seed_session(&pool, user_id, instance_id).await;
+        let voice_session: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_sessions (user_id, instance_id, channel) \
+             VALUES ($1, $2, 'voice') RETURNING id",
+        )
+        .bind(user_id)
+        .bind(instance_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        let state = test_state(pool.clone());
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        let req = Request::builder()
+            .uri(format!("/comp/chat/{user_id}/sessions"))
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .body(Body::empty())
+            .unwrap();
+        let (status, body) = send_request(&mut app, req).await;
+        assert_eq!(status, StatusCode::OK, "got body: {body}");
+
+        let sessions = body["sessions"].as_array().expect("sessions array");
+        assert_eq!(sessions.len(), 2);
+
+        let channel_of = |id: Uuid| -> Option<String> {
+            sessions
+                .iter()
+                .find(|s| s["session_id"].as_str() == Some(id.to_string().as_str()))
+                .and_then(|s| s["channel"].as_str())
+                .map(str::to_string)
+        };
+        assert_eq!(channel_of(text_session), Some("text".to_string()));
+        assert_eq!(channel_of(voice_session), Some("voice".to_string()));
     }
 
     // ─── Bonus: debug affinity endpoint round-trips when enabled ────
@@ -1333,6 +1393,7 @@ mod tests {
             instance_id: None,
             genome_id: Some(genome_id),
             is_demo: None,
+            channel: None,
         };
         let resolved = resolve_or_create_session(&state, user_id, &req)
             .await
@@ -1368,6 +1429,7 @@ mod tests {
             instance_id: None,
             genome_id: Some(genome_id),
             is_demo: None,
+            channel: None,
         };
         let resolved = resolve_or_create_session(&state, user_id, &req)
             .await
@@ -1398,6 +1460,7 @@ mod tests {
             instance_id: Some(instance_id),
             genome_id: None,
             is_demo: None,
+            channel: None,
         };
         let err = resolve_or_create_session(&state, intruder, &req)
             .await
@@ -1426,6 +1489,7 @@ mod tests {
             instance_id: Some(instance_id),
             genome_id: None,
             is_demo: None,
+            channel: None,
         };
         let err = resolve_or_create_session(&state, user_id, &req)
             .await

--- a/crates/eros-engine-server/src/routes/voice.rs
+++ b/crates/eros-engine-server/src/routes/voice.rs
@@ -125,6 +125,19 @@ pub async fn voice_turn_stream(
             "无权访问该会话",
         ));
     }
+    // Channel-scoped enforcement: the voice endpoint writes `channel = 'voice'`
+    // messages, so it must only operate on a voice-channel session. Reject a
+    // text (or otherwise non-voice) session here — before persisting any turn —
+    // so voice messages never leak into a text conversation's history. Voice
+    // clients obtain a voice session via `chat/start` with `channel: "voice"`.
+    if session.channel != "voice" {
+        return Err(pre(
+            StatusCode::CONFLICT,
+            "wrong_channel",
+            "session is not a voice-channel session",
+            "该会话不是语音会话",
+        ));
+    }
     let instance_id = session.instance_id.ok_or_else(|| {
         pre(
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -243,7 +256,14 @@ mod tests {
         axum.with_state(state)
     }
 
+    /// Seed a voice-channel session (the voice endpoint's valid input).
     async fn seed(pool: &PgPool, user_id: Uuid) -> Uuid {
+        seed_channel(pool, user_id, "voice").await
+    }
+
+    /// Seed a session on an explicit `channel` for the voice endpoint's
+    /// channel-scoping tests.
+    async fn seed_channel(pool: &PgPool, user_id: Uuid, channel: &str) -> Uuid {
         let genome_id: Uuid = sqlx::query_scalar(
             "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata) \
              VALUES ('V','p','{}'::jsonb) RETURNING id",
@@ -255,10 +275,11 @@ mod tests {
             "INSERT INTO engine.persona_instances (genome_id, owner_uid) VALUES ($1,$2) RETURNING id",
         ).bind(genome_id).bind(user_id).fetch_one(pool).await.unwrap();
         sqlx::query_scalar(
-            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1,$2) RETURNING id",
+            "INSERT INTO engine.chat_sessions (user_id, instance_id, channel) VALUES ($1,$2,$3) RETURNING id",
         )
         .bind(user_id)
         .bind(instance_id)
+        .bind(channel)
         .fetch_one(pool)
         .await
         .unwrap()
@@ -369,6 +390,37 @@ mod tests {
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn voice_409_when_session_not_voice_channel(pool: PgPool) {
+        // The voice endpoint must only operate on voice-channel sessions.
+        // `seed` creates a default (text-channel) session; posting a voice turn
+        // to it must be rejected pre-stream (409) WITHOUT persisting a user row,
+        // so voice turns never leak into a text conversation.
+        let user_id = Uuid::new_v4();
+        let session_id = seed_channel(&pool, user_id, "text").await;
+        let mut app = build_router(with_voice(crate::routes::companion::test_state(
+            pool.clone(),
+        )));
+        let jwt = mint_jwt(user_id);
+        let resp = post_voice(
+            &mut app,
+            session_id,
+            &jwt,
+            json!({"content":"hi","client_msg_id":"01J2222222222222222222222A"}),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+
+        // No user row persisted — the rejection happened before the insert.
+        let count: i64 =
+            sqlx::query_scalar("SELECT count(*) FROM engine.chat_messages WHERE session_id = $1")
+                .bind(session_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(count, 0, "wrong-channel rejection must not persist a turn");
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
     async fn voice_404_when_persona_instance_missing(pool: PgPool) {
         // A session whose persona instance is missing/inactive must be rejected
         // pre-stream (404) WITHOUT persisting a user row. chat_sessions.instance_id
@@ -377,7 +429,8 @@ mod tests {
         let user_id = Uuid::new_v4();
         let missing_instance = Uuid::new_v4(); // no matching persona_instances row
         let session_id: Uuid = sqlx::query_scalar(
-            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
+            "INSERT INTO engine.chat_sessions (user_id, instance_id, channel) \
+             VALUES ($1, $2, 'voice') RETURNING id",
         )
         .bind(user_id)
         .bind(missing_instance)

--- a/crates/eros-engine-store/Cargo.toml
+++ b/crates/eros-engine-store/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "memory", "pgvector", "postgres", "sqlx"]
 categories = ["database"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "0.7.4-dev" }
+eros-engine-core = { path = "../eros-engine-core", version = "0.7.4" }
 sqlx = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/eros-engine-store/Cargo.toml
+++ b/crates/eros-engine-store/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "memory", "pgvector", "postgres", "sqlx"]
 categories = ["database"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "0.7.3-dev" }
+eros-engine-core = { path = "../eros-engine-core", version = "0.7.4-dev" }
 sqlx = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/eros-engine-store/migrations/0031_chat_sessions_channel.sql
+++ b/crates/eros-engine-store/migrations/0031_chat_sessions_channel.sql
@@ -1,0 +1,20 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+--
+-- engine.chat_sessions gains a `channel` column separating voice-call sessions
+-- from default text-chat sessions. Extends 0030's chat_messages.channel to the
+-- session level: start/resume becomes channel-scoped, so a voice client and a
+-- text client hold independent conversations for the same user × instance.
+--
+-- Unlike the message column (NULL = text), this is NOT NULL DEFAULT 'text':
+-- every pre-existing session IS a text session, and a required value keeps the
+-- resume filter a plain equality. CHECK mirrors 0030 and is trivially extended
+-- when new channels appear.
+
+ALTER TABLE engine.chat_sessions
+    ADD COLUMN channel TEXT NOT NULL DEFAULT 'text'
+        CHECK (channel IN ('text', 'voice'));
+
+-- Covers the channel-scoped resume lookup (latest session per user × instance
+-- × channel, ordered by recency).
+CREATE INDEX idx_chat_sessions_user_instance_channel
+    ON engine.chat_sessions (user_id, instance_id, channel, last_active_at DESC);

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -15,6 +15,8 @@ pub struct ChatSession {
     pub is_converted: bool,
     pub last_active_at: DateTime<Utc>,
     pub metadata: serde_json::Value,
+    /// Conversation channel ('text' or 'voice'); start/resume is channel-scoped.
+    pub channel: String,
     /// Set by the dreaming-lite sweeper after a classification pass.
     /// `None` means the session is still eligible for the next sweep tick.
     pub classified_at: Option<DateTime<Utc>>,
@@ -94,33 +96,37 @@ pub struct ChatRepo<'a> {
 }
 
 impl<'a> ChatRepo<'a> {
-    /// Create a new chat session for `user_id` × `instance_id`.
+    /// Create a new (text-channel) chat session for `user_id` × `instance_id`.
     pub async fn create_session(
         &self,
         user_id: Uuid,
         instance_id: Uuid,
     ) -> Result<ChatSession, sqlx::Error> {
-        self.create_session_with_metadata(user_id, instance_id, serde_json::json!({}))
+        self.create_session_with_metadata(user_id, instance_id, serde_json::json!({}), "text")
             .await
     }
 
     /// Create a session and seed `metadata` as the JSONB column. Used by
     /// callers that need session-scoped flags (e.g. `is_demo`) the
-    /// pipeline reads later.
+    /// pipeline reads later. `channel` scopes the session ('text'/'voice');
+    /// resume is channel-scoped so the two never cross (see
+    /// `resume_latest_session`).
     pub async fn create_session_with_metadata(
         &self,
         user_id: Uuid,
         instance_id: Uuid,
         metadata: serde_json::Value,
+        channel: &str,
     ) -> Result<ChatSession, sqlx::Error> {
         sqlx::query_as::<_, ChatSession>(
-            "INSERT INTO engine.chat_sessions (user_id, instance_id, metadata) \
-             VALUES ($1, $2, $3) \
+            "INSERT INTO engine.chat_sessions (user_id, instance_id, metadata, channel) \
+             VALUES ($1, $2, $3, $4) \
              RETURNING *",
         )
         .bind(user_id)
         .bind(instance_id)
         .bind(metadata)
+        .bind(channel)
         .fetch_one(self.pool)
         .await
     }
@@ -134,6 +140,10 @@ impl<'a> ChatRepo<'a> {
     }
 
     /// Resume the most recent session for a user×instance pair, or create a new one.
+    ///
+    /// WARNING: channel-unaware — resumes the latest session on ANY channel.
+    /// Test-only convenience; production paths use `resume_latest_session`
+    /// with an explicit channel.
     pub async fn create_or_resume(
         &self,
         user_id: Uuid,
@@ -163,16 +173,18 @@ impl<'a> ChatRepo<'a> {
     /// exists (caller then creates). Folds the former SELECT-latest +
     /// separate UPDATE into one round-trip. Callers consume only `id`
     /// (immutable), so returning the post-bump row is immaterial.
+    /// Channel-scoped: only sessions on `channel` are candidates.
     pub async fn resume_latest_session(
         &self,
         user_id: Uuid,
         instance_id: Uuid,
+        channel: &str,
     ) -> Result<Option<ChatSession>, sqlx::Error> {
         sqlx::query_as::<_, ChatSession>(
             "UPDATE engine.chat_sessions SET last_active_at = now() \
              WHERE id = ( \
                  SELECT id FROM engine.chat_sessions \
-                 WHERE user_id = $1 AND instance_id = $2 \
+                 WHERE user_id = $1 AND instance_id = $2 AND channel = $3 \
                  ORDER BY last_active_at DESC \
                  LIMIT 1 \
              ) \
@@ -180,6 +192,7 @@ impl<'a> ChatRepo<'a> {
         )
         .bind(user_id)
         .bind(instance_id)
+        .bind(channel)
         .fetch_optional(self.pool)
         .await
     }
@@ -1016,12 +1029,24 @@ mod tests {
         let i3 = Uuid::new_v4();
 
         repo.create_session(user_id, i1).await.unwrap();
-        repo.create_session(user_id, i2).await.unwrap();
+        repo.create_session_with_metadata(user_id, i2, serde_json::json!({}), "voice")
+            .await
+            .unwrap();
         repo.create_session(other_user, i3).await.unwrap();
 
         let sessions = repo.list_sessions(user_id).await.unwrap();
         assert_eq!(sessions.len(), 2);
         assert!(sessions.iter().all(|s| s.user_id == user_id));
+        // channel is exposed on the projection and distinguishes the two
+        // sessions (the text default vs. the explicit voice session above).
+        let channels: std::collections::HashSet<&str> =
+            sessions.iter().map(|s| s.channel.as_str()).collect();
+        assert_eq!(
+            channels,
+            ["text", "voice"]
+                .into_iter()
+                .collect::<std::collections::HashSet<_>>()
+        );
     }
 
     #[sqlx::test(migrations = "./migrations")]
@@ -1221,7 +1246,7 @@ mod tests {
 
         // no session yet → None
         assert!(repo
-            .resume_latest_session(user_id, instance_id)
+            .resume_latest_session(user_id, instance_id, "text")
             .await
             .unwrap()
             .is_none());
@@ -1254,7 +1279,7 @@ mod tests {
                 .unwrap();
 
         let resumed = repo
-            .resume_latest_session(user_id, instance_id)
+            .resume_latest_session(user_id, instance_id, "text")
             .await
             .unwrap()
             .expect("resume the most-recent session");
@@ -2874,5 +2899,41 @@ mod tests {
             matches!(out, VoiceUserInsert::Duplicate(_)),
             "voice insert colliding with a gift_user row must be Duplicate, got {out:?}"
         );
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn sessions_are_channel_scoped(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let (user_id, instance_id) = (Uuid::new_v4(), Uuid::new_v4());
+
+        let text = repo.create_session(user_id, instance_id).await.unwrap();
+
+        // No voice session yet → nothing to resume on the voice channel.
+        assert!(repo
+            .resume_latest_session(user_id, instance_id, "voice")
+            .await
+            .unwrap()
+            .is_none());
+
+        let voice = repo
+            .create_session_with_metadata(user_id, instance_id, serde_json::json!({}), "voice")
+            .await
+            .unwrap();
+
+        // Each channel resumes ITS OWN latest session, even though the other
+        // channel's session is more recent.
+        let resumed_text = repo
+            .resume_latest_session(user_id, instance_id, "text")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(resumed_text.id, text.id);
+
+        let resumed_voice = repo
+            .resume_latest_session(user_id, instance_id, "voice")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(resumed_voice.id, voice.id);
     }
 }


### PR DESCRIPTION
Promotes `dev` to `main` for the **v0.7.4** stable release.

## Release content since v0.7.3
- **#158 — feat: channel-scoped chat sessions (text/voice).** `engine.chat_sessions` gains a `channel` column (`text` default / `voice`, migration 0031). `chat/start` (canonical + BFF) accepts an optional `channel`; resume-or-create is channel-scoped, so a voice client's session never collides with the text conversation for the same user × instance. The voice turn endpoint (`/comp/voice/{session_id}/turn/stream`) now rejects non-voice sessions with `409 wrong_channel` so voice turns never leak into a text conversation. `GET /comp/chat/{user_id}/sessions` entries expose `channel`.
- **#155 / #156 — docs:** README version-ref catch-up (docker-pull → 0.7.3, library-usage refs → 0.7), superseded here by the 0.7.4 bump.

## Release bump
- Workspace + 3 path-dep pins `0.7.4-dev` → `0.7.4`, `Cargo.lock` + `openapi.json` regenerated, README docker-pull examples → `0.7.4`.

## Compatibility
`channel` is optional and defaults to `text`; existing clients unaffected. Existing sessions backfill as `text` via the column default. Binary requires migration 0031 (standard migrations-first deploy).

## Notes
- The branch merges `main` (ancestry reconnect after v0.7.3's `-s ours` sync) so this PR is conflict-free; content is identical to `dev`.
- Migration 0031 defaults pre-existing (mixed voice/text) sessions to `text` — a deliberate choice, since pre-0031 voice and text already shared one session and can't be cleanly split (codex P1, non-blocking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)