### PR TITLE
feat(voice): interspersed multi-tag audio-tags directive

### DIFF
--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -708,7 +708,7 @@ const VOICE_SPEECH_BASE_AUDIO_TAGS: &str = "You are on a live voice call. Speak 
 /// to improvise. Product-identity-free. Authored ONCE here and reused for both
 /// the built-in audio-tags default and the custom-`filter_prompt` path, so the
 /// tag list lives in a single place.
-pub const AUDIO_TAGS_ADDENDUM: &str = "You may add inline audio tags to make your speech more expressive. An audio tag is a short cue in square brackets placed right before the words it affects — e.g. [laughs] that's so funny, or [whispers] come closer. Use them sparingly, only when they fit the moment. Commonly supported tags: [amazed], [crying], [curious], [excited], [sighs], [gasp], [giggles], [laughs], [mischievously], [panicked], [sarcastic], [serious], [shouting], [tired], [whispers]. You are not limited to this list — you may use other short emotion or action tags in the same bracket form when they suit the delivery. Write tags in English even when speaking another language. Everything outside the brackets is spoken aloud, so keep it natural and short.";
+pub const AUDIO_TAGS_ADDENDUM: &str = "Weave inline audio tags through your speech to make it expressive. An audio tag is a short cue in square brackets placed right before the words it affects. Aim for two to four tags per reply, placed at the emotional beats — mid-sentence placements are better than tagging only the start, and never bunch them all at the beginning. For example: 今天全搞砸了 [sighs] 不想说了…… [giggles] 骗你的啦，你怎么当真了 — or: wait [gasp] you actually did it? [laughs] no way. Commonly supported tags: [amazed], [crying], [curious], [excited], [sighs], [gasp], [giggles], [laughs], [mischievously], [panicked], [sarcastic], [serious], [shouting], [tired], [whispers]. You are not limited to this list — you may use other short emotion or action tags in the same bracket form when they suit the delivery. Write tags in English even when speaking another language. Everything outside the brackets is spoken aloud, so keep it natural and short.";
 
 /// Resolved `[tasks.chat_voice]` (voice channel). `directive` is the effective
 /// voice instruction: the configured `filter_prompt`, or `DEFAULT_VOICE_DIRECTIVE`
@@ -2972,6 +2972,37 @@ retry_depth = 0
         let v = cfg.resolve_voice().expect("voice enabled");
         assert_eq!(v.directive, "Speak like a pirate.");
         assert!(!v.directive.contains("[laughs]"));
+    }
+
+    #[test]
+    fn audio_tags_addendum_encourages_interspersed_multi_tag() {
+        // The reason for the 2026-07-16 rewrite: grok emitted one leading tag.
+        // Density guidance is present, the old minimizing instruction is gone.
+        assert!(
+            AUDIO_TAGS_ADDENDUM.contains("two to four"),
+            "must give a soft density target"
+        );
+        assert!(
+            !AUDIO_TAGS_ADDENDUM.contains("sparingly"),
+            "the old 'use them sparingly' instruction caused single-tag output"
+        );
+        // Examples must show mid-sentence interspersal (tag NOT at position 0),
+        // including a Chinese-sentence-with-English-tags sample.
+        assert!(
+            AUDIO_TAGS_ADDENDUM.contains("[sighs] 不想说了"),
+            "Chinese interspersal example present"
+        );
+        assert!(
+            AUDIO_TAGS_ADDENDUM.contains("[gasp] you actually did it"),
+            "English interspersal example present"
+        );
+        // Preserved clauses (unchanged contract).
+        assert!(
+            AUDIO_TAGS_ADDENDUM.contains("[amazed]") && AUDIO_TAGS_ADDENDUM.contains("[whispers]")
+        );
+        assert!(AUDIO_TAGS_ADDENDUM
+            .contains("Write tags in English even when speaking another language"));
+        assert!(AUDIO_TAGS_ADDENDUM.contains("spoken aloud"));
     }
 
     #[test]

