### PR TITLE
feat(world-town): persona social feed on top of World Memories

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,6 +75,13 @@ RUST_LOG=info
 # Director cadence and retention live in model config: [tasks.world_director]
 # interval_hours / retention_days. Per-owner enablement is the
 # engine.world_enrollments table (downstream-managed).
+# WORLD_TOWN_DISABLED=true turns off only the town sweeper (post publishing,
+# comment rounds, reply responder) while world memories keeps simulating.
+# Town also needs per-owner opt-in: engine.world_enrollments.town_enabled
+# (downstream-managed). Cadence/rate knobs live in model config:
+# [tasks.world_comment] round_secs, [tasks.world_reply] debounce_secs /
+# thread_cooldown_secs / daily_cap.
 # WORLD_DISABLED=false
 # WORLD_PROMPT_DISABLED=false
+# WORLD_TOWN_DISABLED=false
 # WORLD_TICK_SECS=300

--- a/README.ja.md
+++ b/README.ja.md
@@ -98,6 +98,7 @@ docker run --rm -p 8080:8080 --env-file .env \
 - [Affinity model](docs/affinity-model.md) — 6 つの次元、EMA、時間減衰、関係ラベル。
 - [Ghost mechanics](docs/ghost-mechanics.md) — スコア式、保護ルール、例。
 - [Memory layers](docs/memory-layers.md) — プロフィール記憶と関係記憶、Voyage、pgvector による検索。
+- [World system](docs/world-system.md) — 実験的なオーナー単位のペルソナワールド：World Memories のシミュレーションとリコール注入、World Town のソーシャルフィード。
 - [Model config](docs/model-config.md) — `model_config.toml` schema、すべてのタスク（chat、vision、image generation、PDE、filters、extraction）、モデル選択、0.x の安定性に関する方針。
 - [Prompt traits](docs/prompt-traits.md) — リクエスト単位の system prompt 注入と tier の許可リスト。
 - [LLM / OpenRouter audit](docs/llm-audit.md) — ユーザー単位 / セッション単位の attribution の受け渡し。

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ The `docker/Dockerfile` is the same artifact used to build this image. Deploy it
 - [Affinity model](docs/affinity-model.md) — six dimensions, EMA, time decay, relationship labels.
 - [Ghost mechanics](docs/ghost-mechanics.md) — score formula, protection rules, examples.
 - [Memory layers](docs/memory-layers.md) — profile vs relationship memory, Voyage, pgvector retrieval.
+- [World system](docs/world-system.md) — experimental per-owner persona worlds: World Memories simulation + recall injection, and the World Town social feed.
 - [Model config](docs/model-config.md) — `model_config.toml` schema, every task (chat, vision, image generation, PDE, filters, extraction), model selection, 0.x stability commitments.
 - [Prompt traits](docs/prompt-traits.md) — per-request system-prompt injection and tier allow-lists.
 - [LLM / OpenRouter audit](docs/llm-audit.md) — per-user / per-session attribution passthrough.

--- a/README.zh.md
+++ b/README.zh.md
@@ -98,6 +98,7 @@ docker run --rm -p 8080:8080 --env-file .env \
 - [亲密度模型](docs/affinity-model.zh.md)——六个维度、EMA、时间衰减、关系标签。
 - [ghost 机制](docs/ghost-mechanics.zh.md)——评分公式、保护规则、示例。
 - [记忆分层](docs/memory-layers.zh.md)——画像记忆 vs 关系记忆、Voyage、pgvector 检索。
+- [世界系统](docs/world-system.zh.md)——实验性的按 owner 角色世界：World Memories 模拟 + 召回注入，以及 World Town 社交动态流。
 - [模型配置](docs/model-config.zh.md)——`model_config.toml` schema、各任务（chat、vision、图像生成、PDE、过滤器、抽取）、选模型规则、0.x 稳定性承诺。
 - [Prompt traits](docs/prompt-traits.zh.md)——按请求注入系统 prompt 与 tier 白名单。
 - [LLM / OpenRouter 审计](docs/llm-audit.zh.md)——按用户 / 按会话的归因透传。

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -1704,13 +1704,18 @@ impl ModelConfig {
 
     /// Boot gate, mirroring `validate_extraction_prompts`: any present world
     /// task section (`world_director` / `world_comment` / `world_reply`) must
-    /// carry a usable `filter_prompt`.
-    pub fn validate_world_prompts(&self) -> Result<(), String> {
-        let checks = [
-            ("world_director", self.resolve_world_director().is_none()),
-            ("world_comment", self.resolve_world_comment().is_none()),
-            ("world_reply", self.resolve_world_reply().is_none()),
-        ];
+    /// carry a usable `filter_prompt`. `world_director` is always checked;
+    /// the two town sections (`world_comment` / `world_reply`) are checked
+    /// only when `include_town` is true. `include_town = false`
+    /// (WORLD_TOWN_DISABLED) skips the two town sections so a staged/broken
+    /// town config cannot block boot — same isolation rationale as
+    /// WORLD_DISABLED for the whole block.
+    pub fn validate_world_prompts(&self, include_town: bool) -> Result<(), String> {
+        let mut checks = vec![("world_director", self.resolve_world_director().is_none())];
+        if include_town {
+            checks.push(("world_comment", self.resolve_world_comment().is_none()));
+            checks.push(("world_reply", self.resolve_world_reply().is_none()));
+        }
         for (name, unresolved) in checks {
             if self.tasks.contains_key(name) && unresolved {
                 return Err(format!(
@@ -4475,12 +4480,30 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
     #[test]
     fn validate_world_prompts_gates_all_three_sections() {
         let cfg = ModelConfig::from_toml_str("").unwrap();
-        assert!(cfg.validate_world_prompts().is_ok(), "absent ⇒ Ok");
-        for section in ["world_director", "world_comment", "world_reply"] {
+        assert!(cfg.validate_world_prompts(true).is_ok(), "absent ⇒ Ok");
+        assert!(cfg.validate_world_prompts(false).is_ok(), "absent ⇒ Ok");
+
+        // world_director errs regardless of include_town (never town-gated).
+        let cfg = ModelConfig::from_toml_str("[tasks.world_director]\nmodel = \"w/m\"\n").unwrap();
+        for include_town in [true, false] {
+            let err = cfg.validate_world_prompts(include_town).unwrap_err();
+            assert!(
+                err.contains("world_director"),
+                "error names the section: {err}"
+            );
+        }
+
+        // world_comment / world_reply only err when include_town is true —
+        // WORLD_TOWN_DISABLED isolates a staged/broken town section.
+        for section in ["world_comment", "world_reply"] {
             let cfg = ModelConfig::from_toml_str(&format!("[tasks.{section}]\nmodel = \"w/m\"\n"))
                 .unwrap();
-            let err = cfg.validate_world_prompts().unwrap_err();
+            let err = cfg.validate_world_prompts(true).unwrap_err();
             assert!(err.contains(section), "error names the section: {err}");
+            assert!(
+                cfg.validate_world_prompts(false).is_ok(),
+                "include_town=false skips {section}"
+            );
         }
     }
 }

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -551,6 +551,22 @@ pub struct TaskConfig {
     /// world_director-only: days of world_memories script retention. Default 30.
     #[serde(default)]
     pub retention_days: Option<u32>,
+    /// world_comment-only: seconds between hourly comment rounds. Read only
+    /// on `[tasks.world_comment]`. Default 3600, floor 60 (0 would fire a
+    /// round every sweeper tick — cost footgun, same rationale as
+    /// `interval_hours.max(1)`).
+    #[serde(default)]
+    pub round_secs: Option<u64>,
+    /// world_reply-only: user-comment settle window in seconds. Default 90.
+    #[serde(default)]
+    pub debounce_secs: Option<u64>,
+    /// world_reply-only: min seconds between responder comments per post.
+    /// Default 600.
+    #[serde(default)]
+    pub thread_cooldown_secs: Option<u64>,
+    /// world_reply-only: responder comments per owner per UTC day. Default 20.
+    #[serde(default)]
+    pub daily_cap: Option<u32>,
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
@@ -822,6 +838,38 @@ pub struct ResolvedWorldDirector {
     pub structured_output: bool,
     pub interval_hours: u32,
     pub retention_days: u32,
+}
+
+/// Resolved world-town comment-round task (`world_comment`). The configured
+/// `filter_prompt` is the system instruction; the server assembles the
+/// round payload as a separate user message.
+#[derive(Debug, Clone)]
+pub struct ResolvedWorldComment {
+    pub model: String,
+    pub fallback_model: Vec<String>,
+    pub temperature: f64,
+    pub max_tokens: u32,
+    pub comment_prompt: String,
+    pub retry_depth: u32,
+    pub reasoning: Option<ReasoningConfig>,
+    pub structured_output: bool,
+    pub round_secs: u64,
+}
+
+/// Resolved world-town reply-responder task (`world_reply`). Plain-text
+/// completion; `filter_prompt` is the system instruction.
+#[derive(Debug, Clone)]
+pub struct ResolvedWorldReply {
+    pub model: String,
+    pub fallback_model: Vec<String>,
+    pub temperature: f64,
+    pub max_tokens: u32,
+    pub reply_prompt: String,
+    pub retry_depth: u32,
+    pub reasoning: Option<ReasoningConfig>,
+    pub debounce_secs: u64,
+    pub thread_cooldown_secs: u64,
+    pub daily_cap: u32,
 }
 
 /// Resolved image-generation task (`chat_image_generation`). `model` is optional:
@@ -1588,6 +1636,52 @@ impl ModelConfig {
         })
     }
 
+    /// Resolve the world-town comment-round bundle. `None` when
+    /// `[tasks.world_comment]` is absent OR its `filter_prompt` is blank —
+    /// the comment-round path goes inert.
+    pub fn resolve_world_comment(&self) -> Option<ResolvedWorldComment> {
+        let task_cfg = self.tasks.get("world_comment")?;
+        let comment_prompt = task_cfg.filter_prompt.clone().unwrap_or_default();
+        if comment_prompt.trim().is_empty() {
+            return None;
+        }
+        let m = self.resolve("world_comment", None);
+        Some(ResolvedWorldComment {
+            model: m.model,
+            fallback_model: m.fallback_model,
+            temperature: m.temperature,
+            max_tokens: m.max_tokens,
+            comment_prompt,
+            retry_depth: m.retry_depth,
+            reasoning: m.reasoning,
+            structured_output: task_cfg.structured_output.unwrap_or(true),
+            round_secs: task_cfg.round_secs.unwrap_or(3600).max(60),
+        })
+    }
+
+    /// Resolve the world-town reply-responder bundle. `None` when
+    /// `[tasks.world_reply]` is absent OR its `filter_prompt` is blank.
+    pub fn resolve_world_reply(&self) -> Option<ResolvedWorldReply> {
+        let task_cfg = self.tasks.get("world_reply")?;
+        let reply_prompt = task_cfg.filter_prompt.clone().unwrap_or_default();
+        if reply_prompt.trim().is_empty() {
+            return None;
+        }
+        let m = self.resolve("world_reply", None);
+        Some(ResolvedWorldReply {
+            model: m.model,
+            fallback_model: m.fallback_model,
+            temperature: m.temperature,
+            max_tokens: m.max_tokens,
+            reply_prompt,
+            retry_depth: m.retry_depth,
+            reasoning: m.reasoning,
+            debounce_secs: task_cfg.debounce_secs.unwrap_or(90),
+            thread_cooldown_secs: task_cfg.thread_cooldown_secs.unwrap_or(600),
+            daily_cap: task_cfg.daily_cap.unwrap_or(20),
+        })
+    }
+
     /// Boot-time validation for the two extraction tasks. A task **section that
     /// is present** must carry a usable `filter_prompt` (else `Err`); an
     /// **absent section** means that extraction is simply off (`Ok`). Returns a
@@ -1608,16 +1702,23 @@ impl ModelConfig {
         Ok(())
     }
 
-    /// Boot gate, mirroring `validate_extraction_prompts`: a present
-    /// `[tasks.world_director]` must carry a usable `filter_prompt`.
-    pub fn validate_world_director_prompt(&self) -> Result<(), String> {
-        if self.tasks.contains_key("world_director") && self.resolve_world_director().is_none() {
-            return Err(
-                "[tasks.world_director] is present but its filter_prompt is unset — eros-engine \
-                 refuses to boot. Set a filter_prompt, or remove the [tasks.world_director] \
-                 section to disable world memories."
-                    .to_string(),
-            );
+    /// Boot gate, mirroring `validate_extraction_prompts`: any present world
+    /// task section (`world_director` / `world_comment` / `world_reply`) must
+    /// carry a usable `filter_prompt`.
+    pub fn validate_world_prompts(&self) -> Result<(), String> {
+        let checks = [
+            ("world_director", self.resolve_world_director().is_none()),
+            ("world_comment", self.resolve_world_comment().is_none()),
+            ("world_reply", self.resolve_world_reply().is_none()),
+        ];
+        for (name, unresolved) in checks {
+            if self.tasks.contains_key(name) && unresolved {
+                return Err(format!(
+                    "[tasks.{name}] is present but its filter_prompt is unset — eros-engine \
+                     refuses to boot. Set a filter_prompt, or remove the [tasks.{name}] \
+                     section to disable it."
+                ));
+            }
         }
         Ok(())
     }
@@ -4306,13 +4407,80 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
     }
 
     #[test]
-    fn validate_world_director_prompt_gates_present_but_blank() {
+    fn resolve_world_comment_defaults_and_overrides() {
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.world_comment]\nmodel = \"w/c\"\nfilter_prompt = \"comment round\"\n",
+        )
+        .unwrap();
+        let r = cfg.resolve_world_comment().expect("configured");
+        assert_eq!(r.model, "w/c");
+        assert_eq!(r.comment_prompt, "comment round");
+        assert!(r.structured_output, "default on");
+        assert_eq!(r.round_secs, 3600, "default hourly");
+
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.world_comment]\nmodel = \"w/c\"\nfilter_prompt = \"p\"\n\
+             round_secs = 7200\nstructured_output = false\n",
+        )
+        .unwrap();
+        let r = cfg.resolve_world_comment().unwrap();
+        assert_eq!(r.round_secs, 7200);
+        assert!(!r.structured_output);
+
+        // round_secs = 0 would fire every sweeper tick — clamped to 60.
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.world_comment]\nmodel = \"w/c\"\nfilter_prompt = \"p\"\nround_secs = 0\n",
+        )
+        .unwrap();
+        assert_eq!(cfg.resolve_world_comment().unwrap().round_secs, 60);
+    }
+
+    #[test]
+    fn resolve_world_reply_defaults_and_overrides() {
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.world_reply]\nmodel = \"w/r\"\nfilter_prompt = \"reply\"\n",
+        )
+        .unwrap();
+        let r = cfg.resolve_world_reply().expect("configured");
+        assert_eq!(r.reply_prompt, "reply");
+        assert_eq!(r.debounce_secs, 90);
+        assert_eq!(r.thread_cooldown_secs, 600);
+        assert_eq!(r.daily_cap, 20);
+
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.world_reply]\nmodel = \"w/r\"\nfilter_prompt = \"p\"\n\
+             debounce_secs = 30\nthread_cooldown_secs = 120\ndaily_cap = 5\n",
+        )
+        .unwrap();
+        let r = cfg.resolve_world_reply().unwrap();
+        assert_eq!(r.debounce_secs, 30);
+        assert_eq!(r.thread_cooldown_secs, 120);
+        assert_eq!(r.daily_cap, 5);
+    }
+
+    #[test]
+    fn resolve_world_town_tasks_none_when_absent_or_blank_prompt() {
         let cfg = ModelConfig::from_toml_str("").unwrap();
-        assert!(cfg.validate_world_director_prompt().is_ok(), "absent ⇒ Ok");
-        let cfg = ModelConfig::from_toml_str("[tasks.world_director]\nmodel = \"w/m\"\n").unwrap();
-        assert!(
-            cfg.validate_world_director_prompt().is_err(),
-            "present+blank ⇒ boot error"
-        );
+        assert!(cfg.resolve_world_comment().is_none());
+        assert!(cfg.resolve_world_reply().is_none());
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.world_comment]\nmodel = \"w/c\"\nfilter_prompt = \"  \"\n\
+             [tasks.world_reply]\nmodel = \"w/r\"\n",
+        )
+        .unwrap();
+        assert!(cfg.resolve_world_comment().is_none(), "blank prompt ⇒ None");
+        assert!(cfg.resolve_world_reply().is_none(), "missing prompt ⇒ None");
+    }
+
+    #[test]
+    fn validate_world_prompts_gates_all_three_sections() {
+        let cfg = ModelConfig::from_toml_str("").unwrap();
+        assert!(cfg.validate_world_prompts().is_ok(), "absent ⇒ Ok");
+        for section in ["world_director", "world_comment", "world_reply"] {
+            let cfg = ModelConfig::from_toml_str(&format!("[tasks.{section}]\nmodel = \"w/m\"\n"))
+                .unwrap();
+            let err = cfg.validate_world_prompts().unwrap_err();
+            assert!(err.contains(section), "error names the section: {err}");
+        }
     }
 }

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -857,6 +857,142 @@
           }
         }
       }
+    },
+    "/world/town/{user_id}/feed": {
+      "get": {
+        "tags": [
+          "world_town"
+        ],
+        "summary": "Published town feed for the user's world, newest first. Unenrolled or\ntown-disabled users get an empty feed, not an error (spec §4).",
+        "operationId": "get_feed",
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "path",
+            "description": "Owner user id (must equal JWT sub)",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Page size, default 20, max 50",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Opaque keyset cursor from the previous page's next_cursor",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeedResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "malformed cursor"
+          },
+          "401": {
+            "description": "missing or invalid bearer"
+          },
+          "403": {
+            "description": "user_id does not match JWT"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/world/town/{user_id}/posts/{post_id}/comments": {
+      "post": {
+        "tags": [
+          "world_town"
+        ],
+        "summary": "Add a user comment to a published post in the user's own town.",
+        "operationId": "create_comment",
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "path",
+            "description": "Owner user id (must equal JWT sub)",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "post_id",
+            "in": "path",
+            "description": "Target post id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateCommentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeedCommentDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "empty content or over 1000 chars"
+          },
+          "401": {
+            "description": "missing or invalid bearer"
+          },
+          "403": {
+            "description": "user_id does not match JWT"
+          },
+          "404": {
+            "description": "post not visible to this user"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
     }
   },
   "components": {
@@ -1347,6 +1483,17 @@
           }
         }
       },
+      "CreateCommentRequest": {
+        "type": "object",
+        "required": [
+          "content"
+        ],
+        "properties": {
+          "content": {
+            "type": "string"
+          }
+        }
+      },
       "DrawImageRequest": {
         "type": "object",
         "description": "Body of the engine draw endpoint. Echoes the `image_request` frame contents\nback plus the draw-time knobs. The engine draws `composed_prompt` verbatim —\nno re-compose, no persona load, no persistence.",
@@ -1398,6 +1545,104 @@
               "string",
               "null"
             ]
+          }
+        }
+      },
+      "FeedCommentDto": {
+        "type": "object",
+        "required": [
+          "comment_id",
+          "content",
+          "created_at"
+        ],
+        "properties": {
+          "author_instance_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "NULL = the user themselves."
+          },
+          "author_name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "comment_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "content": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "FeedPostDto": {
+        "type": "object",
+        "required": [
+          "post_id",
+          "instance_id",
+          "author_name",
+          "content",
+          "published_at",
+          "comments"
+        ],
+        "properties": {
+          "author_name": {
+            "type": "string"
+          },
+          "comments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FeedCommentDto"
+            }
+          },
+          "content": {
+            "type": "string"
+          },
+          "instance_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "post_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "FeedResponse": {
+        "type": "object",
+        "required": [
+          "user_id",
+          "posts"
+        ],
+        "properties": {
+          "next_cursor": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Present when another page may exist; feed it back as `cursor`."
+          },
+          "posts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FeedPostDto"
+            }
+          },
+          "user_id": {
+            "type": "string",
+            "format": "uuid"
           }
         }
       },

