### PR TITLE
feat: OpenRouter stream hardening — Batch A (mid-stream errors, timeouts, http2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1852,6 +1852,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls", "postgres",
 uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 chrono-tz = "0.10"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream", "http2"] }
 thiserror = "1"
 anyhow = "1"
 tracing = "0.1"

--- a/crates/eros-engine-llm/Cargo.toml
+++ b/crates/eros-engine-llm/Cargo.toml
@@ -30,5 +30,5 @@ async-stream       = { workspace = true }
 
 [dev-dependencies]
 wiremock = "0.6"
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
 tempfile = "3"

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -2067,10 +2067,7 @@ data: [DONE]\n\n";
         // time auto-advances, so this runs in microseconds).
         let inner = futures_util::stream::iter([Ok::<_, std::convert::Infallible>("chunk")])
             .chain(futures_util::stream::pending());
-        let mut s = std::pin::pin!(idle_bounded(
-            inner,
-            std::time::Duration::from_millis(50)
-        ));
+        let mut s = std::pin::pin!(idle_bounded(inner, std::time::Duration::from_millis(50)));
         let first = s.next().await.expect("first item");
         assert_eq!(first.expect("passthrough"), "chunk");
         let second = s.next().await.expect("watchdog fires");
@@ -2084,11 +2081,11 @@ data: [DONE]\n\n";
         use futures_util::StreamExt;
         let inner =
             futures_util::stream::iter(["a", "b", "c"].map(Ok::<_, std::convert::Infallible>));
-        let s = std::pin::pin!(idle_bounded(
-            inner,
-            std::time::Duration::from_millis(50)
-        ));
-        let items: Vec<&str> = s.map(|r| r.expect("no timeout on a live stream")).collect().await;
+        let s = std::pin::pin!(idle_bounded(inner, std::time::Duration::from_millis(50)));
+        let items: Vec<&str> = s
+            .map(|r| r.expect("no timeout on a live stream"))
+            .collect()
+            .await;
         assert_eq!(items, vec!["a", "b", "c"]);
     }
 

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -11,6 +11,40 @@ use crate::model_config::ReasoningConfig;
 
 const BASE_URL: &str = "https://openrouter.ai/api/v1/chat/completions";
 
+/// Max TCP+TLS establishment time for any OpenRouter call.
+const CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+/// How long an idle pooled connection is kept for reuse.
+const POOL_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
+/// Max gap between SSE *bytes* before a live stream is declared dead.
+const STREAM_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(45);
+
+/// Gap-bound a fallible stream: an idle period longer than `idle` between
+/// items becomes an io TimedOut error item. Applied to the raw BYTES stream
+/// (before SSE parsing) deliberately: OpenRouter's `: OPENROUTER PROCESSING`
+/// comment keepalives count as bytes and reset the timer, so a reasoning
+/// model thinking for minutes stays alive while a dead peer trips it.
+fn idle_bounded<S, T, E>(
+    s: S,
+    idle: std::time::Duration,
+) -> impl futures_util::Stream<Item = Result<T, std::io::Error>>
+where
+    S: futures_util::Stream<Item = Result<T, E>>,
+    E: std::error::Error + Send + Sync + 'static,
+{
+    use tokio_stream::StreamExt as _;
+    s.timeout(idle).map(move |r| match r {
+        Ok(Ok(b)) => Ok(b),
+        Ok(Err(e)) => Err(std::io::Error::other(e)),
+        Err(_elapsed) => Err(std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            format!(
+                "openrouter stream idle timeout: no bytes for {}s",
+                idle.as_secs()
+            ),
+        )),
+    })
+}
+
 /// OpenRouter app-attribution header names. Pinned to the current
 /// `https://openrouter.ai/docs/app-attribution` spec. If OpenRouter
 /// renames either header in the future, update the value here; today's
@@ -587,8 +621,14 @@ impl OpenRouterClient {
                 ),
             }
         }
+        // connect/pool bounds only — deliberately NO global `.timeout()` or
+        // client-level read timeout: both would also bound non-streaming calls
+        // (image generation legitimately spends its whole wall-time before the
+        // first body byte). Stream liveness is `idle_bounded`'s job.
         let http = reqwest::Client::builder()
             .default_headers(headers)
