### PR TITLE
feat: MODEL_CONFIG_DIR — merge a directory of model-config .toml fragments at boot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,12 @@ EMA_INERTIA=0.5
 # affinity meters move visibly across the demo turn budget. Lower = faster.
 DEMO_EMA_INERTIA=0.3
 MODEL_CONFIG_PATH=examples/model_config.toml
+# Alternative to MODEL_CONFIG_PATH — the two are mutually exclusive (setting
+# both is a boot error; empty counts as unset). Points at a directory whose
+# top-level *.toml files are merged into one config: [defaults] and each
+# [tasks.<name>] must come from exactly one file, duplicates are boot errors.
+# Files load in filename order; dotfiles and subdirectories are skipped.
+# MODEL_CONFIG_DIR=/etc/eros/model.d
 RUST_LOG=info
 # Optional. When set, the engine writes the fully-assembled MAIN-REPLY prompt
 # for each turn to one human-readable file in this directory (debug aid for

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,6 +533,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
@@ -640,6 +641,12 @@ dependencies = [
  "nom",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ff"
@@ -1311,6 +1318,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1930,6 +1943,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2446,6 +2472,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/README.ja.md
+++ b/README.ja.md
@@ -136,7 +136,7 @@ cargo run -p eros-engine-server -- serve
 
 必須の環境変数は `DATABASE_URL`、`OPENROUTER_API_KEY`、`VOYAGE_API_KEY` と、**いずれか 1 つ**の認証元です。`SUPABASE_URL` / `SUPABASE_JWKS_URL`（JWKS、2025 年以降の Supabase のデフォルト）、**または** `SUPABASE_JWT_SECRET`（旧来の HS256）を設定してください。認証元が未設定の場合、サーバーは起動しません。
 
-その他の項目には適切なデフォルト値があります。モデルルーティング（`MODEL_CONFIG_PATH` → `model_config.toml`）、OpenRouter attribution headers、dreaming-lite / snapshot sweepers、関係性の難易度を調整する `EMA_INERTIA`、debug toggles などです。注釈付きの全項目は [`.env.example`](.env.example)、運用ガイドは [Deploying](docs/deploying.md)、モデルルーティングは [Model config](docs/model-config.md) を参照してください。
+その他の項目には適切なデフォルト値があります。モデルルーティング（`MODEL_CONFIG_PATH` → `model_config.toml`、または `MODEL_CONFIG_DIR` で分割設定ディレクトリ）、OpenRouter attribution headers、dreaming-lite / snapshot sweepers、関係性の難易度を調整する `EMA_INERTIA`、debug toggles などです。注釈付きの全項目は [`.env.example`](.env.example)、運用ガイドは [Deploying](docs/deploying.md)、モデルルーティングは [Model config](docs/model-config.md) を参照してください。
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ For the full request schema, SSE frame layout (including `delta`, `image_request
 
 Required env vars: `DATABASE_URL`, `OPENROUTER_API_KEY`, `VOYAGE_API_KEY`, and **one** auth source — `SUPABASE_URL` / `SUPABASE_JWKS_URL` (JWKS, the post-2025 Supabase default) **or** `SUPABASE_JWT_SECRET` (legacy HS256). The server refuses to boot if no auth source is set.
 
-Everything else has sane defaults: model routing (`MODEL_CONFIG_PATH` → `model_config.toml`), OpenRouter attribution headers, the dreaming-lite / snapshot sweepers, the `EMA_INERTIA` relationship-difficulty dial, and debug toggles. The full annotated list lives in [`.env.example`](.env.example); operational guidance is in [Deploying](docs/deploying.md), and model routing in [Model config](docs/model-config.md).
+Everything else has sane defaults: model routing (`MODEL_CONFIG_PATH` → `model_config.toml`, or a split config directory via `MODEL_CONFIG_DIR`), OpenRouter attribution headers, the dreaming-lite / snapshot sweepers, the `EMA_INERTIA` relationship-difficulty dial, and debug toggles. The full annotated list lives in [`.env.example`](.env.example); operational guidance is in [Deploying](docs/deploying.md), and model routing in [Model config](docs/model-config.md).
 
 ## Roadmap
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -136,7 +136,7 @@ cargo run -p eros-engine-server -- serve
 
 必填环境变量：`DATABASE_URL`、`OPENROUTER_API_KEY`、`VOYAGE_API_KEY`，以及**一个**身份验证来源——`SUPABASE_URL` / `SUPABASE_JWKS_URL`（JWKS，Supabase 在 2025 年之后的默认方式）**或** `SUPABASE_JWT_SECRET`（旧版 HS256）。若未设置身份验证来源，服务将拒绝启动。
 
-其余配置均有合理的默认值：模型路由（`MODEL_CONFIG_PATH` → `model_config.toml`）、OpenRouter 归因标头、dreaming-lite / snapshot sweepers、用于调整关系难度的 `EMA_INERTIA`，以及调试开关。完整注释清单见 [`.env.example`](.env.example)；操作指南见[部署](docs/deploying.zh.md)，模型路由见[模型配置](docs/model-config.zh.md)。
+其余配置均有合理的默认值：模型路由（`MODEL_CONFIG_PATH` → `model_config.toml`，或通过 `MODEL_CONFIG_DIR` 使用拆分的配置目录）、OpenRouter 归因标头、dreaming-lite / snapshot sweepers、用于调整关系难度的 `EMA_INERTIA`，以及调试开关。完整注释清单见 [`.env.example`](.env.example)；操作指南见[部署](docs/deploying.zh.md)，模型路由见[模型配置](docs/model-config.zh.md)。
 
 ## Roadmap
 

--- a/crates/eros-engine-llm/Cargo.toml
+++ b/crates/eros-engine-llm/Cargo.toml
@@ -31,3 +31,4 @@ async-stream       = { workspace = true }
 [dev-dependencies]
 wiremock = "0.6"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tempfile = "3"

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -824,6 +824,36 @@ impl TaskConfig {
     }
 }
 
+/// Where the model config comes from, resolved from the two env vars.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConfigSource {
+    /// Single TOML file (`MODEL_CONFIG_PATH`, or the compiled-in default).
+    File(String),
+    /// Directory of `.toml` fragments (`MODEL_CONFIG_DIR`), merged at load.
+    Dir(String),
+}
+
+/// Pure resolution of the `MODEL_CONFIG_PATH` / `MODEL_CONFIG_DIR` values —
+/// the caller reads the env so this stays unit-testable. Empty strings count
+/// as unset (a dotenv `VAR=` line is not an opt-in). Both set is a hard
+/// error: no silent precedence between the two mechanisms.
+pub fn resolve_config_source(
+    path: Option<String>,
+    dir: Option<String>,
+) -> Result<ConfigSource, LlmError> {
+    let path = path.filter(|s| !s.is_empty());
+    let dir = dir.filter(|s| !s.is_empty());
+    match (path, dir) {
+        (Some(_), Some(_)) => Err(LlmError::Config(
+            "MODEL_CONFIG_PATH and MODEL_CONFIG_DIR are mutually exclusive; set only one"
+                .to_string(),
+        )),
+        (None, Some(d)) => Ok(ConfigSource::Dir(d)),
+        (Some(p), None) => Ok(ConfigSource::File(p)),
+        (None, None) => Ok(ConfigSource::File("examples/model_config.toml".to_string())),
+    }
+}
+
 impl ModelConfig {
     pub fn from_toml_str(text: &str) -> Result<Self, LlmError> {
         Ok(toml::from_str(text)?)
@@ -3855,5 +3885,42 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
         assert_eq!(r.compose_prompt, "compose it");
         assert_eq!(r.retry_depth, 1);
         assert_eq!(r.fallback_model.len(), 1);
+    }
+
+    #[test]
+    fn resolve_config_source_combinations() {
+        // Neither set → compiled-in default single file.
+        assert_eq!(
+            resolve_config_source(None, None).unwrap(),
+            ConfigSource::File("examples/model_config.toml".to_string())
+        );
+        // Path only.
+        assert_eq!(
+            resolve_config_source(Some("my.toml".to_string()), None).unwrap(),
+            ConfigSource::File("my.toml".to_string())
+        );
+        // Dir only.
+        assert_eq!(
+            resolve_config_source(None, Some("conf.d".to_string())).unwrap(),
+            ConfigSource::Dir("conf.d".to_string())
+        );
+        // Both set → hard error mentioning both var names.
+        let err = resolve_config_source(Some("my.toml".to_string()), Some("conf.d".to_string()))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("mutually exclusive"), "{err}");
+        assert!(
+            err.contains("MODEL_CONFIG_PATH") && err.contains("MODEL_CONFIG_DIR"),
+            "{err}"
+        );
+        // Empty string counts as unset (dotenv `VAR=` lines must not trip the exclusion).
+        assert_eq!(
+            resolve_config_source(Some(String::new()), Some("conf.d".to_string())).unwrap(),
+            ConfigSource::Dir("conf.d".to_string())
+        );
+        assert_eq!(
+            resolve_config_source(Some(String::new()), None).unwrap(),
+            ConfigSource::File("examples/model_config.toml".to_string())
+        );
     }
 }

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -859,6 +859,17 @@ impl ModelConfig {
         Ok(toml::from_str(text)?)
     }
 
+    /// Load a single-file config, logging the resolved path on success.
+    /// `from_toml_str` stays available for callers that already hold the text.
+    pub fn from_toml_file(path: &std::path::Path) -> Result<Self, LlmError> {
+        let text = std::fs::read_to_string(path).map_err(|e| {
+            LlmError::Config(format!("model_config read failed: {}: {e}", path.display()))
+        })?;
+        let cfg = Self::from_toml_str(&text)?;
+        tracing::info!(path = %path.display(), "model_config: loaded");
+        Ok(cfg)
+    }
+
     /// Library-side convenience: load the config from `MODEL_CONFIG_PATH`,
     /// or fall back to `examples/model_config.toml` to match the
     /// `eros-engine-server` boot default. The server binary itself reads
@@ -3922,5 +3933,23 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
             resolve_config_source(Some(String::new()), None).unwrap(),
             ConfigSource::File("examples/model_config.toml".to_string())
         );
+    }
+
+    fn write_cfg(dir: &std::path::Path, name: &str, content: &str) {
+        std::fs::write(dir.join(name), content).unwrap();
+    }
+
+    #[test]
+    fn from_toml_file_reads_and_wraps_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_cfg(tmp.path(), "cfg.toml", "[tasks.a]\nmodel = \"p/a\"\n");
+        let cfg = ModelConfig::from_toml_file(&tmp.path().join("cfg.toml")).unwrap();
+        assert!(matches!(&cfg.tasks["a"].model, ModelSpec::Fixed(m) if m == "p/a"));
+
+        // Missing file: error message carries the path.
+        let err = ModelConfig::from_toml_file(&tmp.path().join("nope.toml"))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("nope.toml"), "{err}");
     }
 }

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -971,17 +971,21 @@ impl ModelConfig {
         Ok(cfg)
     }
 
-    /// Library-side convenience: load the config from `MODEL_CONFIG_PATH`,
-    /// or fall back to `examples/model_config.toml` to match the
-    /// `eros-engine-server` boot default. The server binary itself reads
-    /// the file inline via `from_toml_str` rather than calling this; this
-    /// method is provided for embedders who want the same behaviour in
-    /// one call.
+    /// Library-side convenience: resolve `MODEL_CONFIG_PATH` /
+    /// `MODEL_CONFIG_DIR` (mutually exclusive; neither set falls back to
+    /// `examples/model_config.toml` to match the `eros-engine-server` boot
+    /// default) and load. The server binary does the same resolution in
+    /// `main.rs` via `resolve_config_source`, so embedders and the server
+    /// stay behaviour-identical.
     pub fn load() -> Result<Arc<Self>, LlmError> {
-        let path = std::env::var("MODEL_CONFIG_PATH")
-            .unwrap_or_else(|_| "examples/model_config.toml".to_string());
-        let text = std::fs::read_to_string(&path)?;
-        let cfg = Self::from_toml_str(&text)?;
+        let source = resolve_config_source(
+            std::env::var("MODEL_CONFIG_PATH").ok(),
+            std::env::var("MODEL_CONFIG_DIR").ok(),
+        )?;
+        let cfg = match &source {
+            ConfigSource::File(p) => Self::from_toml_file(std::path::Path::new(p))?,
+            ConfigSource::Dir(d) => Self::from_toml_dir(std::path::Path::new(d))?,
+        };
         Ok(Arc::new(cfg))
     }
 

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -865,7 +865,12 @@ impl ModelConfig {
         let text = std::fs::read_to_string(path).map_err(|e| {
             LlmError::Config(format!("model_config read failed: {}: {e}", path.display()))
         })?;
-        let cfg = Self::from_toml_str(&text)?;
+        let cfg = Self::from_toml_str(&text).map_err(|e| {
+            LlmError::Config(format!(
+                "model_config parse failed: {}: {e}",
+                path.display()
+            ))
+        })?;
         tracing::info!(path = %path.display(), "model_config: loaded");
         Ok(cfg)
     }
@@ -4056,6 +4061,14 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
             .unwrap_err()
             .to_string();
         assert!(err.contains("nope.toml"), "{err}");
+
+        // Malformed TOML: error names the file and says parse failed.
+        write_cfg(tmp.path(), "broken.toml", "[tasks.a\nmodel = \n");
+        let err = ModelConfig::from_toml_file(&tmp.path().join("broken.toml"))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("broken.toml"), "{err}");
+        assert!(err.contains("parse failed"), "{err}");
     }
 
     #[test]

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -876,7 +876,7 @@ impl ModelConfig {
     /// never changes the result — it only makes error messages deterministic).
     /// Split-by-section semantics: each `tasks.<name>` and every other top-level
     /// key must come from exactly one file; duplicates fail the load naming both
-    /// files (see Task 4 — added with the conflict tests).
+    /// files.
     pub fn from_toml_dir(dir: &std::path::Path) -> Result<Self, LlmError> {
         let entries = std::fs::read_dir(dir).map_err(|e| {
             LlmError::Config(format!(
@@ -910,6 +910,9 @@ impl ModelConfig {
 
         let mut merged = toml::Table::new();
         let mut file_names: Vec<String> = Vec::new();
+        // Which file first defined each top-level key (or `tasks.<name>`) — so
+        // duplicate-definition errors can name both files.
+        let mut owners: HashMap<String, String> = HashMap::new();
         for file in &files {
             let file_name = file
                 .file_name()
@@ -934,9 +937,22 @@ impl ModelConfig {
                         .as_table_mut()
                         .expect("`tasks` is only ever inserted as a table");
                     for (task_name, task_value) in tasks {
+                        let owner_key = format!("tasks.{task_name}");
+                        if let Some(prev) = owners.get(&owner_key) {
+                            return Err(LlmError::Config(format!(
+                                "model_config merge failed: [tasks.{task_name}] in {file_name} already defined in {prev}"
+                            )));
+                        }
+                        owners.insert(owner_key, file_name.clone());
                         merged_tasks.insert(task_name, task_value);
                     }
                 } else {
+                    if let Some(prev) = owners.get(&key) {
+                        return Err(LlmError::Config(format!(
+                            "model_config merge failed: [{key}] in {file_name} already defined in {prev}"
+                        )));
+                    }
+                    owners.insert(key.clone(), file_name.clone());
                     merged.insert(key, value);
                 }
             }
@@ -4104,5 +4120,57 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
             .unwrap_err()
             .to_string();
         assert!(err.contains("dir read failed"), "{err}");
+    }
+
+    #[test]
+    fn from_toml_dir_duplicate_task_errors_naming_both_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_cfg(
+            tmp.path(),
+            "a.toml",
+            "[tasks.chat_companion]\nmodel = \"p/one\"\n",
+        );
+        write_cfg(
+            tmp.path(),
+            "b.toml",
+            "[tasks.chat_companion]\nmodel = \"p/two\"\n",
+        );
+        let err = ModelConfig::from_toml_dir(tmp.path())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("[tasks.chat_companion]"), "{err}");
+        assert!(err.contains("a.toml"), "{err}");
+        assert!(err.contains("b.toml"), "{err}");
+    }
+
+    #[test]
+    fn from_toml_dir_duplicate_defaults_errors_naming_both_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_cfg(
+            tmp.path(),
+            "a.toml",
+            "[defaults]\nfallback_temperature = 0.1\n",
+        );
+        write_cfg(
+            tmp.path(),
+            "b.toml",
+            "[defaults]\nfallback_temperature = 0.2\n",
+        );
+        let err = ModelConfig::from_toml_dir(tmp.path())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("[defaults]"), "{err}");
+        assert!(err.contains("a.toml") && err.contains("b.toml"), "{err}");
+    }
+
+    #[test]
+    fn from_toml_dir_syntax_error_names_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_cfg(tmp.path(), "good.toml", "[tasks.a]\nmodel = \"p/a\"\n");
+        write_cfg(tmp.path(), "broken.toml", "[tasks.b\nmodel = \n");
+        let err = ModelConfig::from_toml_dir(tmp.path())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("broken.toml"), "{err}");
     }
 }

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -870,6 +870,91 @@ impl ModelConfig {
         Ok(cfg)
     }
 
+    /// Directory mode (`MODEL_CONFIG_DIR`): merge every top-level `*.toml` in
+    /// `dir` into one config. Selection: regular files at the top level only,
+    /// dotfiles skipped, filename byte order (duplicates are errors, so order
+    /// never changes the result — it only makes error messages deterministic).
+    /// Split-by-section semantics: each `tasks.<name>` and every other top-level
+    /// key must come from exactly one file; duplicates fail the load naming both
+    /// files (see Task 4 — added with the conflict tests).
+    pub fn from_toml_dir(dir: &std::path::Path) -> Result<Self, LlmError> {
+        let entries = std::fs::read_dir(dir).map_err(|e| {
+            LlmError::Config(format!(
+                "model_config dir read failed: {}: {e}",
+                dir.display()
+            ))
+        })?;
+        let mut files: Vec<std::path::PathBuf> = Vec::new();
+        for entry in entries {
+            let entry = entry.map_err(|e| {
+                LlmError::Config(format!(
+                    "model_config dir read failed: {}: {e}",
+                    dir.display()
+                ))
+            })?;
+            let path = entry.path();
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if !path.is_file() || name.starts_with('.') || !name.ends_with(".toml") {
+                continue;
+            }
+            files.push(path);
+        }
+        files.sort();
+        if files.is_empty() {
+            return Err(LlmError::Config(format!(
+                "model_config dir contains no .toml files: {}",
+                dir.display()
+            )));
+        }
+
+        let mut merged = toml::Table::new();
+        let mut file_names: Vec<String> = Vec::new();
+        for file in &files {
+            let file_name = file
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_else(|| file.display().to_string());
+            let text = std::fs::read_to_string(file).map_err(|e| {
+                LlmError::Config(format!("model_config read failed: {}: {e}", file.display()))
+            })?;
+            let table: toml::Table = text.parse().map_err(|e: toml::de::Error| {
+                LlmError::Config(format!("model_config parse failed: {file_name}: {e}"))
+            })?;
+            for (key, value) in table {
+                if key == "tasks" {
+                    let toml::Value::Table(tasks) = value else {
+                        return Err(LlmError::Config(format!(
+                            "model_config merge failed: `tasks` in {file_name} is not a table"
+                        )));
+                    };
+                    let merged_tasks = merged
+                        .entry("tasks")
+                        .or_insert_with(|| toml::Value::Table(toml::Table::new()))
+                        .as_table_mut()
+                        .expect("`tasks` is only ever inserted as a table");
+                    for (task_name, task_value) in tasks {
+                        merged_tasks.insert(task_name, task_value);
+                    }
+                } else {
+                    merged.insert(key, value);
+                }
+            }
+            file_names.push(file_name);
+        }
+
+        let cfg: Self = merged.try_into().map_err(|e: toml::de::Error| {
+            LlmError::Config(format!("model_config deserialize failed after merge: {e}"))
+        })?;
+        tracing::info!(
+            dir = %dir.display(),
+            files = ?file_names,
+            count = file_names.len(),
+            "model_config: loaded from dir"
+        );
+        Ok(cfg)
+    }
+
     /// Library-side convenience: load the config from `MODEL_CONFIG_PATH`,
     /// or fall back to `examples/model_config.toml` to match the
     /// `eros-engine-server` boot default. The server binary itself reads
@@ -3951,5 +4036,73 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
             .unwrap_err()
             .to_string();
         assert!(err.contains("nope.toml"), "{err}");
+    }
+
+    #[test]
+    fn from_toml_dir_split_load_succeeds() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_cfg(
+            tmp.path(),
+            "defaults.toml",
+            "[defaults]\nfallback_model = \"p/fall\"\nfallback_temperature = 0.4\n",
+        );
+        write_cfg(
+            tmp.path(),
+            "chat.toml",
+            "[tasks.chat_companion]\nmodel = \"p/chat\"\n",
+        );
+        write_cfg(
+            tmp.path(),
+            "extraction.toml",
+            "[tasks.memory_extraction]\nmodel = \"p/extract\"\n",
+        );
+        let cfg = ModelConfig::from_toml_dir(tmp.path()).unwrap();
+        assert_eq!(cfg.defaults.fallback_model.as_deref(), Some("p/fall"));
+        assert_eq!(cfg.defaults.fallback_temperature, Some(0.4));
+        assert_eq!(cfg.tasks.len(), 2);
+        assert!(matches!(&cfg.tasks["chat_companion"].model, ModelSpec::Fixed(m) if m == "p/chat"));
+        assert!(
+            matches!(&cfg.tasks["memory_extraction"].model, ModelSpec::Fixed(m) if m == "p/extract")
+        );
+    }
+
+    #[test]
+    fn from_toml_dir_ignores_dotfiles_subdirs_and_non_toml() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_cfg(tmp.path(), "base.toml", "[tasks.a]\nmodel = \"p/a\"\n");
+        // All of these define a conflicting tasks.a — they must be skipped, not merged.
+        write_cfg(tmp.path(), ".hidden.toml", "[tasks.a]\nmodel = \"p/dot\"\n");
+        write_cfg(tmp.path(), "notes.txt", "[tasks.a]\nmodel = \"p/txt\"\n");
+        std::fs::create_dir(tmp.path().join("sub.toml")).unwrap(); // directory named *.toml
+        std::fs::create_dir(tmp.path().join("nested")).unwrap();
+        write_cfg(
+            &tmp.path().join("nested"),
+            "extra.toml",
+            "[tasks.a]\nmodel = \"p/nested\"\n",
+        );
+        let cfg = ModelConfig::from_toml_dir(tmp.path()).unwrap();
+        assert_eq!(cfg.tasks.len(), 1);
+        assert!(matches!(&cfg.tasks["a"].model, ModelSpec::Fixed(m) if m == "p/a"));
+    }
+
+    #[test]
+    fn from_toml_dir_empty_missing_or_no_toml_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Empty directory.
+        let err = ModelConfig::from_toml_dir(tmp.path())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("no .toml files"), "{err}");
+        // Non-toml content only.
+        write_cfg(tmp.path(), "readme.md", "# not config");
+        let err = ModelConfig::from_toml_dir(tmp.path())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("no .toml files"), "{err}");
+        // Directory does not exist.
+        let err = ModelConfig::from_toml_dir(&tmp.path().join("nope"))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("dir read failed"), "{err}");
     }
 }

--- a/crates/eros-engine-server/src/main.rs
+++ b/crates/eros-engine-server/src/main.rs
@@ -271,15 +271,24 @@ async fn run_server() -> Result<()> {
 
     // model_config: env override > examples/model_config.toml dev default.
     // The committed example is sanitized; the real config is opted into via
-    // MODEL_CONFIG_PATH (the docker/Dockerfile.fly image bakes it in for prod).
-    let model_config_path =
-        std::env::var("MODEL_CONFIG_PATH").unwrap_or_else(|_| "examples/model_config.toml".into());
-    let model_config_text = std::fs::read_to_string(&model_config_path)
-        .with_context(|| format!("model_config read failed: {model_config_path}"))?;
-    let model_config = Arc::new(
-        eros_engine_llm::model_config::ModelConfig::from_toml_str(&model_config_text)
-            .with_context(|| format!("model_config parse failed: {model_config_path}"))?,
-    );
+    // MODEL_CONFIG_PATH (single file — the docker/Dockerfile.fly image bakes
+    // it in for prod) or MODEL_CONFIG_DIR (a directory of .toml fragments
+    // merged at boot; duplicate sections are boot errors). Mutually exclusive.
+    let source = eros_engine_llm::model_config::resolve_config_source(
+        std::env::var("MODEL_CONFIG_PATH").ok(),
+        std::env::var("MODEL_CONFIG_DIR").ok(),
+    )
+    .context("model_config source resolution failed")?;
+    let model_config = Arc::new(match &source {
+        eros_engine_llm::model_config::ConfigSource::File(p) => {
+            eros_engine_llm::model_config::ModelConfig::from_toml_file(std::path::Path::new(p))
+                .with_context(|| format!("model_config load failed: {p}"))?
+        }
+        eros_engine_llm::model_config::ConfigSource::Dir(d) => {
+            eros_engine_llm::model_config::ModelConfig::from_toml_dir(std::path::Path::new(d))
+                .with_context(|| format!("model_config load failed from dir: {d}"))?
+        }
+    });
 
     // Extraction prompts are required ONLY when the task section exists. A
     // missing [tasks.*_extraction] section means that extraction is off — the

--- a/docs/model-config.md
+++ b/docs/model-config.md
@@ -7,10 +7,38 @@ LLM model selection for the engine lives in a TOML file loaded at server start. 
 ## Where it lives
 
 - Default path: `examples/model_config.toml` (relative to the working directory). The file under `examples/` is an illustrative template — adapt it to your own needs (or point `MODEL_CONFIG_PATH` at your own file).
-- Override: `MODEL_CONFIG_PATH` environment variable
-- Loaded once at server start by `eros-engine-server/src/main.rs` (reads `MODEL_CONFIG_PATH` directly, then `ModelConfig::from_toml_str`). For library embedders, `ModelConfig::load()` in `crates/eros-engine-llm/src/model_config.rs` does the same with the same default path (`examples/model_config.toml`).
+- Override: `MODEL_CONFIG_PATH` environment variable (single file), or `MODEL_CONFIG_DIR` (directory mode, below). The two are mutually exclusive — setting both is a boot error.
+- Loaded once at server start by `eros-engine-server/src/main.rs` (`resolve_config_source` → `ModelConfig::from_toml_file` / `from_toml_dir`). For library embedders, `ModelConfig::load()` in `crates/eros-engine-llm/src/model_config.rs` does the same resolution with the same default path (`examples/model_config.toml`).
 - Held as `Arc<ModelConfig>` in `AppState`; shared across all chat / post-process turns
 - The server also calls `dotenvy::dotenv()` at startup, so `cp .env.example .env` works for the quickstart without an explicit `source .env`
+
+## Directory mode
+
+`MODEL_CONFIG_DIR` points at a directory whose `.toml` files are merged into one config at boot — for splitting a large config by section, not for layering:
+
+- Only the directory's top level is read (no recursion); dotfiles and non-`.toml` entries are skipped. A directory with no `.toml` files is a boot error.
+- Files are parsed independently and merged; load order is filename byte order (order can't change the result — duplicates are errors — it only keeps messages deterministic).
+- `[defaults]` and each `[tasks.<name>]` must come from exactly one file. A section defined twice fails boot naming both files: `model_config merge failed: [tasks.chat_companion] in chat.toml already defined in base.toml`. There is no override or precedence between files.
+- On success the server logs the merged file list: `model_config: loaded from dir` with the directory, filenames, and count.
+
+Example split:
+
+```toml
+# defaults.toml
+[defaults]
+fallback_model       = "x-ai/grok-4-mini"
+fallback_temperature = 0.5
+
+# chat.toml
+[tasks.chat_companion]
+model = "provider/chat-model"
+
+# extraction.toml
+[tasks.insight_extraction]
+model = "provider/extract-model"
+[tasks.memory_extraction]
+model = "provider/extract-model"
+```
 
 ## Schema
 

--- a/docs/model-config.md
+++ b/docs/model-config.md
@@ -20,6 +20,7 @@ LLM model selection for the engine lives in a TOML file loaded at server start. 
 - Files are parsed independently and merged; load order is filename byte order (order can't change the result — duplicates are errors — it only keeps messages deterministic).
 - `[defaults]` and each `[tasks.<name>]` must come from exactly one file. A section defined twice fails boot naming both files: `model_config merge failed: [tasks.chat_companion] in chat.toml already defined in base.toml`. There is no override or precedence between files.
 - On success the server logs the merged file list: `model_config: loaded from dir` with the directory, filenames, and count.
+- The published Docker image bakes `MODEL_CONFIG_PATH` (`docker/Dockerfile`). To use directory mode in that image, clear it alongside your dir: `-e MODEL_CONFIG_PATH= -e MODEL_CONFIG_DIR=/etc/eros/model.d` (an empty value counts as unset).
 
 Example split:
 

--- a/docs/model-config.zh.md
+++ b/docs/model-config.zh.md
@@ -7,10 +7,38 @@
 ## 文件位置
 
 - 默认路径：`examples/model_config.toml`（相对于工作目录）。`examples/` 下的文件是示例模板——请根据自己的需求调整（或通过 `MODEL_CONFIG_PATH` 指向自己的文件）。
-- 覆盖方式：`MODEL_CONFIG_PATH` 环境变量
-- 服务器启动时由 `eros-engine-server/src/main.rs` 加载一次（直接读取 `MODEL_CONFIG_PATH`，然后调用 `ModelConfig::from_toml_str`）。对于嵌入该库的应用，`crates/eros-engine-llm/src/model_config.rs` 中的 `ModelConfig::load()` 以相同方式加载，并使用相同的默认路径（`examples/model_config.toml`）。
+- 覆盖方式：`MODEL_CONFIG_PATH` 环境变量（单文件），或 `MODEL_CONFIG_DIR`（目录模式，见下）。两者互斥——同时设置会导致启动报错。
+- 服务器启动时由 `eros-engine-server/src/main.rs` 加载一次（`resolve_config_source` → `ModelConfig::from_toml_file` / `from_toml_dir`）。对于嵌入该库的应用，`crates/eros-engine-llm/src/model_config.rs` 中的 `ModelConfig::load()` 执行相同的解析逻辑，并使用相同的默认路径（`examples/model_config.toml`）。
 - 以 `Arc<ModelConfig>` 保存在 `AppState` 中；由所有 chat / post-process 轮次共享
 - 服务器启动时还会调用 `dotenvy::dotenv()`，因此快速入门中执行 `cp .env.example .env` 后无需显式执行 `source .env`
+
+## 目录模式
+
+`MODEL_CONFIG_DIR` 指向一个目录，启动时将其中的 `.toml` 文件合并成完整配置——用于把大配置按 section 拆分，而不是分层覆盖：
+
+- 只读取目录第一层（不递归）；dotfile 和非 `.toml` 条目会被跳过。目录中没有任何 `.toml` 文件会导致启动报错。
+- 每个文件独立解析后合并；加载顺序为文件名字节序（重复即报错，因此顺序不影响结果，只保证报错信息可复现）。
+- `[defaults]` 和每个 `[tasks.<name>]` 只能来自一个文件。同一 section 定义两次会启动失败并点名两个文件：`model_config merge failed: [tasks.chat_companion] in chat.toml already defined in base.toml`。文件之间不存在覆盖或优先级。
+- 合并成功后服务器会记录文件清单日志：`model_config: loaded from dir`（含目录、文件名列表和数量）。
+
+拆分示例：
+
+```toml
+# defaults.toml
+[defaults]
+fallback_model       = "x-ai/grok-4-mini"
+fallback_temperature = 0.5
+
+# chat.toml
+[tasks.chat_companion]
+model = "provider/chat-model"
+
+# extraction.toml
+[tasks.insight_extraction]
+model = "provider/extract-model"
+[tasks.memory_extraction]
+model = "provider/extract-model"
+```
 
 ## Schema
 

--- a/docs/model-config.zh.md
+++ b/docs/model-config.zh.md
@@ -20,6 +20,7 @@
 - 每个文件独立解析后合并；加载顺序为文件名字节序（重复即报错，因此顺序不影响结果，只保证报错信息可复现）。
 - `[defaults]` 和每个 `[tasks.<name>]` 只能来自一个文件。同一 section 定义两次会启动失败并点名两个文件：`model_config merge failed: [tasks.chat_companion] in chat.toml already defined in base.toml`。文件之间不存在覆盖或优先级。
 - 合并成功后服务器会记录文件清单日志：`model_config: loaded from dir`（含目录、文件名列表和数量）。
+- 发布的 Docker 镜像内置了 `MODEL_CONFIG_PATH`（`docker/Dockerfile`）。要在该镜像中使用目录模式，需在传入目录的同时清空它：`-e MODEL_CONFIG_PATH= -e MODEL_CONFIG_DIR=/etc/eros/model.d`（空值视为未设置）。
 
 拆分示例：
 

--- a/docs/superpowers/specs/2026-07-18-model-config-dir-design.md
+++ b/docs/superpowers/specs/2026-07-18-model-config-dir-design.md
@@ -1,0 +1,128 @@
+# Model config directory mode (`MODEL_CONFIG_DIR`)
+
+**Date:** 2026-07-18
+**Scope:** engine (this repo). Additive, config-loading only. A new
+`MODEL_CONFIG_DIR` environment variable (mutually exclusive with
+`MODEL_CONFIG_PATH`) that loads a directory of `.toml` files and merges them
+into one `ModelConfig` at boot. No runtime behaviour changes after load; all
+existing validators run unchanged on the merged result.
+
+## Problem
+
+The model config is a single TOML file (`MODEL_CONFIG_PATH`, default
+`examples/model_config.toml`). A real deployment's file carries `[defaults]`
+plus seven-and-growing `[tasks.*]` sections (~500 lines in the example alone),
+each with prompts, tier blocks, and sampling knobs. Editing one task means
+scrolling one large file, and diffs/reviews mix unrelated tasks.
+
+The fix is a directory mode: split the config by section into small files
+(`defaults.toml`, `chat.toml`, `extraction.toml`, …) and have the engine merge
+them at boot. Splitting is the only goal — this is **not** a layering/override
+mechanism; a key defined twice is a configuration error, not a precedence
+question.
+
+## Design
+
+### Environment variable semantics
+
+- New env var `MODEL_CONFIG_DIR`: path to a directory whose `.toml` files are
+  merged into the full model config.
+- Mutually exclusive with `MODEL_CONFIG_PATH`: setting **both** is a boot
+  error telling the operator to pick one. No silent precedence.
+- Neither set → behaviour is unchanged (single-file default
+  `examples/model_config.toml`).
+- `MODEL_CONFIG_DIR` has no default; directory mode is opt-in only.
+
+### File selection rules
+
+- Take `*.toml` files from the directory's **top level only** (no recursion
+  into subdirectories).
+- Skip dotfiles (names starting with `.`) to avoid editor temp files.
+- Sort by filename byte order. Because duplicates are errors, order cannot
+  change the merged result — sorting only makes iteration and error messages
+  deterministic.
+- The directory not existing, or containing no matching `.toml` file, is a
+  boot error (fail fast on misconfiguration).
+
+### Merge rules (per-file parse + table-level merge)
+
+- Each file is parsed standalone into a `toml::Table`; a syntax error reports
+  the offending filename.
+- Merge granularity:
+  - `tasks` merges one level deep: each `tasks.<name>` must come from exactly
+    one file. The same task name in two files is an error naming both files,
+    e.g. `[tasks.chat_companion] in chat.toml already defined in base.toml`.
+  - Every other top-level key (`defaults`, and any future top-level section)
+    is whole-key unique: defined in at most one file, duplicate is an error
+    naming both files.
+- The merged table is then deserialized through the existing path into
+  `ModelConfig`. Existing boot validators (`validate_extraction_prompts`,
+  `validate_voice_model`, `validate_product_qa_prompt`, …) run on the merged
+  config exactly as they do today — zero changes to them.
+
+### Code placement
+
+- `crates/eros-engine-llm/src/model_config.rs`:
+  - New `ModelConfig::from_toml_dir(dir)` — list/sort/parse/merge as above.
+  - A **pure function** for source resolution taking the two env values as
+    `Option<String>` (not reading `std::env` itself) and returning
+    single-file / directory / both-set-error — unit-testable without touching
+    process env.
+  - `ModelConfig::load()` (embedder convenience) gains `MODEL_CONFIG_DIR`
+    support via the same resolution function, staying behaviour-identical to
+    the server.
+- `crates/eros-engine-server/src/main.rs`: the inline load block calls the
+  same crate entry points, keeping its anyhow-context error style.
+
+### Boot logging
+
+- Directory mode: after a successful merge, one `tracing::info!` line listing
+  the directory, the concrete filenames in load order, and the count, e.g.
+  `model_config loaded from dir: /etc/eros/model.d [chat.toml, defaults.toml,
+  extraction.toml] (3 files merged)` — then boot proceeds normally.
+- Single-file mode (including the default path): a symmetric
+  `model_config loaded: <path>` line. This log does not exist today; adding it
+  makes the two modes uniform.
+- Both lines are emitted inside the eros-engine-llm load functions (which hold
+  the sorted file list), so the server and library embedders get them without
+  duplicating the logging at call sites. The server initializes its tracing
+  subscriber well before config load (`main.rs:39` vs `main.rs:275`), so the
+  lines are visible at boot.
+
+### Documentation
+
+- `.env.example`: a `MODEL_CONFIG_DIR` comment block next to
+  `MODEL_CONFIG_PATH`, stating the mutual exclusion.
+- `docs/model-config.md` + `docs/model-config.zh.md`: a "Directory mode"
+  subsection covering the rules above, with a short `defaults.toml` +
+  `chat.toml` split example snippet.
+- `README.md` / `README.zh.md` / `README.ja.md`: mention `MODEL_CONFIG_DIR`
+  in the existing sentence that names `MODEL_CONFIG_PATH`; no new section.
+- **No** `examples/model_config.d/` example directory — the doc snippet is
+  enough, and a second example config would have to be kept in sync with
+  `examples/model_config.toml` forever.
+
+### Testing
+
+Unit tests in `model_config.rs`, writing files into a tempdir:
+
+- Split load succeeds (`defaults.toml` + per-task files ≡ the equivalent
+  single file).
+- Duplicate task across two files errors, message contains both filenames.
+- Duplicate `defaults` across two files errors.
+- Syntax error in one file errors, message contains that filename.
+- Empty directory (and directory with no `.toml`) errors.
+- Dotfiles and non-`.toml` files are ignored.
+- Source-resolution pure function: all four set/unset combinations, including
+  the both-set error.
+
+No integration test and no process-env mutation in tests — the pure resolution
+function covers the env logic.
+
+## Out of scope
+
+- Any override/layering semantics (later-file-wins, key-level deep merge).
+- Recursive directory walks.
+- A default value for `MODEL_CONFIG_DIR`.
+- Shipping an example split directory under `examples/`.
+- Config hot-reload — load-once-at-boot is unchanged.


### PR DESCRIPTION
## What

Adds a `MODEL_CONFIG_DIR` environment variable that loads a **directory** of `.toml` fragments and merges them into one `ModelConfig` at boot — for splitting a large model config by section, not for layering. Mutually exclusive with the existing `MODEL_CONFIG_PATH`.

Spec: `docs/superpowers/specs/2026-07-18-model-config-dir-design.md`

## Behavior

- **Env resolution** — `MODEL_CONFIG_DIR` ⟂ `MODEL_CONFIG_PATH`: both set → boot error; empty string counts as unset; neither → unchanged `examples/model_config.toml` default. A single-file `MODEL_CONFIG_PATH` deployment behaves exactly as before (plus a new `model_config: loaded` boot line).
- **Directory merge** — top level only (no recursion); dotfiles and non-`.toml` skipped; filename byte-order; empty/missing dir → boot error.
- **Split-by-section** — each `[defaults]` and `[tasks.<name>]` must come from exactly one file. A section defined twice fails boot naming **both** files (`model_config merge failed: [tasks.chat_companion] in chat.toml already defined in base.toml`). No override/precedence — this is splitting, not layering.
- **Unified path** — a pure `resolve_config_source()` + `from_toml_file` / `from_toml_dir`, called identically by `ModelConfig::load()` (embedders) and the server `main.rs`. Existing validators run unchanged on the merged config. Both modes log a boot line.

## Out of scope (intentionally absent)

Override/layering, recursion, a `MODEL_CONFIG_DIR` default, an `examples/model_config.d/` example dir, hot-reload.

## Docs

`.env.example`, `docs/model-config.md` + `.zh.md` (new "Directory mode" section with a split example), README ×3. Note documented: the published GHCR image bakes `MODEL_CONFIG_PATH`, so directory mode in-container needs `-e MODEL_CONFIG_PATH= -e MODEL_CONFIG_DIR=…`.

## Tests / gate

All new logic is in `crates/eros-engine-llm/src/model_config.rs` with tempdir-based unit tests (split load, duplicate-task/-defaults errors naming both files, syntax error names file, empty/missing dir, dotfile/subdir/non-toml skip, source-resolution combinations, malformed-file parse-error path). Local gate: fmt clean, `clippy --workspace -D warnings` clean, workspace tests 792/792, OpenAPI snapshot unchanged (no handler/schema touched). All commits signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