--- a/docs/superpowers/specs/2026-07-16-audio-tags-interspersed-design.md
+++ b/docs/superpowers/specs/2026-07-16-audio-tags-interspersed-design.md
@@ -1,0 +1,94 @@
+# Voice audio tags: interspersed multi-tag delivery (`AUDIO_TAGS_ADDENDUM` rewrite)
+
+**Date:** 2026-07-16
+**Status:** Design approved, ready for implementation plan
+**Related:** `docs/superpowers/specs/2026-07-11-voice-tts-audio-tags-design.md`
+(the feature this tunes; shipped in PR #152)
+
+## Summary
+
+Production observation: with `tts_audio_tags = true` (prod voice runs
+grok-4.20), every completion emits exactly **one** audio tag, always at the
+**start** of the reply. Wanted: several tags woven **through** the sentences,
+at the emotional beats.
+
+Root cause is the addendum's own text (`AUDIO_TAGS_ADDENDUM`,
+`crates/eros-engine-llm/src/model_config.rs:711`):
+
+1. "**Use them sparingly**, only when they fit the moment" — the model
+   minimizes to a single tag.
+2. Both inline examples put the tag at utterance start (`[laughs] that's so
+   funny`, `[whispers] come closer`) — the model pattern-matches "one leading
+   tag".
+
+Fix: rewrite the addendum's guidance and examples. **Prompt-text only** — no
+config key, no composition change, no behavior change anywhere else in the
+voice path (tags still flow through verbatim; the four-state
+`resolve_voice` matrix from the #152 spec is untouched).
+
+Explicitly **not** in scope: a density config knob, engine-side
+post-processing that injects or repositions tags, per-persona tag styles, any
+change to `VOICE_SPEECH_BASE_AUDIO_TAGS` / `DEFAULT_VOICE_DIRECTIVE` or the
+`(filter_prompt × tts_audio_tags)` composition logic.
+
+## The change
+
+`AUDIO_TAGS_ADDENDUM` is rewritten with four deltas; everything else in the
+constant is kept verbatim (the 15-tag list, the "not limited to this list"
+clause, the "write tags in English even when speaking another language"
+clause, and the "everything outside the brackets is spoken aloud" closer):
+
+1. **Drop** "Use them sparingly, only when they fit the moment."
+2. **Soft density target:** "Aim for two to four tags per reply."
+3. **Placement directive:** tags go at the emotional beats; mid-sentence
+   placements are better than tagging only the start; never bunch them all at
+   the beginning.
+4. **Examples demonstrate interspersal**, replacing the two leading-tag
+   examples. Two full samples, one Chinese-with-English-tags (mirrors prod
+   usage and demonstrates the English-tags rule in context), one English:
+   - `今天全搞砸了 [sighs] 不想说了…… [giggles] 骗你的啦，你怎么当真了`
+   - `wait [gasp] you actually did it? [laughs] no way`
+
+### Reference text (implementation may polish wording, not semantics)
+
+> Weave inline audio tags through your speech to make it expressive. An audio
+> tag is a short cue in square brackets placed right before the words it
+> affects. Aim for two to four tags per reply, placed at the emotional beats —
+> mid-sentence placements are better than tagging only the start, and never
+> bunch them all at the beginning. For example: 今天全搞砸了 [sighs]
+> 不想说了…… [giggles] 骗你的啦，你怎么当真了 — or: wait [gasp] you actually
+> did it? [laughs] no way. Commonly supported tags: [amazed], [crying],
+> [curious], [excited], [sighs], [gasp], [giggles], [laughs], [mischievously],
+> [panicked], [sarcastic], [serious], [shouting], [tired], [whispers]. You are
+> not limited to this list — you may use other short emotion or action tags in
+> the same bracket form when they suit the delivery. Write tags in English
+> even when speaking another language. Everything outside the brackets is
+> spoken aloud, so keep it natural and short.
+
+## Testing
+
+- The #152 composition tests (`resolve_voice` four-state matrix) reference
+  the constant and follow automatically — no edits expected unless one pins
+  addendum substrings.
+- New/updated content assertions on `AUDIO_TAGS_ADDENDUM`:
+  - contains the density phrase (`two to four`);
+  - does **not** contain `sparingly` (regression guard against the old
+    minimizing instruction);
+  - contains both interspersal examples (pin one distinctive substring each,
+    e.g. `[sighs] 不想说了` and `[gasp] you actually did it`);
+  - still contains the unchanged clauses (tag list spot-check, `Write tags
+    in English`, `spoken aloud`).
+- Voice-path passthrough tests (tags stream/persist verbatim) are untouched —
+  no behavior change.
+
+Standard pre-PR gate: fmt / clippy / workspace tests / openapi (no drift
+expected).
+
+## Rollout
+
+Constant-text change; rides the same unreleased dev train as #161/#162. Prod
+voice (grok-4.20, `tts_audio_tags = true`, no custom voice filter_prompt
+override of the addendum path) picks it up on the next engine image — no
+downstream config change needed. If grok still under-delivers after this,
+the next lever is a custom `filter_prompt` downstream (already supported),
+not more engine code.


### PR DESCRIPTION
## Summary

Production observation: with `tts_audio_tags = true` (prod voice = grok-4.20), every completion emits exactly **one** audio tag, always at the start. Wanted: several tags woven through the sentences at the emotional beats.

Root cause was `AUDIO_TAGS_ADDENDUM`'s own text (`crates/eros-engine-llm/src/model_config.rs`): "**Use them sparingly**" told the model to minimize, and both inline examples put the tag at utterance start. This rewrites the constant:

- **Drop** "Use them sparingly, only when they fit the moment."
- **Soft density target**: "Aim for two to four tags per reply."
- **Placement**: at the emotional beats — "mid-sentence placements are better than tagging only the start, and never bunch them all at the beginning."
- **Examples** now show interspersal, one Chinese-sentence-with-English-tags (mirrors prod usage + demonstrates the English-tags rule in context), one English.

Preserved verbatim: the 15-tag list, "not limited to this list", "Write tags in English even when speaking another language", "everything outside the brackets is spoken aloud".

**Prompt-text only** — the `resolve_voice` four-state composition matrix, `VOICE_SPEECH_BASE_AUDIO_TAGS`, `DEFAULT_VOICE_DIRECTIVE`, and the `tts_audio_tags` key are all untouched; they reference the constant and follow automatically. No config key, no behavior change in the voice path (tags still stream/persist verbatim). Spec: [`docs/superpowers/specs/2026-07-16-audio-tags-interspersed-design.md`](https://github.com/etherfunlab/eros-engine/blob/feat/audio-tags-interspersed/docs/superpowers/specs/2026-07-16-audio-tags-interspersed-design.md).

## Test plan

- New content test on `AUDIO_TAGS_ADDENDUM`: density phrase present, `sparingly` gone (regression guard), both interspersal examples present, preserved clauses intact.
- The pre-existing `resolve_voice_audio_tags_*` composition tests keep passing — the new text retains `audio tag` / `[laughs]` / `[whispers]` / the full addendum substring they assert.
- Full gate at HEAD: `cargo fmt --all -- --check` ✅ · `clippy --workspace --all-targets -D warnings` ✅ · `cargo test --workspace --all-features` ✅ · openapi snapshot no drift ✅.

## Note

This is a behavior *tuning*, verifiable only on prod voice after the next engine image ships. If grok-4.20 still under-delivers, the next lever is a downstream custom voice `filter_prompt` (already supported) — not more engine code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)