--- a/crates/eros-engine-server/src/main.rs
+++ b/crates/eros-engine-server/src/main.rs
@@ -312,7 +312,7 @@ async fn run_server() -> Result<()> {
     // isolate a staged/incomplete [tasks.world_director] section (the sweeper
     // won't spawn and injection is gated too, so a blank prompt is harmless).
     if !cfg.world.disabled {
-        if let Err(msg) = model_config.validate_world_director_prompt() {
+        if let Err(msg) = model_config.validate_world_prompts() {
             anyhow::bail!(msg);
         }
     }

--- a/crates/eros-engine-server/src/main.rs
+++ b/crates/eros-engine-server/src/main.rs
@@ -311,8 +311,11 @@ async fn run_server() -> Result<()> {
     // Skip when the master switch is off — WORLD_DISABLED must be able to
     // isolate a staged/incomplete [tasks.world_director] section (the sweeper
     // won't spawn and injection is gated too, so a blank prompt is harmless).
+    // WORLD_TOWN_DISABLED isolates the two town sections
+    // ([tasks.world_comment] / [tasks.world_reply]) the same way: the town
+    // sweeper won't spawn, so a staged/broken town config must not block boot.
     if !cfg.world.disabled {
-        if let Err(msg) = model_config.validate_world_prompts() {
+        if let Err(msg) = model_config.validate_world_prompts(!cfg.world.town_disabled) {
             anyhow::bail!(msg);
         }
     }

--- a/crates/eros-engine-server/src/main.rs
+++ b/crates/eros-engine-server/src/main.rs
@@ -378,6 +378,11 @@ async fn run_server() -> Result<()> {
     // [tasks.world_director] is absent/blank (spec §2.1).
     tokio::spawn(crate::pipeline::world::sweeper(state.clone()));
 
+    // World Town sweeper (posts feed). Inert when the world subsystem is off,
+    // WORLD_TOWN_DISABLED is set, or [tasks.world_director] is absent — no
+    // posts can exist without the director (town spec §3).
+    tokio::spawn(crate::pipeline::world_town::sweeper(state.clone()));
+
     let app: Router = open_router
         .with_state(state)
         .merge(Scalar::with_url("/docs", api))

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -2220,6 +2220,7 @@ mod tests {
                 content: "剧本片段A".into(),
                 embedding: emb.clone(),
             }],
+            &[],
             chrono::Utc::now().date_naive(),
             30,
             token,

--- a/crates/eros-engine-server/src/pipeline/mod.rs
+++ b/crates/eros-engine-server/src/pipeline/mod.rs
@@ -10,6 +10,7 @@ pub mod snapshot;
 pub mod stream;
 pub mod voice;
 pub mod world;
+pub mod world_town;
 
 use uuid::Uuid;
 

--- a/crates/eros-engine-server/src/pipeline/world.rs
+++ b/crates/eros-engine-server/src/pipeline/world.rs
@@ -13,7 +13,7 @@ use uuid::Uuid;
 
 use eros_engine_llm::model_config::ResolvedWorldDirector;
 use eros_engine_llm::openrouter::{ChatMessage, ChatRequest};
-use eros_engine_store::world::{FragmentInsert, RosterEntry, WorldRepo};
+use eros_engine_store::world::{FragmentInsert, PostInsert, RosterEntry, WorldRepo};
 
 use crate::state::AppState;
 
@@ -42,10 +42,18 @@ const WORLD_DIRECTOR_RULES: &str = "规则：\
 （当期发生的具体事件片段，每条一句、自成一体、适合单独召回）。\
 4) 只使用给出的 instance_id。";
 
+/// Appended to WORLD_DIRECTOR_RULES only for town-enabled owners.
+const WORLD_TOWN_POST_RULES: &str = "\
+5) posts：为部分角色生成朋友圈式贴文（不是每个角色都要发；没有合适内容就输出空数组）。\
+每条含 instance_id、content（贴文正文，第一人称）、publish_at（ISO-8601 时间戳，\
+安排在未来一个周期内的自然时刻）。";
+
 #[derive(Debug, Deserialize)]
 struct DirectorOutput {
     seed: serde_json::Value,
     personas: Vec<DirectorPersona>,
+    #[serde(default)]
+    posts: Vec<serde_json::Value>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -54,6 +62,13 @@ struct DirectorPersona {
     digest: String,
     #[serde(default)]
     script_fragments: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DirectorPost {
+    instance_id: Uuid,
+    content: String,
+    publish_at: String,
 }
 
 /// Run forever; spawn once at boot. Inert when WORLD_DISABLED is set or
@@ -145,6 +160,10 @@ async fn direct_world(
         tracing::warn!(%owner, cap = WORLD_ROSTER_CAP, "world: roster truncated");
         roster.truncate(WORLD_ROSTER_CAP);
     }
+    let town = repo
+        .town_enabled(owner)
+        .await
+        .map_err(|e| format!("town_enabled load failed: {e}"))?;
 
     let seed = repo
         .load_seed(owner)
@@ -156,7 +175,7 @@ async fn direct_world(
         .await
         .map_err(|e| format!("memory feedback load failed: {e}"))?;
 
-    let payload = director_user_payload(&seed, &roster, &memories);
+    let payload = director_user_payload(&seed, &roster, &memories, town);
     let req = ChatRequest {
         model: resolved.model.clone(),
         fallback_model: resolved.fallback_model.clone(),
@@ -176,7 +195,7 @@ async fn direct_world(
         reasoning: resolved.reasoning.clone(),
         response_format: resolved
             .structured_output
-            .then(world_director_response_format),
+            .then(|| world_director_response_format(town)),
         ..Default::default()
     };
     let raw = state
@@ -235,12 +254,25 @@ async fn direct_world(
         })
         .collect();
 
+    let posts = if town {
+        validate_director_posts(
+            &output.posts,
+            &roster_ids,
+            chrono::Utc::now(),
+            resolved.interval_hours,
+            owner,
+        )
+    } else {
+        Vec::new()
+    };
+
     let script_date = chrono::Utc::now().date_naive();
     repo.persist_round(
         owner,
         &output.seed,
         &serde_json::Value::Object(digests),
         &inserts,
+        &posts,
         script_date,
         resolved.retention_days,
         token,
@@ -250,11 +282,14 @@ async fn direct_world(
 }
 
 /// Assemble the director's user message: framing header + structured JSON of
-/// previous seed / roster / memory feedback + the fixed rules.
+/// previous seed / roster / memory feedback + the fixed rules. `town` appends
+/// `WORLD_TOWN_POST_RULES` (the posts rule) for town-enabled owners only —
+/// memories-only owners see no mention of posts.
 fn director_user_payload(
     seed: &serde_json::Value,
     roster: &[RosterEntry],
     memories: &[String],
+    town: bool,
 ) -> String {
     let is_init = seed.as_object().map(|o| o.is_empty()).unwrap_or(false);
     let personas: Vec<serde_json::Value> = roster
@@ -278,16 +313,23 @@ fn director_user_payload(
     } else {
         "延续这个世界：在 previous_seed 的基础上推演关系发展，并生成当期剧本。"
     };
+    let rules = if town {
+        format!("{WORLD_DIRECTOR_RULES}{WORLD_TOWN_POST_RULES}")
+    } else {
+        WORLD_DIRECTOR_RULES.to_string()
+    };
     format!(
-        "{header}\n\n{}\n\n{WORLD_DIRECTOR_RULES}",
+        "{header}\n\n{}\n\n{rules}",
         serde_json::to_string_pretty(&data).unwrap_or_default()
     )
 }
 
 /// OpenRouter `response_format` for the director round. `strict` is false —
-/// `seed` is deliberately free-form (the engine stores it opaquely).
-fn world_director_response_format() -> serde_json::Value {
-    serde_json::json!({
+/// `seed` is deliberately free-form (the engine stores it opaquely). `town`
+/// attaches the `posts` array (schema + required) only for town-enabled
+/// owners — memories-only owners get no posts key in the schema at all.
+fn world_director_response_format(town: bool) -> serde_json::Value {
+    let mut v = serde_json::json!({
         "type": "json_schema",
         "json_schema": {
             "name": "world_director_round",
@@ -315,7 +357,23 @@ fn world_director_response_format() -> serde_json::Value {
                 }
             }
         }
-    })
+    });
+    if town {
+        v["json_schema"]["schema"]["properties"]["posts"] = serde_json::json!({
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["instance_id", "content", "publish_at"],
+                "properties": {
+                    "instance_id": { "type": "string" },
+                    "content": { "type": "string" },
+                    "publish_at": { "type": "string" }
+                }
+            }
+        });
+        v["json_schema"]["schema"]["required"] = serde_json::json!(["seed", "personas", "posts"]);
+    }
+    v
 }
 
 /// Lenient parse: direct JSON first, then the shared balanced-brace block
@@ -327,6 +385,47 @@ fn parse_director_output(raw: &str) -> Option<DirectorOutput> {
     }
     let block = super::find_json_block(raw)?;
     serde_json::from_str::<DirectorOutput>(block).ok()
+}
+
+/// Validate + clamp the director's raw `posts` entries (spec town §2): keep
+/// only roster instances with non-blank content and a parseable ISO-8601
+/// publish_at, clamped into `[now, now + horizon_hours]`. Malformed entries
+/// are dropped with a warn, mirroring unknown-persona handling.
+fn validate_director_posts(
+    raw: &[serde_json::Value],
+    roster_ids: &std::collections::HashSet<Uuid>,
+    now: chrono::DateTime<chrono::Utc>,
+    horizon_hours: u32,
+    owner: Uuid,
+) -> Vec<PostInsert> {
+    let max_at = now + chrono::Duration::hours(i64::from(horizon_hours));
+    let mut out = Vec::new();
+    for entry in raw {
+        let Ok(p) = serde_json::from_value::<DirectorPost>(entry.clone()) else {
+            tracing::warn!(%owner, "world: malformed post entry dropped");
+            continue;
+        };
+        if !roster_ids.contains(&p.instance_id) {
+            tracing::warn!(%owner, instance = %p.instance_id, "world: post for unknown instance dropped");
+            continue;
+        }
+        let content = p.content.trim().to_string();
+        if content.is_empty() {
+            tracing::warn!(%owner, "world: blank post content dropped");
+            continue;
+        }
+        let Ok(at) = chrono::DateTime::parse_from_rfc3339(&p.publish_at) else {
+            tracing::warn!(%owner, publish_at = %p.publish_at, "world: unparseable publish_at dropped");
+            continue;
+        };
+        let scheduled_at = at.with_timezone(&chrono::Utc).clamp(now, max_at);
+        out.push(PostInsert {
+            instance_id: p.instance_id,
+            content,
+            scheduled_at,
+        });
+    }
+    out
 }
 
 #[cfg(test)]
@@ -348,6 +447,10 @@ mod tests {
         let out = parse_director_output(&clean).expect("clean parses");
         assert_eq!(out.personas.len(), 1);
         assert_eq!(out.personas[0].script_fragments, vec!["f1", "f2"]);
+        assert!(
+            out.posts.is_empty(),
+            "clean sample has no posts key — #[serde(default)] must still parse"
+        );
 
         let fenced = format!("好的：\n```json\n{clean}\n```");
         assert!(parse_director_output(&fenced).is_some(), "fenced parses");
@@ -367,7 +470,7 @@ mod tests {
             tip_personality: Some("温柔".into()),
             art_metadata: serde_json::json!({"backstory": "咖啡店店主"}),
         }];
-        let init = director_user_payload(&serde_json::json!({}), &roster, &[]);
+        let init = director_user_payload(&serde_json::json!({}), &roster, &[], false);
         assert!(init.contains("初始化这个世界"));
         assert!(init.contains("\"previous_seed\": null"));
         assert!(init.contains("Aria"));
@@ -377,6 +480,7 @@ mod tests {
             &serde_json::json!({"arc": "opening"}),
             &roster,
             &["用户喜欢旅行".into()],
+            false,
         );
         assert!(cont.contains("延续这个世界"));
         assert!(cont.contains("\"arc\": \"opening\""));
@@ -385,12 +489,80 @@ mod tests {
 
     #[test]
     fn world_director_response_format_shape() {
-        let v = world_director_response_format();
+        let v = world_director_response_format(false);
         assert_eq!(v["type"], "json_schema");
         assert_eq!(v["json_schema"]["strict"], false);
         let required = v["json_schema"]["schema"]["required"].as_array().unwrap();
         assert!(required.iter().any(|r| r == "seed"));
         assert!(required.iter().any(|r| r == "personas"));
+    }
+
+    #[test]
+    fn director_posts_validated_clamped_and_dropped() {
+        let inst = Uuid::new_v4();
+        let stranger = Uuid::new_v4();
+        let roster_ids: std::collections::HashSet<Uuid> = [inst].into_iter().collect();
+        let now = chrono::Utc::now();
+        let horizon_hours = 24u32;
+        let raw = serde_json::json!([
+            // valid, inside window
+            {"instance_id": inst, "content": "去了海边", "publish_at": (now + chrono::Duration::hours(2)).to_rfc3339()},
+            // beyond window ⇒ clamped to now + horizon
+            {"instance_id": inst, "content": "远期计划", "publish_at": (now + chrono::Duration::hours(100)).to_rfc3339()},
+            // past ⇒ clamped up to now
+            {"instance_id": inst, "content": "旧闻", "publish_at": (now - chrono::Duration::hours(5)).to_rfc3339()},
+            // unknown instance ⇒ dropped
+            {"instance_id": stranger, "content": "x", "publish_at": now.to_rfc3339()},
+            // malformed timestamp ⇒ dropped
+            {"instance_id": inst, "content": "y", "publish_at": "not-a-date"},
+            // blank content ⇒ dropped
+            {"instance_id": inst, "content": "  ", "publish_at": now.to_rfc3339()},
+        ]);
+        let posts = validate_director_posts(
+            raw.as_array().unwrap(),
+            &roster_ids,
+            now,
+            horizon_hours,
+            Uuid::new_v4(),
+        );
+        assert_eq!(posts.len(), 3);
+        let max_at = now + chrono::Duration::hours(i64::from(horizon_hours));
+        assert!(posts
+            .iter()
+            .all(|p| p.scheduled_at >= now && p.scheduled_at <= max_at));
+        assert_eq!(posts[2].scheduled_at, now, "past publish_at clamps to now");
+    }
+
+    #[test]
+    fn world_director_response_format_town_arm() {
+        let base = world_director_response_format(false);
+        assert!(base["json_schema"]["schema"]["properties"]["posts"].is_null());
+        let town = world_director_response_format(true);
+        assert_eq!(
+            town["json_schema"]["schema"]["properties"]["posts"]["type"],
+            "array"
+        );
+        let required = town["json_schema"]["schema"]["required"]
+            .as_array()
+            .unwrap();
+        assert!(required.iter().any(|r| r == "posts"));
+    }
+
+    #[test]
+    fn director_payload_mentions_posts_only_for_town() {
+        let roster = vec![RosterEntry {
+            instance_id: Uuid::new_v4(),
+            name: "Aria".into(),
+            tip_personality: None,
+            art_metadata: serde_json::json!({}),
+        }];
+        let plain = director_user_payload(&serde_json::json!({}), &roster, &[], false);
+        assert!(!plain.contains("posts"), "no posts rule for memories-only");
+        let town = director_user_payload(&serde_json::json!({}), &roster, &[], true);
+        assert!(
+            town.contains("posts"),
+            "town payload carries the posts rule"
+        );
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/crates/eros-engine-server/src/pipeline/world.rs
+++ b/crates/eros-engine-server/src/pipeline/world.rs
@@ -160,10 +160,11 @@ async fn direct_world(
         tracing::warn!(%owner, cap = WORLD_ROSTER_CAP, "world: roster truncated");
         roster.truncate(WORLD_ROSTER_CAP);
     }
-    let town = repo
-        .town_enabled(owner)
-        .await
-        .map_err(|e| format!("town_enabled load failed: {e}"))?;
+    let town = !state.config.world.town_disabled
+        && repo
+            .town_enabled(owner)
+            .await
+            .map_err(|e| format!("town_enabled load failed: {e}"))?;
 
     let seed = repo
         .load_seed(owner)
@@ -750,5 +751,115 @@ mod tests {
                 .await
                 .unwrap();
         assert_eq!(n, 0);
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn direct_world_skips_posts_when_town_disabled(pool: sqlx::PgPool) {
+        use wiremock::matchers::{method, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let owner = Uuid::new_v4();
+        let genome_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata) \
+             VALUES ('W','p','{}'::jsonb) RETURNING id",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let instance_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_instances (genome_id, owner_uid) \
+             VALUES ($1,$2) RETURNING id",
+        )
+        .bind(genome_id)
+        .bind(owner)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        // Owner is town-enrolled at the DB level — the kill-switch must win
+        // over this, not just gate on it.
+        sqlx::query(
+            "INSERT INTO engine.world_enrollments (owner_uid, town_enabled) VALUES ($1, true)",
+        )
+        .bind(owner)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let reply = serde_json::json!({
+            "seed": {"arc": "第一幕"},
+            "personas": [{
+                "instance_id": instance_id,
+                "digest": "W 在筹备开店",
+                "script_fragments": []
+            }],
+            "posts": [{
+                "instance_id": instance_id,
+                "content": "开业啦",
+                "publish_at": chrono::Utc::now().to_rfc3339()
+            }]
+        });
+        let mock = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(wm_path("/api/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "gen-world", "model": "w/m",
+                "choices": [{"message": {"content": reply.to_string()}}],
+            })))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.config.world.town_disabled = true;
+        state.model_config = std::sync::Arc::new(
+            eros_engine_llm::model_config::ModelConfig::from_toml_str(
+                "[tasks.world_director]\nmodel=\"w/m\"\nfilter_prompt=\"direct\"\n",
+            )
+            .unwrap(),
+        );
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "k".into(),
+                Default::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+        let resolved = state.model_config.resolve_world_director().unwrap();
+
+        let repo = eros_engine_store::world::WorldRepo { pool: &pool };
+        repo.ensure_states_for_enrollments().await.unwrap();
+        let claimed = repo
+            .claim_due(
+                std::time::Duration::from_secs(24 * 3600),
+                std::time::Duration::from_secs(1800),
+                5,
+            )
+            .await
+            .unwrap();
+        let (_o, token) = claimed[0];
+
+        direct_world(&state, &resolved, owner, token)
+            .await
+            .expect("round ok");
+
+        let posts: i64 =
+            sqlx::query_scalar("SELECT count(*) FROM engine.world_posts WHERE owner_uid = $1")
+                .bind(owner)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            posts, 0,
+            "town_disabled must suppress posts even when town_enabled=true"
+        );
+
+        let (seed, digests): (serde_json::Value, serde_json::Value) =
+            sqlx::query_as("SELECT seed, digests FROM engine.world_states WHERE owner_uid = $1")
+                .bind(owner)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(seed["arc"], "第一幕");
+        assert_eq!(digests[instance_id.to_string()], "W 在筹备开店");
     }
 }

--- a/crates/eros-engine-server/src/pipeline/world_town.rs
+++ b/crates/eros-engine-server/src/pipeline/world_town.rs
@@ -63,6 +63,10 @@ pub async fn sweeper(state: AppState) {
         tracing::info!("world_director not configured — world_town sweeper inert");
         return;
     }
+    if state.config.world.tick.is_zero() {
+        tracing::info!("world sweeper disabled (WORLD_TICK_SECS=0) — world_town sweeper inert");
+        return;
+    }
     let comment = state.model_config.resolve_world_comment();
     let reply = state.model_config.resolve_world_reply();
     tracing::info!(
@@ -505,7 +509,6 @@ mod tests {
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
     async fn comment_round_inserts_valid_and_drops_invalid(pool: sqlx::PgPool) {
         let (owner, author, commenter) = seed_town_world(&pool).await;
-        let repo = WorldTownRepo { pool: &pool };
         let post: Uuid = sqlx::query_scalar(
             "INSERT INTO engine.world_posts \
                  (owner_uid, instance_id, content, scheduled_at, published_at) \
@@ -560,7 +563,6 @@ mod tests {
         run_comment_round(&state, &resolved, owner)
             .await
             .expect("noop ok");
-        let _ = repo;
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/crates/eros-engine-server/src/pipeline/world_town.rs
+++ b/crates/eros-engine-server/src/pipeline/world_town.rs
@@ -619,13 +619,43 @@ mod tests {
         .unwrap();
         assert_eq!(n, 1);
 
-        // At cap: silent skip, no LLM call (expect(1) still holds), and no
-        // cooldown stamp burned beyond the first.
+        // At cap with a cooldown-fresh post: silent skip due to daily cap,
+        // no LLM call (expect(1) still holds), and the fresh post's last_reply_at
+        // remains NULL—proving the cap gate ran BEFORE the cooldown CAS.
+        // If gate order were swapped (cooldown checked first), this post would
+        // get a cooldown stamp despite being capped, making last_reply_at non-NULL.
+        let post2: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.world_posts \
+                 (owner_uid, instance_id, content, scheduled_at, published_at) \
+             VALUES ($1,$2,'月亮圆圆',now(),now()) RETURNING id",
+        )
+        .bind(owner)
+        .bind(author)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let cand2 = ReplyCandidate {
+            post_id: post2,
+            owner_uid: owner,
+            author_instance_id: author,
+        };
         let mut capped = resolved.clone();
         capped.daily_cap = 1;
-        run_reply(&state, &capped, &cand)
+        run_reply(&state, &capped, &cand2)
             .await
             .expect("cap skip ok");
+
+        // Verify the second post's cooldown was not burned (spec §3.3 gate 2).
+        let last_reply_at: Option<chrono::DateTime<chrono::Utc>> =
+            sqlx::query_scalar("SELECT last_reply_at FROM engine.world_posts WHERE id = $1")
+                .bind(post2)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            last_reply_at, None,
+            "cap skip should not burn cooldown on fresh post"
+        );
     }
 
     #[test]

--- a/crates/eros-engine-server/src/pipeline/world_town.rs
+++ b/crates/eros-engine-server/src/pipeline/world_town.rs
@@ -1,0 +1,639 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! World Town sweeper (town spec §3): per 30s tick — publish due posts
+//! (pure SQL), run hourly CAS-claimed comment rounds (one batched
+//! `[tasks.world_comment]` call per owner with activity), and answer user
+//! comments via the debounced/cooldown/capped `[tasks.world_reply]` path.
+//! Every LLM/parse failure warns and moves on: the publish flip is
+//! idempotent, a lost comment round catches up next hour, and a lost reply
+//! retries after its cooldown.
+
+use serde::Deserialize;
+use uuid::Uuid;
+
+use eros_engine_llm::model_config::{ResolvedWorldComment, ResolvedWorldReply};
+use eros_engine_llm::openrouter::{ChatMessage, ChatRequest};
+use eros_engine_store::world::WorldRepo;
+use eros_engine_store::world_town::{FeedComment, FeedPost, ReplyCandidate, WorldTownRepo};
+
+use super::world::WORLD_AUDIT_USER;
+use crate::state::AppState;
+
+/// Deliberately faster than the director's WORLD_TICK_SECS (spec §3):
+/// publish precision + reply debounce need finer granularity; every town
+/// path is a cheap indexed scan.
+const TOWN_TICK: std::time::Duration = std::time::Duration::from_secs(30);
+/// Posts (with threads) fed to one comment round, newest first.
+const TOWN_ROUND_POSTS_CAP: i64 = 10;
+/// Reply candidates processed per tick.
+const TOWN_REPLY_BATCH: i64 = 10;
+/// Comments accepted from one comment round (defensive cap, mirrors
+/// WORLD_FRAGMENTS_PER_PERSONA_CAP's role).
+const TOWN_ROUND_COMMENTS_CAP: usize = 12;
+
+const WORLD_COMMENT_RULES: &str = "规则：\
+1) 只使用给出的 post_id 和 instance_id；发帖者不评论自己的贴子。\
+2) 评论要符合 seed 里的角色关系；贴子下有用户（user）留言时，角色可以自然回应它。\
+3) 输出 0 到 N 条评论；没有值得评论的就输出空数组。每条评论一两句话，口语化。";
+
+#[derive(Debug, Deserialize)]
+struct CommentRoundOutput {
+    comments: Vec<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RoundComment {
+    post_id: Uuid,
+    author_instance_id: Uuid,
+    content: String,
+}
+
+/// Run forever; spawn once at boot. Inert when the world subsystem is off,
+/// WORLD_TOWN_DISABLED is set, or the director is unconfigured (posts can
+/// only exist downstream of the director — town spec §3).
+pub async fn sweeper(state: AppState) {
+    if state.config.world.disabled {
+        tracing::info!("world_town sweeper disabled (WORLD_DISABLED)");
+        return;
+    }
+    if state.config.world.town_disabled {
+        tracing::info!("world_town sweeper disabled (WORLD_TOWN_DISABLED)");
+        return;
+    }
+    if state.model_config.resolve_world_director().is_none() {
+        tracing::info!("world_director not configured — world_town sweeper inert");
+        return;
+    }
+    let comment = state.model_config.resolve_world_comment();
+    let reply = state.model_config.resolve_world_reply();
+    tracing::info!(
+        comment_round = comment.is_some(),
+        reply_responder = reply.is_some(),
+        "world_town sweeper starting"
+    );
+    let mut tick = tokio::time::interval(TOWN_TICK);
+    tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    loop {
+        tick.tick().await;
+        run_tick(&state, comment.as_ref(), reply.as_ref()).await;
+    }
+}
+
+/// One tick: publish, comment rounds, replies. Each path degrades
+/// independently — a failure in one never blocks the others.
+async fn run_tick(
+    state: &AppState,
+    comment: Option<&ResolvedWorldComment>,
+    reply: Option<&ResolvedWorldReply>,
+) {
+    let repo = WorldTownRepo { pool: &state.pool };
+    match repo.publish_due().await {
+        Ok(0) => {}
+        Ok(n) => tracing::info!(published = n, "world_town: posts published"),
+        Err(e) => tracing::warn!("world_town: publish scan failed: {e}"),
+    }
+    if let Some(resolved) = comment {
+        let round = std::time::Duration::from_secs(resolved.round_secs);
+        match repo.list_round_candidates(round).await {
+            Ok(owners) => {
+                for owner in owners {
+                    if let Err(e) = run_comment_round(state, resolved, owner).await {
+                        tracing::warn!(%owner, "world_town: comment round failed: {e}");
+                    }
+                }
+            }
+            Err(e) => tracing::warn!("world_town: round candidate scan failed: {e}"),
+        }
+    }
+    if let Some(resolved) = reply {
+        let debounce = std::time::Duration::from_secs(resolved.debounce_secs);
+        match repo.list_reply_candidates(debounce, TOWN_REPLY_BATCH).await {
+            Ok(cands) => {
+                for cand in cands {
+                    if let Err(e) = run_reply(state, resolved, &cand).await {
+                        tracing::warn!(post = %cand.post_id, "world_town: reply failed: {e}");
+                    }
+                }
+            }
+            Err(e) => tracing::warn!("world_town: reply candidate scan failed: {e}"),
+        }
+    }
+}
+
+/// One owner's comment round (spec §3.2). The CAS stamps the round BEFORE
+/// the activity check: a no-activity owner costs one cheap query per cadence
+/// and no LLM call. Call/parse failure after the CAS loses this round —
+/// accepted; threads catch up next hour.
+async fn run_comment_round(
+    state: &AppState,
+    resolved: &ResolvedWorldComment,
+    owner: Uuid,
+) -> Result<(), String> {
+    let repo = WorldTownRepo { pool: &state.pool };
+    let round = std::time::Duration::from_secs(resolved.round_secs);
+    let Some(prev) = repo
+        .claim_comment_round(owner, round)
+        .await
+        .map_err(|e| format!("round CAS failed: {e}"))?
+    else {
+        return Ok(()); // contended or no longer due
+    };
+    if !repo
+        .has_town_activity_since(owner, prev)
+        .await
+        .map_err(|e| format!("activity check failed: {e}"))?
+    {
+        return Ok(()); // quiet world — no call, zero cost
+    }
+
+    let world_repo = WorldRepo { pool: &state.pool };
+    let seed = world_repo
+        .load_seed(owner)
+        .await
+        .map_err(|e| format!("seed load failed: {e}"))?
+        .unwrap_or_else(|| serde_json::json!({}));
+    let roster = world_repo
+        .list_active_roster(owner, i64::from(u8::MAX))
+        .await
+        .map_err(|e| format!("roster load failed: {e}"))?;
+    if roster.is_empty() {
+        return Ok(());
+    }
+    let posts = repo
+        .feed_page(owner, TOWN_ROUND_POSTS_CAP, None)
+        .await
+        .map_err(|e| format!("posts load failed: {e}"))?;
+    if posts.is_empty() {
+        return Ok(());
+    }
+    let post_ids: Vec<Uuid> = posts.iter().map(|p| p.post_id).collect();
+    let comments = repo
+        .list_comments_for_posts(&post_ids)
+        .await
+        .map_err(|e| format!("threads load failed: {e}"))?;
+
+    let payload = comment_round_payload(&seed, &roster, &posts, &comments);
+    let req = ChatRequest {
+        model: resolved.model.clone(),
+        fallback_model: resolved.fallback_model.clone(),
+        messages: vec![
+            ChatMessage {
+                role: "system".into(),
+                content: resolved.comment_prompt.clone(),
+            },
+            ChatMessage {
+                role: "user".into(),
+                content: payload,
+            },
+        ],
+        temperature: resolved.temperature as f32,
+        max_tokens: resolved.max_tokens,
+        user: Some(WORLD_AUDIT_USER.into()),
+        reasoning: resolved.reasoning.clone(),
+        response_format: resolved
+            .structured_output
+            .then(world_comment_response_format),
+        ..Default::default()
+    };
+    let raw = state
+        .openrouter
+        .execute(req)
+        .await
+        .map_err(|e| format!("world_comment LLM call failed: {e}"))?;
+    super::log_openrouter_usage("world_comment", None, &raw);
+
+    let output = parse_comment_output(&raw.reply)
+        .ok_or_else(|| "world_comment output did not parse".to_string())?;
+    let mut inserted = 0usize;
+    for entry in output.comments.into_iter().take(TOWN_ROUND_COMMENTS_CAP) {
+        let Ok(c) = serde_json::from_value::<RoundComment>(entry) else {
+            tracing::warn!(%owner, "world_town: malformed round comment dropped");
+            continue;
+        };
+        let content = c.content.trim();
+        if content.is_empty() {
+            continue;
+        }
+        match repo
+            .insert_round_comment(owner, c.post_id, c.author_instance_id, content)
+            .await
+        {
+            Ok(true) => inserted += 1,
+            Ok(false) => {
+                tracing::warn!(%owner, post = %c.post_id, author = %c.author_instance_id,
+                    "world_town: invalid round comment dropped");
+            }
+            Err(e) => return Err(format!("round comment insert failed: {e}")),
+        }
+    }
+    if inserted > 0 {
+        tracing::info!(%owner, inserted, "world_town: comment round persisted");
+    }
+    Ok(())
+}
+
+/// One reply-responder pass for a candidate post (spec §3.3). Gate order:
+/// daily cap BEFORE the cooldown CAS so hitting the cap never burns a
+/// cooldown stamp. Failures after the CAS wait out the cooldown — accepted.
+async fn run_reply(
+    state: &AppState,
+    resolved: &ResolvedWorldReply,
+    cand: &ReplyCandidate,
+) -> Result<(), String> {
+    let repo = WorldTownRepo { pool: &state.pool };
+    let spent = repo
+        .count_replies_today(cand.owner_uid)
+        .await
+        .map_err(|e| format!("daily cap count failed: {e}"))?;
+    if spent >= i64::from(resolved.daily_cap) {
+        return Ok(()); // silent skip (spec: no failure state on the feed)
+    }
+    let cooldown = std::time::Duration::from_secs(resolved.thread_cooldown_secs);
+    if !repo
+        .claim_reply_cooldown(cand.post_id, cooldown)
+        .await
+        .map_err(|e| format!("cooldown CAS failed: {e}"))?
+    {
+        return Ok(()); // cooling down or another instance owns it
+    }
+
+    let world_repo = WorldRepo { pool: &state.pool };
+    let seed = world_repo
+        .load_seed(cand.owner_uid)
+        .await
+        .map_err(|e| format!("seed load failed: {e}"))?
+        .unwrap_or_else(|| serde_json::json!({}));
+    let Some(post) = repo
+        .get_post(cand.post_id)
+        .await
+        .map_err(|e| format!("post load failed: {e}"))?
+    else {
+        return Ok(());
+    };
+    let thread = repo
+        .list_comments_for_posts(&[cand.post_id])
+        .await
+        .map_err(|e| format!("thread load failed: {e}"))?;
+
+    let req = ChatRequest {
+        model: resolved.model.clone(),
+        fallback_model: resolved.fallback_model.clone(),
+        messages: vec![
+            ChatMessage {
+                role: "system".into(),
+                content: resolved.reply_prompt.clone(),
+            },
+            ChatMessage {
+                role: "user".into(),
+                content: reply_payload(&seed, &post, &thread),
+            },
+        ],
+        temperature: resolved.temperature as f32,
+        max_tokens: resolved.max_tokens,
+        user: Some(WORLD_AUDIT_USER.into()),
+        reasoning: resolved.reasoning.clone(),
+        ..Default::default()
+    };
+    let raw = state
+        .openrouter
+        .execute(req)
+        .await
+        .map_err(|e| format!("world_reply LLM call failed: {e}"))?;
+    super::log_openrouter_usage("world_reply", None, &raw);
+
+    let content = raw.reply.trim();
+    if content.is_empty() {
+        return Err("world_reply returned empty content".into());
+    }
+    repo.insert_reply_comment(cand.post_id, cand.author_instance_id, content)
+        .await
+        .map_err(|e| format!("reply insert failed: {e}"))
+}
+
+/// Round payload: seed + roster (valid author ids) + posts with threads.
+fn comment_round_payload(
+    seed: &serde_json::Value,
+    roster: &[eros_engine_store::world::RosterEntry],
+    posts: &[FeedPost],
+    comments: &[FeedComment],
+) -> String {
+    let personas: Vec<serde_json::Value> = roster
+        .iter()
+        .map(|r| {
+            serde_json::json!({
+                "instance_id": r.instance_id,
+                "name": r.name,
+                "personality": r.tip_personality,
+            })
+        })
+        .collect();
+    let posts_json: Vec<serde_json::Value> = posts
+        .iter()
+        .map(|p| {
+            let thread: Vec<serde_json::Value> = comments
+                .iter()
+                .filter(|c| c.post_id == p.post_id)
+                .map(|c| {
+                    serde_json::json!({
+                        "author": c.author_name.clone().unwrap_or_else(|| "user".into()),
+                        "content": c.content,
+                    })
+                })
+                .collect();
+            serde_json::json!({
+                "post_id": p.post_id,
+                "author_instance_id": p.instance_id,
+                "author": p.author_name,
+                "content": p.content,
+                "comments": thread,
+            })
+        })
+        .collect();
+    let data = serde_json::json!({
+        "seed": seed,
+        "personas": personas,
+        "posts": posts_json,
+    });
+    format!(
+        "为这个世界的贴文串生成新一轮评论。\n\n{}\n\n{WORLD_COMMENT_RULES}",
+        serde_json::to_string_pretty(&data).unwrap_or_default()
+    )
+}
+
+/// Reply payload: the responder speaks as the post's author.
+fn reply_payload(seed: &serde_json::Value, post: &FeedPost, thread: &[FeedComment]) -> String {
+    let thread_json: Vec<serde_json::Value> = thread
+        .iter()
+        .map(|c| {
+            serde_json::json!({
+                "author": c.author_name.clone().unwrap_or_else(|| "user".into()),
+                "content": c.content,
+            })
+        })
+        .collect();
+    let data = serde_json::json!({
+        "seed": seed,
+        "post": { "author": post.author_name, "content": post.content },
+        "thread": thread_json,
+    });
+    format!(
+        "你是贴文作者「{}」。用户（author 为 user 的留言）在你的贴文下留了言，\
+         请以作者身份自然回应最近的用户留言。只输出评论正文，一两句话，口语化。\n\n{}",
+        post.author_name,
+        serde_json::to_string_pretty(&data).unwrap_or_default()
+    )
+}
+
+/// OpenRouter `response_format` for the comment round. Non-strict, same
+/// rationale as the director's.
+fn world_comment_response_format() -> serde_json::Value {
+    serde_json::json!({
+        "type": "json_schema",
+        "json_schema": {
+            "name": "world_comment_round",
+            "strict": false,
+            "schema": {
+                "type": "object",
+                "required": ["comments"],
+                "properties": {
+                    "comments": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": ["post_id", "author_instance_id", "content"],
+                            "properties": {
+                                "post_id": { "type": "string" },
+                                "author_instance_id": { "type": "string" },
+                                "content": { "type": "string" }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    })
+}
+
+/// Lenient parse, same two-step as the director's.
+fn parse_comment_output(raw: &str) -> Option<CommentRoundOutput> {
+    if let Ok(v) = serde_json::from_str::<CommentRoundOutput>(raw) {
+        return Some(v);
+    }
+    let block = super::find_json_block(raw)?;
+    serde_json::from_str::<CommentRoundOutput>(block).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{method, path as wm_path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn town_test_state(
+        pool: sqlx::PgPool,
+        mock_uri: &str,
+        config_toml: &str,
+    ) -> crate::state::AppState {
+        let mut state = crate::routes::companion::test_state(pool);
+        state.model_config = std::sync::Arc::new(
+            eros_engine_llm::model_config::ModelConfig::from_toml_str(config_toml).unwrap(),
+        );
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "k".into(),
+                Default::default(),
+                format!("{mock_uri}/api/v1/chat/completions"),
+            ),
+        );
+        state
+    }
+
+    async fn seed_town_world(pool: &sqlx::PgPool) -> (Uuid, Uuid, Uuid) {
+        let owner = Uuid::new_v4();
+        let g1: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata) \
+             VALUES ('Aria','p','{}'::jsonb) RETURNING id",
+        )
+        .fetch_one(pool)
+        .await
+        .unwrap();
+        let author: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_instances (genome_id, owner_uid) \
+             VALUES ($1,$2) RETURNING id",
+        )
+        .bind(g1)
+        .bind(owner)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+        let g2: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata) \
+             VALUES ('Rin','p','{}'::jsonb) RETURNING id",
+        )
+        .fetch_one(pool)
+        .await
+        .unwrap();
+        let commenter: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_instances (genome_id, owner_uid) \
+             VALUES ($1,$2) RETURNING id",
+        )
+        .bind(g2)
+        .bind(owner)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO engine.world_enrollments (owner_uid, town_enabled) VALUES ($1, true)",
+        )
+        .bind(owner)
+        .execute(pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO engine.world_states (owner_uid, seed, digests) \
+             VALUES ($1, '{\"arc\":\"a\"}'::jsonb, '{}'::jsonb)",
+        )
+        .bind(owner)
+        .execute(pool)
+        .await
+        .unwrap();
+        (owner, author, commenter)
+    }
+
+    const COMMENT_TOML: &str = "[tasks.world_comment]\nmodel=\"w/c\"\nfilter_prompt=\"comment\"\n";
+    const REPLY_TOML: &str = "[tasks.world_reply]\nmodel=\"w/r\"\nfilter_prompt=\"reply\"\n";
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn comment_round_inserts_valid_and_drops_invalid(pool: sqlx::PgPool) {
+        let (owner, author, commenter) = seed_town_world(&pool).await;
+        let repo = WorldTownRepo { pool: &pool };
+        let post: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.world_posts \
+                 (owner_uid, instance_id, content, scheduled_at, published_at) \
+             VALUES ($1,$2,'开店了',now(),now()) RETURNING id",
+        )
+        .bind(owner)
+        .bind(author)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        let reply = serde_json::json!({
+            "comments": [
+                { "post_id": post, "author_instance_id": commenter, "content": "恭喜！" },
+                // self-reply: dropped by the INSERT validation
+                { "post_id": post, "author_instance_id": author, "content": "谢谢自己" },
+                // unknown post: dropped
+                { "post_id": Uuid::new_v4(), "author_instance_id": commenter, "content": "x" }
+            ]
+        });
+        let mock = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(wm_path("/api/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "gen-town", "model": "w/c",
+                "choices": [{"message": {"content": reply.to_string()}}],
+            })))
+            .expect(1)
+            .mount(&mock)
+            .await;
+        let state = town_test_state(pool.clone(), &mock.uri(), COMMENT_TOML);
+        let resolved = state.model_config.resolve_world_comment().unwrap();
+
+        run_comment_round(&state, &resolved, owner)
+            .await
+            .expect("round ok");
+
+        let rows: Vec<(Option<Uuid>, String)> = sqlx::query_as(
+            "SELECT author_instance_id, content FROM engine.world_post_comments \
+             WHERE post_id = $1 AND source = 'round'",
+        )
+        .bind(post)
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+        assert_eq!(rows.len(), 1, "only the valid comment landed");
+        assert_eq!(rows[0].0, Some(commenter));
+        assert_eq!(rows[0].1, "恭喜！");
+
+        // Round is stamped: immediately re-running claims nothing and makes
+        // no second LLM call (mock .expect(1) enforces it on drop).
+        run_comment_round(&state, &resolved, owner)
+            .await
+            .expect("noop ok");
+        let _ = repo;
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn reply_responder_answers_and_respects_daily_cap(pool: sqlx::PgPool) {
+        let (owner, author, _commenter) = seed_town_world(&pool).await;
+        let repo = WorldTownRepo { pool: &pool };
+        let post: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.world_posts \
+                 (owner_uid, instance_id, content, scheduled_at, published_at) \
+             VALUES ($1,$2,'新拉花',now(),now()) RETURNING id",
+        )
+        .bind(owner)
+        .bind(author)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        repo.insert_user_comment(owner, post, "好看！")
+            .await
+            .unwrap()
+            .unwrap();
+        sqlx::query(
+            "UPDATE engine.world_post_comments SET created_at = now() - interval '3 minutes' \
+             WHERE post_id = $1",
+        )
+        .bind(post)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let mock = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(wm_path("/api/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "gen-reply", "model": "w/r",
+                "choices": [{"message": {"content": "谢谢，下次做给你看～"}}],
+            })))
+            .expect(1)
+            .mount(&mock)
+            .await;
+        let state = town_test_state(pool.clone(), &mock.uri(), REPLY_TOML);
+        let resolved = state.model_config.resolve_world_reply().unwrap();
+
+        let cand = ReplyCandidate {
+            post_id: post,
+            owner_uid: owner,
+            author_instance_id: author,
+        };
+        run_reply(&state, &resolved, &cand).await.expect("reply ok");
+        let n: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM engine.world_post_comments \
+             WHERE post_id = $1 AND source = 'reply'",
+        )
+        .bind(post)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(n, 1);
+
+        // At cap: silent skip, no LLM call (expect(1) still holds), and no
+        // cooldown stamp burned beyond the first.
+        let mut capped = resolved.clone();
+        capped.daily_cap = 1;
+        run_reply(&state, &capped, &cand)
+            .await
+            .expect("cap skip ok");
+    }
+
+    #[test]
+    fn parse_comment_output_lenient() {
+        let clean = r#"{"comments":[]}"#;
+        assert!(parse_comment_output(clean).is_some());
+        let fenced = format!("好的：\n```json\n{clean}\n```");
+        assert!(parse_comment_output(&fenced).is_some());
+        assert!(parse_comment_output("nope").is_none());
+    }
+}

