### PR TITLE
feat(affinity): LLM-evaluated patience (absolute read + rule delta)

### DIFF
--- a/crates/eros-engine-server/src/pipeline/post_process.rs
+++ b/crates/eros-engine-server/src/pipeline/post_process.rs
@@ -269,6 +269,7 @@ async fn persist_affinity(
                     event_type,
                     context,
                     meta.as_ref(),
+                    None,
                 )
                 .await
             {

--- a/crates/eros-engine-server/src/pipeline/post_process.rs
+++ b/crates/eros-engine-server/src/pipeline/post_process.rs
@@ -125,7 +125,7 @@ pub async fn run(
             eval_text.trim().is_empty(),
         );
 
-        let (llm_deltas, reason, affinity_meta, skip_reason) = if pre_skip.is_none() {
+        let (llm_deltas, patience_abs, reason, affinity_meta, skip_reason) = if pre_skip.is_none() {
             let persona_repo = PersonaRepo { pool: &state.pool };
             let affinity_repo = AffinityRepo { pool: &state.pool };
             let persona_name = match persona_repo.load_companion(instance_id).await {
@@ -149,6 +149,7 @@ pub async fn run(
                 }
                 _ => (
                     eros_engine_core::affinity::AffinityDeltas::default(),
+                    None,
                     String::new(),
                     None,
                     Some("no_persona_or_affinity"),
@@ -157,6 +158,7 @@ pub async fn run(
         } else {
             (
                 eros_engine_core::affinity::AffinityDeltas::default(),
+                None,
                 String::new(),
                 None,
                 pre_skip,
@@ -164,6 +166,7 @@ pub async fn run(
         };
 
         let combined = merge_deltas(&plan.affinity_deltas, &llm_deltas);
+        let patience_tgt = patience_target(patience_abs, combined.patience);
         let context = build_affinity_context(&reason, skip_reason);
 
         persist_affinity(
@@ -175,6 +178,7 @@ pub async fn run(
             combined,
             context,
             affinity_meta,
+            patience_tgt,
         )
         .await;
     };
@@ -208,6 +212,7 @@ async fn persist_affinity(
     deltas: eros_engine_core::affinity::AffinityDeltas,
     context: serde_json::Value,
     meta: Option<eros_engine_store::OpenRouterCallMeta>,
+    patience_target: Option<f64>,
 ) {
     let repo = AffinityRepo { pool: &state.pool };
 
@@ -269,7 +274,7 @@ async fn persist_affinity(
                     event_type,
                     context,
                     meta.as_ref(),
-                    None,
+                    patience_target,
                 )
                 .await
             {
@@ -487,6 +492,14 @@ fn parse_affinity_eval(
     )
 }
 
+/// Combine the LLM's absolute patience read `L` with the PDE rule delta into
+/// the turn's absolute patience target. `None` (no LLM read) → the caller
+/// falls back to the rule-delta-through-EMA path. The sum is NOT re-snapped —
+/// the 0.1 grid constrains the LLM read only, so the rule nudge survives.
+fn patience_target(patience_abs: Option<f64>, rule_delta: f64) -> Option<f64> {
+    patience_abs.map(|l| (l + rule_delta).clamp(0.0, 1.0))
+}
+
 /// Sum the rule (behavioral) and LLM (semantic) contributions per axis.
 /// `patience` is rule-owned — the evaluator always passes 0 for it — so
 /// the sum naturally keeps the rule value.
@@ -628,9 +641,11 @@ fn build_affinity_context(reason: &str, skip_reason: Option<&str>) -> serde_json
 }
 
 /// Run the haiku affinity evaluator for one Reply turn. Returns the clamped
-/// per-axis LLM deltas + the model's reason. Any failure (LLM error,
-/// non-JSON) yields all-zero deltas + empty reason so the rule deltas still
-/// persist and the affinity write never fails because the evaluator failed.
+/// per-axis LLM deltas, the snapped absolute patience read (`None` when the
+/// model omitted it), and the model's reason. Any failure (LLM error,
+/// non-JSON) yields all-zero deltas + no patience read + empty reason so the
+/// rule deltas still persist and the affinity write never fails because the
+/// evaluator failed.
 async fn evaluate_affinity(
     state: &AppState,
     session_id: Uuid,
@@ -641,6 +656,7 @@ async fn evaluate_affinity(
     audit_user: Option<&str>,
 ) -> (
     eros_engine_core::affinity::AffinityDeltas,
+    Option<f64>,
     String,
     Option<eros_engine_store::OpenRouterCallMeta>,
     Option<&'static str>,
@@ -679,6 +695,7 @@ async fn evaluate_affinity(
                 tracing::warn!("affinity eval LLM call failed: {e}");
                 return (
                     AffinityDeltas::default(),
+                    None,
                     String::new(),
                     None,
                     Some("eval_error"),
@@ -690,6 +707,7 @@ async fn evaluate_affinity(
             );
                 return (
                     AffinityDeltas::default(),
+                    None,
                     String::new(),
                     None,
                     Some("eval_timeout"),
@@ -697,12 +715,12 @@ async fn evaluate_affinity(
             }
         };
 
-    let (deltas, _patience_abs, reason) = parse_affinity_eval(&raw);
+    let (deltas, patience_abs, reason) = parse_affinity_eval(&raw);
     tracing::debug!(affinity_reason = %reason, "affinity eval parsed");
     // Eval ran, but a salvaged response can still lack a generation_id — mark it
     // so a NULL audit join key is never left unexplained.
     let skip = meta.as_ref().and_then(meta_skip_reason);
-    (deltas, reason, meta, skip)
+    (deltas, patience_abs, reason, meta, skip)
 }
 
 const INSIGHT_TASK: &str = "insight_extraction";
@@ -1179,6 +1197,20 @@ mod tests {
     fn parse_affinity_eval_garbage_patience_none() {
         let (_d, p, _) = parse_affinity_eval("not json at all");
         assert_eq!(p, None);
+    }
+
+    #[test]
+    fn patience_target_combines_absolute_and_rule_delta() {
+        // L 0.9 + rule delta 0.03 = 0.93, no snap on the sum. Float arithmetic →
+        // compare with a tolerance, NOT assert_eq! on the raw f64 (0.9+0.03 is
+        // not bit-identical to the 0.93 literal).
+        let t = patience_target(Some(0.9), 0.03).expect("Some");
+        assert!((t - 0.93).abs() < 1e-9, "got {t}");
+        // clamps land on exact bound literals → assert_eq is safe here.
+        assert_eq!(patience_target(Some(1.0), 0.05), Some(1.0)); // ceiling clamp
+        assert_eq!(patience_target(Some(0.0), -0.05), Some(0.0)); // floor clamp
+                                                                  // no LLM read → None (fallback path)
+        assert_eq!(patience_target(None, -0.02), None);
     }
 
     #[test]
@@ -1880,6 +1912,60 @@ mod tests {
             (patience - 0.48).abs() < 1e-9,
             "rule delta (-0.02 patience) still applied even though the reply \
              was empty; got {patience}"
+        );
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn persist_affinity_sets_patience_from_target(pool: sqlx::PgPool) {
+        use eros_engine_store::affinity::AffinityRepo;
+
+        let user_id = Uuid::new_v4();
+        let instance_id = Uuid::new_v4();
+        let session_id = sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(user_id)
+        .bind(instance_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        // persist_affinity calls load_or_create, but seeding the row first is
+        // explicit and lets us assert against a known 0.5 seed.
+        AffinityRepo { pool: &pool }
+            .load_or_create(session_id, user_id, instance_id)
+            .await
+            .unwrap();
+
+        // test_state has ema_inertia = 0.0, so the None path would land patience
+        // at 0.5 + 0.03 = 0.53. Passing Some(0.93) must win → 0.93.
+        let state = crate::routes::companion::test_state(pool.clone());
+        let deltas = eros_engine_core::affinity::AffinityDeltas {
+            patience: 0.03, // the rule delta R (also present in `deltas`)
+            ..Default::default()
+        };
+        persist_affinity(
+            &state,
+            session_id,
+            user_id,
+            instance_id,
+            ActionType::ReplyText,
+            deltas,
+            serde_json::json!({}),
+            None,
+            Some(0.93), // patience_target = clamp(L 0.9 + R 0.03)
+        )
+        .await;
+
+        let patience: f64 = sqlx::query_scalar(
+            "SELECT patience FROM engine.companion_affinity WHERE session_id = $1",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert!(
+            (patience - 0.93).abs() < 1e-9,
+            "patience_target set directly through the server layer (not 0.53); got {patience}"
         );
     }
 }

--- a/crates/eros-engine-server/src/pipeline/post_process.rs
+++ b/crates/eros-engine-server/src/pipeline/post_process.rs
@@ -452,17 +452,21 @@ struct LlmAffinityEval {
 /// Lenient deserializer for the optional absolute `patience` read. A quoted
 /// number (`"patience":"0.5"`) is a common LLM formatting slip; without this,
 /// serde would fail the *entire* `LlmAffinityEval` parse on it and drop the five
-/// valid delta axes too. Accepts a JSON number or a numeric string → `Some`;
-/// null / bool / any other shape → `None`. Never errors, so a malformed patience
-/// value can only affect patience — never the deltas.
+/// valid delta axes too. Accepts a JSON number or a *finite* numeric string →
+/// `Some`; null / bool / any other shape / a non-finite string (`"NaN"`,
+/// `"inf"`, which `f64::from_str` otherwise accepts) → `None`. Never errors, so
+/// a malformed patience value can only affect patience — never the deltas — and
+/// a non-finite value can never reach `snap_patience`/`clamp` (they preserve
+/// NaN) or be persisted as a patience target.
 fn de_lenient_patience<'de, D>(de: D) -> Result<Option<f64>, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
     let v = <serde_json::Value as serde::Deserialize>::deserialize(de)?;
     Ok(match v {
+        // JSON numbers cannot encode NaN/inf, so the number path is finite by construction.
         serde_json::Value::Number(n) => n.as_f64(),
-        serde_json::Value::String(s) => s.trim().parse::<f64>().ok(),
+        serde_json::Value::String(s) => s.trim().parse::<f64>().ok().filter(|v| v.is_finite()),
         _ => None,
     })
 }
@@ -1245,6 +1249,12 @@ mod tests {
             r#"{"warmth":0.2,"patience":true,"reason":"x"}"#,
             r#"{"warmth":0.2,"patience":{"v":1},"reason":"x"}"#,
             r#"{"warmth":0.2,"patience":null,"reason":"x"}"#,
+            // Non-finite quoted strings: `f64::from_str` accepts these, but they
+            // must NOT leak (NaN survives snap/clamp and would poison scoring).
+            r#"{"warmth":0.2,"patience":"NaN","reason":"x"}"#,
+            r#"{"warmth":0.2,"patience":"inf","reason":"x"}"#,
+            r#"{"warmth":0.2,"patience":"-inf","reason":"x"}"#,
+            r#"{"warmth":0.2,"patience":"infinity","reason":"x"}"#,
         ] {
             let (d, p, _) = parse_affinity_eval(raw);
             assert!((d.warmth - 0.2).abs() < 1e-9, "warmth survives: {raw}");

--- a/crates/eros-engine-server/src/pipeline/post_process.rs
+++ b/crates/eros-engine-server/src/pipeline/post_process.rs
@@ -423,9 +423,9 @@ pub(crate) fn find_json_block(raw: &str) -> Option<&str> {
 const LLM_AXIS_POS_CAP: f64 = 0.4;
 const LLM_AXIS_NEG_CAP: f64 = -0.6;
 
-/// Raw shape of the affinity evaluator's JSON output. `patience` is
-/// intentionally absent — it is rule-owned, so any `patience` the model
-/// emits is dropped by serde (unknown field). Missing axes default to 0.
+/// Raw shape of the affinity evaluator's JSON output. Missing axes default to 0.
+/// `patience` is read as an absolute (snapped to 0.1), separate from the rule-owned
+/// per-axis deltas.
 #[derive(Debug, Default, serde::Deserialize)]
 struct LlmAffinityEval {
     #[serde(default)]
@@ -439,22 +439,40 @@ struct LlmAffinityEval {
     #[serde(default)]
     tension: f64,
     #[serde(default)]
+    patience: Option<f64>,
+    #[serde(default)]
     reason: String,
+}
+
+/// Snap the LLM's absolute patience read to the nearest 0.1 step, clamped to
+/// [0,1]. The 0.1 quantisation is a spec contract on the read only — a model
+/// that emits 0.83 is snapped to 0.8.
+fn snap_patience(v: f64) -> f64 {
+    ((v * 10.0).round() / 10.0).clamp(0.0, 1.0)
 }
 
 /// Parse + per-axis clamp the evaluator output into rule-mergeable deltas.
 /// Any failure (non-JSON, no object) → all-zero deltas + empty reason, so
 /// the rule deltas still persist and the affinity write never fails because
-/// the evaluator failed. `patience` is forced to 0 (rule-owned).
-fn parse_affinity_eval(raw: &str) -> (eros_engine_core::affinity::AffinityDeltas, String) {
+/// the evaluator failed. Returns a 3-tuple: (deltas, snapped_patience, reason).
+/// `patience` is read as an absolute (snapped to 0.1) and returned separately;
+/// the deltas.patience stays 0.0 (rule-owned channel).
+fn parse_affinity_eval(
+    raw: &str,
+) -> (
+    eros_engine_core::affinity::AffinityDeltas,
+    Option<f64>,
+    String,
+) {
     use eros_engine_core::affinity::AffinityDeltas;
     let parsed: Option<LlmAffinityEval> = serde_json::from_str(raw)
         .ok()
         .or_else(|| find_json_block(raw).and_then(|b| serde_json::from_str(b).ok()));
     let Some(e) = parsed else {
-        return (AffinityDeltas::default(), String::new());
+        return (AffinityDeltas::default(), None, String::new());
     };
     let cap = |v: f64| v.clamp(LLM_AXIS_NEG_CAP, LLM_AXIS_POS_CAP);
+    let patience_abs = e.patience.map(snap_patience);
     (
         AffinityDeltas {
             warmth: cap(e.warmth),
@@ -464,6 +482,7 @@ fn parse_affinity_eval(raw: &str) -> (eros_engine_core::affinity::AffinityDeltas
             tension: cap(e.tension),
             patience: 0.0,
         },
+        patience_abs,
         e.reason,
     )
 }
@@ -678,7 +697,7 @@ async fn evaluate_affinity(
             }
         };
 
-    let (deltas, reason) = parse_affinity_eval(&raw);
+    let (deltas, _patience_abs, reason) = parse_affinity_eval(&raw);
     tracing::debug!(affinity_reason = %reason, "affinity eval parsed");
     // Eval ran, but a salvaged response can still lack a generation_id — mark it
     // so a NULL audit join key is never left unexplained.
@@ -1113,7 +1132,7 @@ mod tests {
     #[test]
     fn parse_affinity_eval_valid_clamps_and_keeps_reason() {
         let raw = r#"{"warmth":0.08,"trust":0.03,"intimacy":0.06,"intrigue":0.02,"tension":-0.01,"reason":"暖"}"#;
-        let (d, reason) = parse_affinity_eval(raw);
+        let (d, _p, reason) = parse_affinity_eval(raw);
         assert!((d.warmth - 0.08).abs() < 1e-9);
         assert!((d.trust - 0.03).abs() < 1e-9);
         assert!((d.intimacy - 0.06).abs() < 1e-9);
@@ -1126,22 +1145,58 @@ mod tests {
     #[test]
     fn parse_affinity_eval_clamps_out_of_range() {
         let raw = r#"{"warmth":5.0,"trust":-2.0,"reason":"x"}"#;
-        let (d, _) = parse_affinity_eval(raw);
+        let (d, _p, _) = parse_affinity_eval(raw);
         assert!((d.warmth - 0.4).abs() < 1e-9, "warmth caps at +0.4");
         assert!((d.trust - (-0.6)).abs() < 1e-9, "trust delta caps at -0.6");
     }
 
     #[test]
-    fn parse_affinity_eval_ignores_patience_field() {
-        let raw = r#"{"warmth":0.1,"patience":0.99,"reason":"x"}"#;
-        let (d, _) = parse_affinity_eval(raw);
-        assert_eq!(d.patience, 0.0, "patience from the model is ignored");
+    fn parse_affinity_eval_reads_patience_as_absolute_snapped() {
+        // 0.83 snaps to the nearest 0.1 → 0.8; the five delta axes are unaffected.
+        let raw = r#"{"warmth":0.1,"patience":0.83,"reason":"x"}"#;
+        let (d, p, _) = parse_affinity_eval(raw);
+        assert_eq!(
+            d.patience, 0.0,
+            "AffinityDeltas.patience stays 0 (rule-only channel)"
+        );
         assert!((d.warmth - 0.1).abs() < 1e-9);
+        assert_eq!(p, Some(0.8), "patience is read as a snapped absolute");
+    }
+
+    #[test]
+    fn parse_affinity_eval_patience_clamped() {
+        assert_eq!(parse_affinity_eval(r#"{"patience":1.4}"#).1, Some(1.0));
+        assert_eq!(parse_affinity_eval(r#"{"patience":-0.3}"#).1, Some(0.0));
+    }
+
+    #[test]
+    fn parse_affinity_eval_absent_patience_is_none() {
+        let (_d, p, _) = parse_affinity_eval(r#"{"warmth":0.1,"reason":"x"}"#);
+        assert_eq!(p, None, "model omitting patience → None → fallback path");
+    }
+
+    #[test]
+    fn parse_affinity_eval_garbage_patience_none() {
+        let (_d, p, _) = parse_affinity_eval("not json at all");
+        assert_eq!(p, None);
+    }
+
+    #[test]
+    fn snap_patience_rounds_to_nearest_tenth_and_clamps() {
+        assert_eq!(snap_patience(0.83), 0.8);
+        assert_eq!(snap_patience(0.86), 0.9); // rounds up to the nearest 0.1
+        assert_eq!(snap_patience(0.84), 0.8); // rounds down
+        assert_eq!(snap_patience(0.04), 0.0);
+        assert_eq!(snap_patience(1.4), 1.0);
+        assert_eq!(snap_patience(-0.2), 0.0);
+        // NOTE: 0.85 is intentionally NOT tested — as an f64 it is 8.4999…×10,
+        // so it snaps to 0.8, not 0.9; the exact half-point is representation-
+        // dependent and a poor test anchor.
     }
 
     #[test]
     fn parse_affinity_eval_garbage_returns_default() {
-        let (d, reason) = parse_affinity_eval("not json at all");
+        let (d, _p, reason) = parse_affinity_eval("not json at all");
         assert_eq!(d.warmth, 0.0);
         assert_eq!(d.trust, 0.0);
         assert_eq!(d.intrigue, 0.0);
@@ -1154,7 +1209,7 @@ mod tests {
     #[test]
     fn parse_affinity_eval_missing_fields_default_zero() {
         let raw = r#"{"warmth":0.1,"reason":"only warmth"}"#;
-        let (d, _) = parse_affinity_eval(raw);
+        let (d, _p, _) = parse_affinity_eval(raw);
         assert!((d.warmth - 0.1).abs() < 1e-9);
         assert_eq!(d.trust, 0.0);
         assert_eq!(d.intimacy, 0.0);
@@ -1163,7 +1218,7 @@ mod tests {
     #[test]
     fn parse_affinity_eval_extracts_from_fenced_block() {
         let raw = "```json\n{\"warmth\":0.05,\"reason\":\"fenced\"}\n```";
-        let (d, reason) = parse_affinity_eval(raw);
+        let (d, _p, reason) = parse_affinity_eval(raw);
         assert!((d.warmth - 0.05).abs() < 1e-9);
         assert_eq!(reason, "fenced");
     }

--- a/crates/eros-engine-server/src/pipeline/post_process.rs
+++ b/crates/eros-engine-server/src/pipeline/post_process.rs
@@ -430,7 +430,7 @@ const LLM_AXIS_NEG_CAP: f64 = -0.6;
 
 /// Raw shape of the affinity evaluator's JSON output. Missing axes default to 0.
 /// `patience` is read as an absolute (snapped to 0.1), separate from the rule-owned
-/// per-axis deltas.
+/// per-axis deltas, and parsed leniently (see `de_lenient_patience`).
 #[derive(Debug, Default, serde::Deserialize)]
 struct LlmAffinityEval {
     #[serde(default)]
@@ -443,10 +443,28 @@ struct LlmAffinityEval {
     intimacy: f64,
     #[serde(default)]
     tension: f64,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_lenient_patience")]
     patience: Option<f64>,
     #[serde(default)]
     reason: String,
+}
+
+/// Lenient deserializer for the optional absolute `patience` read. A quoted
+/// number (`"patience":"0.5"`) is a common LLM formatting slip; without this,
+/// serde would fail the *entire* `LlmAffinityEval` parse on it and drop the five
+/// valid delta axes too. Accepts a JSON number or a numeric string → `Some`;
+/// null / bool / any other shape → `None`. Never errors, so a malformed patience
+/// value can only affect patience — never the deltas.
+fn de_lenient_patience<'de, D>(de: D) -> Result<Option<f64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let v = <serde_json::Value as serde::Deserialize>::deserialize(de)?;
+    Ok(match v {
+        serde_json::Value::Number(n) => n.as_f64(),
+        serde_json::Value::String(s) => s.trim().parse::<f64>().ok(),
+        _ => None,
+    })
 }
 
 /// Snap the LLM's absolute patience read to the nearest 0.1 step, clamped to
@@ -1197,6 +1215,41 @@ mod tests {
     fn parse_affinity_eval_garbage_patience_none() {
         let (_d, p, _) = parse_affinity_eval("not json at all");
         assert_eq!(p, None);
+    }
+
+    #[test]
+    fn parse_affinity_eval_quoted_patience_salvaged_deltas_survive() {
+        // A quoted number ("0.5") is a common LLM slip. It must NOT fail the
+        // whole struct parse (which would zero the five valid delta axes too):
+        // the deltas survive AND the numeric string is salvaged + snapped.
+        let raw = r#"{"warmth":0.1,"trust":0.05,"patience":"0.5","reason":"x"}"#;
+        let (d, p, _) = parse_affinity_eval(raw);
+        assert!(
+            (d.warmth - 0.1).abs() < 1e-9,
+            "warmth survives a bad patience"
+        );
+        assert!(
+            (d.trust - 0.05).abs() < 1e-9,
+            "trust survives a bad patience"
+        );
+        assert_eq!(p, Some(0.5), "quoted numeric patience is salvaged");
+    }
+
+    #[test]
+    fn parse_affinity_eval_malformed_patience_ignored_deltas_survive() {
+        // Non-numeric / wrong-typed patience → None, but the five deltas still
+        // parse (the regression codex flagged: one bad optional field must not
+        // discard the whole turn's affinity update).
+        for raw in [
+            r#"{"warmth":0.2,"patience":"abc","reason":"x"}"#,
+            r#"{"warmth":0.2,"patience":true,"reason":"x"}"#,
+            r#"{"warmth":0.2,"patience":{"v":1},"reason":"x"}"#,
+            r#"{"warmth":0.2,"patience":null,"reason":"x"}"#,
+        ] {
+            let (d, p, _) = parse_affinity_eval(raw);
+            assert!((d.warmth - 0.2).abs() < 1e-9, "warmth survives: {raw}");
+            assert_eq!(p, None, "malformed patience → None: {raw}");
+        }
     }
 
     #[test]

--- a/crates/eros-engine-server/src/prompt.rs
+++ b/crates/eros-engine-server/src/prompt.rs
@@ -188,9 +188,9 @@ pub fn style_directive(style: ReplyStyle) -> &'static str {
 /// Build the per-turn affinity-evaluation prompt for the post-process LLM
 /// scorer. Asks the model to rate how this single exchange should move the
 /// LLM-owned axes (warmth/trust/intimacy + content nudges to
-/// intrigue/tension) as small per-turn *changes*, not absolute values.
-/// All six current values are shown for context, but `patience` is
-/// rule-owned and is deliberately excluded from the requested output.
+/// intrigue/tension) as small per-turn *changes* (deltas), while `patience`
+/// is requested separately as an *absolute* 0~1 read (0.1 steps), not a
+/// delta. All six current values are shown for context.
 /// Called by the post-process affinity evaluator.
 pub fn affinity_eval_prompt(
     persona_name: &str,
@@ -205,7 +205,7 @@ pub fn affinity_eval_prompt(
          - trust 信任（0~1）：当前 {trust:.2}。自我袒露、言行一致会提升。\n\
          - intrigue 好奇（0~1）：当前 {intrigue:.2}。话题新鲜、有内容会提升。\n\
          - intimacy 亲密（0~1）：当前 {intimacy:.2}。情感或身体上的靠近会提升。\n\
-         - patience 耐心（0~1）：当前 {patience:.2}。由规则维护，请勿评估。\n\
+         - patience 耐心（0~1）：当前 {patience:.2}。请给【绝对值】，不是变化量。\n\
          - tension 张力（0~1）：当前 {tension:.2}。调情、暧昧或冲突会提升。\n\
          \n\
          本轮对话：\n\
@@ -213,14 +213,17 @@ pub fn affinity_eval_prompt(
          {persona_name}：{assistant_msg}\n\
          \n\
          判断这一轮应让 warmth、trust、intrigue、intimacy、tension 各变化多少\
-         （是【变化量】，不是绝对值；patience 不要输出）。\n\
+         （warmth、trust、intrigue、intimacy、tension 是【变化量】。）\n\
          绝大多数普通对话、寒暄、附和都给 0（就是数字 0，不是小数）。\n\
          只有出现真正推进关系的时刻（真诚的温暖、自我袒露、脆弱、成功的调情暧昧）\
          才给正分；这种时刻不常见，但一旦出现可以给较大正分（每个维度最高约 +0.4）。\n\
          负面时刻（冷淡、敷衍、重复、无聊、越界、冲突、被无视）要更敢扣、也更常见，\
          扣分可以更大（每个维度最低约 -0.6）。\n\
+         patience 耐心请另外给一个【绝对值】（0~1，每 0.1 一档，如 0.0/0.1/…/1.0），\
+         代表你现在对这个用户还有多少耐心、愿意继续搭理的程度。用户投入、认真、\
+         有来有回、被尊重会拉高；敷衍、重复、命令式、越界、晾着不理、粗鲁会拉低。\n\
          严格只输出 JSON，reason 用一句中文简述：\n\
-         {{\"warmth\": 0.0, \"trust\": 0.0, \"intrigue\": 0.0, \"intimacy\": 0.0, \"tension\": 0.0, \"reason\": \"...\"}}",
+         {{\"warmth\": 0.0, \"trust\": 0.0, \"intrigue\": 0.0, \"intimacy\": 0.0, \"patience\": 0.5, \"tension\": 0.0, \"reason\": \"...\"}}",
         warmth = affinity.warmth,
         trust = affinity.trust,
         intrigue = affinity.intrigue,
@@ -1552,10 +1555,14 @@ mod tests {
         for v in ["0.42", "0.31", "0.55", "0.22", "0.66", "0.13"] {
             assert!(p.contains(v), "missing current value {v} in prompt");
         }
-        // patience must NOT be a requested output key
+        // patience IS now a requested output key (absolute read)
         assert!(
-            !p.contains("\"patience\""),
-            "patience is rule-owned and must not be in the JSON output schema"
+            p.contains("\"patience\""),
+            "patience IS now in the JSON output schema (absolute read)"
+        );
+        assert!(
+            p.contains("绝对值"),
+            "the prompt frames patience as an absolute, not a delta"
         );
         // axis-to-label binding: the labeled line must carry the correct value
         assert!(
@@ -1566,12 +1573,12 @@ mod tests {
             p.contains("patience 耐心（0~1）：当前 0.66"),
             "patience display value must render"
         );
-        // five-axis JSON output schema (+reason) must be present
+        // six-axis JSON output schema (+reason) must be present (including patience)
         assert!(
             p.contains(
-                r#"{"warmth": 0.0, "trust": 0.0, "intrigue": 0.0, "intimacy": 0.0, "tension": 0.0, "reason": "..."}"#
+                r#"{"warmth": 0.0, "trust": 0.0, "intrigue": 0.0, "intimacy": 0.0, "patience": 0.5, "tension": 0.0, "reason": "..."}"#
             ),
-            "five-axis JSON output schema (+reason) must be present"
+            "six-axis JSON output schema (+reason) with patience must be present"
         );
         // new sparse/asymmetric scoring guidance present
         assert!(p.contains("+0.4"), "positive cap guidance present");

--- a/crates/eros-engine-store/src/affinity.rs
+++ b/crates/eros-engine-store/src/affinity.rs
@@ -228,7 +228,7 @@ impl<'a> AffinityRepo<'a> {
     /// bug the six-axis activation makes real — design spec §6.2). Time
     /// decay is computed from the locked row, not a pre-read snapshot.
     /// Mutates `affinity` in place to reflect the persisted state.
-    /// `patience_target: Some(p)` overwrites patience with `p` directly after `apply_deltas`, bypassing EMA and the caps; `None` keeps the EMA path.
+    /// `patience_target: Some(p)` overwrites patience with `p` directly after `apply_deltas`, bypassing EMA smoothing (the value is still `[0,1]`-clamped); `None` keeps the EMA path.
     #[allow(clippy::too_many_arguments)] // each arg is a distinct persist concern; patience_target is the odd one out
     pub async fn persist_with_event(
         &self,
@@ -267,7 +267,10 @@ impl<'a> AffinityRepo<'a> {
         current.apply_deltas(deltas, ema_inertia);
 
         // patience is LLM-owned as an ABSOLUTE this turn: overwrite the EMA'd
-        // value with the target (L + rule_delta), bypassing EMA + the ±caps.
+        // value with the target (L + rule_delta), bypassing EMA smoothing (the
+        // value is still clamped to [0,1] below). The ±0.4/−0.6 caps never
+        // applied to patience in the first place — they're per-axis in
+        // parse_affinity_eval, on the five LLM delta axes only.
         // L and the rule delta are both independent of the current value, so
         // this direct set is race-safe. `apply_deltas` is left unchanged; its
         // EMA'd patience from above is simply discarded here.
@@ -1085,6 +1088,19 @@ mod tests {
             reloaded.patience
         );
         assert!((a.patience - 0.9).abs() < 1e-9, "in-memory mutated too");
+
+        let eff: (Option<serde_json::Value>,) = sqlx::query_as(
+            "SELECT effective_deltas FROM engine.companion_affinity_events WHERE affinity_id = $1",
+        )
+        .bind(a.id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let effective = eff.0.expect("effective_deltas present");
+        assert!(
+            (effective["patience"].as_f64().unwrap() - 0.4).abs() < 1e-9,
+            "effective patience = target(0.9) − before(0.5) = 0.4, got {effective}"
+        );
     }
 
     #[sqlx::test(migrations = "./migrations")]

--- a/crates/eros-engine-store/src/affinity.rs
+++ b/crates/eros-engine-store/src/affinity.rs
@@ -228,6 +228,8 @@ impl<'a> AffinityRepo<'a> {
     /// bug the six-axis activation makes real — design spec §6.2). Time
     /// decay is computed from the locked row, not a pre-read snapshot.
     /// Mutates `affinity` in place to reflect the persisted state.
+    /// `patience_target: Some(p)` overwrites patience with `p` directly after `apply_deltas`, bypassing EMA and the caps; `None` keeps the EMA path.
+    #[allow(clippy::too_many_arguments)] // each arg is a distinct persist concern; patience_target is the odd one out
     pub async fn persist_with_event(
         &self,
         affinity: &mut Affinity,
@@ -236,6 +238,7 @@ impl<'a> AffinityRepo<'a> {
         event_type: &str,
         context: serde_json::Value,
         meta: Option<&crate::OpenRouterCallMeta>,
+        patience_target: Option<f64>,
     ) -> Result<(), sqlx::Error> {
         let mut tx = self.pool.begin().await?;
 
@@ -262,6 +265,16 @@ impl<'a> AffinityRepo<'a> {
         };
 
         current.apply_deltas(deltas, ema_inertia);
+
+        // patience is LLM-owned as an ABSOLUTE this turn: overwrite the EMA'd
+        // value with the target (L + rule_delta), bypassing EMA + the ±caps.
+        // L and the rule delta are both independent of the current value, so
+        // this direct set is race-safe. `apply_deltas` is left unchanged; its
+        // EMA'd patience from above is simply discarded here.
+        if let Some(p) = patience_target {
+            current.patience = p.clamp(0.0, 1.0);
+        }
+
         let label = current.legacy_relationship_label();
         current.relationship_label = Some(label);
 
@@ -433,6 +446,7 @@ mod tests {
             "message",
             serde_json::json!({ "source": "test" }),
             None,
+            None,
         )
         .await
         .unwrap();
@@ -494,9 +508,17 @@ mod tests {
             warmth: 0.4,
             ..Default::default()
         };
-        repo.persist_with_event(&mut a, &deltas, 0.8, "message", serde_json::json!({}), None)
-            .await
-            .unwrap();
+        repo.persist_with_event(
+            &mut a,
+            &deltas,
+            0.8,
+            "message",
+            serde_json::json!({}),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
 
         let row: (serde_json::Value, Option<serde_json::Value>) = sqlx::query_as(
             "SELECT deltas, effective_deltas FROM engine.companion_affinity_events \
@@ -533,9 +555,17 @@ mod tests {
             trust: 5.0,
             ..Default::default()
         };
-        repo.persist_with_event(&mut a, &deltas, 0.0, "message", serde_json::json!({}), None)
-            .await
-            .unwrap();
+        repo.persist_with_event(
+            &mut a,
+            &deltas,
+            0.0,
+            "message",
+            serde_json::json!({}),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
 
         let eff: Option<serde_json::Value> = sqlx::query_scalar(
             "SELECT effective_deltas FROM engine.companion_affinity_events WHERE affinity_id = $1",
@@ -606,6 +636,7 @@ mod tests {
                 "message",
                 serde_json::json!({}),
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -622,6 +653,7 @@ mod tests {
                 0.0,
                 "message",
                 serde_json::json!({}),
+                None,
                 None,
             )
             .await
@@ -666,9 +698,17 @@ mod tests {
             tension: 0.3,  // 0.1 -> 0.4
             ..Default::default()
         };
-        repo.persist_with_event(&mut a, &deltas, 0.0, "message", serde_json::json!({}), None)
-            .await
-            .unwrap();
+        repo.persist_with_event(
+            &mut a,
+            &deltas,
+            0.0,
+            "message",
+            serde_json::json!({}),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
         let reloaded = repo.load(session_id).await.unwrap().unwrap();
         assert_eq!(
             reloaded.relationship_label,
@@ -949,9 +989,17 @@ mod tests {
             patience: 0.0,
             tension: 0.2,
         };
-        repo.persist_with_event(&mut a, &deltas, 0.0, "message", serde_json::json!({}), None)
-            .await
-            .unwrap();
+        repo.persist_with_event(
+            &mut a,
+            &deltas,
+            0.0,
+            "message",
+            serde_json::json!({}),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
         let (bond, chemistry): (f64, f64) =
             sqlx::query_as("SELECT bond, chemistry FROM engine.companion_affinity WHERE id = $1")
                 .bind(a.id)
@@ -978,13 +1026,100 @@ mod tests {
             tension: 0.9,
             ..Default::default()
         };
-        repo.persist_with_event(&mut a, &deltas, 0.0, "message", serde_json::json!({}), None)
-            .await
-            .unwrap();
+        repo.persist_with_event(
+            &mut a,
+            &deltas,
+            0.0,
+            "message",
+            serde_json::json!({}),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
         let reloaded = repo.load(session_id).await.unwrap().unwrap();
         assert_eq!(
             reloaded.relationship_label,
             Some(RelationshipLabel::Romantic)
+        );
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn persist_with_event_patience_target_sets_directly_bypassing_ema(pool: PgPool) {
+        let repo = AffinityRepo { pool: &pool };
+        let user_id = Uuid::new_v4();
+        let instance_id = Uuid::new_v4();
+        let session_id = make_session(&pool, user_id, instance_id).await;
+        let mut a = repo
+            .load_or_create(session_id, user_id, instance_id)
+            .await
+            .unwrap();
+        assert!(
+            (a.patience - 0.5).abs() < 1e-9,
+            "fresh seed patience is 0.5"
+        );
+
+        // A rule delta that WOULD (via EMA 0.8 → blend 0.2) move patience to
+        // 0.5 + 0.2*0.4 = 0.58, plus an absolute target of 0.9. The target must
+        // win: patience lands on 0.9, NOT 0.58.
+        let deltas = AffinityDeltas {
+            patience: 0.4,
+            ..Default::default()
+        };
+        repo.persist_with_event(
+            &mut a,
+            &deltas,
+            0.8,
+            "message",
+            serde_json::json!({}),
+            None,
+            Some(0.9),
+        )
+        .await
+        .unwrap();
+
+        let reloaded = repo.load(session_id).await.unwrap().unwrap();
+        assert!(
+            (reloaded.patience - 0.9).abs() < 1e-9,
+            "patience_target set directly, bypassing EMA; got {}",
+            reloaded.patience
+        );
+        assert!((a.patience - 0.9).abs() < 1e-9, "in-memory mutated too");
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn persist_with_event_patience_none_keeps_ema_path(pool: PgPool) {
+        let repo = AffinityRepo { pool: &pool };
+        let user_id = Uuid::new_v4();
+        let instance_id = Uuid::new_v4();
+        let session_id = make_session(&pool, user_id, instance_id).await;
+        let mut a = repo
+            .load_or_create(session_id, user_id, instance_id)
+            .await
+            .unwrap();
+
+        let deltas = AffinityDeltas {
+            patience: 0.4,
+            ..Default::default()
+        };
+        repo.persist_with_event(
+            &mut a,
+            &deltas,
+            0.8,
+            "message",
+            serde_json::json!({}),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let reloaded = repo.load(session_id).await.unwrap().unwrap();
+        // EMA blend 0.2 * 0.4 = 0.08 → 0.5 + 0.08 = 0.58.
+        assert!(
+            (reloaded.patience - 0.58).abs() < 1e-9,
+            "None → normal EMA path; got {}",
+            reloaded.patience
         );
     }
 
@@ -1004,9 +1139,17 @@ mod tests {
             intrigue: 0.9,
             ..Default::default()
         };
-        repo.persist_with_event(&mut a, &deltas, 0.0, "message", serde_json::json!({}), None)
-            .await
-            .unwrap();
+        repo.persist_with_event(
+            &mut a,
+            &deltas,
+            0.0,
+            "message",
+            serde_json::json!({}),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
         // Flat turn crosses nothing.
         repo.persist_with_event(
             &mut a,
@@ -1014,6 +1157,7 @@ mod tests {
             0.0,
             "message",
             serde_json::json!({}),
+            None,
             None,
         )
         .await
@@ -1051,9 +1195,17 @@ mod tests {
             warmth: -0.4,
             ..Default::default()
         };
-        repo.persist_with_event(&mut a, &deltas, 0.0, "message", serde_json::json!({}), None)
-            .await
-            .unwrap();
+        repo.persist_with_event(
+            &mut a,
+            &deltas,
+            0.0,
+            "message",
+            serde_json::json!({}),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
         // before: warmth 0.1, bond=(0.1+0+0)/3=0.0333 ; after: warmth -0.3 → floored 0 → bond 0.
         // exact line delta = 0 - 0.0333 = -0.0333 (a raw fold would give -0.4/3 = -0.133).
         let line: serde_json::Value = sqlx::query_scalar(
@@ -1102,6 +1254,7 @@ mod tests {
             "message",
             serde_json::json!({}),
             Some(&meta),
+            None,
         )
         .await
         .unwrap();

--- a/docs/affinity-model.md
+++ b/docs/affinity-model.md
@@ -15,7 +15,7 @@ for scores, labels, and per-turn label transitions.
 | `trust` | 0.0 ↔ 1.0 | `0.0` | Topic depth, willingness to disclose self. Bond axis. |
 | `intrigue` | 0.0 ↔ 1.0 | `0.0` | Curiosity, follow-up questions, anti-ghost driver. Bond axis. |
 | `intimacy` | 0.0 ↔ 1.0 | `0.0` | Inside jokes, nicknames, callbacks to earlier details. Chemistry axis. |
-| `patience` | 0.0 ↔ 1.0 | `0.5` | Tolerance for short / low-effort messages; ghost-threshold input. The LLM gives an absolute read each turn (0–1, 0.1 steps) + a rule delta, written directly (bypasses EMA/caps). Excluded from both lines. |
+| `patience` | 0.0 ↔ 1.0 | `0.5` | Tolerance for short / low-effort messages; ghost-threshold input. The LLM gives an absolute read each turn (0–1, 0.1 steps) + a rule delta, written directly (bypasses EMA; still `[0,1]`-clamped). Excluded from both lines. |
 | `tension` | 0.0 ↔ 1.0 | `0.0` | Push-pull, playful friction, tsundere affordance. Chemistry axis. |
 
 `warmth` is the only axis that can go negative. The other five are bounded to
@@ -65,17 +65,19 @@ The PDE still computes the reply/proactive-turn rule delta `R` as before
 
 The turn's target is `patience_target = clamp(L + R, 0, 1)`; the sum is **not**
 re-rounded to the `0.1` grid (the grid constrains the LLM read only, so `R` can nudge
-the result off-grid). On persist, `apply_deltas` still runs first as usual (all six
-axes go through EMA + the asymmetric caps), and patience is then **overwritten
-directly** with `patience_target` — bypassing EMA smoothing and the ±0.4/−0.6 caps
-(those caps still apply to the other five delta axes). Because both `L` and `R` are
-independent of the currently stored value, this write is race-safe with no
+the result off-grid). The ±0.4/−0.6 asymmetric caps are applied earlier, in
+`parse_affinity_eval`, to the five LLM delta axes only — patience is never subject to
+them. On persist, `apply_deltas` still runs first as usual (all six axes go through
+EMA smoothing + the `[0,1]` clamp), and patience is then **overwritten directly** with
+`patience_target` — bypassing EMA smoothing (still `[0,1]`-clamped). Because both `L`
+and `R` are independent of the currently stored value, this write is race-safe with no
 read-modify-write needed.
 
 **Fallback:** when there is no LLM patience read this turn — Proactive, a short user
-message, an empty assistant reply, or the eval call erroring, timing out, or the
-model omitting the `patience` field — `patience_target` is `None` and patience takes
-the **old** path: `R` is added through EMA and clamped.
+message, an empty assistant reply, `no_persona_or_affinity` (persona load fails or no
+affinity row exists), or the eval call erroring, timing out, or the model omitting the
+`patience` field — `patience_target` is `None` and patience takes the **old** path: `R`
+is added through EMA and clamped.
 
 **Ghost is a separate path, not a fallback.** A Ghost turn never reaches
 `persist_with_event` — `persist_affinity` dispatches it to `record_ghost` instead,

--- a/docs/affinity-model.md
+++ b/docs/affinity-model.md
@@ -15,7 +15,7 @@ for scores, labels, and per-turn label transitions.
 | `trust` | 0.0 ↔ 1.0 | `0.0` | Topic depth, willingness to disclose self. Bond axis. |
 | `intrigue` | 0.0 ↔ 1.0 | `0.0` | Curiosity, follow-up questions, anti-ghost driver. Bond axis. |
 | `intimacy` | 0.0 ↔ 1.0 | `0.0` | Inside jokes, nicknames, callbacks to earlier details. Chemistry axis. |
-| `patience` | 0.0 ↔ 1.0 | `0.5` | Tolerance for short / low-effort messages; ghost-threshold input. Rule-owned — never scored by the evaluator; excluded from both lines. |
+| `patience` | 0.0 ↔ 1.0 | `0.5` | Tolerance for short / low-effort messages; ghost-threshold input. The LLM gives an absolute read each turn (0–1, 0.1 steps) + a rule delta, written directly (bypasses EMA/caps). Excluded from both lines. |
 | `tension` | 0.0 ↔ 1.0 | `0.0` | Push-pull, playful friction, tsundere affordance. Chemistry axis. |
 
 `warmth` is the only axis that can go negative. The other five are bounded to
@@ -51,6 +51,41 @@ tension  = clamp(tension  − 0.005 × days_elapsed, 0.0, 1.0)
 
 `warmth`, `trust`, and `intimacy` do not decay — they are "deep" dimensions.
 
+### Patience: LLM absolute read + rule delta
+
+`patience` is no longer a purely rule-owned axis. Each turn's `affinity_evaluation`
+call (the same LLM call that produces the other five axes — no new round-trip) now
+also emits an **absolute** `patience` read (`0.0`–`1.0`, in `0.1` steps, representing
+how much patience remains for this user right now, not a change). The engine rounds
+the model's read to the nearest `0.1` and clamps to `[0, 1]` — call this `L`.
+
+The PDE still computes the reply/proactive-turn rule delta `R` as before
+(`predict_reply_deltas`: long user message `+0.02` / very short `−0.02` / stale gap
+>24h `−0.05`) — unchanged.
+
+The turn's target is `patience_target = clamp(L + R, 0, 1)`; the sum is **not**
+re-rounded to the `0.1` grid (the grid constrains the LLM read only, so `R` can nudge
+the result off-grid). On persist, `apply_deltas` still runs first as usual (all six
+axes go through EMA + the asymmetric caps), and patience is then **overwritten
+directly** with `patience_target` — bypassing EMA smoothing and the ±0.4/−0.6 caps
+(those caps still apply to the other five delta axes). Because both `L` and `R` are
+independent of the currently stored value, this write is race-safe with no
+read-modify-write needed.
+
+**Fallback:** when there is no LLM patience read this turn — Proactive, a short user
+message, an empty assistant reply, or the eval call erroring, timing out, or the
+model omitting the `patience` field — `patience_target` is `None` and patience takes
+the **old** path: `R` is added through EMA and clamped.
+
+**Ghost is a separate path, not a fallback.** A Ghost turn never reaches
+`persist_with_event` — `persist_affinity` dispatches it to `record_ghost` instead,
+which takes no deltas, never runs `apply_deltas`/EMA, and only bumps `ghost_streak` /
+`total_ghosts` / `last_ghost_at` (it writes an all-zero `effective_deltas`). The
+PDE's `ghost_affinity_deltas()` (patience `−0.05`, tension `+0.05` — a function
+separate from `predict_reply_deltas`) is computed onto the `ActionPlan` but discarded
+at persist time. So on a Ghost turn `patience` is moved by neither a delta nor EMA —
+only the ghost counters change.
+
 ## The two derived lines
 
 The six axes produce two composite scores. `warm_pos` is `warmth.max(0.0)` —
@@ -62,8 +97,8 @@ chemistry = (warm_pos + intimacy + tension)  / 3    ∈ [0, 1]
 ```
 
 `warmth` feeds both lines: cold replies reduce both Bond and Chemistry.
-`patience` is excluded from both because it is rule-owned and never evaluated
-per-turn.
+`patience` is excluded from both — it is maintained by an LLM absolute read + rule
+delta and written directly; both lines still omit patience (by design).
 
 With the default seed (`warmth 0.1`, `trust/intrigue/tension 0`), a fresh
 session starts at bond ≈ chemistry ≈ 0.033 — both in tier 1 (stranger).

--- a/docs/affinity-model.zh.md
+++ b/docs/affinity-model.zh.md
@@ -13,7 +13,7 @@
 | `trust` | 0.0 ↔ 1.0 | `0.0` | 话题深度，是否愿意暴露自己。Bond 轴。 |
 | `intrigue` | 0.0 ↔ 1.0 | `0.0` | 好奇心、追问动力，抗 ghost 的主力。Bond 轴。 |
 | `intimacy` | 0.0 ↔ 1.0 | `0.0` | 内部梗、昵称、回头呼应之前的细节。Chemistry 轴。 |
-| `patience` | 0.0 ↔ 1.0 | `0.5` | 对短消息/敷衍回复的容忍度；ghost 阈值的输入。规则所有——不参与评估，不计入两条线。 |
+| `patience` | 0.0 ↔ 1.0 | `0.5` | 对短消息/敷衍回复的容忍度；ghost 阈值的输入。LLM 每轮给绝对值（0~1，每 0.1 档）+ 规则 delta，直接写入（不走 EMA/上限）。不计入两条线。 |
 | `tension` | 0.0 ↔ 1.0 | `0.0` | 推拉、玩闹式的小摩擦、傲娇空间。Chemistry 轴。 |
 
 只有 `warmth` 可以为负值。其余五个都限制在 `[0, 1]`。每次更新都会对六个轴做夹钳（clamp）。
@@ -44,6 +44,18 @@ tension  = clamp(tension  − 0.005 × days_elapsed, 0.0, 1.0)
 
 `warmth`、`trust`、`intimacy` 不衰退——它们是"深层"维度。
 
+### Patience：LLM 绝对读数 + 规则 delta
+
+`patience` 不再是纯规则轴。每轮的 `affinity_evaluation`（与其余五轴同一次 LLM 调用，不产生新的往返）中，模型现在会额外给出一个**绝对**的 `patience` 读数（`0.0`–`1.0`，每 `0.1` 一档，代表当前对用户还剩多少耐心，而非变化量）。引擎把模型读数四舍五入到最近的 `0.1` 并夹钳到 `[0, 1]`，记为 `L`。
+
+PDE 仍照常计算这一轮回复/主动消息的规则 delta `R`（`predict_reply_deltas`：长消息 +0.02 / 极短消息 −0.02 / 超过 24 小时未活动 −0.05）——这部分不变。
+
+本轮目标值为 `patience_target = clamp(L + R, 0, 1)`；该和值**不会**再被四舍五入回 0.1 档（网格只约束 LLM 读数，`R` 可以把结果推离网格）。持久化时，`apply_deltas` 照常先跑一遍（六轴统一走 EMA + 非对称上限），随后 patience 被 `patience_target` **直接覆盖**——绕过 EMA 平滑与 ±0.4/−0.6 上限（那两项上限仍作用于其余五个 delta 轴）。因为 `L` 和 `R` 都与当前存储值无关，这个写入在并发场景下是安全的，不需要读改写。
+
+**兜底：** 当本轮没有 LLM patience 读数时——Proactive、用户消息过短、助手回复为空、或评估调用报错/超时/模型省略了 `patience` 字段——`patience_target` 为 `None`，patience 走**旧路径**：把 `R` 通过 EMA 叠加并夹钳。
+
+**Ghost 走独立路径，不是兜底。** Ghost 回合根本不会进入 `persist_with_event`——`persist_affinity` 把它分派给 `record_ghost`，该函数不接收任何 delta、从不跑 `apply_deltas`/EMA，只递增 `ghost_streak` / `total_ghosts` / `last_ghost_at`（写入的是全零 `effective_deltas`）。PDE 的 `ghost_affinity_deltas()`（patience `−0.05`、tension `+0.05`——与 `predict_reply_deltas` 是不同的函数）会被计算进 `ActionPlan`，但在持久化时被丢弃。因此 Ghost 回合的 `patience` 既不会被任何 delta 移动，也不会经过 EMA——只有 ghost 计数器会变化。
+
 ## 两条衍生线
 
 六个轴会生成两个合成分数。`warm_pos` 是 `warmth.max(0.0)` —— 以 0 为下界，而不是整体平移；因此中性或冷漠的会话贡献为零：
@@ -54,7 +66,7 @@ chemistry = (warm_pos + intimacy + tension)  / 3    ∈ [0, 1]
 ```
 
 `warmth` 会进入两条线：冷漠的回复会同时拉低 Bond 和 Chemistry。
-`patience` 不计入任何一条线，因为它由规则所有，不参与每轮评估。
+`patience` 不计入任何一条线——它由 LLM 绝对读数 + 规则 delta 维护，直接写入；两条线仍不含 patience（设计如此）。
 
 以默认种子（`warmth 0.1`，`trust/intrigue/tension 0`）开始，新会话的
 bond ≈ chemistry ≈ 0.033——两条线均在第 1 档（陌生人）。

--- a/docs/affinity-model.zh.md
+++ b/docs/affinity-model.zh.md
@@ -13,7 +13,7 @@
 | `trust` | 0.0 ↔ 1.0 | `0.0` | 话题深度，是否愿意暴露自己。Bond 轴。 |
 | `intrigue` | 0.0 ↔ 1.0 | `0.0` | 好奇心、追问动力，抗 ghost 的主力。Bond 轴。 |
 | `intimacy` | 0.0 ↔ 1.0 | `0.0` | 内部梗、昵称、回头呼应之前的细节。Chemistry 轴。 |
-| `patience` | 0.0 ↔ 1.0 | `0.5` | 对短消息/敷衍回复的容忍度；ghost 阈值的输入。LLM 每轮给绝对值（0~1，每 0.1 档）+ 规则 delta，直接写入（不走 EMA/上限）。不计入两条线。 |
+| `patience` | 0.0 ↔ 1.0 | `0.5` | 对短消息/敷衍回复的容忍度；ghost 阈值的输入。LLM 每轮给绝对值（0~1，每 0.1 档）+ 规则 delta，直接写入（不走 EMA，仍夹钳到 `[0, 1]`）。不计入两条线。 |
 | `tension` | 0.0 ↔ 1.0 | `0.0` | 推拉、玩闹式的小摩擦、傲娇空间。Chemistry 轴。 |
 
 只有 `warmth` 可以为负值。其余五个都限制在 `[0, 1]`。每次更新都会对六个轴做夹钳（clamp）。
@@ -50,9 +50,9 @@ tension  = clamp(tension  − 0.005 × days_elapsed, 0.0, 1.0)
 
 PDE 仍照常计算这一轮回复/主动消息的规则 delta `R`（`predict_reply_deltas`：长消息 +0.02 / 极短消息 −0.02 / 超过 24 小时未活动 −0.05）——这部分不变。
 
-本轮目标值为 `patience_target = clamp(L + R, 0, 1)`；该和值**不会**再被四舍五入回 0.1 档（网格只约束 LLM 读数，`R` 可以把结果推离网格）。持久化时，`apply_deltas` 照常先跑一遍（六轴统一走 EMA + 非对称上限），随后 patience 被 `patience_target` **直接覆盖**——绕过 EMA 平滑与 ±0.4/−0.6 上限（那两项上限仍作用于其余五个 delta 轴）。因为 `L` 和 `R` 都与当前存储值无关，这个写入在并发场景下是安全的，不需要读改写。
+本轮目标值为 `patience_target = clamp(L + R, 0, 1)`；该和值**不会**再被四舍五入回 0.1 档（网格只约束 LLM 读数，`R` 可以把结果推离网格）。±0.4/−0.6 非对称上限在更早的 `parse_affinity_eval` 中就已作用于五个 LLM delta 轴——patience 从不受这两项上限约束。持久化时，`apply_deltas` 照常先跑一遍（六轴统一走 EMA 平滑 + `[0, 1]` 夹钳），随后 patience 被 `patience_target` **直接覆盖**——绕过 EMA 平滑（仍会夹钳到 `[0, 1]`）。因为 `L` 和 `R` 都与当前存储值无关，这个写入在并发场景下是安全的，不需要读改写。
 
-**兜底：** 当本轮没有 LLM patience 读数时——Proactive、用户消息过短、助手回复为空、或评估调用报错/超时/模型省略了 `patience` 字段——`patience_target` 为 `None`，patience 走**旧路径**：把 `R` 通过 EMA 叠加并夹钳。
+**兜底：** 当本轮没有 LLM patience 读数时——Proactive、用户消息过短、助手回复为空、`no_persona_or_affinity`（persona 加载失败或不存在好感度行）、或评估调用报错/超时/模型省略了 `patience` 字段——`patience_target` 为 `None`，patience 走**旧路径**：把 `R` 通过 EMA 叠加并夹钳。
 
 **Ghost 走独立路径，不是兜底。** Ghost 回合根本不会进入 `persist_with_event`——`persist_affinity` 把它分派给 `record_ghost`，该函数不接收任何 delta、从不跑 `apply_deltas`/EMA，只递增 `ghost_streak` / `total_ghosts` / `last_ghost_at`（写入的是全零 `effective_deltas`）。PDE 的 `ghost_affinity_deltas()`（patience `−0.05`、tension `+0.05`——与 `predict_reply_deltas` 是不同的函数）会被计算进 `ActionPlan`，但在持久化时被丢弃。因此 Ghost 回合的 `patience` 既不会被任何 delta 移动，也不会经过 EMA——只有 ghost 计数器会变化。
 

--- a/docs/superpowers/specs/2026-07-18-patience-llm-eval-design.md
+++ b/docs/superpowers/specs/2026-07-18-patience-llm-eval-design.md
@@ -21,8 +21,10 @@ caps for patience only). No new LLM round-trip; no config flag.
   evaluator's JSON schema omits patience; `parse_affinity_eval` force-zeroes it;
   `merge_deltas` therefore keeps the rule value only.
 - **Per-turn rule delta** (`pde.rs::predict_reply_deltas`): long user msg (≥30 chars)
-  `+0.02`, very short (≤3) `−0.02`, stale gap (>24h) `−0.05`; a self-ghost turn applies
-  `−0.05` (`ghost_affinity_deltas`).
+  `+0.02`, very short (≤3) `−0.02`, stale gap (>24h) `−0.05`. Ghost turns compute a
+  *separate* `ghost_affinity_deltas()` (patience `−0.05`) onto the `ActionPlan`, but
+  `persist_affinity` routes Ghost to `record_ghost` instead of `persist_with_event`,
+  which discards it — so patience is **not** actually moved on a Ghost turn (see §1.4).
 - **EMA** (`Affinity::apply_deltas`, default `ema_inertia=0.5`): the combined delta is
   halved before landing, then clamped to `[0,1]`.
 - **Time decay** (`apply_time_decay`): patience **recovers** `+0.005/day` when idle —
@@ -107,11 +109,17 @@ large single-turn value, e.g. `+0.4` — expected, and surfaced on the debug/BFF
 
 ### 1.4 Fallback (no LLM patience read this turn)
 
-When `patience_target` is `None` — Proactive, Ghost (`R=−0.05`), short-user-msg skip,
-empty-assistant skip, eval timeout/error, or the model omitting `patience` — patience
-takes the **existing** path: add `R` through EMA + clamp. Fully backward-compatible;
-this is why **no config flag is needed** (prompt and parser ship together in one
-version, so there is no version skew to gate).
+When `patience_target` is `None` — Proactive, short-user-msg skip, empty-assistant
+skip, eval timeout/error, or the model omitting `patience` — patience takes the
+**existing** path: add `R` through EMA + clamp. Fully backward-compatible; this is why
+**no config flag is needed** (prompt and parser ship together in one version, so there
+is no version skew to gate).
+
+Ghost is **not** part of this fallback. `eval_skip_reason` marks Ghost turns `"ghost"`
+(no eval call is attempted, mirroring today), but that is moot for patience: Ghost
+persists via `record_ghost`, not `persist_with_event`, which discards the computed
+`ghost_affinity_deltas()` entirely. So patience is untouched by any delta or EMA on a
+Ghost turn — only `ghost_streak` / `total_ghosts` / `last_ghost_at` move.
 
 ### 1.5 Data threading (keeps core untouched)
 

--- a/docs/superpowers/specs/2026-07-18-patience-llm-eval-design.md
+++ b/docs/superpowers/specs/2026-07-18-patience-llm-eval-design.md
@@ -7,8 +7,9 @@ moves at a meaningful pace. Today `patience` is **rule-owned** — the affinity
 evaluator is told not to touch it, and it drifts only by tiny deterministic nudges
 (±0.02 / ±0.05 raw, then halved by EMA), so it crawls. This spec has the existing
 `affinity_evaluation` LLM emit an **absolute** patience level, combines it with the
-PDE rule delta, and writes the result **directly** (bypassing EMA and the per-axis
-caps for patience only). No new LLM round-trip; no config flag.
+PDE rule delta, and writes the result **directly** (bypassing EMA for patience only;
+patience was never subject to the ±0.4 / −0.6 per-axis caps to begin with). No new
+LLM round-trip; no config flag.
 
 ---
 
@@ -84,19 +85,21 @@ patience_target = clamp(L + R, 0, 1)
   re-snapped** — snapping it would round `R` away and defeat "再加规则 delta". The 0.1
   quantisation constrains the LLM read only, not the stored value.
 
-### 1.3 Write it directly (bypass EMA + caps for patience)
+### 1.3 Write it directly (bypass EMA for patience)
 
 In `persist_with_event`, after the row is locked and time-decayed and the pre-delta
 baseline snapshotted:
 
-1. `apply_deltas(deltas, ema_inertia)` runs **unchanged** — it applies all six axes
-   through EMA + the ±0.4 / −0.6 asymmetric caps (patience included, harmlessly, since
-   it is overwritten next).
+1. `apply_deltas(deltas, ema_inertia)` runs **unchanged** — it applies EMA smoothing
+   and the `[0,1]` clamp to all six axes (patience included, harmlessly, since it is
+   overwritten next). The ±0.4 / −0.6 asymmetric caps were already applied earlier, in
+   `parse_affinity_eval`, to the five LLM delta axes only — patience is never subject
+   to them.
 2. When `patience_target.is_some()`, **patience is overwritten** with `patience_target`
-   directly — no EMA, no cap (the EMA'd rule application from step 1 is discarded, so
-   there is no double count). This is the "全量落地" behaviour: patience lands on the
-   LLM read (± rule nudge) this turn. `apply_deltas` itself is **not** modified to skip
-   patience.
+   directly — no EMA (the EMA'd rule application from step 1 is discarded, so there is
+   no double count); the value is still clamped to `[0,1]`. This is the "全量落地"
+   behaviour: patience lands on the LLM read (± rule nudge) this turn. `apply_deltas`
+   itself is **not** modified to skip patience.
 
 **Race-safety.** `L` (an absolute LLM read of the snapshot) and `R` (a rule delta) are
 both **independent of the current patience value**. `patience_target = L + R` is an
@@ -110,7 +113,8 @@ large single-turn value, e.g. `+0.4` — expected, and surfaced on the debug/BFF
 ### 1.4 Fallback (no LLM patience read this turn)
 
 When `patience_target` is `None` — Proactive, short-user-msg skip, empty-assistant
-skip, eval timeout/error, or the model omitting `patience` — patience takes the
+skip, `no_persona_or_affinity` (persona load fails or no affinity row exists), eval
+timeout/error, or the model omitting `patience` — patience takes the
 **existing** path: add `R` through EMA + clamp. Fully backward-compatible; this is why
 **no config flag is needed** (prompt and parser ship together in one version, so there
 is no version skew to gate).

--- a/docs/superpowers/specs/2026-07-18-patience-llm-eval-design.md
+++ b/docs/superpowers/specs/2026-07-18-patience-llm-eval-design.md
@@ -1,0 +1,188 @@
+# eros-engine — LLM-evaluated patience (absolute read + rule delta)
+
+**Status**: design, pending implementation plan
+**Target release**: `0.8.x` dev track. **No migration.**
+**Scope**: bring the `patience` affinity axis into the per-turn LLM evaluation so it
+moves at a meaningful pace. Today `patience` is **rule-owned** — the affinity
+evaluator is told not to touch it, and it drifts only by tiny deterministic nudges
+(±0.02 / ±0.05 raw, then halved by EMA), so it crawls. This spec has the existing
+`affinity_evaluation` LLM emit an **absolute** patience level, combines it with the
+PDE rule delta, and writes the result **directly** (bypassing EMA and the per-axis
+caps for patience only). No new LLM round-trip; no config flag.
+
+---
+
+## 0. Background
+
+### 0.1 patience today
+
+- **Range** `[0, 1]`, seed `0.5` (migration 0029). One of six affinity axes.
+- **Rule-owned.** `affinity_eval_prompt` states "patience 由规则维护，请勿评估"; the
+  evaluator's JSON schema omits patience; `parse_affinity_eval` force-zeroes it;
+  `merge_deltas` therefore keeps the rule value only.
+- **Per-turn rule delta** (`pde.rs::predict_reply_deltas`): long user msg (≥30 chars)
+  `+0.02`, very short (≤3) `−0.02`, stale gap (>24h) `−0.05`; a self-ghost turn applies
+  `−0.05` (`ghost_affinity_deltas`).
+- **EMA** (`Affinity::apply_deltas`, default `ema_inertia=0.5`): the combined delta is
+  halved before landing, then clamped to `[0,1]`.
+- **Time decay** (`apply_time_decay`): patience **recovers** `+0.005/day` when idle —
+  the only axis that drifts upward.
+
+Net: max per-turn change ≈ `0.05 × 0.5 = 0.025`. Going 0.5 → 0.9 takes ~16 turns.
+This is the "太慢" the change targets.
+
+### 0.2 What patience feeds
+
+- **Ghost score** — `(1−intrigue)·0.4 + (1−patience)·0.4 + tension·0.2` (`ghost.rs`).
+  patience is 40% of the score. When the **LLM PDE judge** is on, the score-threshold
+  layer is skipped (the judge decides ghost-worthiness); the deterministic
+  `ghost::decide` uses the score only when the judge is off/failed. Hard protections
+  (msg-count floor, anti-streak, cooldown) always hold.
+- **Prompt attitude directive** (`prompt.rs`, only when the patience scope is active):
+  `<0.3` → curter/shorter replies; `>0.7` → patient, willing to chat.
+- **Not** part of the Bond/Chemistry derived lines (rule-owned, excluded by design).
+
+### 0.3 Where the two LLM touchpoints sit
+
+1. **Pre-response PDE judge** (opt-in, `stream.rs`): decides action / ghost / inner_state.
+2. **Post-response `affinity_evaluation`** (`post_process.rs`): the haiku call that
+   produces the six-axis semantic deltas. Runs on every substantive reply turn.
+
+patience is updated at the **end** of a turn and read at the **start** of the next —
+so updating it in the post-response evaluator (2) is time-consistent with today and
+requires **no new round-trip**. This spec uses touchpoint (2).
+
+---
+
+## 1. The mechanism
+
+### 1.1 LLM emits an absolute patience level
+
+The `affinity_evaluation` call gains one field: `patience`, an **absolute** value in
+`[0, 1]`, one decimal place (`0.0 / 0.1 / … / 1.0` — ten steps). The other five axes
+stay **deltas**, exactly as today.
+
+On receipt the engine **snaps** the model's `patience` to the nearest `0.1` and clamps
+to `[0, 1]` (so `0.83` → `0.8`, a robust guard against off-grid output). Call the
+snapped absolute read `L`.
+
+`patience` is `Option<f64>` in the parse struct: **absent → `None`** (old prompt, parse
+failure, or the model omitting it) → the turn falls back to rule-only behaviour (§1.4).
+
+### 1.2 Combine with the rule delta
+
+`R` = the PDE's per-turn patience rule delta (`plan.affinity_deltas.patience`,
+unchanged). The turn's patience **target** is:
+
+```
+patience_target = clamp(L + R, 0, 1)
+```
+
+- `L` is on the 0.1 grid; `R` is a small off-grid nudge. The **final target is not
+  re-snapped** — snapping it would round `R` away and defeat "再加规则 delta". The 0.1
+  quantisation constrains the LLM read only, not the stored value.
+
+### 1.3 Write it directly (bypass EMA + caps for patience)
+
+In `persist_with_event`, after the row is locked and time-decayed and the pre-delta
+baseline snapshotted:
+
+1. `apply_deltas(deltas, ema_inertia)` runs **unchanged** — it applies all six axes
+   through EMA + the ±0.4 / −0.6 asymmetric caps (patience included, harmlessly, since
+   it is overwritten next).
+2. When `patience_target.is_some()`, **patience is overwritten** with `patience_target`
+   directly — no EMA, no cap (the EMA'd rule application from step 1 is discarded, so
+   there is no double count). This is the "全量落地" behaviour: patience lands on the
+   LLM read (± rule nudge) this turn. `apply_deltas` itself is **not** modified to skip
+   patience.
+
+**Race-safety.** `L` (an absolute LLM read of the snapshot) and `R` (a rule delta) are
+both **independent of the current patience value**. `patience_target = L + R` is an
+absolute quantity, so setting it needs no read-modify-write on patience and a
+concurrent turn cannot make it drift — unlike a delta computed as `L − current`, which
+this design deliberately avoids.
+
+`effective_deltas.patience` is still recorded as `new − before` (now potentially a
+large single-turn value, e.g. `+0.4` — expected, and surfaced on the debug/BFF event).
+
+### 1.4 Fallback (no LLM patience read this turn)
+
+When `patience_target` is `None` — Proactive, Ghost (`R=−0.05`), short-user-msg skip,
+empty-assistant skip, eval timeout/error, or the model omitting `patience` — patience
+takes the **existing** path: add `R` through EMA + clamp. Fully backward-compatible;
+this is why **no config flag is needed** (prompt and parser ship together in one
+version, so there is no version skew to gate).
+
+### 1.5 Data threading (keeps core untouched)
+
+The absolute read travels as a **separate `Option<f64>`**, *not* inside
+`AffinityDeltas.patience`:
+
+- `AffinityDeltas.patience` continues to carry the **rule delta** (`llm_deltas.patience`
+  stays `0`), so `merge_deltas` semantics are unchanged and `Affinity::apply_deltas`
+  needs **no change**.
+- `parse_affinity_eval → (AffinityDeltas, Option<f64> /*patience_abs*/, String)`.
+- `evaluate_affinity` returns `patience_abs`.
+- `fut_affinity` computes `patience_target = patience_abs.map(|l| clamp(l + R, 0, 1))`
+  and passes it to `persist_affinity → persist_with_event(..., patience_target)`.
+- `persist_with_event` applies step (2) of §1.3 only when `patience_target.is_some()`.
+
+---
+
+## 2. Prompt change
+
+`affinity_eval_prompt` (`prompt.rs`) — a hardcoded Rust `format!`, so it ships with the
+parser change (no config drift):
+
+- Remove "patience … 由规则维护，请勿评估" from the axis list.
+- Reframe patience as an **absolute** read with drivers, e.g.: *patience 耐心请给一个
+  【绝对值】(0~1，每 0.1 一档)，代表你现在对这个用户还有多少耐心 / 愿意继续搭理的程度
+  —— 不是变化量。用户投入、认真、有来有回、被尊重 → 高；敷衍、重复、命令式、越界、
+  晾着不理、粗鲁 → 低。其它五个维度仍然是【变化量】。*
+- JSON schema adds `patience` (absolute) alongside the five deltas:
+  `{"warmth":0.0,"trust":0.0,"intrigue":0.0,"intimacy":0.0,"patience":0.5,"tension":0.0,"reason":"…"}`.
+
+The prompt still shows all six **current** values for context (unchanged).
+
+---
+
+## 3. Unchanged invariants
+
+- patience stays **out** of the Bond/Chemistry lines and their labels.
+- Time-decay recovery `+0.005/day` **stays** (idle / proactive-only turns).
+- Hard ghost protections and the ghost-score formula are **unchanged** — only the
+  *value* of patience moves faster, which (by intent) makes the deterministic ghost
+  path and the attitude directive more responsive. The user has accepted the increased
+  ghost jitter this implies.
+- Non-eval turns keep today's rule-delta-through-EMA behaviour.
+
+---
+
+## 4. Blast radius
+
+| File | Change |
+| --- | --- |
+| `eros-engine-server/src/prompt.rs` | `affinity_eval_prompt`: patience → absolute + drivers; schema adds `patience`. |
+| `eros-engine-server/src/pipeline/post_process.rs` | `LlmAffinityEval.patience: Option<f64>`; `parse_affinity_eval` snaps+clamps, returns `Option<f64>`; `evaluate_affinity` passthrough; `persist_affinity`/`fut_affinity` compute + thread `patience_target`. |
+| `eros-engine-store/src/affinity.rs` | `persist_with_event(..., patience_target: Option<f64>)`; after `apply_deltas`, `set` patience when `Some`. |
+| `docs/affinity-model.md` + `.zh.md` | Rewrite the "patience is rule-owned / not evaluated" sections; document absolute-read + rule-delta + direct write. |
+
+**Reversed / updated tests**
+- `post_process.rs::parse_affinity_eval_ignores_patience_field` → now patience **is**
+  read as an absolute (snapped); rewrite.
+- `post_process.rs::merge_deltas_..._patience_from_rule_only` → still valid (merge is
+  unchanged; llm patience stays 0); keep, possibly rename for clarity.
+- `prompt.rs` "patience is rule-owned and must not be in the JSON output schema" →
+  invert: assert patience **is** in the schema and rendered as an absolute.
+- New tests: snap-to-0.1 + clamp; `patience_target = clamp(L+R)`; `None` → rule-only
+  fallback; `persist_with_event` sets patience directly (a store-level `sqlx::test`
+  asserting a big single-turn jump lands unclamped-by-EMA and rule delta still nudges).
+
+No migration. No new config key.
+
+---
+
+## 5. Open question (resolved)
+
+- **Final-value snapping** — resolved: **do not** re-snap `L + R`; snap the LLM read
+  `L` only. (Snapping the final would erase the ±0.02 rule nudge.)


### PR DESCRIPTION
## What

Bring the `patience` affinity axis into the per-turn LLM evaluation so it moves at a meaningful pace. Today `patience` is **rule-owned** — the evaluator is told not to touch it and it drifts only by tiny deterministic nudges (±0.02 / ±0.05 raw, then halved by EMA), so it crawls (~16 turns to go 0.5 → 0.9). Now the existing `affinity_evaluation` haiku call (no new round-trip) emits an **absolute** patience read, combined with the PDE rule delta and written **directly**.

## Mechanism

- The `affinity_evaluation` LLM emits an **absolute** `patience ∈ [0,1]`, quantized to `0.1` steps. The engine snaps the read to the nearest `0.1` and clamps to `[0,1]` → `L`. The other five axes stay **deltas**.
- `patience_target = clamp(L + R)` where `R` is the unchanged PDE rule delta. The sum is **not** re-snapped (the 0.1 grid constrains the LLM read only).
- In `persist_with_event`, after `apply_deltas` runs, patience is **set directly** to `patience_target` — bypassing the EMA smoothing the five delta axes receive (still `[0,1]`-clamped; the ±0.4/−0.6 per-turn caps only ever applied to the LLM delta axes, never to patience). **Race-safe**: `L` and `R` are both independent of the current value, so the write needs no read-modify-write.
- The absolute read rides a **separate `Option<f64>`**, so `AffinityDeltas.patience` still carries only the rule delta — core `apply_deltas` / `merge_deltas` are untouched.
- **Fallback:** when there is no LLM read (model omits `patience`, eval skipped for short-user / empty-assistant, Proactive, eval error/timeout, no-persona) → `None` → the old rule-delta-through-EMA path. **Ghost** turns are a separate path (`record_ghost`, no deltas applied).

**Unchanged:** patience stays excluded from the Bond/Chemistry lines + labels; time-decay recovery `+0.005/day` intact; the other five axes still EMA + capped. **No migration, no config flag.**

## Behavioral note

patience now moves fast and feeds the ghost score (40%) + the prompt attitude directive — a knowing trade for responsiveness (one harsh read can flip curt-mode and push the deterministic ghost path over threshold in the same turn; hard protections — msg-count floor, anti-streak, cooldown — still hold). Worth watching post-deploy: a week-1 histogram of `effective_deltas.patience` and raw `L` (if `L` clusters at the schema example `0.5`, adjust the example value).

## Commits

1. `docs(spec)` — design spec
2. `feat(store)` — `persist_with_event` sets patience directly on a target
3. `feat(affinity)` — parse patience as a snapped absolute read
4. `feat(affinity)` — write LLM absolute patience + rule delta directly (wiring)
5. `feat(affinity)` — eval prompt requests patience as an absolute read (activation)
6. `docs(affinity)` — document LLM-evaluated patience (docs + spec)
7. `docs+test(affinity)` — final-review polish (cap-location wording, fallback list, `effective_deltas` assertion)

## Testing

- New store tests: `persist_with_event` sets target directly (bypasses EMA) vs `None` keeps EMA path; `effective_deltas.patience == target − before`.
- New server tests: `snap_patience` (rounding/clamp), `parse_affinity_eval` absolute read (snap / clamp / absent→None / garbage→None), `patience_target(L,R)` combine + `None`, `persist_affinity` sets patience from target directly (no `run()` — avoids the unmockable/no-timeout Voyage path).
- Inverted the prompt test asserting patience is now in the schema as an absolute.
- Local gate green: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --all-features` (all pass), openapi snapshot no drift.

Not released — release is a separate flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
