### PR TITLE
ci: native arm64 multi-arch GHCR + main-tag guard + ci.yml permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,11 @@ on:
     branches: [main]
   pull_request:
 
+# All jobs here are read-only checks (fmt / clippy / test / openapi snapshot).
+# Pin the token to the minimum so a compromised action can't write.
+permissions:
+  contents: read
+
 jobs:
   fmt:
     runs-on: ubuntu-latest
@@ -75,6 +80,14 @@ jobs:
   cla:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    # Override the read-only top-level default: the CLA assistant comments on the
+    # PR and sets a commit status. Signature storage uses CLA_BOT_TOKEN, so the
+    # GITHUB_TOKEN only needs PR + status writes (contents stays read).
+    permissions:
+      contents: read
+      pull-requests: write
+      statuses: write
+      actions: write
     steps:
       - uses: contributor-assistant/github-action@v2.4.0
         env:

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -14,9 +14,20 @@ permissions:
   contents: read
   packages: write
 
+env:
+  IMAGE: ghcr.io/etherfunlab/eros-engine
+
 jobs:
-  build-and-push:
+  # Resolve the release ref/version and gate on tag provenance. On a real tag
+  # push we refuse to publish unless the tagged commit is on `main` — a stray
+  # `v*` tag on a feature branch must never ship an image. Manual dispatch is
+  # operator-chosen, so it skips the guard.
+  meta:
     runs-on: ubuntu-latest
+    outputs:
+      ref: ${{ steps.ref.outputs.ref }}
+      version: ${{ steps.ref.outputs.version }}
+      moving: ${{ steps.ref.outputs.moving }}
     steps:
       - name: Resolve ref
         id: ref
@@ -39,6 +50,41 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ steps.ref.outputs.ref }}
+          fetch-depth: 0
+
+      - name: Require the tag to be on main (push events only)
+        if: github.event_name == 'push'
+        run: |
+          git fetch --no-tags origin main
+          tag_sha="$(git rev-parse HEAD)"
+          if ! git merge-base --is-ancestor "$tag_sha" origin/main; then
+            echo "::error::Tag ${{ steps.ref.outputs.ref }} ($tag_sha) is not reachable from main — refusing to publish."
+            exit 1
+          fi
+          echo "Tag ${{ steps.ref.outputs.ref }} is on main; proceeding."
+
+  # One native runner per architecture — NO QEMU emulation. amd64 and arm64
+  # build in parallel, so wall-clock is a single native build (minutes), not the
+  # old ~1h emulated multi-arch. Each pushes its image BY DIGEST (no tag); the
+  # merge job stitches them into one multi-arch manifest. `provenance: false`
+  # keeps GHCR clean (no `unknown/unknown` attestation package versions).
+  build:
+    needs: meta
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.meta.outputs.ref }}
 
       - uses: docker/setup-buildx-action@v3
 
@@ -49,19 +95,66 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Build and push by digest (${{ matrix.arch }}, native)
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           file: docker/Dockerfile
-          platforms: linux/amd64
-          push: true
-          tags: |
-            ghcr.io/etherfunlab/eros-engine:${{ steps.ref.outputs.version }}
-            ghcr.io/etherfunlab/eros-engine:${{ steps.ref.outputs.moving }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          platforms: ${{ matrix.platform }}
+          provenance: false
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
           labels: |
             org.opencontainers.image.source=https://github.com/etherfunlab/eros-engine
-            org.opencontainers.image.version=${{ steps.ref.outputs.version }}
+            org.opencontainers.image.version=${{ needs.meta.outputs.version }}
             org.opencontainers.image.licenses=AGPL-3.0-only
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Assemble the per-arch digests into a single multi-arch manifest list under
+  # the real tags (:version + :latest / :latest-dev). `docker pull …:X.Y.Z` then
+  # auto-selects amd64 or arm64.
+  merge:
+    needs: [meta, build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digest-*
+          merge-multiple: true
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create multi-arch manifest
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            -t ${{ env.IMAGE }}:${{ needs.meta.outputs.version }} \
+            -t ${{ env.IMAGE }}:${{ needs.meta.outputs.moving }} \
+            $(printf '${{ env.IMAGE }}@sha256:%s ' *)
+
+      - name: Inspect
+        run: docker buildx imagetools inspect ${{ env.IMAGE }}:${{ needs.meta.outputs.version }}


### PR DESCRIPTION
## release-docker.yml — native multi-arch, no QEMU

Reworked into **meta → build (matrix) → merge**:
- **build** runs `amd64` on `ubuntu-24.04` and `arm64` on **`ubuntu-24.04-arm`** — GitHub's free native arm64 runners (public repo), in **parallel**, no `setup-qemu`. Wall-clock ≈ one native build (minutes) instead of the old ~1h emulated arm64.
- Each arch pushes **by digest** (`push-by-digest=true`); **merge** stitches them into one multi-arch manifest under `:version` + `:latest`/`:latest-dev`, so `docker pull …:X.Y.Z` auto-selects the arch.
- **`provenance: false`** — removes the `unknown/unknown` attestation child manifests, so a release yields a clean `index + 2 arch` (that's the "2–4 images" cleanup).
- **meta guard**: a real `v*` tag push only publishes if the tagged commit is **on `main`** (a stray tag on a feature branch is refused). `workflow_dispatch` is operator-chosen and skips the guard.

The workflow already triggered only on `v*` tags — never on main PRs — so no trigger widening was needed; this only *narrows* it (main-reachable tags).

## ci.yml — least-privilege token

Adds top-level `permissions: { contents: read }` (clears the CodeQL *"Workflow does not contain permissions"* warning; fmt/clippy/test/openapi are read-only). The `cla` job overrides with `pull-requests: write` + `statuses: write` + `actions: write` so the CLA assistant keeps commenting/setting status.

Takes effect for the **next** release tag; v0.8.1 will be re-published via `workflow_dispatch` off `dev` once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)