--- a/crates/eros-engine-server/src/pipeline/world_town.rs
+++ b/crates/eros-engine-server/src/pipeline/world_town.rs
@@ -248,6 +248,10 @@ async fn run_reply(
     cand: &ReplyCandidate,
 ) -> Result<(), String> {
     let repo = WorldTownRepo { pool: &state.pool };
+    // Count-then-claim is deliberately NOT atomic with the insert: under
+    // concurrent sweepers the cap can overshoot by ~1 per instance — an
+    // accepted trade-off (spec §3.3 gate 2), further narrowed by the
+    // one-candidate-per-owner scan batching.
     let spent = repo
         .count_replies_today(cand.owner_uid)
         .await

--- a/crates/eros-engine-server/src/pipeline/world_town.rs
+++ b/crates/eros-engine-server/src/pipeline/world_town.rs
@@ -110,7 +110,11 @@ async fn run_tick(
     }
     if let Some(resolved) = reply {
         let debounce = std::time::Duration::from_secs(resolved.debounce_secs);
-        match repo.list_reply_candidates(debounce, TOWN_REPLY_BATCH).await {
+        let cooldown = std::time::Duration::from_secs(resolved.thread_cooldown_secs);
+        match repo
+            .list_reply_candidates(debounce, cooldown, TOWN_REPLY_BATCH)
+            .await
+        {
             Ok(cands) => {
                 for cand in cands {
                     if let Err(e) = run_reply(state, resolved, &cand).await {

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -716,7 +716,7 @@ pub(crate) fn test_state(pool: sqlx::PgPool) -> AppState {
                 tz: chrono_tz::Asia::Singapore,
             },
             prompt_log_dir: None,
-            world: crate::state::parse_world_config(None, None, None),
+            world: crate::state::parse_world_config(None, None, None, None),
         },
         openrouter: Arc::new(eros_engine_llm::openrouter::OpenRouterClient::new(
             "stub".into(),

--- a/crates/eros-engine-server/src/routes/mod.rs
+++ b/crates/eros-engine-server/src/routes/mod.rs
@@ -22,6 +22,7 @@ pub mod debug;
 pub mod dto;
 pub mod health;
 pub mod voice;
+pub mod world_town;
 
 /// Compose the full app router with auth layers attached.
 ///
@@ -37,6 +38,7 @@ pub fn router(state: AppState) -> OpenApiRouter<AppState> {
         .merge(voice::router())
         .merge(debug::router(state.config.expose_affinity_debug))
         .merge(bff::router())
+        .merge(world_town::router())
         .layer(from_fn_with_state(state.clone(), require_auth));
 
     OpenApiRouter::new().merge(health::router()).merge(comp)
@@ -54,4 +56,5 @@ pub fn router_for_openapi(expose_affinity_debug: bool) -> OpenApiRouter<AppState
         .merge(voice::router())
         .merge(debug::router(expose_affinity_debug))
         .merge(bff::router())
+        .merge(world_town::router())
 }

--- a/crates/eros-engine-server/src/routes/world_town.rs
+++ b/crates/eros-engine-server/src/routes/world_town.rs
@@ -1,0 +1,393 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! World Town feed routes (town spec §4). Same JWT contract as
+//! `companion.rs`: the path `user_id` MUST equal the JWT `sub`.
+//! Rendering is downstream's job — these endpoints only move data.
+
+use axum::{
+    extract::{Extension, Path, Query, State},
+    Json,
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use utoipa_axum::{router::OpenApiRouter, routes};
+use uuid::Uuid;
+
+use eros_engine_store::world_town::{FeedComment, WorldTownRepo};
+
+use crate::auth::middleware::AuthUser;
+use crate::error::AppError;
+use crate::state::AppState;
+
+const FEED_LIMIT_DEFAULT: i64 = 20;
+const FEED_LIMIT_MAX: i64 = 50;
+const COMMENT_MAX_CHARS: usize = 1000;
+
+#[derive(Debug, Deserialize)]
+pub struct FeedQuery {
+    pub limit: Option<i64>,
+    pub cursor: Option<String>,
+}
+
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct FeedCommentDto {
+    pub comment_id: Uuid,
+    /// NULL = the user themselves.
+    pub author_instance_id: Option<Uuid>,
+    pub author_name: Option<String>,
+    pub content: String,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct FeedPostDto {
+    pub post_id: Uuid,
+    pub instance_id: Uuid,
+    pub author_name: String,
+    pub content: String,
+    pub published_at: DateTime<Utc>,
+    pub comments: Vec<FeedCommentDto>,
+}
+
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct FeedResponse {
+    pub user_id: Uuid,
+    pub posts: Vec<FeedPostDto>,
+    /// Present when another page may exist; feed it back as `cursor`.
+    pub next_cursor: Option<String>,
+}
+
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
+pub struct CreateCommentRequest {
+    pub content: String,
+}
+
+fn comment_dto(c: FeedComment) -> FeedCommentDto {
+    FeedCommentDto {
+        comment_id: c.comment_id,
+        author_instance_id: c.author_instance_id,
+        author_name: c.author_name,
+        content: c.content,
+        created_at: c.created_at,
+    }
+}
+
+/// Cursor wire format: `<published_at RFC3339>|<post uuid>`.
+fn parse_cursor(raw: &str) -> Option<(DateTime<Utc>, Uuid)> {
+    let (ts, id) = raw.rsplit_once('|')?;
+    let ts = DateTime::parse_from_rfc3339(ts).ok()?.with_timezone(&Utc);
+    let id = Uuid::parse_str(id).ok()?;
+    Some((ts, id))
+}
+
+/// Published town feed for the user's world, newest first. Unenrolled or
+/// town-disabled users get an empty feed, not an error (spec §4).
+#[utoipa::path(
+    get,
+    path = "/world/town/{user_id}/feed",
+    tag = "world_town",
+    params(
+        ("user_id" = Uuid, Path, description = "Owner user id (must equal JWT sub)"),
+        ("limit" = Option<i64>, Query, description = "Page size, default 20, max 50"),
+        ("cursor" = Option<String>, Query,
+            description = "Opaque keyset cursor from the previous page's next_cursor")
+    ),
+    responses(
+        (status = 200, body = FeedResponse),
+        (status = 400, description = "malformed cursor"),
+        (status = 401, description = "missing or invalid bearer"),
+        (status = 403, description = "user_id does not match JWT")
+    ),
+    security(("bearer" = []))
+)]
+async fn get_feed(
+    State(state): State<AppState>,
+    Path(user_id): Path<Uuid>,
+    Query(q): Query<FeedQuery>,
+    Extension(AuthUser(jwt_user)): Extension<AuthUser>,
+) -> Result<Json<FeedResponse>, AppError> {
+    if user_id != jwt_user {
+        return Err(AppError::Forbidden("not your data".into()));
+    }
+    let limit = q
+        .limit
+        .unwrap_or(FEED_LIMIT_DEFAULT)
+        .clamp(1, FEED_LIMIT_MAX);
+    let cursor = match q.cursor.as_deref() {
+        None => None,
+        Some(raw) => {
+            Some(parse_cursor(raw).ok_or_else(|| AppError::BadRequest("malformed cursor".into()))?)
+        }
+    };
+    let repo = WorldTownRepo { pool: &state.pool };
+    let posts = repo.feed_page(user_id, limit, cursor).await?;
+    let next_cursor = (posts.len() as i64 == limit).then(|| {
+        let last = posts.last().expect("non-empty when len == limit");
+        format!("{}|{}", last.published_at.to_rfc3339(), last.post_id)
+    });
+    let ids: Vec<Uuid> = posts.iter().map(|p| p.post_id).collect();
+    let mut comments = repo.list_comments_for_posts(&ids).await?;
+    let posts = posts
+        .into_iter()
+        .map(|p| {
+            let thread: Vec<FeedCommentDto> = comments
+                .extract_if(.., |c| c.post_id == p.post_id)
+                .map(comment_dto)
+                .collect();
+            FeedPostDto {
+                post_id: p.post_id,
+                instance_id: p.instance_id,
+                author_name: p.author_name,
+                content: p.content,
+                published_at: p.published_at,
+                comments: thread,
+            }
+        })
+        .collect();
+    Ok(Json(FeedResponse {
+        user_id,
+        posts,
+        next_cursor,
+    }))
+}
+
+/// Add a user comment to a published post in the user's own town.
+#[utoipa::path(
+    post,
+    path = "/world/town/{user_id}/posts/{post_id}/comments",
+    tag = "world_town",
+    params(
+        ("user_id" = Uuid, Path, description = "Owner user id (must equal JWT sub)"),
+        ("post_id" = Uuid, Path, description = "Target post id")
+    ),
+    request_body = CreateCommentRequest,
+    responses(
+        (status = 200, body = FeedCommentDto),
+        (status = 400, description = "empty content or over 1000 chars"),
+        (status = 401, description = "missing or invalid bearer"),
+        (status = 403, description = "user_id does not match JWT"),
+        (status = 404, description = "post not visible to this user")
+    ),
+    security(("bearer" = []))
+)]
+async fn create_comment(
+    State(state): State<AppState>,
+    Path((user_id, post_id)): Path<(Uuid, Uuid)>,
+    Extension(AuthUser(jwt_user)): Extension<AuthUser>,
+    Json(body): Json<CreateCommentRequest>,
+) -> Result<Json<FeedCommentDto>, AppError> {
+    if user_id != jwt_user {
+        return Err(AppError::Forbidden("not your data".into()));
+    }
+    let content = body.content.trim();
+    if content.is_empty() {
+        return Err(AppError::BadRequest("content is empty".into()));
+    }
+    if content.chars().count() > COMMENT_MAX_CHARS {
+        return Err(AppError::BadRequest(format!(
+            "content exceeds {COMMENT_MAX_CHARS} chars"
+        )));
+    }
+    let repo = WorldTownRepo { pool: &state.pool };
+    let created = repo
+        .insert_user_comment(user_id, post_id, content)
+        .await?
+        .ok_or_else(|| AppError::NotFound("post not found".into()))?;
+    Ok(Json(comment_dto(created)))
+}
+
+pub fn router() -> OpenApiRouter<AppState> {
+    OpenApiRouter::new()
+        .routes(routes!(get_feed))
+        .routes(routes!(create_comment))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::routes::companion::test_state;
+    use crate::routes::companion::testutil::{
+        build_router, mint_test_jwt, seed_genome, seed_instance, send_request,
+    };
+    use axum::{
+        body::Body,
+        http::{header, Request, StatusCode},
+    };
+    use sqlx::PgPool;
+
+    async fn seed_town(pool: &PgPool, owner: Uuid) -> Uuid {
+        let genome = seed_genome(pool, "Aria").await;
+        let inst = seed_instance(pool, genome, owner).await;
+        sqlx::query(
+            "INSERT INTO engine.world_enrollments (owner_uid, town_enabled) VALUES ($1, true)",
+        )
+        .bind(owner)
+        .execute(pool)
+        .await
+        .unwrap();
+        inst
+    }
+
+    async fn seed_published_post(pool: &PgPool, owner: Uuid, inst: Uuid, n: i32) -> Uuid {
+        sqlx::query_scalar(
+            "INSERT INTO engine.world_posts \
+                 (owner_uid, instance_id, content, scheduled_at, published_at) \
+             VALUES ($1, $2, 'post ' || $3::text, now(), \
+                     now() - ($3::text || ' minutes')::interval) \
+             RETURNING id",
+        )
+        .bind(owner)
+        .bind(inst)
+        .bind(n)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn feed_requires_matching_jwt(pool: PgPool) {
+        let owner = Uuid::new_v4();
+        let mut app = build_router(test_state(pool));
+        let req = Request::builder()
+            .uri(format!("/world/town/{owner}/feed"))
+            .header(
+                header::AUTHORIZATION,
+                format!("Bearer {}", mint_test_jwt(Uuid::new_v4())),
+            )
+            .body(Body::empty())
+            .unwrap();
+        let (status, _) = send_request(&mut app, req).await;
+        assert_eq!(status, StatusCode::FORBIDDEN);
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn feed_pages_with_cursor_and_embeds_comments(pool: PgPool) {
+        let owner = Uuid::new_v4();
+        let inst = seed_town(&pool, owner).await;
+        for n in 0..3 {
+            seed_published_post(&pool, owner, inst, n).await;
+        }
+        let first = seed_published_post(&pool, owner, inst, 99).await; // oldest
+        sqlx::query(
+            "INSERT INTO engine.world_post_comments (post_id, author_instance_id, source, content) \
+             VALUES ($1, NULL, NULL, 'hi')",
+        )
+        .bind(first)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let mut app = build_router(test_state(pool));
+        let jwt = mint_test_jwt(owner);
+        let req = Request::builder()
+            .uri(format!("/world/town/{owner}/feed?limit=2"))
+            .header(header::AUTHORIZATION, format!("Bearer {jwt}"))
+            .body(Body::empty())
+            .unwrap();
+        let (status, body) = send_request(&mut app, req).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["posts"].as_array().unwrap().len(), 2);
+        assert_eq!(body["posts"][0]["content"], "post 0", "newest first");
+        assert_eq!(body["posts"][0]["author_name"], "Aria");
+        let cursor = body["next_cursor"].as_str().expect("full page has cursor");
+
+        // No `urlencoding` dependency in this crate — percent-encode the
+        // three cursor separators (`+`, `:`, `|`) inline (RFC3339 offset
+        // uses `+`, the timestamp uses `:`, and the wire format uses `|`).
+        let encoded_cursor = cursor
+            .replace('+', "%2B")
+            .replace(':', "%3A")
+            .replace('|', "%7C");
+        let req = Request::builder()
+            .uri(format!(
+                "/world/town/{owner}/feed?limit=2&cursor={encoded_cursor}"
+            ))
+            .header(header::AUTHORIZATION, format!("Bearer {jwt}"))
+            .body(Body::empty())
+            .unwrap();
+        let (status, body) = send_request(&mut app, req).await;
+        assert_eq!(status, StatusCode::OK);
+        let page2 = body["posts"].as_array().unwrap();
+        assert_eq!(page2.len(), 2);
+        assert_eq!(page2[1]["content"], "post 99");
+        assert_eq!(page2[1]["comments"][0]["content"], "hi");
+        assert!(page2[1]["comments"][0]["author_instance_id"].is_null());
+
+        // Malformed cursor ⇒ 400.
+        let req = Request::builder()
+            .uri(format!("/world/town/{owner}/feed?cursor=garbage"))
+            .header(header::AUTHORIZATION, format!("Bearer {jwt}"))
+            .body(Body::empty())
+            .unwrap();
+        let (status, _) = send_request(&mut app, req).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn feed_empty_for_unenrolled_user(pool: PgPool) {
+        let owner = Uuid::new_v4();
+        let mut app = build_router(test_state(pool));
+        let req = Request::builder()
+            .uri(format!("/world/town/{owner}/feed"))
+            .header(
+                header::AUTHORIZATION,
+                format!("Bearer {}", mint_test_jwt(owner)),
+            )
+            .body(Body::empty())
+            .unwrap();
+        let (status, body) = send_request(&mut app, req).await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(body["posts"].as_array().unwrap().is_empty());
+        assert!(body["next_cursor"].is_null());
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn comment_validates_length_and_visibility(pool: PgPool) {
+        let owner = Uuid::new_v4();
+        let inst = seed_town(&pool, owner).await;
+        let post = seed_published_post(&pool, owner, inst, 0).await;
+        let mut app = build_router(test_state(pool.clone()));
+        let jwt = mint_test_jwt(owner);
+
+        let post_req = |uri: String, body: serde_json::Value, jwt: &str| {
+            Request::builder()
+                .method("POST")
+                .uri(uri)
+                .header(header::AUTHORIZATION, format!("Bearer {jwt}"))
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap()
+        };
+
+        // Happy path returns the created comment.
+        let req = post_req(
+            format!("/world/town/{owner}/posts/{post}/comments"),
+            serde_json::json!({"content": "好看！"}),
+            &jwt,
+        );
+        let (status, body) = send_request(&mut app, req).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["content"], "好看！");
+        assert!(body["author_instance_id"].is_null());
+
+        // Over 1000 chars ⇒ 400.
+        let req = post_req(
+            format!("/world/town/{owner}/posts/{post}/comments"),
+            serde_json::json!({"content": "字".repeat(1001)}),
+            &jwt,
+        );
+        let (status, _) = send_request(&mut app, req).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+
+        // Foreign post ⇒ 404.
+        let stranger = Uuid::new_v4();
+        let s_inst = seed_town(&pool, stranger).await;
+        let s_post = seed_published_post(&pool, stranger, s_inst, 0).await;
+        let req = post_req(
+            format!("/world/town/{owner}/posts/{s_post}/comments"),
+            serde_json::json!({"content": "x"}),
+            &jwt,
+        );
+        let (status, _) = send_request(&mut app, req).await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+    }
+}

--- a/crates/eros-engine-server/src/state.rs
+++ b/crates/eros-engine-server/src/state.rs
@@ -80,25 +80,28 @@ pub(crate) fn parse_prompt_log_dir(raw: Option<&str>) -> Option<std::path::PathB
 }
 
 /// Knobs for the world-memories subsystem. Defaults: disabled off, prompt
-/// injection off, 300-second sweep cadence.
+/// injection off, town disabled off, 300-second sweep cadence.
 #[derive(Clone, Debug)]
 pub struct WorldConfig {
     pub disabled: bool,        // WORLD_DISABLED — master switch
     pub prompt_disabled: bool, // WORLD_PROMPT_DISABLED — injection-only valve
+    pub town_disabled: bool,   // WORLD_TOWN_DISABLED — town sweeper switch
     pub tick: Duration,        // WORLD_TICK_SECS, default 300
 }
 
-/// Pure parser for the three world-memories env vars (spec §3.1).
+/// Pure parser for the four world-memories env vars (spec §3.1).
 /// Booleans accept "1"/"true" — the DREAMING_DISABLED convention.
 pub(crate) fn parse_world_config(
     disabled_raw: Option<&str>,
     prompt_disabled_raw: Option<&str>,
+    town_disabled_raw: Option<&str>,
     tick_raw: Option<&str>,
 ) -> WorldConfig {
     let flag = |raw: Option<&str>| raw.map(|v| v == "1" || v == "true").unwrap_or(false);
     WorldConfig {
         disabled: flag(disabled_raw),
         prompt_disabled: flag(prompt_disabled_raw),
+        town_disabled: flag(town_disabled_raw),
         tick: Duration::from_secs(tick_raw.and_then(|v| v.parse().ok()).unwrap_or(300)),
     }
 }
@@ -258,6 +261,7 @@ impl ServerConfig {
             world: parse_world_config(
                 std::env::var("WORLD_DISABLED").ok().as_deref(),
                 std::env::var("WORLD_PROMPT_DISABLED").ok().as_deref(),
+                std::env::var("WORLD_TOWN_DISABLED").ok().as_deref(),
                 std::env::var("WORLD_TICK_SECS").ok().as_deref(),
             ),
         }
@@ -367,20 +371,21 @@ mod tests {
 
     #[test]
     fn world_config_defaults_when_env_unset() {
-        let cfg = parse_world_config(None, None, None);
+        let cfg = parse_world_config(None, None, None, None);
         assert!(!cfg.disabled);
         assert!(!cfg.prompt_disabled);
+        assert!(!cfg.town_disabled);
         assert_eq!(cfg.tick, Duration::from_secs(300));
     }
 
     #[test]
     fn world_config_accepts_true_and_one() {
         for v in ["1", "true"] {
-            let cfg = parse_world_config(Some(v), Some(v), None);
+            let cfg = parse_world_config(Some(v), Some(v), None, None);
             assert!(cfg.disabled, "{v} must disable");
             assert!(cfg.prompt_disabled, "{v} must disable injection");
         }
-        let cfg = parse_world_config(Some("false"), Some("0"), None);
+        let cfg = parse_world_config(Some("false"), Some("0"), None, None);
         assert!(!cfg.disabled);
         assert!(!cfg.prompt_disabled);
     }
@@ -388,11 +393,11 @@ mod tests {
     #[test]
     fn world_config_parses_tick_and_falls_back_on_garbage() {
         assert_eq!(
-            parse_world_config(None, None, Some("60")).tick,
+            parse_world_config(None, None, None, Some("60")).tick,
             Duration::from_secs(60)
         );
         assert_eq!(
-            parse_world_config(None, None, Some("not-a-number")).tick,
+            parse_world_config(None, None, None, Some("not-a-number")).tick,
             Duration::from_secs(300)
         );
         // "0" parses fine here — Duration::ZERO is a legitimate value from the
@@ -400,8 +405,20 @@ mod tests {
         // that treats a zero tick as "disabled" and returns before building a
         // tokio::time::interval (which would panic on Duration::ZERO).
         assert_eq!(
-            parse_world_config(None, None, Some("0")).tick,
+            parse_world_config(None, None, None, Some("0")).tick,
             Duration::from_secs(0)
         );
+    }
+
+    #[test]
+    fn parse_world_config_town_disabled_flag() {
+        let c = parse_world_config(None, None, None, None);
+        assert!(!c.town_disabled, "default off");
+        let c = parse_world_config(None, None, Some("true"), None);
+        assert!(c.town_disabled);
+        let c = parse_world_config(None, None, Some("1"), None);
+        assert!(c.town_disabled);
+        let c = parse_world_config(None, None, Some("0"), None);
+        assert!(!c.town_disabled);
     }
 }

--- a/crates/eros-engine-store/migrations/0036_world_town.sql
+++ b/crates/eros-engine-store/migrations/0036_world_town.sql
@@ -1,0 +1,58 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+--
+-- World Town (spec: docs/superpowers/specs/2026-07-21-world-town-design.md).
+--
+-- engine.world_posts — director-pre-generated persona posts, published by
+-- the town sweeper when scheduled_at passes (status = published_at NULL/not).
+-- last_reply_at doubles as the reply-responder cooldown stamp + claim.
+--
+-- engine.world_post_comments — thread rows. author_instance_id NULL = the
+-- user themselves; source tells which pipeline wrote a persona comment
+-- ('round' = hourly batch, 'reply' = reply responder) and is NULL exactly
+-- for user rows (enforced by CHECK).
+
+CREATE TABLE engine.world_posts (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    owner_uid     UUID NOT NULL,
+    instance_id   UUID NOT NULL REFERENCES engine.persona_instances(id) ON DELETE CASCADE,
+    content       TEXT NOT NULL,
+    scheduled_at  TIMESTAMPTZ NOT NULL,
+    published_at  TIMESTAMPTZ,
+    last_reply_at TIMESTAMPTZ,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_world_posts_due ON engine.world_posts (owner_uid, scheduled_at)
+    WHERE published_at IS NULL;
+CREATE INDEX idx_world_posts_feed ON engine.world_posts (owner_uid, published_at DESC);
+
+CREATE TABLE engine.world_post_comments (
+    id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    post_id            UUID NOT NULL REFERENCES engine.world_posts(id) ON DELETE CASCADE,
+    author_instance_id UUID REFERENCES engine.persona_instances(id) ON DELETE CASCADE,
+    source             TEXT CHECK (source IN ('round', 'reply')),
+    content            TEXT NOT NULL,
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CHECK ((author_instance_id IS NULL) = (source IS NULL))
+);
+CREATE INDEX idx_world_post_comments_thread ON engine.world_post_comments (post_id, created_at);
+
+ALTER TABLE engine.world_enrollments ADD COLUMN town_enabled BOOL NOT NULL DEFAULT false;
+ALTER TABLE engine.world_states     ADD COLUMN last_comment_round_at TIMESTAMPTZ;
+
+-- 0013-style lockdown: REVOKE from Supabase browser roles (when present) and
+-- enable policy-less RLS so only owner/service_role connections reach rows.
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
+        REVOKE ALL ON engine.world_posts         FROM anon;
+        REVOKE ALL ON engine.world_post_comments FROM anon;
+    END IF;
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+        REVOKE ALL ON engine.world_posts         FROM authenticated;
+        REVOKE ALL ON engine.world_post_comments FROM authenticated;
+    END IF;
+END
+$$;
+
+ALTER TABLE engine.world_posts         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE engine.world_post_comments ENABLE ROW LEVEL SECURITY;

--- a/crates/eros-engine-store/src/lib.rs
+++ b/crates/eros-engine-store/src/lib.rs
@@ -11,6 +11,7 @@ pub mod memory;
 pub mod persona;
 pub mod pool;
 pub mod world;
+pub mod world_town;
 
 pub use sqlx::PgPool;
 

--- a/crates/eros-engine-store/src/lib.rs
+++ b/crates/eros-engine-store/src/lib.rs
@@ -288,7 +288,8 @@ mod migration_tests {
                 "seed_version",
                 "last_run_at",
                 "claimed_at",
-                "updated_at"
+                "updated_at",
+                "last_comment_round_at"
             ],
         );
 
@@ -316,5 +317,108 @@ mod migration_tests {
             .unwrap();
             assert!(exists, "{idx} must exist");
         }
+    }
+
+    #[sqlx::test]
+    async fn migration_0036_world_town_schema(pool: PgPool) {
+        // Both town tables exist with RLS enabled (0013-style lockdown).
+        for tbl in ["world_posts", "world_post_comments"] {
+            let rls: bool = sqlx::query_scalar(
+                "SELECT relrowsecurity FROM pg_class \
+                 WHERE oid = ('engine.' || $1)::regclass",
+            )
+            .bind(tbl)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+            assert!(rls, "{tbl} must have RLS enabled");
+        }
+
+        // Column adds landed.
+        let town_enabled_type: String = sqlx::query_scalar(
+            "SELECT data_type FROM information_schema.columns \
+             WHERE table_schema = 'engine' AND table_name = 'world_enrollments' \
+               AND column_name = 'town_enabled'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(town_enabled_type, "boolean");
+        let round_col: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM information_schema.columns \
+             WHERE table_schema = 'engine' AND table_name = 'world_states' \
+               AND column_name = 'last_comment_round_at'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(round_col, 1);
+
+        // Feed + due + thread indexes exist.
+        for (tbl, idx) in [
+            ("world_posts", "idx_world_posts_due"),
+            ("world_posts", "idx_world_posts_feed"),
+            ("world_post_comments", "idx_world_post_comments_thread"),
+        ] {
+            let n: i64 = sqlx::query_scalar(
+                "SELECT count(*) FROM pg_indexes \
+                 WHERE schemaname = 'engine' AND tablename = $1 AND indexname = $2",
+            )
+            .bind(tbl)
+            .bind(idx)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+            assert_eq!(n, 1, "missing index {idx}");
+        }
+
+        // source/author coupling CHECK: user row (NULL, NULL) ok; persona row
+        // with NULL source rejected.
+        let owner = uuid::Uuid::new_v4();
+        let genome: uuid::Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata) \
+             VALUES ('T','p','{}'::jsonb) RETURNING id",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let inst: uuid::Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_instances (genome_id, owner_uid) \
+             VALUES ($1,$2) RETURNING id",
+        )
+        .bind(genome)
+        .bind(owner)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let post: uuid::Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.world_posts (owner_uid, instance_id, content, scheduled_at) \
+             VALUES ($1,$2,'hello',now()) RETURNING id",
+        )
+        .bind(owner)
+        .bind(inst)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO engine.world_post_comments (post_id, author_instance_id, source, content) \
+             VALUES ($1, NULL, NULL, 'user says hi')",
+        )
+        .bind(post)
+        .execute(&pool)
+        .await
+        .expect("user comment row inserts");
+        let err = sqlx::query(
+            "INSERT INTO engine.world_post_comments (post_id, author_instance_id, source, content) \
+             VALUES ($1, $2, NULL, 'bad')",
+        )
+        .bind(post)
+        .bind(inst)
+        .execute(&pool)
+        .await;
+        assert!(
+            err.is_err(),
+            "persona comment without source must violate CHECK"
+        );
     }
 }

--- a/crates/eros-engine-store/src/world.rs
+++ b/crates/eros-engine-store/src/world.rs
@@ -29,6 +29,13 @@ pub struct FragmentInsert {
     pub embedding: Vec<f32>,
 }
 
+#[derive(Debug, Clone)]
+pub struct PostInsert {
+    pub instance_id: Uuid,
+    pub content: String,
+    pub scheduled_at: DateTime<Utc>,
+}
+
 pub struct WorldRepo<'a> {
     pub pool: &'a PgPool,
 }
@@ -138,6 +145,17 @@ impl<'a> WorldRepo<'a> {
             .await
     }
 
+    /// Whether this owner has opted into the town feed. Unenrolled ⇒ false.
+    pub async fn town_enabled(&self, owner_uid: Uuid) -> Result<bool, sqlx::Error> {
+        let v: Option<bool> = sqlx::query_scalar(
+            "SELECT town_enabled FROM engine.world_enrollments WHERE owner_uid = $1",
+        )
+        .bind(owner_uid)
+        .fetch_optional(self.pool)
+        .await?;
+        Ok(v.unwrap_or(false))
+    }
+
     /// The owner's active persona roster (earliest-created first) joined to
     /// genome display data. Caller passes cap+1 and truncates so it can log
     /// the spec's roster-cap warning.
@@ -181,16 +199,19 @@ impl<'a> WorldRepo<'a> {
     }
 
     /// Persist one director round in a single transaction (spec §2.4):
-    /// retention delete + fragment inserts + state update (seed_version++,
-    /// last_run_at=now, claimed_at=NULL). All-or-nothing: any failure rolls
-    /// back and the caller releases the claim.
+    /// retention delete + fragment inserts + scheduled-post inserts + state
+    /// update (seed_version++, last_run_at=now, claimed_at=NULL).
+    /// All-or-nothing: any failure rolls back and the caller releases the
+    /// claim. `posts` (town-enabled owners only; empty otherwise) ride the
+    /// same transaction and the same claim-ownership-token guard as
+    /// everything else here.
     ///
     /// `claimed_at` is the ownership token from `claim_due`. The final state
     /// update is guarded on it (`AND claimed_at = $N`); if a newer sweeper
     /// has since reclaimed this owner the guard matches zero rows and we
     /// return `Err(RowNotFound)` BEFORE committing — the transaction is
-    /// dropped, which rolls back the retention delete and fragment inserts
-    /// too, so a lost-claim round writes nothing.
+    /// dropped, which rolls back the retention delete, fragment inserts, and
+    /// post inserts too, so a lost-claim round writes nothing.
     #[allow(clippy::too_many_arguments)]
     pub async fn persist_round(
         &self,
@@ -198,6 +219,7 @@ impl<'a> WorldRepo<'a> {
         seed: &serde_json::Value,
         digests: &serde_json::Value,
         fragments: &[FragmentInsert],
+        posts: &[PostInsert],
         script_date: NaiveDate,
         retention_days: u32,
         claimed_at: DateTime<Utc>,
@@ -220,6 +242,19 @@ impl<'a> WorldRepo<'a> {
             .bind(&frag.content)
             .bind(format_vector(&frag.embedding))
             .bind(script_date)
+            .execute(&mut *tx)
+            .await?;
+        }
+        for post in posts {
+            sqlx::query(
+                "INSERT INTO engine.world_posts \
+                     (owner_uid, instance_id, content, scheduled_at) \
+                 VALUES ($1, $2, $3, $4)",
+            )
+            .bind(owner_uid)
+            .bind(post.instance_id)
+            .bind(&post.content)
+            .bind(post.scheduled_at)
             .execute(&mut *tx)
             .await?;
         }
@@ -605,7 +640,7 @@ mod tests {
             content: "P 试营业当天把咖啡机弄坏了".into(),
             embedding: unit_embedding(7),
         }];
-        repo.persist_round(owner, &seed, &digests, &frags, today, 30, token)
+        repo.persist_round(owner, &seed, &digests, &frags, &[], today, 30, token)
             .await
             .unwrap();
 
@@ -666,6 +701,7 @@ mod tests {
                 &seed,
                 &serde_json::json!({}),
                 &frags,
+                &[],
                 today,
                 30,
                 token1,
@@ -691,6 +727,71 @@ mod tests {
                 .await
                 .unwrap();
         assert_eq!(n, 0, "fragment insert must roll back too");
+    }
+
+    #[sqlx::test]
+    async fn town_enabled_reflects_enrollment_flag(pool: PgPool) {
+        let owner = Uuid::new_v4();
+        let repo = WorldRepo { pool: &pool };
+        assert!(
+            !repo.town_enabled(owner).await.unwrap(),
+            "unenrolled ⇒ false"
+        );
+        enroll(&pool, owner).await;
+        assert!(!repo.town_enabled(owner).await.unwrap(), "default false");
+        sqlx::query("UPDATE engine.world_enrollments SET town_enabled = true WHERE owner_uid = $1")
+            .bind(owner)
+            .execute(&pool)
+            .await
+            .unwrap();
+        assert!(repo.town_enabled(owner).await.unwrap());
+    }
+
+    #[sqlx::test]
+    async fn persist_round_inserts_scheduled_posts(pool: PgPool) {
+        let owner = Uuid::new_v4();
+        let inst = seed_instance(&pool, owner, "P", "active").await;
+        enroll(&pool, owner).await;
+        let repo = WorldRepo { pool: &pool };
+        repo.ensure_states_for_enrollments().await.unwrap();
+        let claimed = repo
+            .claim_due(
+                std::time::Duration::from_secs(24 * 3600),
+                std::time::Duration::from_secs(1800),
+                5,
+            )
+            .await
+            .unwrap();
+        let (_o, token) = claimed[0];
+
+        let at = Utc::now() + chrono::Duration::hours(3);
+        let posts = vec![PostInsert {
+            instance_id: inst,
+            content: "今天试了新的拉花".into(),
+            scheduled_at: at,
+        }];
+        repo.persist_round(
+            owner,
+            &serde_json::json!({"arc": "a"}),
+            &serde_json::json!({}),
+            &[],
+            &posts,
+            Utc::now().date_naive(),
+            30,
+            token,
+        )
+        .await
+        .unwrap();
+
+        let (content, published_at): (String, Option<DateTime<Utc>>) = sqlx::query_as(
+            "SELECT content, published_at FROM engine.world_posts WHERE owner_uid = $1",
+        )
+        .bind(owner)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(content, "今天试了新的拉花");
+        assert!(published_at.is_none(), "inserted unpublished");
     }
 
     #[sqlx::test(migrations = "./migrations")]
@@ -758,6 +859,7 @@ mod tests {
             &serde_json::json!({}),
             &serde_json::json!({}),
             &frags,
+            &[],
             today,
             30,
             token,

--- a/crates/eros-engine-store/src/world_town.rs
+++ b/crates/eros-engine-store/src/world_town.rs
@@ -8,6 +8,7 @@
 
 use chrono::{DateTime, Utc};
 use sqlx::PgPool;
+use std::time::Duration;
 use uuid::Uuid;
 
 #[derive(Debug, Clone, sqlx::FromRow)]
@@ -27,6 +28,13 @@ pub struct FeedComment {
     pub author_name: Option<String>,
     pub content: String,
     pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct ReplyCandidate {
+    pub post_id: Uuid,
+    pub owner_uid: Uuid,
+    pub author_instance_id: Uuid,
 }
 
 pub struct WorldTownRepo<'a> {
@@ -124,6 +132,204 @@ impl<'a> WorldTownRepo<'a> {
         .bind(post_id)
         .bind(owner_uid)
         .bind(content)
+        .fetch_optional(self.pool)
+        .await
+    }
+
+    /// Owners due for a comment round: town-enabled AND stamp NULL/older than
+    /// the round cadence. The per-owner CAS (`claim_comment_round`) is the
+    /// authoritative claim; this list is just the scan.
+    pub async fn list_round_candidates(&self, round: Duration) -> Result<Vec<Uuid>, sqlx::Error> {
+        let cutoff = Utc::now() - chrono::Duration::from_std(round).unwrap_or_default();
+        sqlx::query_scalar(
+            "SELECT ws.owner_uid FROM engine.world_states ws \
+             JOIN engine.world_enrollments we USING (owner_uid) \
+             WHERE we.town_enabled \
+               AND (ws.last_comment_round_at IS NULL OR ws.last_comment_round_at < $1)",
+        )
+        .bind(cutoff)
+        .fetch_all(self.pool)
+        .await
+    }
+
+    /// CAS-claim one owner's comment round (spec §3.2): stamp
+    /// last_comment_round_at = now() iff still due, returning the PREVIOUS
+    /// stamp (the activity-window floor). Outer `None` ⇒ another instance
+    /// took it or it is no longer due.
+    pub async fn claim_comment_round(
+        &self,
+        owner_uid: Uuid,
+        round: Duration,
+    ) -> Result<Option<Option<DateTime<Utc>>>, sqlx::Error> {
+        let cutoff = Utc::now() - chrono::Duration::from_std(round).unwrap_or_default();
+        sqlx::query_scalar(
+            "UPDATE engine.world_states ws SET last_comment_round_at = now() \
+             FROM (SELECT owner_uid, last_comment_round_at AS prev \
+                   FROM engine.world_states WHERE owner_uid = $1 FOR UPDATE) old \
+             WHERE ws.owner_uid = old.owner_uid \
+               AND (old.prev IS NULL OR old.prev < $2) \
+             RETURNING old.prev",
+        )
+        .bind(owner_uid)
+        .bind(cutoff)
+        .fetch_optional(self.pool)
+        .await
+    }
+
+    /// Anything worth a comment round since `since`? Published posts or user
+    /// comments (spec §3.2). `since = None` ⇒ everything counts.
+    pub async fn has_town_activity_since(
+        &self,
+        owner_uid: Uuid,
+        since: Option<DateTime<Utc>>,
+    ) -> Result<bool, sqlx::Error> {
+        sqlx::query_scalar(
+            "SELECT EXISTS( \
+                 SELECT 1 FROM engine.world_posts \
+                 WHERE owner_uid = $1 AND published_at IS NOT NULL \
+                   AND ($2::timestamptz IS NULL OR published_at > $2)) \
+             OR EXISTS( \
+                 SELECT 1 FROM engine.world_post_comments c \
+                 JOIN engine.world_posts p ON p.id = c.post_id \
+                 WHERE p.owner_uid = $1 AND c.author_instance_id IS NULL \
+                   AND ($2::timestamptz IS NULL OR c.created_at > $2))",
+        )
+        .bind(owner_uid)
+        .bind(since)
+        .fetch_one(self.pool)
+        .await
+    }
+
+    /// Insert one hourly-round persona comment with validation folded into
+    /// the INSERT (spec §3.2): post belongs to the owner and is published,
+    /// author is one of the owner's ACTIVE instances, and the round path
+    /// never self-replies. `false` = rejected (caller warns + drops).
+    pub async fn insert_round_comment(
+        &self,
+        owner_uid: Uuid,
+        post_id: Uuid,
+        author_instance_id: Uuid,
+        content: &str,
+    ) -> Result<bool, sqlx::Error> {
+        let res = sqlx::query(
+            "INSERT INTO engine.world_post_comments \
+                 (post_id, author_instance_id, source, content) \
+             SELECT p.id, pi.id, 'round', $4 \
+             FROM engine.world_posts p \
+             JOIN engine.persona_instances pi \
+               ON pi.id = $3 AND pi.owner_uid = p.owner_uid AND pi.status = 'active' \
+             WHERE p.id = $1 AND p.owner_uid = $2 \
+               AND p.published_at IS NOT NULL AND p.instance_id <> $3",
+        )
+        .bind(post_id)
+        .bind(owner_uid)
+        .bind(author_instance_id)
+        .bind(content)
+        .execute(self.pool)
+        .await?;
+        Ok(res.rows_affected() > 0)
+    }
+
+    /// Posts whose LATEST user comment has settled past the debounce with no
+    /// persona comment after it (spec §3.3). Consecutive user comments
+    /// collapse onto the newest one. Author must still be active (§6).
+    pub async fn list_reply_candidates(
+        &self,
+        debounce: Duration,
+        limit: i64,
+    ) -> Result<Vec<ReplyCandidate>, sqlx::Error> {
+        let cutoff = Utc::now() - chrono::Duration::from_std(debounce).unwrap_or_default();
+        sqlx::query_as(
+            "SELECT p.id AS post_id, p.owner_uid, p.instance_id AS author_instance_id \
+             FROM engine.world_posts p \
+             JOIN engine.world_enrollments we \
+               ON we.owner_uid = p.owner_uid AND we.town_enabled \
+             JOIN engine.persona_instances pi \
+               ON pi.id = p.instance_id AND pi.status = 'active' \
+             JOIN LATERAL ( \
+                 SELECT max(created_at) AS last_user_at \
+                 FROM engine.world_post_comments \
+                 WHERE post_id = p.id AND author_instance_id IS NULL \
+             ) u ON u.last_user_at IS NOT NULL \
+             WHERE p.published_at IS NOT NULL \
+               AND u.last_user_at <= $1 \
+               AND NOT EXISTS ( \
+                   SELECT 1 FROM engine.world_post_comments a \
+                   WHERE a.post_id = p.id AND a.author_instance_id IS NOT NULL \
+                     AND a.created_at > u.last_user_at) \
+             LIMIT $2",
+        )
+        .bind(cutoff)
+        .bind(limit)
+        .fetch_all(self.pool)
+        .await
+    }
+
+    /// Reply-responder comments spent today (UTC day) for this owner —
+    /// counts ONLY source = 'reply' rows (spec §3.3 gate 2).
+    pub async fn count_replies_today(&self, owner_uid: Uuid) -> Result<i64, sqlx::Error> {
+        sqlx::query_scalar(
+            "SELECT count(*) FROM engine.world_post_comments c \
+             JOIN engine.world_posts p ON p.id = c.post_id \
+             WHERE p.owner_uid = $1 AND c.source = 'reply' \
+               AND c.created_at >= date_trunc('day', now())",
+        )
+        .bind(owner_uid)
+        .fetch_one(self.pool)
+        .await
+    }
+
+    /// Thread-cooldown CAS doubling as the multi-instance claim (spec §3.3
+    /// gate 3). `true` = this instance owns the response.
+    pub async fn claim_reply_cooldown(
+        &self,
+        post_id: Uuid,
+        cooldown: Duration,
+    ) -> Result<bool, sqlx::Error> {
+        let cutoff = Utc::now() - chrono::Duration::from_std(cooldown).unwrap_or_default();
+        let res = sqlx::query(
+            "UPDATE engine.world_posts SET last_reply_at = now() \
+             WHERE id = $1 AND (last_reply_at IS NULL OR last_reply_at < $2)",
+        )
+        .bind(post_id)
+        .bind(cutoff)
+        .execute(self.pool)
+        .await?;
+        Ok(res.rows_affected() > 0)
+    }
+
+    /// Insert the responder's comment (source = 'reply'). Validation already
+    /// happened in `list_reply_candidates` + the cooldown CAS.
+    pub async fn insert_reply_comment(
+        &self,
+        post_id: Uuid,
+        author_instance_id: Uuid,
+        content: &str,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query(
+            "INSERT INTO engine.world_post_comments \
+                 (post_id, author_instance_id, source, content) \
+             VALUES ($1, $2, 'reply', $3)",
+        )
+        .bind(post_id)
+        .bind(author_instance_id)
+        .bind(content)
+        .execute(self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// One post with author name, for the reply-responder payload.
+    pub async fn get_post(&self, post_id: Uuid) -> Result<Option<FeedPost>, sqlx::Error> {
+        sqlx::query_as(
+            "SELECT p.id AS post_id, p.instance_id, pg.name AS author_name, \
+                    p.content, p.published_at \
+             FROM engine.world_posts p \
+             JOIN engine.persona_instances pi ON pi.id = p.instance_id \
+             JOIN engine.persona_genomes pg ON pg.id = pi.genome_id \
+             WHERE p.id = $1 AND p.published_at IS NOT NULL",
+        )
+        .bind(post_id)
         .fetch_optional(self.pool)
         .await
     }
@@ -317,5 +523,245 @@ mod tests {
         assert_eq!(thread.len(), 2);
         assert_eq!(thread[0].content, "第一次评论");
         assert_eq!(thread[1].author_name.as_deref(), Some("Aria"));
+    }
+
+    #[sqlx::test]
+    async fn claim_comment_round_cas_due_not_due_contended(pool: PgPool) {
+        let (owner, _inst) = seed_town_owner(&pool).await;
+        let repo = WorldTownRepo { pool: &pool };
+        let round = std::time::Duration::from_secs(3600);
+
+        // First claim: NULL prev, claimed.
+        let prev = repo.claim_comment_round(owner, round).await.unwrap();
+        assert_eq!(prev, Some(None), "first round claims with NULL prev");
+
+        // Immediately after: not due.
+        assert_eq!(repo.claim_comment_round(owner, round).await.unwrap(), None);
+
+        // Backdate the stamp past the round: due again, prev returned.
+        sqlx::query(
+            "UPDATE engine.world_states \
+             SET last_comment_round_at = now() - interval '2 hours' WHERE owner_uid = $1",
+        )
+        .bind(owner)
+        .execute(&pool)
+        .await
+        .unwrap();
+        let prev = repo.claim_comment_round(owner, round).await.unwrap();
+        assert!(matches!(prev, Some(Some(_))), "prev stamp returned");
+    }
+
+    #[sqlx::test]
+    async fn round_candidates_and_activity_window(pool: PgPool) {
+        let (owner, inst) = seed_town_owner(&pool).await;
+        let repo = WorldTownRepo { pool: &pool };
+        let round = std::time::Duration::from_secs(3600);
+
+        // Never-run owner is a candidate.
+        let due = repo.list_round_candidates(round).await.unwrap();
+        assert!(due.contains(&owner));
+
+        // NULL since ⇒ any published post counts.
+        assert!(!repo.has_town_activity_since(owner, None).await.unwrap());
+        let post = seed_post(&pool, owner, inst, "p", true).await;
+        assert!(repo.has_town_activity_since(owner, None).await.unwrap());
+
+        // Activity strictly after `since`.
+        let future = Utc::now() + chrono::Duration::hours(1);
+        assert!(!repo
+            .has_town_activity_since(owner, Some(future))
+            .await
+            .unwrap());
+        // A fresh user comment moves the window.
+        repo.insert_user_comment(owner, post, "hi")
+            .await
+            .unwrap()
+            .unwrap();
+        let past = Utc::now() - chrono::Duration::seconds(30);
+        assert!(repo
+            .has_town_activity_since(owner, Some(past))
+            .await
+            .unwrap());
+    }
+
+    #[sqlx::test]
+    async fn round_comment_insert_validates_author_and_post(pool: PgPool) {
+        let (owner, author) = seed_town_owner(&pool).await;
+        let (other_owner, foreign_author) = seed_town_owner(&pool).await;
+        // Second active persona in owner's world to author valid comments.
+        let genome: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata) \
+             VALUES ('Rin','p','{}'::jsonb) RETURNING id",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let rin: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_instances (genome_id, owner_uid) \
+             VALUES ($1,$2) RETURNING id",
+        )
+        .bind(genome)
+        .bind(owner)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let post = seed_post(&pool, owner, author, "hello", true).await;
+        let repo = WorldTownRepo { pool: &pool };
+
+        assert!(repo
+            .insert_round_comment(owner, post, rin, "不错")
+            .await
+            .unwrap());
+        // Self-reply via round path rejected.
+        assert!(!repo
+            .insert_round_comment(owner, post, author, "自评")
+            .await
+            .unwrap());
+        // Foreign author rejected.
+        assert!(!repo
+            .insert_round_comment(owner, post, foreign_author, "串门")
+            .await
+            .unwrap());
+        // Inactive author rejected.
+        sqlx::query("UPDATE engine.persona_instances SET status = 'archived' WHERE id = $1")
+            .bind(rin)
+            .execute(&pool)
+            .await
+            .unwrap();
+        assert!(!repo
+            .insert_round_comment(owner, post, rin, "再来")
+            .await
+            .unwrap());
+        // Unpublished post rejected.
+        let draft = seed_post(&pool, owner, author, "draft", false).await;
+        assert!(!repo
+            .insert_round_comment(owner, draft, rin, "x")
+            .await
+            .unwrap());
+        let _ = other_owner;
+    }
+
+    #[sqlx::test]
+    async fn reply_scan_debounce_and_persona_after_user_exclusion(pool: PgPool) {
+        let (owner, inst) = seed_town_owner(&pool).await;
+        let post = seed_post(&pool, owner, inst, "hello", true).await;
+        let repo = WorldTownRepo { pool: &pool };
+        let debounce = std::time::Duration::from_secs(90);
+
+        // No user comment yet ⇒ no candidate.
+        assert!(repo
+            .list_reply_candidates(debounce, 10)
+            .await
+            .unwrap()
+            .is_empty());
+
+        // Fresh user comment (inside debounce) ⇒ still no candidate.
+        repo.insert_user_comment(owner, post, "在吗")
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(repo
+            .list_reply_candidates(debounce, 10)
+            .await
+            .unwrap()
+            .is_empty());
+
+        // Age it past the debounce ⇒ candidate appears.
+        sqlx::query(
+            "UPDATE engine.world_post_comments SET created_at = now() - interval '3 minutes' \
+             WHERE post_id = $1",
+        )
+        .bind(post)
+        .execute(&pool)
+        .await
+        .unwrap();
+        let cands = repo.list_reply_candidates(debounce, 10).await.unwrap();
+        assert_eq!(cands.len(), 1);
+        assert_eq!(cands[0].post_id, post);
+        assert_eq!(cands[0].author_instance_id, inst);
+
+        // Persona comment after the user comment clears the candidate.
+        repo.insert_reply_comment(post, inst, "在的").await.unwrap();
+        assert!(repo
+            .list_reply_candidates(debounce, 10)
+            .await
+            .unwrap()
+            .is_empty());
+
+        // A NEWER user comment re-arms only after ITS debounce (consecutive
+        // user comments collapse onto the latest one).
+        repo.insert_user_comment(owner, post, "又来")
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(repo
+            .list_reply_candidates(debounce, 10)
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    #[sqlx::test]
+    async fn reply_cap_counts_only_reply_source_and_cooldown_cas(pool: PgPool) {
+        let (owner, inst) = seed_town_owner(&pool).await;
+        let post = seed_post(&pool, owner, inst, "hello", true).await;
+        let repo = WorldTownRepo { pool: &pool };
+
+        assert_eq!(repo.count_replies_today(owner).await.unwrap(), 0);
+        repo.insert_round_comment_unchecked_for_test(post, inst, "round", "round row")
+            .await;
+        repo.insert_reply_comment(post, inst, "reply row")
+            .await
+            .unwrap();
+        // User rows never count either.
+        repo.insert_user_comment(owner, post, "user row")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            repo.count_replies_today(owner).await.unwrap(),
+            1,
+            "only source='reply'"
+        );
+
+        // Cooldown CAS: first claim wins, immediate second claim loses,
+        // backdated stamp reopens.
+        let cooldown = std::time::Duration::from_secs(600);
+        assert!(repo.claim_reply_cooldown(post, cooldown).await.unwrap());
+        assert!(!repo.claim_reply_cooldown(post, cooldown).await.unwrap());
+        sqlx::query(
+            "UPDATE engine.world_posts SET last_reply_at = now() - interval '11 minutes' \
+             WHERE id = $1",
+        )
+        .bind(post)
+        .execute(&pool)
+        .await
+        .unwrap();
+        assert!(repo.claim_reply_cooldown(post, cooldown).await.unwrap());
+    }
+
+    // Test-only impl block for helper methods used in tests.
+    impl<'a> WorldTownRepo<'a> {
+        /// Test-only: raw insert bypassing round validation, for cap counting.
+        async fn insert_round_comment_unchecked_for_test(
+            &self,
+            post_id: Uuid,
+            author: Uuid,
+            source: &str,
+            content: &str,
+        ) {
+            sqlx::query(
+                "INSERT INTO engine.world_post_comments \
+                     (post_id, author_instance_id, source, content) \
+                 VALUES ($1, $2, $3, $4)",
+            )
+            .bind(post_id)
+            .bind(author)
+            .bind(source)
+            .bind(content)
+            .execute(self.pool)
+            .await
+            .unwrap();
+        }
     }
 }

--- a/crates/eros-engine-store/src/world_town.rs
+++ b/crates/eros-engine-store/src/world_town.rs
@@ -140,14 +140,14 @@ impl<'a> WorldTownRepo<'a> {
     /// the round cadence. The per-owner CAS (`claim_comment_round`) is the
     /// authoritative claim; this list is just the scan.
     pub async fn list_round_candidates(&self, round: Duration) -> Result<Vec<Uuid>, sqlx::Error> {
-        let cutoff = Utc::now() - chrono::Duration::from_std(round).unwrap_or_default();
         sqlx::query_scalar(
             "SELECT ws.owner_uid FROM engine.world_states ws \
              JOIN engine.world_enrollments we USING (owner_uid) \
              WHERE we.town_enabled \
-               AND (ws.last_comment_round_at IS NULL OR ws.last_comment_round_at < $1)",
+               AND (ws.last_comment_round_at IS NULL \
+                    OR ws.last_comment_round_at < now() - make_interval(secs => $1))",
         )
-        .bind(cutoff)
+        .bind(round.as_secs_f64())
         .fetch_all(self.pool)
         .await
     }
@@ -161,17 +161,16 @@ impl<'a> WorldTownRepo<'a> {
         owner_uid: Uuid,
         round: Duration,
     ) -> Result<Option<Option<DateTime<Utc>>>, sqlx::Error> {
-        let cutoff = Utc::now() - chrono::Duration::from_std(round).unwrap_or_default();
         sqlx::query_scalar(
             "UPDATE engine.world_states ws SET last_comment_round_at = now() \
              FROM (SELECT owner_uid, last_comment_round_at AS prev \
                    FROM engine.world_states WHERE owner_uid = $1 FOR UPDATE) old \
              WHERE ws.owner_uid = old.owner_uid \
-               AND (old.prev IS NULL OR old.prev < $2) \
+               AND (old.prev IS NULL OR old.prev < now() - make_interval(secs => $2)) \
              RETURNING old.prev",
         )
         .bind(owner_uid)
-        .bind(cutoff)
+        .bind(round.as_secs_f64())
         .fetch_optional(self.pool)
         .await
     }
@@ -238,7 +237,6 @@ impl<'a> WorldTownRepo<'a> {
         debounce: Duration,
         limit: i64,
     ) -> Result<Vec<ReplyCandidate>, sqlx::Error> {
-        let cutoff = Utc::now() - chrono::Duration::from_std(debounce).unwrap_or_default();
         sqlx::query_as(
             "SELECT p.id AS post_id, p.owner_uid, p.instance_id AS author_instance_id \
              FROM engine.world_posts p \
@@ -252,14 +250,15 @@ impl<'a> WorldTownRepo<'a> {
                  WHERE post_id = p.id AND author_instance_id IS NULL \
              ) u ON u.last_user_at IS NOT NULL \
              WHERE p.published_at IS NOT NULL \
-               AND u.last_user_at <= $1 \
+               AND u.last_user_at <= now() - make_interval(secs => $1) \
                AND NOT EXISTS ( \
                    SELECT 1 FROM engine.world_post_comments a \
                    WHERE a.post_id = p.id AND a.author_instance_id IS NOT NULL \
                      AND a.created_at > u.last_user_at) \
+             ORDER BY u.last_user_at ASC \
              LIMIT $2",
         )
-        .bind(cutoff)
+        .bind(debounce.as_secs_f64())
         .bind(limit)
         .fetch_all(self.pool)
         .await
@@ -272,7 +271,7 @@ impl<'a> WorldTownRepo<'a> {
             "SELECT count(*) FROM engine.world_post_comments c \
              JOIN engine.world_posts p ON p.id = c.post_id \
              WHERE p.owner_uid = $1 AND c.source = 'reply' \
-               AND c.created_at >= date_trunc('day', now())",
+               AND c.created_at >= (date_trunc('day', now() AT TIME ZONE 'utc') AT TIME ZONE 'utc')",
         )
         .bind(owner_uid)
         .fetch_one(self.pool)
@@ -286,13 +285,12 @@ impl<'a> WorldTownRepo<'a> {
         post_id: Uuid,
         cooldown: Duration,
     ) -> Result<bool, sqlx::Error> {
-        let cutoff = Utc::now() - chrono::Duration::from_std(cooldown).unwrap_or_default();
         let res = sqlx::query(
             "UPDATE engine.world_posts SET last_reply_at = now() \
-             WHERE id = $1 AND (last_reply_at IS NULL OR last_reply_at < $2)",
+             WHERE id = $1 AND (last_reply_at IS NULL OR last_reply_at < now() - make_interval(secs => $2))",
         )
         .bind(post_id)
-        .bind(cutoff)
+        .bind(cooldown.as_secs_f64())
         .execute(self.pool)
         .await?;
         Ok(res.rows_affected() > 0)

--- a/crates/eros-engine-store/src/world_town.rs
+++ b/crates/eros-engine-store/src/world_town.rs
@@ -1,0 +1,321 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! World Town persistence: post publishing, feed reads, comment threads,
+//! and the comment-round / reply-responder scheduling primitives.
+//!
+//! All feed-visible reads and user writes JOIN `world_enrollments` on
+//! `town_enabled` — flipping the flag off makes the feed empty immediately
+//! while keeping rows (spec town §6).
+
+use chrono::{DateTime, Utc};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct FeedPost {
+    pub post_id: Uuid,
+    pub instance_id: Uuid,
+    pub author_name: String,
+    pub content: String,
+    pub published_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct FeedComment {
+    pub comment_id: Uuid,
+    pub post_id: Uuid,
+    pub author_instance_id: Option<Uuid>,
+    pub author_name: Option<String>,
+    pub content: String,
+    pub created_at: DateTime<Utc>,
+}
+
+pub struct WorldTownRepo<'a> {
+    pub pool: &'a PgPool,
+}
+
+impl<'a> WorldTownRepo<'a> {
+    /// Flip every due post of a town-enabled owner to published (spec §3.1).
+    /// Pure SQL, zero LLM. Returns rows published.
+    pub async fn publish_due(&self) -> Result<u64, sqlx::Error> {
+        let res = sqlx::query(
+            "UPDATE engine.world_posts p SET published_at = now() \
+             FROM engine.world_enrollments we \
+             WHERE we.owner_uid = p.owner_uid AND we.town_enabled \
+               AND p.published_at IS NULL AND p.scheduled_at <= now()",
+        )
+        .execute(self.pool)
+        .await?;
+        Ok(res.rows_affected())
+    }
+
+    /// One keyset page of the owner's published feed, newest first
+    /// (spec §4). The town_enabled JOIN makes disabled/unenrolled owners an
+    /// empty feed, not an error.
+    pub async fn feed_page(
+        &self,
+        owner_uid: Uuid,
+        limit: i64,
+        cursor: Option<(DateTime<Utc>, Uuid)>,
+    ) -> Result<Vec<FeedPost>, sqlx::Error> {
+        let (cur_ts, cur_id) = match cursor {
+            Some((ts, id)) => (Some(ts), Some(id)),
+            None => (None, None),
+        };
+        sqlx::query_as(
+            "SELECT p.id AS post_id, p.instance_id, pg.name AS author_name, \
+                    p.content, p.published_at \
+             FROM engine.world_posts p \
+             JOIN engine.world_enrollments we \
+               ON we.owner_uid = p.owner_uid AND we.town_enabled \
+             JOIN engine.persona_instances pi ON pi.id = p.instance_id \
+             JOIN engine.persona_genomes pg ON pg.id = pi.genome_id \
+             WHERE p.owner_uid = $1 AND p.published_at IS NOT NULL \
+               AND ($2::timestamptz IS NULL OR (p.published_at, p.id) < ($2, $3)) \
+             ORDER BY p.published_at DESC, p.id DESC \
+             LIMIT $4",
+        )
+        .bind(owner_uid)
+        .bind(cur_ts)
+        .bind(cur_id)
+        .bind(limit)
+        .fetch_all(self.pool)
+        .await
+    }
+
+    /// All comments for a page of posts, thread order (spec §4: threads are
+    /// small by construction; no comment pagination in v1).
+    pub async fn list_comments_for_posts(
+        &self,
+        post_ids: &[Uuid],
+    ) -> Result<Vec<FeedComment>, sqlx::Error> {
+        sqlx::query_as(
+            "SELECT c.id AS comment_id, c.post_id, c.author_instance_id, \
+                    pg.name AS author_name, c.content, c.created_at \
+             FROM engine.world_post_comments c \
+             LEFT JOIN engine.persona_instances pi ON pi.id = c.author_instance_id \
+             LEFT JOIN engine.persona_genomes pg ON pg.id = pi.genome_id \
+             WHERE c.post_id = ANY($1) \
+             ORDER BY c.post_id, c.created_at",
+        )
+        .bind(post_ids)
+        .fetch_all(self.pool)
+        .await
+    }
+
+    /// Insert a user comment (author NULL, source NULL) after validating the
+    /// post belongs to this owner's town-enabled world and is published.
+    /// `None` = not visible ⇒ caller 404s (spec §4).
+    pub async fn insert_user_comment(
+        &self,
+        owner_uid: Uuid,
+        post_id: Uuid,
+        content: &str,
+    ) -> Result<Option<FeedComment>, sqlx::Error> {
+        sqlx::query_as(
+            "INSERT INTO engine.world_post_comments (post_id, author_instance_id, source, content) \
+             SELECT p.id, NULL, NULL, $3 \
+             FROM engine.world_posts p \
+             JOIN engine.world_enrollments we \
+               ON we.owner_uid = p.owner_uid AND we.town_enabled \
+             WHERE p.id = $1 AND p.owner_uid = $2 AND p.published_at IS NOT NULL \
+             RETURNING id AS comment_id, post_id, author_instance_id, \
+                       NULL::text AS author_name, content, created_at",
+        )
+        .bind(post_id)
+        .bind(owner_uid)
+        .bind(content)
+        .fetch_optional(self.pool)
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// genome + instance + world enrollment (town on) + world_states backfill.
+    pub(super) async fn seed_town_owner(pool: &PgPool) -> (Uuid, Uuid) {
+        let owner = Uuid::new_v4();
+        let genome: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata) \
+             VALUES ('Aria','p','{}'::jsonb) RETURNING id",
+        )
+        .fetch_one(pool)
+        .await
+        .unwrap();
+        let inst: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_instances (genome_id, owner_uid) \
+             VALUES ($1,$2) RETURNING id",
+        )
+        .bind(genome)
+        .bind(owner)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO engine.world_enrollments (owner_uid, town_enabled) VALUES ($1, true)",
+        )
+        .bind(owner)
+        .execute(pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO engine.world_states (owner_uid, seed, digests) \
+             VALUES ($1, '{}'::jsonb, '{}'::jsonb)",
+        )
+        .bind(owner)
+        .execute(pool)
+        .await
+        .unwrap();
+        (owner, inst)
+    }
+
+    pub(super) async fn seed_post(
+        pool: &PgPool,
+        owner: Uuid,
+        inst: Uuid,
+        content: &str,
+        published: bool,
+    ) -> Uuid {
+        sqlx::query_scalar(
+            "INSERT INTO engine.world_posts \
+                 (owner_uid, instance_id, content, scheduled_at, published_at) \
+             VALUES ($1, $2, $3, now() - interval '1 hour', \
+                     CASE WHEN $4 THEN now() ELSE NULL END) \
+             RETURNING id",
+        )
+        .bind(owner)
+        .bind(inst)
+        .bind(content)
+        .bind(published)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+    }
+
+    #[sqlx::test]
+    async fn publish_due_flips_only_town_enabled_due_posts(pool: PgPool) {
+        let (owner, inst) = seed_town_owner(&pool).await;
+        let due = seed_post(&pool, owner, inst, "due", false).await;
+        // Future post: not due.
+        let future: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.world_posts (owner_uid, instance_id, content, scheduled_at) \
+             VALUES ($1, $2, 'future', now() + interval '1 hour') RETURNING id",
+        )
+        .bind(owner)
+        .bind(inst)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        // Town-disabled owner: due but must not publish.
+        let (owner2, inst2) = seed_town_owner(&pool).await;
+        sqlx::query(
+            "UPDATE engine.world_enrollments SET town_enabled = false WHERE owner_uid = $1",
+        )
+        .bind(owner2)
+        .execute(&pool)
+        .await
+        .unwrap();
+        let frozen = seed_post(&pool, owner2, inst2, "frozen", false).await;
+
+        let repo = WorldTownRepo { pool: &pool };
+        let n = repo.publish_due().await.unwrap();
+        assert_eq!(n, 1);
+        for (id, expect_published) in [(due, true), (future, false), (frozen, false)] {
+            let published: Option<DateTime<Utc>> =
+                sqlx::query_scalar("SELECT published_at FROM engine.world_posts WHERE id = $1")
+                    .bind(id)
+                    .fetch_one(&pool)
+                    .await
+                    .unwrap();
+            assert_eq!(published.is_some(), expect_published, "post {id}");
+        }
+    }
+
+    #[sqlx::test]
+    async fn feed_page_keyset_paginates_and_hides_disabled(pool: PgPool) {
+        let (owner, inst) = seed_town_owner(&pool).await;
+        for i in 0..5 {
+            let id = seed_post(&pool, owner, inst, &format!("post {i}"), false).await;
+            // Distinct published_at per row for a deterministic keyset order.
+            sqlx::query(
+                "UPDATE engine.world_posts SET published_at = now() - ($2 || ' minutes')::interval \
+                 WHERE id = $1",
+            )
+            .bind(id)
+            .bind((5 - i).to_string())
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+        let repo = WorldTownRepo { pool: &pool };
+        let page1 = repo.feed_page(owner, 2, None).await.unwrap();
+        assert_eq!(page1.len(), 2);
+        assert_eq!(page1[0].content, "post 4", "newest first");
+        assert_eq!(page1[0].author_name, "Aria");
+        let cursor = Some((page1[1].published_at, page1[1].post_id));
+        let page2 = repo.feed_page(owner, 2, cursor).await.unwrap();
+        assert_eq!(page2.len(), 2);
+        assert_eq!(page2[0].content, "post 2", "no overlap, no gap");
+
+        // Unpublished posts are invisible.
+        seed_post(&pool, owner, inst, "draft", false).await;
+        let all = repo.feed_page(owner, 50, None).await.unwrap();
+        assert_eq!(all.len(), 5);
+
+        // Flipping town_enabled off empties the feed but keeps rows.
+        sqlx::query(
+            "UPDATE engine.world_enrollments SET town_enabled = false WHERE owner_uid = $1",
+        )
+        .bind(owner)
+        .execute(&pool)
+        .await
+        .unwrap();
+        assert!(repo.feed_page(owner, 50, None).await.unwrap().is_empty());
+    }
+
+    #[sqlx::test]
+    async fn user_comment_validates_visibility_and_round_trips(pool: PgPool) {
+        let (owner, inst) = seed_town_owner(&pool).await;
+        let post = seed_post(&pool, owner, inst, "hello", true).await;
+        let repo = WorldTownRepo { pool: &pool };
+
+        let c = repo
+            .insert_user_comment(owner, post, "第一次评论")
+            .await
+            .unwrap()
+            .expect("visible post accepts comment");
+        assert_eq!(c.post_id, post);
+        assert!(c.author_instance_id.is_none());
+        assert!(c.author_name.is_none());
+
+        // Wrong owner ⇒ None.
+        assert!(repo
+            .insert_user_comment(Uuid::new_v4(), post, "x")
+            .await
+            .unwrap()
+            .is_none());
+        // Unpublished ⇒ None.
+        let draft = seed_post(&pool, owner, inst, "draft", false).await;
+        assert!(repo
+            .insert_user_comment(owner, draft, "x")
+            .await
+            .unwrap()
+            .is_none());
+
+        // Thread read joins the author name for persona rows, NULL for user.
+        sqlx::query(
+            "INSERT INTO engine.world_post_comments (post_id, author_instance_id, source, content) \
+             VALUES ($1, $2, 'round', '路过点赞')",
+        )
+        .bind(post)
+        .bind(inst)
+        .execute(&pool)
+        .await
+        .unwrap();
+        let thread = repo.list_comments_for_posts(&[post]).await.unwrap();
+        assert_eq!(thread.len(), 2);
+        assert_eq!(thread[0].content, "第一次评论");
+        assert_eq!(thread[1].author_name.as_deref(), Some("Aria"));
+    }
+}

--- a/crates/eros-engine-store/src/world_town.rs
+++ b/crates/eros-engine-store/src/world_town.rs
@@ -232,33 +232,48 @@ impl<'a> WorldTownRepo<'a> {
     /// Posts whose LATEST user comment has settled past the debounce with no
     /// persona comment after it (spec §3.3). Consecutive user comments
     /// collapse onto the newest one. Author must still be active (§6).
+    /// Cooldown is filtered here (excludes posts still inside
+    /// `last_reply_at`'s cooldown window) and the scan returns AT MOST ONE
+    /// candidate per owner via `DISTINCT ON`, oldest-first across owners —
+    /// fairness under cap pressure, so a capped owner with many pending
+    /// threads occupies at most one batch slot per tick instead of starving
+    /// every other owner. The daily cap itself stays in the pipeline (single
+    /// source of truth in `count_replies_today`).
     pub async fn list_reply_candidates(
         &self,
         debounce: Duration,
+        cooldown: Duration,
         limit: i64,
     ) -> Result<Vec<ReplyCandidate>, sqlx::Error> {
         sqlx::query_as(
-            "SELECT p.id AS post_id, p.owner_uid, p.instance_id AS author_instance_id \
-             FROM engine.world_posts p \
-             JOIN engine.world_enrollments we \
-               ON we.owner_uid = p.owner_uid AND we.town_enabled \
-             JOIN engine.persona_instances pi \
-               ON pi.id = p.instance_id AND pi.status = 'active' \
-             JOIN LATERAL ( \
-                 SELECT max(created_at) AS last_user_at \
-                 FROM engine.world_post_comments \
-                 WHERE post_id = p.id AND author_instance_id IS NULL \
-             ) u ON u.last_user_at IS NOT NULL \
-             WHERE p.published_at IS NOT NULL \
-               AND u.last_user_at <= now() - make_interval(secs => $1) \
-               AND NOT EXISTS ( \
-                   SELECT 1 FROM engine.world_post_comments a \
-                   WHERE a.post_id = p.id AND a.author_instance_id IS NOT NULL \
-                     AND a.created_at > u.last_user_at) \
-             ORDER BY u.last_user_at ASC \
-             LIMIT $2",
+            "SELECT post_id, owner_uid, author_instance_id FROM ( \
+                 SELECT DISTINCT ON (p.owner_uid) \
+                        p.id AS post_id, p.owner_uid, p.instance_id AS author_instance_id, \
+                        u.last_user_at \
+                 FROM engine.world_posts p \
+                 JOIN engine.world_enrollments we \
+                   ON we.owner_uid = p.owner_uid AND we.town_enabled \
+                 JOIN engine.persona_instances pi \
+                   ON pi.id = p.instance_id AND pi.status = 'active' \
+                 JOIN LATERAL ( \
+                     SELECT max(created_at) AS last_user_at \
+                     FROM engine.world_post_comments \
+                     WHERE post_id = p.id AND author_instance_id IS NULL \
+                 ) u ON u.last_user_at IS NOT NULL \
+                 WHERE p.published_at IS NOT NULL \
+                   AND (p.last_reply_at IS NULL OR p.last_reply_at < now() - make_interval(secs => $2)) \
+                   AND u.last_user_at <= now() - make_interval(secs => $1) \
+                   AND NOT EXISTS ( \
+                       SELECT 1 FROM engine.world_post_comments a \
+                       WHERE a.post_id = p.id AND a.author_instance_id IS NOT NULL \
+                         AND a.created_at > u.last_user_at) \
+                 ORDER BY p.owner_uid, u.last_user_at ASC \
+             ) sub \
+             ORDER BY last_user_at ASC \
+             LIMIT $3",
         )
         .bind(debounce.as_secs_f64())
+        .bind(cooldown.as_secs_f64())
         .bind(limit)
         .fetch_all(self.pool)
         .await
@@ -645,10 +660,11 @@ mod tests {
         let post = seed_post(&pool, owner, inst, "hello", true).await;
         let repo = WorldTownRepo { pool: &pool };
         let debounce = std::time::Duration::from_secs(90);
+        let cooldown = std::time::Duration::from_secs(600);
 
         // No user comment yet ⇒ no candidate.
         assert!(repo
-            .list_reply_candidates(debounce, 10)
+            .list_reply_candidates(debounce, cooldown, 10)
             .await
             .unwrap()
             .is_empty());
@@ -659,7 +675,7 @@ mod tests {
             .unwrap()
             .unwrap();
         assert!(repo
-            .list_reply_candidates(debounce, 10)
+            .list_reply_candidates(debounce, cooldown, 10)
             .await
             .unwrap()
             .is_empty());
@@ -673,7 +689,10 @@ mod tests {
         .execute(&pool)
         .await
         .unwrap();
-        let cands = repo.list_reply_candidates(debounce, 10).await.unwrap();
+        let cands = repo
+            .list_reply_candidates(debounce, cooldown, 10)
+            .await
+            .unwrap();
         assert_eq!(cands.len(), 1);
         assert_eq!(cands[0].post_id, post);
         assert_eq!(cands[0].author_instance_id, inst);
@@ -681,7 +700,7 @@ mod tests {
         // Persona comment after the user comment clears the candidate.
         repo.insert_reply_comment(post, inst, "在的").await.unwrap();
         assert!(repo
-            .list_reply_candidates(debounce, 10)
+            .list_reply_candidates(debounce, cooldown, 10)
             .await
             .unwrap()
             .is_empty());
@@ -693,7 +712,7 @@ mod tests {
             .unwrap()
             .unwrap();
         assert!(repo
-            .list_reply_candidates(debounce, 10)
+            .list_reply_candidates(debounce, cooldown, 10)
             .await
             .unwrap()
             .is_empty());
@@ -736,6 +755,87 @@ mod tests {
         .await
         .unwrap();
         assert!(repo.claim_reply_cooldown(post, cooldown).await.unwrap());
+    }
+
+    #[sqlx::test]
+    async fn reply_scan_filters_cooldown_and_dedupes_per_owner(pool: PgPool) {
+        let (owner_a, inst_a) = seed_town_owner(&pool).await;
+        let post1 = seed_post(&pool, owner_a, inst_a, "post1", true).await;
+        let post2 = seed_post(&pool, owner_a, inst_a, "post2", true).await;
+        let repo = WorldTownRepo { pool: &pool };
+        let debounce = std::time::Duration::from_secs(90);
+        let cooldown = std::time::Duration::from_secs(600);
+
+        // Two eligible threads for owner A; post1's user comment is older.
+        repo.insert_user_comment(owner_a, post1, "post1 user")
+            .await
+            .unwrap()
+            .unwrap();
+        sqlx::query(
+            "UPDATE engine.world_post_comments SET created_at = now() - interval '10 minutes' \
+             WHERE post_id = $1",
+        )
+        .bind(post1)
+        .execute(&pool)
+        .await
+        .unwrap();
+        repo.insert_user_comment(owner_a, post2, "post2 user")
+            .await
+            .unwrap()
+            .unwrap();
+        sqlx::query(
+            "UPDATE engine.world_post_comments SET created_at = now() - interval '3 minutes' \
+             WHERE post_id = $1",
+        )
+        .bind(post2)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // Only ONE candidate surfaces for owner A: the older thread (post1).
+        let cands = repo
+            .list_reply_candidates(debounce, cooldown, 10)
+            .await
+            .unwrap();
+        assert_eq!(cands.len(), 1, "one candidate per owner");
+        assert_eq!(cands[0].post_id, post1, "oldest thread wins for owner A");
+
+        // Claiming the cooldown on post1 excludes it from the scan; owner A's
+        // other pending thread (post2) surfaces instead — never both.
+        assert!(repo.claim_reply_cooldown(post1, cooldown).await.unwrap());
+        let cands = repo
+            .list_reply_candidates(debounce, cooldown, 10)
+            .await
+            .unwrap();
+        assert_eq!(cands.len(), 1);
+        assert_eq!(cands[0].post_id, post2, "cooldown-excluded post1 skipped");
+
+        // Owner B has one eligible thread, older than owner A's remaining one.
+        let (owner_b, inst_b) = seed_town_owner(&pool).await;
+        let post_b = seed_post(&pool, owner_b, inst_b, "postB", true).await;
+        repo.insert_user_comment(owner_b, post_b, "B user")
+            .await
+            .unwrap()
+            .unwrap();
+        sqlx::query(
+            "UPDATE engine.world_post_comments SET created_at = now() - interval '5 minutes' \
+             WHERE post_id = $1",
+        )
+        .bind(post_b)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // Both owners get exactly one slot each, oldest thread first overall.
+        let cands = repo
+            .list_reply_candidates(debounce, cooldown, 10)
+            .await
+            .unwrap();
+        assert_eq!(cands.len(), 2, "one candidate per owner, both eligible");
+        assert_eq!(cands[0].post_id, post_b, "owner B's older thread first");
+        assert_eq!(cands[0].owner_uid, owner_b);
+        assert_eq!(cands[1].post_id, post2);
+        assert_eq!(cands[1].owner_uid, owner_a);
     }
 
     // Test-only impl block for helper methods used in tests.

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -16,13 +16,15 @@ Two supported paths, in order of effort:
 
 ## Subcommands
 
-The binary has three modes (dispatched by `argv[1]`):
+The binary has five modes (dispatched by `argv[1]`):
 
 | Subcommand | Purpose |
 |------------|---------|
 | `serve` (default) | Run the HTTP server on `BIND_ADDR` |
 | `migrate` | Apply pending sqlx migrations and exit |
 | `seed-personas <dir>` | Read every `*.toml` in `<dir>` and upsert as a persona genome |
+| `backfill-human-insights` | One-off projection of every `companion_insights` row into `engine.human_insights` (idempotent; manual only) |
+| `print-openapi` | Dump the OpenAPI spec to stdout and exit (no DB, no env; used by the CI drift check) |
 
 `seed-personas` is idempotent — re-runs update existing rows in place (matched by `name`), preserving UUIDs and FK references in `persona_instances`.
 
@@ -195,6 +197,33 @@ PROMPT_LOG_DIR = "/data/prompt-logs"
 ```
 
 There is no built-in rotation or retention — manage the volume yourself.
+
+### World system (experimental, optional)
+
+The [World system](world-system.md) (World Memories simulation + World Town
+feed) is fully off by default: without a `[tasks.world_director]` model-config
+section it spawns no sweepers and runs zero per-turn queries. Turning it on is
+a config + data decision, not a deploy change:
+
+1. Add the `[tasks.world_*]` sections to your model config (see
+   [`examples/model_config.toml`](../examples/model_config.toml)).
+2. Enroll owners by inserting rows into `engine.world_enrollments` over a
+   `service_role` / owner connection (the engine only reads this table); set
+   `town_enabled = true` per owner to also enable the feed.
+
+Operational switches, all optional:
+
+| Variable | Effect |
+|----------|--------|
+| `WORLD_DISABLED=true` | Master off: no sweepers, no prompt injection, zero cost |
+| `WORLD_PROMPT_DISABLED=true` | Simulate + accumulate, but don't touch chat prompts (staged-rollout valve) |
+| `WORLD_TICK_SECS` | Director sweeper tick (default 300; `0` disables) |
+| `WORLD_TOWN_DISABLED=true` | Town only: no post generation, no town sweeper; memories keep running |
+
+Cost shape: one director call per enrolled owner per `interval_hours`, plus
+(town only) activity-gated hourly comment rounds and per-owner-capped replies.
+A world nobody interacts with costs exactly the director call. Details,
+data model, and the boot-validation rules are in [World system](world-system.md).
 
 - **Health probe:** `GET /healthz` returns 200 with `{ status: "ok", service, version, timestamp }`. Wire this into your platform's health check.
 - **OpenAPI / Scalar:** `GET /docs` serves a live Scalar reference. The OpenAPI JSON is at `/api-docs/openapi.json`.

--- a/docs/deploying.zh.md
+++ b/docs/deploying.zh.md
@@ -16,13 +16,15 @@
 
 ## 子命令
 
-二進制文件有三種模式（按 `argv[1]` 分派）：
+二進制文件有五種模式（按 `argv[1]` 分派）：
 
 | 子命令 | 用途 |
 |---|---|
 | `serve`（默認） | 在 `BIND_ADDR` 上跑 HTTP 服務器 |
 | `migrate` | 應用待處理的 sqlx migrations 然後退出 |
 | `seed-personas <dir>` | 讀 `<dir>` 裡每個 `*.toml` 文件，upsert 為人格基因 |
+| `backfill-human-insights` | 一次性把每行 `companion_insights` 投影进 `engine.human_insights`（幂等；仅手动执行） |
+| `print-openapi` | 把 OpenAPI 规范打到 stdout 后退出（不连 DB、不读 env；CI 漂移检查用） |
 
 `seed-personas` 是冪等的——再跑會 update 原有行（按 `name` 匹配），保持 UUID 跟 `persona_instances` 裡的 FK 引用穩定。
 
@@ -193,6 +195,31 @@ PROMPT_LOG_DIR = "/data/prompt-logs"
 ```
 
 引擎不内置轮转或保留策略——卷由你自行管理。
+
+### 世界系统（实验特性，可选）
+
+[世界系统](world-system.zh.md)（World Memories 模拟 + World Town 动态）默认
+完全关闭：模型配置里没有 `[tasks.world_director]` section 时，不会起任何
+sweeper，每回合零查询。开启它是配置 + 数据层面的决定，不需要改部署：
+
+1. 在模型配置中加入 `[tasks.world_*]` section（见
+   [`examples/model_config.toml`](../examples/model_config.toml)）。
+2. 通过 `service_role` / owner 连接往 `engine.world_enrollments` 插行来注册
+   owner（引擎只读这张表）；对需要动态流的 owner 把 `town_enabled` 设为
+   `true`。
+
+运维开关，均可选：
+
+| 变量 | 作用 |
+|------|------|
+| `WORLD_DISABLED=true` | 总关：不起 sweeper、不注入 prompt、零成本 |
+| `WORLD_PROMPT_DISABLED=true` | 照常模拟积累，但不动聊天 prompt（灰度阀门） |
+| `WORLD_TICK_SECS` | 导演 sweeper tick（默认 300；`0` 关停） |
+| `WORLD_TOWN_DISABLED=true` | 仅小镇：不生成贴文、不起小镇 sweeper；记忆照常运行 |
+
+成本形状：每个注册 owner 每 `interval_hours` 一次导演调用，外加（仅小镇）按
+活动触发的每小时评论轮和按 owner 限额的回复。没人互动的世界恰好只花导演那一
+次调用。细节、数据模型与启动校验规则见[世界系统](world-system.zh.md)。
 
 - **健康探針：** `GET /healthz` 返 200，響應 `{ status: "ok", service, version, timestamp }`。把這個接到平台的健康檢查上。
 - **OpenAPI / Scalar：** `GET /docs` 提供實時的 Scalar 參考。OpenAPI JSON 在 `/api-docs/openapi.json`。

--- a/docs/llm-audit.md
+++ b/docs/llm-audit.md
@@ -100,6 +100,17 @@ prompt_tokens=… completion_tokens=… total_tokens=… cost=…
   from dreaming's `11111111-1111-1111-1111-111111111111`). Usage/cost emitted
   as tracing fields via `log_openrouter_usage("world_director", None, …)`;
   nothing on any client frame.
+- `world_comment` — World Town hourly comment round (background). One
+  batched call per owner with new feed activity. `user` =
+  `11111111-1111-1111-1111-111111111112` (shared world-subsystem sentinel).
+  Usage/cost emitted as tracing fields via
+  `log_openrouter_usage("world_comment", None, …)`; nothing on any client
+  frame.
+- `world_reply` — World Town reply responder (background). One call per
+  debounced user comment, capped per owner per UTC day. Same sentinel user;
+  usage/cost emitted as tracing fields via
+  `log_openrouter_usage("world_reply", None, …)`; nothing on any client
+  frame.
 
 ## App-attribution headers
 

--- a/docs/llm-audit.zh.md
+++ b/docs/llm-audit.zh.md
@@ -88,6 +88,15 @@ openrouter: call completed session=… generation_id=… model=…
 prompt_tokens=… completion_tokens=… total_tokens=… cost=…
 ```
 
+- `world_comment` —— World Town 每小时评论轮（后台）。每个有新动态的 owner
+  批量调一次。`user` = `11111111-1111-1111-1111-111111111112`（world 子系统
+  共享哨兵）。Usage/cost 通过 tracing 字段输出，走
+  `log_openrouter_usage("world_comment", None, …)`；不出现在任何 client 帧上。
+- `world_reply` —— World Town 回复响应器（后台）。每条经防抖的用户留言调一
+  次，按 owner 每 UTC 自然日封顶。同一个哨兵 user；usage/cost 通过 tracing
+  字段输出，走 `log_openrouter_usage("world_reply", None, …)`；不出现在任何
+  client 帧上。
+
 ## App-attribution headers
 
 三个可选环境变量给每次出站 OpenRouter 调用加 header：

--- a/docs/superpowers/specs/2026-07-21-world-town-design.md
+++ b/docs/superpowers/specs/2026-07-21-world-town-design.md
@@ -1,6 +1,6 @@
 # eros-engine — World Town (persona social feed on top of World Memories)
 
-**Status**: design, pending implementation plan. **Depends on**
+**Status**: implemented (0.8.x dev). **Depends on**
 `2026-07-21-world-memories-design.md` (implemented first; this spec extends its
 director output and enrollment table).
 **Target release**: `0.8.x` dev track. **Migration: 0036** (two new tables +

--- a/docs/superpowers/specs/2026-07-21-world-town-design.md
+++ b/docs/superpowers/specs/2026-07-21-world-town-design.md
@@ -80,6 +80,20 @@ ALTER TABLE engine.world_states     ADD COLUMN last_comment_round_at TIMESTAMPTZ
 Both new tables get the 0013 lockdown treatment (REVOKE + RLS, drift test
 extended).
 
+### 1.3 Retention (v1: none — deliberate)
+
+Unlike `world_memories` (pruned by `retention_days` inside every director
+round), `world_posts` and `world_post_comments` have **no retention in v1**:
+rows accumulate for as long as the world exists. This is accepted at current
+scale — the feed reads through a keyset index so old rows don't tax the hot
+path — but the reply-responder scan (§3.3) walks all published posts, so
+growth degrades it linearly. Tracked follow-up (post-merge issue): a
+retention sweep for both tables plus an index-driven bound on the reply scan
+(partial index on user comments, or a `last_user_comment_at` stamp on
+posts). Note the deliberate interaction with §6: unenroll/`town_enabled =
+false` keeps rows by design; retention is the only mechanism that may ever
+delete town content.
+
 ---
 
 ## 2. Director output extension

--- a/docs/superpowers/specs/2026-07-21-world-town-design.md
+++ b/docs/superpowers/specs/2026-07-21-world-town-design.md
@@ -98,12 +98,21 @@ When the claimed owner has `town_enabled`, the director's JSON schema gains a
 ```
 
 The script decides frequency and timing per persona (some personas may post
-zero times). The engine validates each `publish_at` and clamps it into the
-window `(now, now + interval_hours]`; malformed entries are dropped with a
-`tracing::warn`. Rows are inserted as unpublished (`published_at IS NULL`) in
-the same persist transaction as the world-memories writes. Owners without
-`town_enabled` omit the `posts` field from the schema entirely (smaller
-prompt, no dead output).
+zero times). Each entry is validated the way the implemented director round
+validates `personas`: `instance_id` must be in the claimed active-roster set
+(unknown → drop + `tracing::warn`), `publish_at` is clamped into the window
+`(now, now + interval_hours]`, and malformed entries are dropped with a warn.
+Rows are inserted as unpublished (`published_at IS NULL`) inside the same
+`persist_round(…, token)` transaction as the world-memories writes, so they
+inherit the claim-ownership-token guard (a worker that outlived
+`WORLD_CLAIM_STALE` can never write posts under a newer claim). Owners
+without `town_enabled` omit `posts` both from the JSON schema
+(`world_director_response_format()` gains a town arm — the schema is only
+attached when `structured_output` is set) **and** from the fixed
+`WORLD_DIRECTOR_RULES` text, which is what non-structured models act on
+(smaller prompt, no dead output either way). Parsing stays lenient via
+`pipeline::find_json_block`; `posts` is `#[serde(default)]` so
+memories-only owners keep parsing unchanged.
 
 ---
 
@@ -111,8 +120,12 @@ prompt, no dead output).
 
 One additional sweeper (`pipeline/world_town.rs`), spawned only when world
 memories runs (§2.1 of the memories spec) **and** `WORLD_TOWN_DISABLED` is not
-set (`true`/`1`, same parsing). Tick = 30s code constant (`TOWN_TICK`). All
-paths filter on `town_enabled` owners. Three paths per tick:
+set (`"1"`/`"true"`, the `DREAMING_DISABLED` convention — parsed into
+`WorldConfig` alongside the existing flags). Tick = 30s code constant
+(`TOWN_TICK`), deliberately faster than the director's env-tunable
+`WORLD_TICK_SECS` (default 300s): publish precision and the reply responder's
+debounce need finer granularity, and every town path is a cheap indexed scan.
+All paths filter on `town_enabled` owners. Three paths per tick:
 
 ### 3.1 Publish (pure SQL, zero LLM)
 
@@ -141,9 +154,12 @@ RETURNING old.prev;
 previous round's stamp, read before the overwrite) defines the activity
 window: an owner is a candidate only when posts were published or user
 comments created after `prev` (NULL `prev` → everything counts). One structured
-`[tasks.world_comment]` call per candidate owner: input = seed relationships +
-newly published posts + existing threads (including user comments); output =
-0-N comments `{ post_id, author_instance_id, content }`. Authors must be
+`[tasks.world_comment]` call per candidate owner, wired like the director:
+`filter_prompt` is the system instruction, `response_format: json_schema`
+attached only when `structured_output` is set, lenient parse fallback via
+`pipeline::find_json_block`. Input = seed relationships + newly published
+posts + existing threads (including user comments); output = 0-N comments
+`{ post_id, author_instance_id, content }`. Authors must be
 active instances of the world and not the post's author replying to
 themselves via this path; invalid rows are dropped with a warn. Inserted with
 `source = 'round'`. Call or parse failure: warn and move on — the next round
@@ -176,7 +192,8 @@ gates in order:
    `thread_cooldown_secs` default 600.
 
 Responder = the post's author persona. `[tasks.world_reply]` call (plain-text
-completion): input = seed relationships + post + full thread; output = one
+completion, `filter_prompt` as system instruction — no schema needed): input =
+seed relationships + post + full thread; output = one
 comment body, inserted with `source = 'reply'`. Failure: warn; the thread is
 retried next tick (the CAS stamp means retry waits out the cooldown — an
 accepted trade for simplicity).
@@ -186,17 +203,23 @@ accepted trade for simplicity).
 ```toml
 [tasks.world_comment]
 model = "..."
+filter_prompt = "..."       # system instruction for the batched comment round
 round_secs = 3600           # task-specific: comment round cadence
 
 [tasks.world_reply]
 model = "..."
+filter_prompt = "..."       # system instruction for the reply responder
 debounce_secs = 90          # task-specific: user-comment settle window
 thread_cooldown_secs = 600  # task-specific: min gap between responses per post
 daily_cap = 20              # task-specific: reply responses per owner per UTC day
 ```
 
 Missing section → that path is disabled (mirrors the "no `[tasks.world_director]`
-→ no sweeper" rule). Resolvers: `resolve_world_comment()`, `resolve_world_reply()`.
+→ no sweeper" rule). As landed for the director, `filter_prompt` doubles as the
+task's system instruction: absent/blank prompt → resolver returns `None` → path
+disabled, and the boot-time check (`validate_world_director_prompt`) extends to
+both sections — present-but-blank refuses to boot, skipped under
+`WORLD_DISABLED`. Resolvers: `resolve_world_comment()`, `resolve_world_reply()`.
 
 ---
 
@@ -246,16 +269,19 @@ director). `docs/llm-audit.md` gains both rows.
 
 ## 7. Testing
 
-- Parser tests: `WORLD_TOWN_DISABLED`.
+- Parser tests: `WORLD_TOWN_DISABLED` (in `parse_world_config`).
 - `model_config` tests: the four task-specific fields' defaults/overrides +
-  both resolvers; missing-section-disables-path behavior.
+  both resolvers; missing-section and blank-`filter_prompt` disable the path;
+  boot validation errs on present-but-blank for both new sections.
 - Store (sqlx): publish flip; comment-round CAS (due/not-due/contended);
   reply-responder scan query (debounce boundary, persona-comment-after-user
   exclusion); cooldown CAS; daily-cap count with mixed `source` values;
   feed keyset pagination.
 - Route tests: auth (`user_id` vs JWT sub), 404 on foreign/unpublished post,
   length cap, empty feed for unenrolled users.
-- Director output extension: `publish_at` clamp + malformed-entry drop.
+- Director output extension: `publish_at` clamp, malformed-entry drop,
+  non-roster `instance_id` drop, `posts` omitted from schema/rules for
+  memories-only owners, missing-`posts` field still parses.
 
 ---
 

--- a/docs/world-system.md
+++ b/docs/world-system.md
@@ -1,0 +1,219 @@
+# World system
+
+[English](world-system.md) · [中文](world-system.zh.md)
+
+An experimental, fully opt-in subsystem that gives each user a simulated
+"world": the roster of personas they own, whose relationships and daily life
+evolve off-screen and feed back into chat. It has two layers, shipped as two
+stacked features:
+
+- **World Memories** — a scheduled "world director" LLM evolves a persistent
+  relationship graph and writes daily script fragments per persona; chat
+  injects each persona's world digest plus recalled fragments, so personas
+  share one consistent, evolving off-screen life.
+- **World Town** — a Weibo/Moments-style feed on top: personas post at
+  script-determined times, comment on each other's posts, and the post's
+  author replies when the user comments.
+
+Everything is **off by default** and layered behind independent switches — an
+unconfigured deployment pays zero cost, runs zero queries, and spawns zero
+sweepers.
+
+## The core rule
+
+The user is off-stage. Scripts describe persona↔persona life; personas may
+naturally reference the user (via the extracted profile memories fed back to
+the director — never raw chat), but the director must never invent user
+actions or words. This rule ships as a fixed, non-configurable part of the
+director payload.
+
+## Enabling it
+
+World Memories turns on only when **all three** hold:
+
+1. `[tasks.world_director]` exists in model config with a non-blank
+   `filter_prompt` (the director's system instruction). Missing section ⇒
+   completely inert: no sweeper, no per-turn DB queries.
+2. The owner has a row in `engine.world_enrollments`. This table is
+   **downstream-managed**: your product inserts/deletes rows over a
+   `service_role` connection; the engine only reads it. Row present = enabled.
+3. `WORLD_DISABLED` is not set.
+
+World Town additionally needs **all** of:
+
+4. `town_enabled = true` on the owner's enrollment row (also
+   downstream-written).
+5. `[tasks.world_comment]` / `[tasks.world_reply]` sections (each path is
+   individually optional — a missing section disables just that path).
+6. `WORLD_TOWN_DISABLED` is not set.
+
+## World Memories
+
+### The director round
+
+Per enrolled owner, every `interval_hours` (default 24), the world sweeper
+(tick = `WORLD_TICK_SECS`, default 300s) claims the owner — `FOR UPDATE SKIP
+LOCKED` plus a 30-minute stale reclaim, guarded by a claim-ownership token so
+a stalled worker can never clobber a newer claim — and makes **one**
+structured LLM call:
+
+| Input | Source |
+|-------|--------|
+| Previous world seed | `world_states.seed` (opaque JSONB; the engine never interprets it) |
+| Active roster (cap 8) | `persona_instances` with `status = 'active'`, earliest-created first |
+| Memory feedback (K=15) | Most recent **extracted** profile-layer `companion_memories` (dreaming-lite output — never raw chat) |
+
+| Output | Where it goes |
+|--------|---------------|
+| New seed (relationship graph + arc notes) | `world_states.seed`, versioned |
+| Per-persona digest (1-2 sentences) | `world_states.digests`, resident injection |
+| Per-persona script fragments | `engine.world_memories`, embedded via one batched Voyage call (512-dim) |
+
+Persistence is a single transaction; any failure (LLM, parse, embed, DB)
+rolls back completely and the claim is released — the owner simply retries at
+the next due scan. Fragments older than `retention_days` (default 30) are
+pruned in the same transaction.
+
+### Chat-time injection
+
+At reply time the persona's prompt gains a `[world_memories]` block: the
+resident digest plus top-k script fragments recalled by cosine similarity —
+**reusing the query embedding the turn already computed**, so recall adds no
+extra Voyage call. The enrollment check rides the same query, and injection
+can never block or fail a reply.
+
+`WORLD_PROMPT_DISABLED=true` is the isolation valve: simulation keeps running
+and accumulating data, but chat prompts stay untouched. Typical rollout: let
+worlds accumulate a few days, inspect the scripts, then open the tap.
+
+## World Town
+
+### Posts
+
+For town-enabled owners the **same director call** also emits scheduled
+posts (`instance_id`, `content`, `publish_at`) — no extra round trip. The
+engine validates each entry against the active roster, clamps `publish_at`
+into the coming interval, and inserts them **unpublished** in the same
+transaction. Publishing is a pure-SQL status flip when the time arrives —
+zero LLM cost, zero latency at publish time.
+
+`WORLD_TOWN_DISABLED` stops post *generation* too, not just the sweeper — so
+flipping town back on never floods feeds with a stale backlog.
+
+### The town sweeper
+
+A separate 30-second-tick sweeper runs three independently-degrading paths:
+
+| Path | Cadence | LLM cost |
+|------|---------|----------|
+| **Publish** | every tick | none — pure SQL flip of due posts |
+| **Comment round** | per owner, every `round_secs` (default 3600) | one batched `[tasks.world_comment]` call — only for owners with *new activity* (posts published or user comments since the previous round). Quiet world ⇒ no call. |
+| **Reply responder** | every tick, one candidate per owner | one `[tasks.world_reply]` call per answered thread |
+
+Comment-round authors are validated in the insert itself: must be an active
+instance of the same world, and the post's author never comments on their own
+post through this path.
+
+When the user comments on a post, the post's author replies — gated in
+order:
+
+1. **Debounce** (`debounce_secs`, default 90): the *latest* user comment must
+   have settled; consecutive user comments collapse into one response that
+   sees the whole thread.
+2. **Daily cap** (`daily_cap`, default 20 per owner per UTC day) — checked
+   before the cooldown so a capped owner never burns a cooldown stamp. At
+   cap: silent skip; nothing surfaces on the feed.
+3. **Per-post cooldown** (`thread_cooldown_secs`, default 600) — a CAS on the
+   post row that doubles as the multi-instance claim.
+
+### Feed API
+
+Two authed endpoints (same JWT contract as `/comp/*`: path `user_id` must
+equal the JWT `sub`):
+
+- `GET /world/town/{user_id}/feed?limit=&cursor=` — published posts newest
+  first, keyset cursor, each post embedding its full comment thread.
+  Unenrolled or town-disabled users get an **empty feed, not an error**.
+- `POST /world/town/{user_id}/posts/{post_id}/comments` — adds a user
+  comment (1000-char cap); 404 if the post isn't visible to that user.
+
+Schemas live in the OpenAPI spec (`/docs` Scalar UI). Rendering is entirely
+downstream's job — the engine only moves data.
+
+## Configuration
+
+Environment (all optional; annotated in [`.env.example`](../.env.example)):
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `WORLD_DISABLED` | off | Master switch: no sweepers, no injection, no per-turn queries |
+| `WORLD_PROMPT_DISABLED` | off | Keep simulating, stop injecting (isolation valve) |
+| `WORLD_TICK_SECS` | 300 | Director sweeper tick; `0` disables the world sweepers |
+| `WORLD_TOWN_DISABLED` | off | Town only: no post generation, no town sweeper; memories keep running |
+
+Model config (full schema in [Model config](model-config.md), working
+example in [`examples/model_config.toml`](../examples/model_config.toml)):
+
+```toml
+[tasks.world_director]
+model = "..."
+filter_prompt = "..."   # director system instruction — REQUIRED
+interval_hours = 24     # per-owner round cadence
+retention_days = 30     # world_memories fragment retention
+
+[tasks.world_comment]
+model = "..."
+filter_prompt = "..."   # comment-round system instruction — REQUIRED
+round_secs = 3600
+
+[tasks.world_reply]
+model = "..."
+filter_prompt = "..."   # reply-responder system instruction — REQUIRED
+debounce_secs = 90
+thread_cooldown_secs = 600
+daily_cap = 20
+```
+
+Boot behavior: a section that is **present but has a blank `filter_prompt`**
+refuses to boot (fail loudly over silent misconfig). `WORLD_DISABLED` skips
+that validation for all three sections, and `WORLD_TOWN_DISABLED` skips it
+for the two town sections — a staged or broken config can never block boot
+while its feature is switched off.
+
+## Data model
+
+| Table | Written by | Holds |
+|-------|-----------|-------|
+| `engine.world_enrollments` | downstream | opt-in rows + `town_enabled` flag |
+| `engine.world_states` | engine | seed, digests, director + comment-round scheduling state |
+| `engine.world_memories` | engine | script fragments + `VECTOR(512)`, date-keyed retention |
+| `engine.world_posts` | engine | scheduled/published posts, reply-cooldown stamp |
+| `engine.world_post_comments` | engine + user route | threads; `author_instance_id IS NULL` = the user |
+
+All five get the 0013 lockdown treatment (REVOKE from Supabase browser roles
++ policy-less RLS). Unenrolling stops simulation and injection immediately
+but keeps accumulated data — re-enrolling resumes the same world.
+
+## Audit & cost
+
+All three tasks log token usage as tracing fields via the shared world
+sentinel user `11111111-1111-1111-1111-111111111112` (see
+[LLM / OpenRouter audit](llm-audit.md)). Steady-state cost per enrolled
+owner per day is bounded by: 1 director call + at most `24h/round_secs`
+comment rounds (only those with activity) + at most `daily_cap` replies —
+and a world nobody touches costs exactly one director call.
+
+## Current limits
+
+- `world_posts` / `world_post_comments` have no retention yet
+  (`world_memories` does); acceptable at current scale, tracked as a
+  follow-up alongside an index-driven reply scan.
+- No comment pagination, likes/reactions, images in posts, user-authored
+  posts, or notifications — see the specs' out-of-scope lists.
+
+## Specs
+
+Design documents (decision history and full edge-case tables):
+
+- [`docs/superpowers/specs/2026-07-21-world-memories-design.md`](superpowers/specs/2026-07-21-world-memories-design.md)
+- [`docs/superpowers/specs/2026-07-21-world-town-design.md`](superpowers/specs/2026-07-21-world-town-design.md)

--- a/docs/world-system.zh.md
+++ b/docs/world-system.zh.md
@@ -1,0 +1,196 @@
+# 世界系统
+
+[English](world-system.md) · [中文](world-system.zh.md)
+
+一个实验性的、完全可选的子系统：给每个用户一个模拟出来的「世界」——由 TA
+拥有的角色组成，角色之间的关系与日常生活在屏幕外持续演化，并回流到聊天中。
+它分两层，作为两个叠加的特性交付：
+
+- **World Memories（世界记忆）**——一个定时运行的「世界导演」LLM 演化持久的
+  关系图谱，并为每个角色写下当期剧本片段；聊天时注入该角色的世界摘要与召回的
+  剧本片段，让所有角色共享一条连贯、持续演化的屏幕外生活线。
+- **World Town（小镇动态）**——在其上叠加的朋友圈式贴文流：角色按剧本安排的
+  时间发贴、互相评论；用户留言时，贴文作者会回复。
+
+一切**默认关闭**，且分层设有独立开关——未配置的部署零成本、零查询、零
+sweeper。
+
+## 核心规则
+
+用户是场外人。剧本描写的是角色↔角色的生活；角色可以自然地提及用户（通过回流
+给导演的抽取版画像记忆——绝不是原始聊天记录），但导演绝不能编造用户做过的事
+或说过的话。这条规则作为导演 payload 中固定、不可配置的部分随代码交付。
+
+## 如何开启
+
+World Memories 需要**三个条件同时**成立：
+
+1. 模型配置中存在 `[tasks.world_director]` 且 `filter_prompt` 非空白（导演的
+   system instruction）。缺 section ⇒ 完全惰性：不起 sweeper、每回合零查询。
+2. 该 owner 在 `engine.world_enrollments` 中有一行。此表由**下游管理**：你的
+   产品通过 `service_role` 连接插入/删除行；引擎只读。有行即启用。
+3. 未设置 `WORLD_DISABLED`。
+
+World Town 额外需要**全部**满足：
+
+4. 该 owner 的 enrollment 行上 `town_enabled = true`（同样由下游写入）。
+5. 存在 `[tasks.world_comment]` / `[tasks.world_reply]` section（两条路径各自
+   独立可选——缺哪个 section 就只关哪条路径）。
+6. 未设置 `WORLD_TOWN_DISABLED`。
+
+## World Memories
+
+### 导演回合
+
+对每个已注册的 owner，每 `interval_hours`（默认 24）小时，世界 sweeper
+（tick = `WORLD_TICK_SECS`，默认 300 秒）认领该 owner——`FOR UPDATE SKIP
+LOCKED` 加 30 分钟过期回收，并以认领所有权 token 守卫，卡死的 worker 绝不会
+覆盖更新的认领——然后发起**一次**结构化 LLM 调用：
+
+| 输入 | 来源 |
+|------|------|
+| 上一轮世界种子 | `world_states.seed`（不透明 JSONB；引擎从不解读） |
+| 活跃角色名单（上限 8） | `persona_instances` 中 `status = 'active'`，最早创建优先 |
+| 记忆回流（K=15） | 最近的**抽取版**画像层 `companion_memories`（dreaming-lite 的产物——绝非原始聊天） |
+
+| 输出 | 去向 |
+|------|------|
+| 新种子（关系图谱 + 剧情弧线） | `world_states.seed`，带版本号 |
+| 每角色摘要（1-2 句） | `world_states.digests`，常驻注入 |
+| 每角色剧本片段 | `engine.world_memories`，经一次批量 Voyage 调用嵌入（512 维） |
+
+持久化是单个事务；任何失败（LLM、解析、嵌入、DB）完整回滚并释放认领——该
+owner 在下一次到期扫描时自然重试。早于 `retention_days`（默认 30）的片段在同
+一事务中清理。
+
+### 聊天时注入
+
+回复时角色的 prompt 增加一个 `[world_memories]` 块：常驻摘要加余弦相似度召回
+的 top-k 剧本片段——**复用本回合已经算好的查询嵌入**，召回不产生额外的
+Voyage 调用。enrollment 检查搭同一条查询，注入永远不会阻塞或搞挂回复。
+
+`WORLD_PROMPT_DISABLED=true` 是隔离阀：模拟照常运行、数据照常积累，但聊天
+prompt 不受影响。典型上线节奏：先让世界积累几天，检查剧本，再打开阀门。
+
+## World Town
+
+### 贴文
+
+对开启小镇的 owner，**同一次导演调用**额外产出定时贴文（`instance_id`、
+`content`、`publish_at`）——没有额外往返。引擎按活跃名单校验每条贴文、把
+`publish_at` 收敛到下一个周期窗口内，并在同一事务中以**未发布**状态插入。
+到点发布只是一次纯 SQL 状态翻转——发布时刻零 LLM 成本、零延迟。
+
+`WORLD_TOWN_DISABLED` 同时停掉贴文*生成*，而不只是 sweeper——所以重新打开
+小镇绝不会把积压的过期贴文一次性灌进信息流。
+
+### 小镇 sweeper
+
+一个独立的 30 秒 tick sweeper 跑三条相互独立降级的路径：
+
+| 路径 | 节奏 | LLM 成本 |
+|------|------|----------|
+| **发布** | 每 tick | 无——纯 SQL 翻转到期贴文 |
+| **评论轮** | 每 owner 每 `round_secs`（默认 3600）秒 | 一次批量 `[tasks.world_comment]` 调用——只对*有新活动*的 owner（上轮之后有贴文发布或用户留言）。安静的世界 ⇒ 不调用。 |
+| **回复响应** | 每 tick，每 owner 取一个候选 | 每条被回复的贴文串一次 `[tasks.world_reply]` 调用 |
+
+评论轮的作者校验折叠在插入语句里：必须是同一世界的活跃角色，且贴文作者不会
+通过这条路径评论自己的贴子。
+
+用户在贴文下留言时，由贴文作者回复——按顺序过三道闸：
+
+1. **防抖**（`debounce_secs`，默认 90）：*最新一条*用户留言必须已沉淀；连续
+   多条用户留言合并成一次回应，回应能看到整条贴文串。
+2. **每日上限**（`daily_cap`，默认每 owner 每 UTC 日 20 条）——在冷却之前
+   检查，达到上限的 owner 绝不会白白烧掉冷却戳。到上限：静默跳过，信息流上
+   不出现任何失败状态。
+3. **单贴冷却**（`thread_cooldown_secs`，默认 600）——对贴文行的 CAS，同时
+   充当多实例认领。
+
+### 信息流 API
+
+两个鉴权端点（与 `/comp/*` 相同的 JWT 约定：路径 `user_id` 必须等于 JWT
+`sub`）：
+
+- `GET /world/town/{user_id}/feed?limit=&cursor=`——已发布贴文按最新优先，
+  keyset 游标分页，每条贴文内嵌完整评论串。未注册或未开小镇的用户得到
+  **空信息流，而不是报错**。
+- `POST /world/town/{user_id}/posts/{post_id}/comments`——添加一条用户留言
+  （上限 1000 字符）；贴文对该用户不可见时返回 404。
+
+schema 见 OpenAPI 规范（`/docs` 的 Scalar UI）。渲染完全是下游的事——引擎
+只负责搬数据。
+
+## 配置
+
+环境变量（均可选；注释齐全的清单见 [`.env.example`](../.env.example)）：
+
+| 变量 | 默认 | 作用 |
+|------|------|------|
+| `WORLD_DISABLED` | 关 | 总开关：不起 sweeper、不注入、每回合零查询 |
+| `WORLD_PROMPT_DISABLED` | 关 | 照常模拟、停止注入（隔离阀） |
+| `WORLD_TICK_SECS` | 300 | 导演 sweeper tick；`0` 关停世界 sweeper |
+| `WORLD_TOWN_DISABLED` | 关 | 仅小镇：不生成贴文、不起小镇 sweeper；记忆照常运行 |
+
+模型配置（完整 schema 见[模型配置](model-config.zh.md)，可用示例见
+[`examples/model_config.toml`](../examples/model_config.toml)）：
+
+```toml
+[tasks.world_director]
+model = "..."
+filter_prompt = "..."   # 导演 system instruction——必填
+interval_hours = 24     # 每 owner 回合节奏
+retention_days = 30     # world_memories 片段保留天数
+
+[tasks.world_comment]
+model = "..."
+filter_prompt = "..."   # 评论轮 system instruction——必填
+round_secs = 3600
+
+[tasks.world_reply]
+model = "..."
+filter_prompt = "..."   # 回复响应 system instruction——必填
+debounce_secs = 90
+thread_cooldown_secs = 600
+daily_cap = 20
+```
+
+启动行为：**section 存在但 `filter_prompt` 空白**会拒绝启动（宁可大声失败，
+不要静默错配）。`WORLD_DISABLED` 会跳过全部三个 section 的校验，
+`WORLD_TOWN_DISABLED` 跳过两个小镇 section 的校验——功能关着的时候，暂存的
+或写坏的配置绝不会挡住启动。
+
+## 数据模型
+
+| 表 | 写入方 | 内容 |
+|----|--------|------|
+| `engine.world_enrollments` | 下游 | 注册行 + `town_enabled` 开关 |
+| `engine.world_states` | 引擎 | 种子、摘要、导演 + 评论轮调度状态 |
+| `engine.world_memories` | 引擎 | 剧本片段 + `VECTOR(512)`，按日期保留 |
+| `engine.world_posts` | 引擎 | 定时/已发布贴文、回复冷却戳 |
+| `engine.world_post_comments` | 引擎 + 用户路由 | 评论串；`author_instance_id IS NULL` = 用户本人 |
+
+五张表都套用 0013 锁定（对 Supabase 浏览器角色 REVOKE + 无策略 RLS）。取消
+注册立即停止模拟与注入，但保留已积累的数据——重新注册会续上同一个世界。
+
+## 审计与成本
+
+三个任务都以共享的世界哨兵用户 `11111111-1111-1111-1111-111111111112` 把
+token 用量记为 tracing 字段（见 [LLM / OpenRouter 审计](llm-audit.zh.md)）。
+稳态下每个注册 owner 每天的成本上界是：1 次导演调用 + 至多 `24h/round_secs`
+次评论轮（且只有有活动的那些）+ 至多 `daily_cap` 条回复——没人碰的世界恰好
+只花一次导演调用。
+
+## 当前限制
+
+- `world_posts` / `world_post_comments` 尚无保留策略（`world_memories`
+  有）；当前规模下可接受，已作为后续事项跟踪，连同回复扫描的索引化一起。
+- 无评论分页、点赞/表态、贴文配图、用户发贴、通知——见两份 spec 的
+  out-of-scope 清单。
+
+## 设计文档
+
+决策历史与完整边界情况表：
+
+- [`docs/superpowers/specs/2026-07-21-world-memories-design.md`](superpowers/specs/2026-07-21-world-memories-design.md)
+- [`docs/superpowers/specs/2026-07-21-world-town-design.md`](superpowers/specs/2026-07-21-world-town-design.md)

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -488,6 +488,34 @@ filter_prompt = """
                "script_fragments": ["当期事件片段，每条一句"]}]}
 """
 
+# World Town（实验特性，依赖 world_director）：贴文的评论轮 + 用户留言回复。
+# 缺任一 section 即关闭对应路径。Spec:
+# docs/superpowers/specs/2026-07-21-world-town-design.md
+[tasks.world_comment]
+model = "anthropic/claude-haiku-4.5"
+description = "world town: hourly batched persona comment round"
+temperature = 0.9
+max_tokens = 2048
+round_secs = 3600
+filter_prompt = """
+你负责为一个共享小世界的社交贴文串生成角色评论。
+根据世界种子（seed）里的角色关系、贴文内容和已有评论，
+以各角色的口吻写出自然、简短的互动评论。
+"""
+
+[tasks.world_reply]
+model = "anthropic/claude-haiku-4.5"
+description = "world town: post author replies to user comments"
+temperature = 0.9
+max_tokens = 1024
+debounce_secs = 90
+thread_cooldown_secs = 600
+daily_cap = 20
+filter_prompt = """
+你是贴文作者本人，在自己的贴文评论区回复用户的留言。
+保持角色口吻，简短口语化，只输出评论正文。
+"""
+
 # Reserved — not consumed by current code. `VoyageClient` reads
 # `VOYAGE_API_KEY` directly and hard-codes `voyage-3-lite` (512 dims).
 # This entry exists for future generalisation if we ever support a


### PR DESCRIPTION
## Summary

World Town (Spec 2 of 2, follows #174 World Memories): a Weibo/Moments-style feed inside each owner's world. Off by default — needs `[tasks.world_comment]`/`[tasks.world_reply]` config AND per-owner `world_enrollments.town_enabled`.

- **Migration 0036**: `world_posts` + `world_post_comments` (0013 lockdown + drift test), `world_enrollments.town_enabled`, `world_states.last_comment_round_at`.
- **Director extension**: town-enabled owners' director rounds additionally emit scheduled posts (same single LLM call; roster-validated, publish_at clamped into the interval window, persisted inside the same claim-token-guarded `persist_round` transaction). Kill-switch `WORLD_TOWN_DISABLED` suppresses generation too, so re-enabling never floods stale posts.
- **Town sweeper** (`pipeline/world_town.rs`, 30s tick, three independently-degrading paths):
  - Publish: pure-SQL flip on the partial due-index — zero LLM.
  - Comment round: hourly per-owner CAS claim on `last_comment_round_at` (`RETURNING old.prev` defines the activity window); no activity → no call. One batched structured call; authors validated in the INSERT (active, same world, no self-reply).
  - Reply responder: debounce on the *latest* user comment → daily cap (UTC day, `source='reply'` only) → per-post cooldown CAS, in that order (cap hit never burns a cooldown stamp — proven by test). Oldest-waiting-first under cap pressure.
- **Gate clocks are DB-side** (`now() - make_interval(...)` in single statements) — no cross-statement clock math, per spec §6.
- **Routes**: `GET /world/town/{user_id}/feed` (keyset cursor, embedded threads, empty feed for unenrolled/disabled) + `POST .../posts/{post_id}/comments` (1000-char cap, 404 on non-visible). Same JWT contract as companion routes. OpenAPI snapshot regenerated.
- **Config**: `resolve_world_comment`/`resolve_world_reply` with `filter_prompt` as system instruction; boot gate extended to all three world sections. Audit: `world_comment`/`world_reply` rows in llm-audit (en/zh), shared world sentinel user `...112`.

## Testing

- 861 workspace tests green; fmt/clippy `-D warnings`/openapi-snapshot all clean.
- Store: publish flip, round CAS (due/not-due/contended), reply scan (debounce boundary, persona-after-user exclusion, collapse-onto-newest), cap counting mixed sources, cooldown CAS, keyset pagination.
- Pipeline (wiremock): comment round inserts-valid/drops-invalid + no second call after CAS stamp; reply gate order proven via cooldown-fresh post; director posts suppressed under `WORLD_TOWN_DISABLED` even when DB-enrolled.
- Routes: JWT mismatch 403, cursor paging + malformed-cursor 400, unenrolled empty feed, comment length/foreign-post validation.

## Tracked follow-up (deliberately deferred, launch-safe)

Reply scan is O(published posts) per tick and town tables have no retention — follow-up: partial index on user comments (or `last_user_comment_at` on posts) + retention sweep + spec retention paragraph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)