+            .connect_timeout(CONNECT_TIMEOUT)
+            .pool_idle_timeout(POOL_IDLE_TIMEOUT)
             .build()
             .expect("reqwest client build never fails with empty config");
         Self {
@@ -1096,8 +1136,7 @@ impl OpenRouterClient {
             return Err(LlmError::Status(status, text));
         }
 
-        let stream = resp
-            .bytes_stream()
+        let stream = idle_bounded(resp.bytes_stream(), STREAM_IDLE_TIMEOUT)
             .eventsource()
             .filter_map(|ev| async move {
                 match ev {
@@ -2018,6 +2057,39 @@ data: [DONE]\n\n";
             matches!(item, Err(LlmError::StreamParse(_))),
             "expected StreamParse error, got {item:?}"
         );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn idle_bounded_times_out_on_stalled_stream() {
+        use futures_util::StreamExt;
+        // One item arrives, then the stream stalls forever: the watchdog must
+        // pass the item through, then yield a TimedOut error (paused tokio
+        // time auto-advances, so this runs in microseconds).
+        let inner = futures_util::stream::iter([Ok::<_, std::convert::Infallible>("chunk")])
+            .chain(futures_util::stream::pending());
+        let mut s = std::pin::pin!(idle_bounded(
+            inner,
+            std::time::Duration::from_millis(50)
+        ));
+        let first = s.next().await.expect("first item");
+        assert_eq!(first.expect("passthrough"), "chunk");
+        let second = s.next().await.expect("watchdog fires");
+        let err = second.expect_err("stalled gap must error");
+        assert_eq!(err.kind(), std::io::ErrorKind::TimedOut);
+        assert!(err.to_string().contains("idle timeout"), "{err}");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn idle_bounded_passes_healthy_stream_untouched() {
+        use futures_util::StreamExt;
+        let inner =
+            futures_util::stream::iter(["a", "b", "c"].map(Ok::<_, std::convert::Infallible>));
+        let s = std::pin::pin!(idle_bounded(
+            inner,
+            std::time::Duration::from_millis(50)
+        ));
+        let items: Vec<&str> = s.map(|r| r.expect("no timeout on a live stream")).collect().await;
+        assert_eq!(items, vec!["a", "b", "c"]);
     }
 
     #[tokio::test]

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -483,6 +483,17 @@ struct WireStreamChoice {
     finish_reason: Option<String>,
 }
 
+/// Top-level `error` object OpenRouter embeds in an HTTP-200 SSE data frame
+/// when a provider fails mid-stream (docs: "API Streaming — error handling").
+/// `code` is upstream-defined (int or string) — kept opaque.
+#[derive(Debug, Deserialize)]
+struct WireStreamError {
+    #[serde(default)]
+    code: Option<serde_json::Value>,
+    #[serde(default)]
+    message: String,
+}
+
 #[derive(Debug, Deserialize)]
 struct WireStreamFrame {
     #[serde(default)]
@@ -493,6 +504,8 @@ struct WireStreamFrame {
     usage: Option<UsageBlock>,
     #[serde(default)]
     choices: Vec<WireStreamChoice>,
+    #[serde(default)]
+    error: Option<WireStreamError>,
 }
 
 /// App-Attribution headers sent on every outbound OpenRouter call.
@@ -1094,7 +1107,26 @@ impl OpenRouterClient {
                         }
                         match serde_json::from_str::<WireStreamFrame>(&e.data) {
                             Ok(frame) => {
+                                // A mid-stream provider failure arrives as a
+                                // normal-looking 200 SSE frame with a top-level
+                                // `error` (and/or finish_reason:"error"). It
+                                // must fail the attempt so the pipeline's
+                                // fallback chain runs — NOT parse as an
+                                // all-None chunk that lets a partial reply
+                                // persist as a clean success.
+                                if let Some(err) = frame.error {
+                                    return Some(Err(LlmError::Provider(format!(
+                                        "openrouter mid-stream error: code={:?}: {}",
+                                        err.code, err.message
+                                    ))));
+                                }
                                 let choice = frame.choices.into_iter().next().unwrap_or_default();
+                                if choice.finish_reason.as_deref() == Some("error") {
+                                    return Some(Err(LlmError::Provider(
+                                        "openrouter stream terminated with finish_reason=error"
+                                            .into(),
+                                    )));
+                                }
                                 Some(Ok(DeltaChunk {
                                     content: choice.delta.content.filter(|s| !s.is_empty()),
                                     finish_reason: choice.finish_reason,
@@ -1985,6 +2017,107 @@ data: [DONE]\n\n";
         assert!(
             matches!(item, Err(LlmError::StreamParse(_))),
             "expected StreamParse error, got {item:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_stream_surfaces_mid_stream_error_frame() {
+        use futures_util::StreamExt;
+        // OpenRouter signals a mid-stream provider failure on an HTTP-200 SSE
+        // stream as a data frame with a top-level `error` object (plus a
+        // finish_reason:"error" choice). It must surface as Err, not parse as
+        // an all-None chunk that lets a partial reply persist as success.
+        let server = MockServer::start().await;
+        let body = "\
+data: {\"id\":\"gen-1\",\"choices\":[{\"delta\":{\"content\":\"部分\"}}]}\n\n\
+data: {\"choices\":[{\"delta\":{\"content\":\"\"},\"finish_reason\":\"error\"}],\"error\":{\"code\":502,\"message\":\"provider disconnected\"}}\n\n\
+data: [DONE]\n\n";
+        Mock::given(path("/api/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(body, "text/event-stream"),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = OpenRouterClient::with_base_url(
+            "test-key".into(),
+            AppAttribution::default(),
+            format!("{}/api/v1/chat/completions", server.uri()),
+        );
+        let mut stream = client
+            .execute_stream(ChatRequest {
+                model: "x-ai/grok-4-fast".into(),
+                messages: vec![ChatMessage {
+                    role: "user".into(),
+                    content: "hi".into(),
+                }],
+                temperature: 0.0,
+                max_tokens: 16,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        let first = stream.next().await.expect("delta arrives");
+        let chunk = first.expect("first frame is a normal delta");
+        assert_eq!(chunk.content.as_deref(), Some("部分"));
+
+        let second = stream.next().await.expect("error frame arrives");
+        match second {
+            Err(LlmError::Provider(msg)) => {
+                assert!(
+                    msg.contains("provider disconnected"),
+                    "error message carries the upstream detail: {msg}"
+                );
+            }
+            other => panic!("expected Provider error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_stream_surfaces_finish_reason_error_without_error_object() {
+        use futures_util::StreamExt;
+        // Some providers set finish_reason:"error" without the top-level error
+        // object; that terminal frame must also fail the attempt.
+        let server = MockServer::start().await;
+        let body = "\
+data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"error\"}]}\n\n\
+data: [DONE]\n\n";
+        Mock::given(path("/api/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(body, "text/event-stream"),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = OpenRouterClient::with_base_url(
+            "test-key".into(),
+            AppAttribution::default(),
+            format!("{}/api/v1/chat/completions", server.uri()),
+        );
+        let mut stream = client
+            .execute_stream(ChatRequest {
+                model: "x-ai/grok-4-fast".into(),
+                messages: vec![ChatMessage {
+                    role: "user".into(),
+                    content: "hi".into(),
+                }],
+                temperature: 0.0,
+                max_tokens: 16,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        let item = stream.next().await.expect("terminal frame arrives");
+        assert!(
+            matches!(item, Err(LlmError::Provider(_))),
+            "finish_reason=error must surface as Provider error, got {item:?}"
         );
     }
 

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -527,10 +527,28 @@ fn drive_chat_burst(
                 per_model_req.model = model_id.clone();
                 per_model_req.fallback_model = Vec::new();
 
-                match state.openrouter.execute_stream(per_model_req).await {
-                    Ok(mut s) => {
+                match tokio::time::timeout(
+                    STREAM_OPEN_TIMEOUT,
+                    state.openrouter.execute_stream(per_model_req),
+                )
+                .await
+                {
+                    Ok(Ok(mut s)) => {
                         use futures_util::StreamExt as _;
-                        while let Some(item) = s.next().await {
+                        let deadline = tokio::time::Instant::now() + STREAM_TOTAL_TIMEOUT;
+                        loop {
+                            let item = match tokio::time::timeout_at(deadline, s.next()).await {
+                                Ok(Some(item)) => item,
+                                Ok(None) => break,
+                                Err(_) => {
+                                    tracing::warn!(
+                                        "stream: total timeout ({}s), advancing chain",
+                                        STREAM_TOTAL_TIMEOUT.as_secs()
+                                    );
+                                    truncated = true;
+                                    break;
+                                }
+                            };
                             match item {
                                 Ok(c) => {
                                     if let Some(content) = c.content {
@@ -565,8 +583,15 @@ fn drive_chat_burst(
                             empty_completion = true;
                         }
                     }
-                    Err(e) => {
+                    Ok(Err(e)) => {
                         tracing::warn!("stream: upstream open err: {e}");
+                        truncated = true;
+                    }
+                    Err(_) => {
+                        tracing::warn!(
+                            "stream: open timeout ({}s), advancing chain",
+                            STREAM_OPEN_TIMEOUT.as_secs()
+                        );
                         truncated = true;
                     }
                 }
@@ -787,10 +812,28 @@ fn drive_chat_burst(
             let mut per_model_req = req.clone();
             per_model_req.model = model_id.clone();
             per_model_req.fallback_model = Vec::new();
-            match state.openrouter.execute_stream(per_model_req).await {
-                Ok(mut s) => {
+            match tokio::time::timeout(
+                STREAM_OPEN_TIMEOUT,
+                state.openrouter.execute_stream(per_model_req),
+            )
+            .await
+            {
+                Ok(Ok(mut s)) => {
                     use futures_util::StreamExt as _;
-                    while let Some(item) = s.next().await {
+                    let deadline = tokio::time::Instant::now() + STREAM_TOTAL_TIMEOUT;
+                    loop {
+                        let item = match tokio::time::timeout_at(deadline, s.next()).await {
+                            Ok(Some(item)) => item,
+                            Ok(None) => break,
+                            Err(_) => {
+                                tracing::warn!(
+                                    "stream(filtered): total timeout ({}s), advancing chain",
+                                    STREAM_TOTAL_TIMEOUT.as_secs()
+                                );
+                                truncated = true;
+                                break;
+                            }
+                        };
                         match item {
                             Ok(c) => {
                                 if let Some(content) = c.content { acc.push_str(&content); }
@@ -803,7 +846,14 @@ fn drive_chat_burst(
                     }
                     if !truncated && acc.is_empty() { empty_completion = true; }
                 }
-                Err(e) => { tracing::warn!("stream(filtered): open err: {e}"); truncated = true; }
+                Ok(Err(e)) => { tracing::warn!("stream(filtered): open err: {e}"); truncated = true; }
+                Err(_) => {
+                    tracing::warn!(
+                        "stream(filtered): open timeout ({}s), advancing chain",
+                        STREAM_OPEN_TIMEOUT.as_secs()
+                    );
+                    truncated = true;
+                }
             }
 
             if eros_engine_llm::byte_bpe::looks_byte_garbled(&acc) {
@@ -1292,6 +1342,15 @@ fn filter_output_invalidity(text: &str, finish_reason: Option<&str>) -> Option<&
 
 /// Per-model timeout for a single filter LLM call.
 const FILTER_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+
+/// Max wait for a chat stream to OPEN (connect + queue + response headers).
+/// A provider that accepts the socket but never sends headers must not hold
+/// the turn — timeout ⇒ attempt fails ⇒ chain advances.
+const STREAM_OPEN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
+/// Hard per-attempt cap on one model's whole generation (spec §1.5's 120s).
+/// Byte-level idle liveness is bounded upstream in the llm client; this caps
+/// a stream that keeps trickling forever.
+const STREAM_TOTAL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
 
 /// Run the output-filter LLM over `original`, walking the (already
 /// depth-capped) fallback chain one model at a time.  After each successful
@@ -2906,18 +2965,44 @@ pub fn run_stream(
                         reasoning: p.reasoning.clone(),
                         ..Default::default()
                     };
-                    let stream = match state.openrouter.execute_stream(req).await {
-                        Ok(s) => s,
-                        Err(e) => {
+                    let stream = match tokio::time::timeout(
+                        STREAM_OPEN_TIMEOUT,
+                        state.openrouter.execute_stream(req),
+                    )
+                    .await
+                    {
+                        Ok(Ok(s)) => s,
+                        Ok(Err(e)) => {
                             tracing::warn!(model = %model_id, error = %e, "product_qa: open stream failed");
+                            if acc.is_empty() { continue 'candidates; }
+                            truncated = true;
+                            break 'candidates;
+                        }
+                        Err(_) => {
+                            tracing::warn!(model = %model_id, "product_qa: open timeout");
                             if acc.is_empty() { continue 'candidates; }
                             truncated = true;
                             break 'candidates;
                         }
                     };
                     futures_util::pin_mut!(stream);
+                    let deadline = tokio::time::Instant::now() + STREAM_TOTAL_TIMEOUT;
                     loop {
-                        match futures_util::StreamExt::next(&mut stream).await {
+                        let item = match tokio::time::timeout_at(
+                            deadline,
+                            futures_util::StreamExt::next(&mut stream),
+                        )
+                        .await
+                        {
+                            Ok(item) => item,
+                            Err(_) => {
+                                tracing::warn!(model = %model_id, "product_qa: total timeout");
+                                if acc.is_empty() { continue 'candidates; }
+                                truncated = true;
+                                break 'candidates;
+                            }
+                        };
+                        match item {
                             Some(Ok(chunk)) => {
                                 if chunk.usage.is_some() { last_usage = chunk.usage.clone(); }
                                 if chunk.generation_id.is_some() { last_gen_id = chunk.generation_id.clone(); }

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -542,7 +542,15 @@ fn drive_chat_burst(
                                     }
                                     if c.usage.is_some()         { last_usage = c.usage; }
                                     if c.generation_id.is_some() { last_gen_id = c.generation_id; }
-                                    if matches!(c.finish_reason.as_deref(), Some("length")) {
+                                    // "content_filter" = mid-generation safety cut
+                                    // (Gemini/OpenAI): the text is incomplete, so it
+                                    // rides the same truncation → chain-advance path
+                                    // as "length" (parity with the sync path's
+                                    // filter_output_invalidity gate).
+                                    if matches!(
+                                        c.finish_reason.as_deref(),
+                                        Some("length") | Some("content_filter")
+                                    ) {
                                         truncated = true;
                                     }
                                 }
@@ -788,7 +796,7 @@ fn drive_chat_burst(
                                 if let Some(content) = c.content { acc.push_str(&content); }
                                 if c.usage.is_some() { last_usage = c.usage; }
                                 if c.generation_id.is_some() { last_gen_id = c.generation_id; }
-                                if matches!(c.finish_reason.as_deref(), Some("length")) { truncated = true; }
+                                if matches!(c.finish_reason.as_deref(), Some("length") | Some("content_filter")) { truncated = true; }
                             }
                             Err(e) => { tracing::warn!("stream(filtered): chunk err: {e}"); truncated = true; break; }
                         }
@@ -2921,7 +2929,7 @@ pub fn run_stream(
                                         content: text,
                                     };
                                 }
-                                if chunk.finish_reason.as_deref() == Some("length") { truncated = true; }
+                                if matches!(chunk.finish_reason.as_deref(), Some("length") | Some("content_filter")) { truncated = true; }
                             }
                             Some(Err(e)) => {
                                 tracing::warn!(model = %model_id, error = %e, "product_qa: mid-stream error");
@@ -9309,6 +9317,144 @@ data: [DONE]\n\n";
             "only the accepted fallback remains in produced; got {produced:?}"
         );
         assert_eq!(produced[0].full_text, "hi there");
+    }
+
+    /// Stream-hardening A1: a mid-generation `finish_reason:"content_filter"`
+    /// (Gemini/OpenAI safety cut) is an incomplete reply. It must ride the same
+    /// truncation → chain-advance path as "length" — never persist as a clean
+    /// success — restoring parity with the sync path's filter_output_invalidity
+    /// gate (production chat is 100% streaming).
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn live_content_filter_finish_advances_chain_as_truncated(pool: PgPool) {
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+        use futures_util::StreamExt;
+        use wiremock::matchers::{body_partial_json, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        // Primary "cf/x" streams partial text then a content_filter cut;
+        // fallback "f/x" streams clean text.
+        let cut = concat!(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"部分回\"}}],",
+            "\"id\":\"gen-cf\",\"model\":\"cf/x\"}\n\n",
+            "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"content_filter\"}]}\n\n",
+            "data: [DONE]\n\n"
+        );
+        let clean = concat!(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"hi there\"}}],",
+            "\"id\":\"gen-f\",\"model\":\"f/x\"}\n\n",
+            "data: [DONE]\n\n"
+        );
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .and(body_partial_json(serde_json::json!({"model": "cf/x"})))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(cut, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .and(body_partial_json(serde_json::json!({"model": "f/x"})))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(clean, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+
+        let user_id = Uuid::new_v4();
+        let (_g, _instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                eros_engine_llm::openrouter::AppAttribution::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+        let state = std::sync::Arc::new(state);
+
+        let chat_repo = ChatRepo { pool: &pool };
+        let user_message_id = match chat_repo
+            .upsert_user_message_idempotent(
+                session_id,
+                "hi",
+                "01JCONTENTFILTER00000000A",
+                "user",
+                None,
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
+
+        let req = eros_engine_llm::openrouter::ChatRequest {
+            model: "cf/x".into(),
+            fallback_model: vec!["f/x".into()],
+            messages: vec![eros_engine_llm::openrouter::ChatMessage {
+                role: "user".into(),
+                content: "hi".into(),
+            }],
+            temperature: 0.0,
+            max_tokens: 64,
+            ..Default::default()
+        };
+        let outcome = std::sync::Arc::new(std::sync::Mutex::new(BurstOutcome::default()));
+        let burst = drive_chat_burst(
+            state.clone(),
+            session_id,
+            user_message_id,
+            FrameActionType::Reply,
+            "reply",
+            ActionType::ReplyText,
+            req,
+            None,
+            None,
+            vec![],
+            None,
+            Default::default(),
+            Default::default(),
+            None,
+            outcome.clone(),
+        );
+        let frames: Vec<ProtocolFrame> = Box::pin(burst).collect().await;
+
+        let dones: Vec<(bool, bool)> = frames
+            .iter()
+            .filter_map(|f| match f {
+                ProtocolFrame::Done {
+                    truncated,
+                    ghost_fallback,
+                    ..
+                } => Some((*truncated, *ghost_fallback)),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(dones.len(), 2, "one Done per attempt: {frames:?}");
+        assert_eq!(
+            dones[0],
+            (true, false),
+            "content_filter cut must be truncated (replace-me), not a clean success: {frames:?}"
+        );
+        assert_eq!(
+            dones[1],
+            (false, false),
+            "the clean fallback is a normal accepted reply: {frames:?}"
+        );
+        let produced = &outcome.lock().unwrap().produced;
+        assert_eq!(
+            produced.len(),
+            1,
+            "only the accepted fallback feeds post-process; got {produced:?}"
+        );
+        assert_eq!(
+            produced[0].full_text, "hi there",
+            "the safety-cut partial must never reach memory/insight/affinity"
+        );
     }
 
     /// Codex P2 (PR #141, round 3): the FILTERED empty-completion ghost fallback

--- a/docs/superpowers/specs/2026-07-23-openrouter-stream-latency-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-23-openrouter-stream-latency-hardening-design.md
@@ -1,0 +1,392 @@
+# eros-engine — OpenRouter stream hardening: correctness, timeouts, TTFT
+
+Driven by an external static review plus an independent code audit of
+`crates/eros-engine-llm/src/openrouter.rs` and the chat streaming pipeline
+(`crates/eros-engine-server/src/pipeline/stream.rs`). Four findings dominate,
+ordered by real-world impact:
+
+1. **Mid-stream OpenRouter error frames are silently swallowed** — a partial
+   reply persists as a complete non-truncated success, fallback never runs,
+   and the `content_filter` safety signal is dropped on the streaming path
+   (the non-streaming path gates on it; production chat is 100% streaming).
+2. **No timeout anywhere on the chat generation path** — a provider that
+   accepts the connection and stalls hangs the turn forever, holding one of
+   the user's 3 concurrent stream slots; `StreamErrorCode::Timeout` is
+   documented as "not yet implemented".
+3. **`reqwest` is compiled without the `http2` feature** — confirmed via
+   `cargo tree -i h2 --edges normal,build` (no `h2` in the production graph;
+   the lockfile `h2` comes from dev-only wiremock feature-unification). Every
+   concurrent SSE stream burns its own TCP+TLS connection.
+4. **`output_regex` forces buffered mode chain-wide** — with the real
+   downstream config, every `chat_companion` model appears in a rule's
+   `models` list, so **every chat turn buffers and TTFT equals full
+   generation time**. The actual production patterns are streaming-safe with
+   a small bounded holdback.
+
+Work is split into four batches, landed in order:
+
+- **Batch A** (correctness + safety net): A1 error frames, A2 timeouts, A3 http2.
+- **Batch B** (observability): TTFT/latency structured logging, header
+  generation-id capture — lands before C so C's win is measurable.
+- **Batch C** (the TTFT lever): streaming-safe output_regex; buffered mode
+  gated on the LLM output_filter only.
+- **Batch D** (tuning, opt-in): borrow instead of clone per fallback attempt;
+  provider routing `sort` knob.
+
+---
+
+## 0. Decisions (settled during review)
+
+- **Local fallback chain stays; OpenRouter native `models: [...]` array is
+  rejected.** Native failover would collapse the chain into one request but
+  loses per-attempt audit rows (a deliberate design — one `AssistantInsert`
+  per attempt) and the business-semantic gates OpenRouter cannot perform:
+  empty-completion ghost fallback, byte-BPE garble repair, length/error
+  truncation. Not worth it.
+- **No SSE parser rewrite.** `eventsource-stream` correctly swallows
+  `: OPENROUTER PROCESSING` comment keepalives and `[DONE]`; parsing cost is
+  noise next to generation time.
+- **No `stream_options: {include_usage: true}`.** Usage/cost reconciliation
+  goes through OpenRouter's own logs by design (the audit records
+  `generation_id` as the join key); in-band streaming usage stays best-effort.
+- **Timeout values are module consts, not config.** Follows the existing
+  `FILTER_TIMEOUT` precedent (`stream.rs`). No new config surface until a
+  downstream deployment actually needs to tune them.
+- **The regex streaming applier governs the wire only; persistence always
+  re-runs the existing whole-text `apply_output_regex`.** The DB row and the
+  regex audit are byte-identical to today's buffered behavior in every case;
+  only what streams to the client is scrubbed incrementally. In the one
+  pathological fail-open case (unclosed `[` span exceeding the holdback cap)
+  the wire may briefly show what the persisted row stripped — accepted, the
+  cap is far above the real artifact length.
+- **Provider routing exposes `sort` only, boot-level, off by default.**
+  Mirrors the existing `ignore_providers` plumbing. `preferred_max_latency`
+  is NOT adopted until verified against current OpenRouter docs (the external
+  review's citation is unconfirmed). Setting `sort` disables OpenRouter's
+  price-based load balancing — a cost decision that belongs to the deployer,
+  hence opt-in with no default.
+
+---
+
+## 1. Batch A1 — mid-stream error frames (correctness)
+
+OpenRouter signals a mid-stream provider failure on an HTTP-200 SSE stream as
+a data frame carrying a top-level `error` object, typically alongside
+`choices: [{delta: {...}, finish_reason: "error"}]`. Today
+`WireStreamFrame` (`openrouter.rs`) has no `error` field, serde ignores it,
+and the frame becomes an all-`None` `DeltaChunk`; the pipeline only treats
+`finish_reason == "length"` as truncation (`stream.rs` live/filtered/QA
+loops), so the attempt ends as a *success* with partial text.
+
+### 1.1 Wire layer (`openrouter.rs`)
+
+```rust
+#[derive(Debug, Deserialize)]
+struct WireStreamError {
+    #[serde(default)]
+    code: Option<serde_json::Value>, // int or string upstream; opaque here
+    #[serde(default)]
+    message: String,
+}
+```
+
+- Add `error: Option<WireStreamError>` to `WireStreamFrame`.
+- In `execute_stream`'s `filter_map`: when `frame.error` is `Some`, emit
+  `Err(LlmError::Provider(format!("openrouter mid-stream error: {code:?}: {message}")))`
+  **instead of** a `DeltaChunk`. The existing consumer `Err` arms already set
+  `truncated = true` and advance the chain — no new pipeline plumbing for
+  this case.
+- When a choice carries `finish_reason: "error"` *without* a top-level error
+  object, also emit `Err(LlmError::Provider("finish_reason=error"))` — same
+  treatment.
+
+### 1.2 Pipeline layer (`stream.rs`)
+
+- `finish_reason == "content_filter"` mid-stream (Gemini/OpenAI safety cut):
+  treat exactly like `"length"` — set `truncated = true` — in all three
+  consume loops (live burst, filtered burst, product-QA). This restores the
+  parity the non-streaming path already has via `filter_output_invalidity`.
+- No metadata/schema change; the existing `truncated` flag + pseudo-ghost /
+  chain-advance machinery carries the behavior.
+
+### 1.3 Why not handle `content_filter` in the client layer
+
+`content_filter` is not a transport failure — the text up to the cut is
+valid, and `LlmError::Garbled`-style salvage semantics don't apply. The
+pipeline owns the "is this reply acceptable" decision (mirrors the sync
+path's validity gates), so the client keeps passing `finish_reason` through
+verbatim.
+
+## 2. Batch A2 — timeouts (bound the hang)
+
+Three layers, all constants in the crate that owns them:
+
+### 2.1 reqwest client (`openrouter.rs`, both constructors)
+
+```rust
+.connect_timeout(Duration::from_secs(5))
+.pool_idle_timeout(Duration::from_secs(300))
+```
+
+No global `.timeout()` and no client-level `.read_timeout()`: both would
+also bound non-streaming calls (image generation legitimately spends its
+whole wall-time before the first body byte).
+
+### 2.2 SSE byte-level idle timeout (`openrouter.rs::execute_stream`)
+
+Insert an idle-gap watchdog on the **bytes** stream, *before*
+`.eventsource()`:
+
+```rust
+const STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(45);
+```
+
+Implemented with `tokio_stream::StreamExt::timeout` (or an equivalent
+hand-rolled poll wrapper if adding `tokio-stream` is unwanted); an elapsed
+gap maps to `Err(LlmError::Stream("idle timeout: no bytes for 45s"))`.
+Byte-level placement is deliberate: OpenRouter's `: OPENROUTER PROCESSING`
+comment keepalives count as bytes and reset the timer (so a reasoning model
+thinking for minutes stays alive), while a dead peer trips it.
+
+### 2.3 Per-attempt open + total caps (`stream.rs`, all three consume loops)
+
+```rust
+const STREAM_OPEN_TIMEOUT:  Duration = Duration::from_secs(20);  // headers
+const STREAM_TOTAL_TIMEOUT: Duration = Duration::from_secs(120); // spec §1.5
+```
+
+- Wrap `state.openrouter.execute_stream(...)` in
+  `tokio::time::timeout(STREAM_OPEN_TIMEOUT, ...)`; timeout ⇒ same handling
+  as the existing open-`Err` arm (`truncated = true`, next model).
+- Take `let deadline = tokio::time::Instant::now() + STREAM_TOTAL_TIMEOUT;`
+  per attempt and replace `s.next().await` with
+  `tokio::time::timeout_at(deadline, s.next()).await`; elapsed ⇒ same
+  handling as the existing chunk-`Err` arm.
+- Timeouts are *attempt-level* failures that ride the existing fallback /
+  pseudo-ghost machinery. `StreamErrorCode::Timeout` stays reserved — no new
+  wire error is emitted (chain exhaustion still surfaces as today's
+  pseudo-ghost or `UpstreamUnavailable`).
+
+## 3. Batch A3 — enable HTTP/2
+
+`Cargo.toml` workspace dep gains the feature:
+
+```toml
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream", "http2"] }
+```
+
+ALPN negotiates h2 automatically against OpenRouter; HTTP/1.1 remains for
+servers that don't offer h2 (wiremock tests are unaffected). No builder
+changes (`http2_adaptive_window` deferred until B-metrics show window
+stalls). Acceptance: `cargo tree -i h2 -e normal` now shows a
+`reqwest → hyper` edge in the production graph; after deploy, Batch B's
+`http_version` field should read `HTTP/2.0`.
+
+## 4. Batch B — latency observability
+
+No metrics crate exists in-tree; everything is structured `tracing` fields
+(downstream scrapes logs). One `info!` event per attempt, one `debug!` in
+the client:
+
+### 4.1 Client (`openrouter.rs::execute_stream`)
+
+- Around `send()`: record `headers_ms` (request-start → response-headers) and
+  `http_version = ?resp.version()`; emit as
+  `tracing::debug!(target: "openrouter_stream", model, headers_ms, ?http_version, "stream opened")`.
+- Capture the **`X-Generation-Id` response header** the moment headers
+  arrive. If present, prepend it to the delta stream as a synthetic first
+  chunk (`futures_util::stream::once(... DeltaChunk { generation_id, ..Default::default() })`
+  chained before the SSE stream). The pipeline's existing
+  "latest non-None wins" accumulation picks it up; a body `id` later
+  overwrites with the same value. This closes the "stream died before its
+  first id-bearing chunk ⇒ no generation handle for audit reconciliation"
+  gap.
+
+### 4.2 Pipeline (`stream.rs`, per attempt)
+
+One structured event per attempt in each consume loop:
+
+```rust
+tracing::info!(
+    target: "stream_metrics",
+    model = %model_id,
+    attempt = idx,
+    ttft_ms,            // execute_stream call → first content delta; None if none arrived
+    total_ms,           // execute_stream call → stream end
+    outcome,            // "served" | "length" | "content_filter" | "error_frame"
+                        //   | "open_error" | "chunk_error" | "open_timeout"
+                        //   | "idle_timeout" | "total_timeout" | "empty" | "garbled"
+    "chat stream attempt"
+);
+```
+
+`outcome` is a `&'static str` assigned where each condition is detected
+(the existing `warn!` lines stay; this event is the aggregate-friendly one).
+
+## 5. Batch C — streaming-safe `output_regex` (the TTFT lever)
+
+### 5.1 Problem shape
+
+`filtered_mode = llm_filter_arms || regex_targets_chain` (`stream.rs`)
+buffers the whole reply whenever *any* chain model has *any* regex rule. The
+real downstream config's bracket rule lists every production chat model, so
+live mode is dead code in production. The active patterns:
+
+| pattern | anchor | streaming strategy |
+|---|---|---|
+| `\[[^\]]*\]` | anywhere | span holdback: emit freely until `[`, hold from `[` until `]` (strip span) or 256-char cap (flush, fail-open) |
+| `^嗯(?:\.{3,6}\|…{1,2})\s*` | prefix | head holdback: buffer first 64 chars, apply once, then passthrough |
+| `^(?:[(（][^)）]*[)）]\|\.{3,6}\s*\|…{1,2}\s*)` | prefix | same head holdback |
+
+### 5.2 `StreamScrubber` (new, `eros-engine-llm`)
+
+```rust
+pub struct StreamScrubber { /* rules for this model, head/span state */ }
+
+impl StreamScrubber {
+    /// Rules pre-filtered to `model_id`. Empty rules ⇒ pure passthrough.
+    pub fn new(rules: &[CompiledRegexRule], model_id: &str) -> Self;
+    /// Feed a delta; returns the text now safe to emit (possibly empty).
+    pub fn push(&mut self, delta: &str) -> String;
+    /// Stream ended; flush and clean whatever is still held.
+    pub fn finish(&mut self) -> String;
+}
+```
+
+- **Classification** (at `Self::new`, via `regex-syntax`'s HIR — already a
+  transitive dep of `regex`): a rule whose HIR is start-anchored
+  (`look_set_prefix` contains `Look::Start`) is a **head rule**; a rule whose
+  possible matches all start with a literal `[` (prefix-literal extraction)
+  is a **span rule** with open `[` / close `]`. Any other shape makes the
+  scrubber **degenerate to full buffering** for this attempt (emit nothing
+  from `push`, everything from `finish` after a whole-text
+  `apply_output_regex`) — correct for arbitrary rules, just without the TTFT
+  win; downstream deployments with exotic patterns lose nothing vs today.
+- **Head phase:** hold the first `HEAD_HOLDBACK = 64` chars; once exceeded
+  (or at `finish`), apply the head rules to the held prefix once, emit, and
+  leave head phase permanently.
+- **Span phase (steady state):** emit passthrough until an un-emitted `[`
+  appears; hold from there; on `]`, run the span rule over the held segment,
+  emit the cleaned remainder; if `SPAN_HOLDBACK_CAP = 256` chars accumulate
+  with no `]`, flush held text verbatim (fail-open) and resume scanning
+  *after* it.
+- Char-boundary safe (operates on `char` indices, never splits a CJK
+  scalar); a marker straddling any chunk boundary must be stripped
+  identically to the whole-text result (test matrix below).
+
+### 5.3 Pipeline rewiring (`stream.rs`)
+
+- `filtered_mode = llm_filter_arms;` — regex alone no longer buffers.
+- Live burst, per attempt: build `StreamScrubber::new(&state.output_regex, model_id)`;
+  each content delta is `let emit = scrubber.push(&content);` — `acc` still
+  accumulates the **raw** text; `ProtocolFrame::Delta` carries the scrubbed
+  `emit` (skip the frame when empty). After the loop, `scrubber.finish()`
+  emits the tail.
+- Persist path (unchanged semantics, new location): before the
+  `AssistantInsert`, run the existing whole-text
+  `apply_output_regex(&state.output_regex, model_id, &acc)`; persist
+  `cleaned`, carry the regex audit exactly as the filtered path does today
+  (raw on the audit field when rules matched), and port the
+  **strip-to-empty ⇒ ghost-fallback** branch (`ghost_fallback_metadata`
+  with the regex reason) into the live burst. The whitespace-only-deltas
+  edge (raw `"\n\n[...]"` streams two blank deltas, then strips to empty ⇒
+  ghost) is accepted — clients render nothing for whitespace.
+- Filtered burst (LLM output_filter armed): completely unchanged — it
+  already buffers for the rewrite and applies regex on the buffered text.
+- Beta-tier turns (output_filter trigger passing) therefore still buffer —
+  inherent to an LLM rewrite; default/free-tier turns get true streaming.
+
+### 5.4 Invariants preserved (test-gated)
+
+1. Persisted content, regex audit rows, and ghost/suppression decisions are
+   byte-identical to today's buffered mode for every input (modulo the
+   documented span-cap fail-open, which affects the wire only).
+2. Concatenated emitted deltas == `apply_output_regex(raw)` for all
+   classifiable rules, across arbitrary chunk splits.
+3. A reply that strips to empty emits no non-whitespace delta.
+
+## 6. Batch D — tuning
+
+### 6.1 D1: stop cloning `ChatRequest` per fallback attempt
+
+New borrowing entry point; the owned-`req` version stays for API compat
+(published crate):
+
+```rust
+/// Open a stream for one specific model, borrowing the shared request.
+pub async fn execute_stream_as(&self, req: &ChatRequest, model: &str)
+    -> Result<DeltaStream, LlmError>;
+
+pub async fn execute_stream(&self, req: ChatRequest) -> Result<DeltaStream, LlmError> {
+    let model = req.model.clone();
+    self.execute_stream_as(&req, &model).await
+}
+```
+
+`WireRequest` already borrows everything, so `execute_stream_as` just feeds
+`model` into the wire body (and sends no fallback array — same as today's
+cleared `fallback_model`). The three burst loops switch to
+`execute_stream_as(&req, model_id)` and drop the per-attempt
+`req.clone()` / field surgery.
+
+### 6.2 D2: provider routing `sort` (opt-in)
+
+- `ProviderPrefs` gains `#[serde(skip_serializing_if = "Option::is_none")] sort: Option<&'a str>`.
+- Plumbed like `ignore_providers`: a boot-time
+  `OpenRouterClient::with_provider_sort(Option<String>)` consuming builder,
+  sourced from the same engine config that supplies the exclusion list;
+  absent ⇒ wire body byte-identical to today.
+- Accepted values passed through verbatim (`"latency"` / `"throughput"` /
+  `"price"`); OpenRouter validates. Documented tradeoff: any explicit sort
+  disables OpenRouter's default price load-balancing.
+- Field name/shape verified against the live provider-routing docs at
+  implementation time; if the API differs, adjust to the documented schema
+  rather than this sketch.
+
+## 7. Testing
+
+- **A1 (wiremock SSE):** mid-stream frame with top-level `error` after two
+  content deltas ⇒ attempt fails, chain advances, partial text is not
+  persisted as success; `finish_reason: "error"` without error object ⇒
+  same; `finish_reason: "content_filter"` ⇒ `truncated`, chain advances;
+  last-attempt versions land on the pseudo-ghost path.
+- **A2 (wiremock delays):** response headers delayed past
+  `STREAM_OPEN_TIMEOUT` ⇒ open-timeout outcome, next model; a stream that
+  sends one delta then stalls past the idle window ⇒ idle-timeout, next
+  model (wiremock supports chunk delays via `set_body_raw` +
+  `set_delay`-style helpers; if per-chunk stalls prove un-mockable, the
+  idle watchdog gets a direct unit test around a hand-built
+  `futures::stream` instead). Existing suites stay green (no global
+  timeout regressions on slow-but-healthy mocks).
+- **A3:** compile-time only (`cargo tree` acceptance above); wiremock tests
+  keep negotiating HTTP/1.1 and must stay green.
+- **B:** unit-test the synthetic first chunk (header id present ⇒ first
+  `DeltaChunk.generation_id` matches; absent ⇒ stream unchanged). Log
+  events are not test-gated.
+- **C (the big matrix):** `StreamScrubber` unit tests — every production
+  pattern × chunk splits at every char boundary (property-style loop, not
+  hand-picked splits) asserting invariant 5.4-2; artifact-only reply ⇒
+  everything held, `finish` returns empty; span-cap overflow ⇒ fail-open
+  flush; non-classifiable rule ⇒ degenerate buffering equals
+  `apply_output_regex`. Burst-level (wiremock): regex model streams live
+  (Delta frames arrive before `[DONE]`), marker stripped on the wire,
+  persisted row + audit identical to the pre-change buffered run;
+  strip-to-empty ⇒ ghost fallback frames.
+- **D1:** existing fallback-chain tests pass against `execute_stream_as`;
+  wire-body assertion that the fallback attempt sends the fallback model id.
+- **D2:** wire body omits `provider.sort` when unset (byte-identical guard);
+  includes it when configured; composes with a non-empty `ignore` list.
+
+## 8. Out of scope
+
+- OpenRouter native `models: [...]` request-level fallback (rejected, §0).
+- SSE parser replacement or byte-oriented reparse (verified fine).
+- `stream_options.include_usage` (usage reconciliation stays in OpenRouter
+  logs).
+- Per-task provider preferences, `preferred_max_latency` / `order` routing
+  knobs (YAGNI until a deployment asks; `sort` covers the latency case).
+- Any change to image-gen / vision / non-streaming task timeouts beyond the
+  shared `connect_timeout` (they keep their existing `FILTER_TIMEOUT`
+  wrappers or deliberate unboundedness).
+- Server-side axum `TimeoutLayer` (the SSE route is long-lived by design;
+  per-attempt caps above bound the real failure mode).


### PR DESCRIPTION
Batch A of the OpenRouter stream-hardening work (spec:
`docs/superpowers/specs/2026-07-23-openrouter-stream-latency-hardening-design.md`,
included in this PR). Correctness + safety-net changes; Batches B/C/D follow in
separate PRs after this merges.

## The problem

An external static review plus an independent code audit of `openrouter.rs` +
the chat streaming pipeline surfaced three issues, ordered by real-world impact:

1. **Mid-stream OpenRouter error frames were silently swallowed.** A 200 SSE
   stream can carry a top-level `error` object (and/or `finish_reason:"error"`)
   when a provider dies mid-generation. `WireStreamFrame` had no `error` field,
   so the frame parsed as an all-`None` `DeltaChunk` and the partial reply
   persisted as a **clean, non-truncated success with no fallback**. The
   `content_filter` safety signal was likewise dropped on the streaming path
   (the sync path already gates on it, but production chat is 100% streaming),
   and the partial fed downstream memory/insight/affinity extraction.
2. **No timeout anywhere on the chat generation path.** A provider that
   accepted the socket then stalled hung the turn forever, holding one of the
   user's 3 concurrent stream slots. `StreamErrorCode::Timeout` was documented
   as "not yet implemented".
3. **`reqwest` was compiled without the `http2` feature.** `default-features =
   false` had silently dropped it, so every concurrent SSE stream paid its own
   TCP+TLS handshake on HTTP/1.1 (long-lived streams can't share a busy h1
   connection).

## The changes

- **A1 — mid-stream errors** (`992ddd9`): `execute_stream` surfaces
  `LlmError::Provider` on a top-level `error` or `finish_reason:"error"` frame;
  all three pipeline consume loops treat `finish_reason:"content_filter"` as
  truncation, restoring parity with the sync path's validity gate. Both ride
  the existing chain-advance / pseudo-ghost machinery — no new wire plumbing.
- **A2 — timeouts** (`3a3e906`): client `connect_timeout(5s)` +
  `pool_idle_timeout(300s)` (no global timeout — image gen legitimately spends
  its wall-time before first byte); a byte-level 45s idle watchdog on the raw
  SSE stream (OpenRouter comment keepalives reset it, a dead peer trips it);
  20s stream-open + 120s per-attempt total caps in all three loops.
- **A3 — http2** (`181a7a5`): added `"http2"` to the reqwest features. Verified
  `cargo tree -i h2 -e normal` now shows the reqwest edge in the production
  graph.

## Testing

`cargo fmt` + `clippy --all-targets -D warnings` clean; full workspace **872
tests green**; openapi snapshot no drift. New coverage: 2 client-layer
error-frame tests, 2 idle-watchdog tests (paused-time), 1 content_filter burst
test asserting the safety-cut partial never reaches `produced`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
