### PR TITLE
feat: OpenRouter stream hardening — Batch B (observability + error-body redaction)

### DIFF
--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -1230,6 +1230,7 @@ impl OpenRouterClient {
             response_format: None,
         };
 
+        let started = std::time::Instant::now();
         let resp = self
             .http
             .post(&self.base_url)
@@ -1244,6 +1245,34 @@ impl OpenRouterClient {
             let text = resp.text().await.unwrap_or_default();
             return Err(LlmError::Status(status, scrub_error_body(&text)));
         }
+
+        // Observability: connect+headers latency and the negotiated HTTP
+        // version (should read HTTP/2.0 post-Batch-A3). Prompt content is never
+        // logged — only the model id and timing.
+        tracing::debug!(
+            target: "openrouter_stream",
+            model = %req.model,
+            headers_ms = started.elapsed().as_millis() as u64,
+            http_version = ?resp.version(),
+            "stream opened"
+        );
+
+        // Capture the authoritative generation id from the X-Generation-Id
+        // header the moment headers arrive, so a stream that dies before its
+        // first id-bearing body chunk still yields an audit handle. Prepended
+        // as a synthetic first chunk; the pipeline's "latest non-None wins"
+        // accumulation adopts it, and a later body `id` (identical) overwrites.
+        let header_gen_id = resp
+            .headers()
+            .get("x-generation-id")
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_string);
+        let head = futures_util::stream::iter(header_gen_id.map(|id| {
+            Ok(DeltaChunk {
+                generation_id: Some(id),
+                ..Default::default()
+            })
+        }));
 
         let stream = idle_bounded(resp.bytes_stream(), STREAM_IDLE_TIMEOUT)
             .eventsource()
@@ -1292,7 +1321,7 @@ impl OpenRouterClient {
                 }
             });
 
-        Ok(DeltaStream(stream.boxed()))
+        Ok(DeltaStream(head.chain(stream).boxed()))
     }
 }
 
@@ -2466,6 +2495,79 @@ data: [DONE]\n\n";
             matches!(item, Err(LlmError::Provider(_))),
             "finish_reason=error must surface as Provider error, got {item:?}"
         );
+    }
+
+    // ─── B1: X-Generation-Id header capture ─────────────────────────────────
+
+    #[tokio::test]
+    async fn execute_stream_prepends_generation_id_from_header() {
+        use futures_util::StreamExt;
+        // Header carries the id; the body frames carry none. The synthetic first
+        // chunk must surface the header id so audit has a handle even if the
+        // stream dies before any body id.
+        let server = MockServer::start().await;
+        let body = "data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\ndata: [DONE]\n\n";
+        Mock::given(path("/api/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .insert_header("x-generation-id", "gen-hdr-1")
+                    .set_body_raw(body, "text/event-stream"),
+            )
+            .mount(&server)
+            .await;
+        let client = OpenRouterClient::with_base_url(
+            "test-key".into(),
+            AppAttribution::default(),
+            format!("{}/api/v1/chat/completions", server.uri()),
+        );
+        let mut stream = client
+            .execute_stream(ChatRequest {
+                model: "x-ai/grok-4-fast".into(),
+                messages: vec![ChatMessage { role: "user".into(), content: "hi".into() }],
+                temperature: 0.0,
+                max_tokens: 16,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        let first = stream.next().await.expect("synthetic first chunk").expect("ok");
+        assert_eq!(first.generation_id.as_deref(), Some("gen-hdr-1"));
+        assert!(first.content.is_none(), "synthetic chunk carries no content");
+    }
+
+    #[tokio::test]
+    async fn execute_stream_no_header_no_synthetic_chunk() {
+        use futures_util::StreamExt;
+        // Without the header, the first chunk is the real body delta (no
+        // spurious empty synthetic chunk).
+        let server = MockServer::start().await;
+        let body = "data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\ndata: [DONE]\n\n";
+        Mock::given(path("/api/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(body, "text/event-stream"),
+            )
+            .mount(&server)
+            .await;
+        let client = OpenRouterClient::with_base_url(
+            "test-key".into(),
+            AppAttribution::default(),
+            format!("{}/api/v1/chat/completions", server.uri()),
+        );
+        let mut stream = client
+            .execute_stream(ChatRequest {
+                model: "x-ai/grok-4-fast".into(),
+                messages: vec![ChatMessage { role: "user".into(), content: "hi".into() }],
+                temperature: 0.0,
+                max_tokens: 16,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        let first = stream.next().await.expect("first chunk").expect("ok");
+        assert_eq!(first.content.as_deref(), Some("hi"), "first chunk is the real delta");
     }
 
     #[test]

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -271,9 +271,14 @@ fn scrub_error_body(raw: &str) -> String {
         .code
         .map(|c| c.to_string())
         .unwrap_or_else(|| "?".into());
+    // Assemble the raw parts, then run the WHOLE string through body_preview
+    // once. provider_name / reasons are provider-controlled and could carry
+    // newlines or be arbitrarily long, so the single final flatten+cap is what
+    // upholds the "bounded, single-line" guarantee for every field — not just
+    // the message.
     let mut out = format!(
         "code={code}: {}",
-        body_preview(env.error.message.as_deref().unwrap_or(""))
+        env.error.message.as_deref().unwrap_or("")
     );
     // Provider identity + moderation reasons are safe to surface; flagged_input
     // (the user's prompt excerpt) is never read.
@@ -288,7 +293,7 @@ fn scrub_error_body(raw: &str) -> String {
             }
         }
     }
-    out
+    body_preview(&out)
 }
 
 /// A 200 body that failed to decode as a chat/vision completion: if it is in
@@ -1864,6 +1869,28 @@ mod tests {
         assert!(
             out.contains("moderation_reasons=sexual"),
             "keeps reasons: {out}"
+        );
+    }
+
+    #[test]
+    fn scrub_error_body_bounds_and_flattens_hostile_metadata() {
+        // provider_name/reasons are provider-controlled: a newline-laden, very
+        // long value must not defeat the single-line, bounded guarantee.
+        let evil = format!("{}\n{}", "A".repeat(300), "B".repeat(300));
+        let raw = serde_json::json!({
+            "error": {
+                "code": 500,
+                "message": "boom",
+                "metadata": { "provider_name": evil, "reasons": ["x\ny"] }
+            }
+        })
+        .to_string();
+        let out = scrub_error_body(&raw);
+        assert!(!out.contains('\n'), "must be single-line: {out:?}");
+        assert!(
+            out.chars().count() <= ERROR_PREVIEW_MAX + 1,
+            "must be bounded, got {} chars",
+            out.chars().count()
         );
     }
 

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -302,7 +302,10 @@ fn decode_or_api_error(body: &str, err: serde_json::Error) -> LlmError {
         .and_then(|v| v.get("error").cloned())
         .is_some();
     if is_api_error {
-        LlmError::Provider(format!("openrouter 200 error body: {}", scrub_error_body(body)))
+        LlmError::Provider(format!(
+            "openrouter 200 error body: {}",
+            scrub_error_body(body)
+        ))
     } else {
         LlmError::Decode(err)
     }
@@ -1824,7 +1827,11 @@ mod tests {
         assert_eq!(body_preview("  hi\nthere\r "), "hi\\nthere");
         let long: String = "x".repeat(ERROR_PREVIEW_MAX + 50);
         let out = body_preview(&long);
-        assert_eq!(out.chars().count(), ERROR_PREVIEW_MAX + 1, "capped + ellipsis");
+        assert_eq!(
+            out.chars().count(),
+            ERROR_PREVIEW_MAX + 1,
+            "capped + ellipsis"
+        );
         assert!(out.ends_with('…'));
     }
 
@@ -1845,10 +1852,19 @@ mod tests {
         })
         .to_string();
         let out = scrub_error_body(&raw);
-        assert!(!out.contains("SECRET USER PROMPT TEXT"), "flagged_input leaked: {out}");
+        assert!(
+            !out.contains("SECRET USER PROMPT TEXT"),
+            "flagged_input leaked: {out}"
+        );
         assert!(out.contains("code=\"moderation\""), "keeps code: {out}");
-        assert!(out.contains("provider=SomeProvider"), "keeps provider: {out}");
-        assert!(out.contains("moderation_reasons=sexual"), "keeps reasons: {out}");
+        assert!(
+            out.contains("provider=SomeProvider"),
+            "keeps provider: {out}"
+        );
+        assert!(
+            out.contains("moderation_reasons=sexual"),
+            "keeps reasons: {out}"
+        );
     }
 
     #[test]
@@ -1861,14 +1877,19 @@ mod tests {
         // Non-envelope junk falls back to a bounded preview.
         let junk: String = "boom ".repeat(100);
         let out = scrub_error_body(&junk);
-        assert!(out.chars().count() <= ERROR_PREVIEW_MAX + 1, "bounded: {}", out.len());
+        assert!(
+            out.chars().count() <= ERROR_PREVIEW_MAX + 1,
+            "bounded: {}",
+            out.len()
+        );
     }
 
     #[test]
     fn decode_or_api_error_surfaces_embedded_error() {
         // A 200 body that is really an error envelope → Provider (chain advances
         // with a useful, redacted reason), not a bare Decode.
-        let body = serde_json::json!({"error": {"code": 400, "message": "bad request"}}).to_string();
+        let body =
+            serde_json::json!({"error": {"code": 400, "message": "bad request"}}).to_string();
         let err = serde_json::from_str::<WireResponse>(&body).expect_err("no choices");
         match decode_or_api_error(&body, err) {
             LlmError::Provider(msg) => assert!(msg.contains("bad request"), "{msg}"),
@@ -1877,7 +1898,10 @@ mod tests {
         // Genuine junk stays a Decode error (no body leak — Display is a serde offset).
         let junk = "not json at all";
         let err = serde_json::from_str::<WireResponse>(junk).expect_err("bad json");
-        assert!(matches!(decode_or_api_error(junk, err), LlmError::Decode(_)));
+        assert!(matches!(
+            decode_or_api_error(junk, err),
+            LlmError::Decode(_)
+        ));
     }
 
     #[tokio::test]
@@ -1904,7 +1928,10 @@ mod tests {
         let err = client
             .execute(ChatRequest {
                 model: "m".into(),
-                messages: vec![ChatMessage { role: "user".into(), content: "hi".into() }],
+                messages: vec![ChatMessage {
+                    role: "user".into(),
+                    content: "hi".into(),
+                }],
                 temperature: 0.0,
                 max_tokens: 16,
                 ..Default::default()
@@ -1912,7 +1939,10 @@ mod tests {
             .await
             .expect_err("403 fails the chain");
         let shown = err.to_string();
-        assert!(!shown.contains("RAW USER CHAT"), "flagged_input leaked into error: {shown}");
+        assert!(
+            !shown.contains("RAW USER CHAT"),
+            "flagged_input leaked into error: {shown}"
+        );
         assert!(shown.contains("moderation_reasons=harassment"), "{shown}");
     }
 
@@ -1924,14 +1954,18 @@ mod tests {
         // Primary returns 200 with finish_reason:"error" (mid-generation death);
         // fallback returns a clean reply.
         Mock::given(path("/api/v1/chat/completions"))
-            .and(wiremock::matchers::body_partial_json(serde_json::json!({"model": "p"})))
+            .and(wiremock::matchers::body_partial_json(
+                serde_json::json!({"model": "p"}),
+            ))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "choices": [{ "message": { "content": "partial" }, "finish_reason": "error" }]
             })))
             .mount(&server)
             .await;
         Mock::given(path("/api/v1/chat/completions"))
-            .and(wiremock::matchers::body_partial_json(serde_json::json!({"model": "f"})))
+            .and(wiremock::matchers::body_partial_json(
+                serde_json::json!({"model": "f"}),
+            ))
             .respond_with(ResponseTemplate::new(200).set_body_json(ok_response()))
             .mount(&server)
             .await;
@@ -1944,14 +1978,20 @@ mod tests {
             .execute(ChatRequest {
                 model: "p".into(),
                 fallback_model: vec!["f".into()],
-                messages: vec![ChatMessage { role: "user".into(), content: "hi".into() }],
+                messages: vec![ChatMessage {
+                    role: "user".into(),
+                    content: "hi".into(),
+                }],
                 temperature: 0.0,
                 max_tokens: 16,
                 ..Default::default()
             })
             .await
             .expect("fallback serves the clean reply");
-        assert_eq!(resp.reply, "ok", "the finish_reason=error partial must not be returned");
+        assert_eq!(
+            resp.reply, "ok",
+            "the finish_reason=error partial must not be returned"
+        );
     }
 
     // ─── B-err3: 200 body that is an error envelope ─────────────────────────
@@ -1973,7 +2013,10 @@ mod tests {
         let err = client
             .execute(ChatRequest {
                 model: "m".into(),
-                messages: vec![ChatMessage { role: "user".into(), content: "hi".into() }],
+                messages: vec![ChatMessage {
+                    role: "user".into(),
+                    content: "hi".into(),
+                }],
                 temperature: 0.0,
                 max_tokens: 16,
                 ..Default::default()
@@ -2524,16 +2567,26 @@ data: [DONE]\n\n";
         let mut stream = client
             .execute_stream(ChatRequest {
                 model: "x-ai/grok-4-fast".into(),
-                messages: vec![ChatMessage { role: "user".into(), content: "hi".into() }],
+                messages: vec![ChatMessage {
+                    role: "user".into(),
+                    content: "hi".into(),
+                }],
                 temperature: 0.0,
                 max_tokens: 16,
                 ..Default::default()
             })
             .await
             .unwrap();
-        let first = stream.next().await.expect("synthetic first chunk").expect("ok");
+        let first = stream
+            .next()
+            .await
+            .expect("synthetic first chunk")
+            .expect("ok");
         assert_eq!(first.generation_id.as_deref(), Some("gen-hdr-1"));
-        assert!(first.content.is_none(), "synthetic chunk carries no content");
+        assert!(
+            first.content.is_none(),
+            "synthetic chunk carries no content"
+        );
     }
 
     #[tokio::test]
@@ -2559,7 +2612,10 @@ data: [DONE]\n\n";
         let mut stream = client
             .execute_stream(ChatRequest {
                 model: "x-ai/grok-4-fast".into(),
-                messages: vec![ChatMessage { role: "user".into(), content: "hi".into() }],
+                messages: vec![ChatMessage {
+                    role: "user".into(),
+                    content: "hi".into(),
+                }],
                 temperature: 0.0,
                 max_tokens: 16,
                 ..Default::default()
@@ -2567,7 +2623,11 @@ data: [DONE]\n\n";
             .await
             .unwrap();
         let first = stream.next().await.expect("first chunk").expect("ok");
-        assert_eq!(first.content.as_deref(), Some("hi"), "first chunk is the real delta");
+        assert_eq!(
+            first.content.as_deref(),
+            Some("hi"),
+            "first chunk is the real delta"
+        );
     }
 
     #[test]

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -224,6 +224,90 @@ fn cap_provider_message(s: &str) -> String {
     }
 }
 
+/// Max chars kept from a raw provider error body in ordinary logs. Short by
+/// design: logs are for triage, not forensics — full error forensics live in
+/// OpenRouter's own logs, joined on `generation_id`.
+const ERROR_PREVIEW_MAX: usize = 200;
+
+/// Flatten newlines and cap a string to [`ERROR_PREVIEW_MAX`] chars so it is a
+/// single bounded log line. An ellipsis marks truncation.
+fn body_preview(s: &str) -> String {
+    let flat = s.trim().replace('\r', "\\r").replace('\n', "\\n");
+    if flat.chars().count() <= ERROR_PREVIEW_MAX {
+        flat
+    } else {
+        flat.chars().take(ERROR_PREVIEW_MAX).collect::<String>() + "…"
+    }
+}
+
+/// Turn a raw provider error body into a bounded, redacted one-line string safe
+/// for ordinary logs. Best-effort parses the OpenRouter
+/// `{"error":{code,message,metadata}}` envelope and keeps only `code`
+/// (as `serde_json::Value` — codes are sometimes strings, not ints), a
+/// length-capped `message`, and — from a moderation `metadata` block —
+/// `provider_name` + `reasons`. It deliberately DROPS `metadata.flagged_input`,
+/// which is an excerpt of the user's flagged prompt that a moderation rejection
+/// echoes back (logging it would leak raw chat content). Non-envelope bodies
+/// fall back to a plain length-capped preview.
+fn scrub_error_body(raw: &str) -> String {
+    #[derive(Deserialize)]
+    struct Env {
+        error: ErrBody,
+    }
+    #[derive(Deserialize)]
+    struct ErrBody {
+        #[serde(default)]
+        code: Option<serde_json::Value>,
+        #[serde(default)]
+        message: Option<String>,
+        #[serde(default)]
+        metadata: Option<serde_json::Value>,
+    }
+    let Ok(env) = serde_json::from_str::<Env>(raw) else {
+        return body_preview(raw);
+    };
+    let code = env
+        .error
+        .code
+        .map(|c| c.to_string())
+        .unwrap_or_else(|| "?".into());
+    let mut out = format!(
+        "code={code}: {}",
+        body_preview(env.error.message.as_deref().unwrap_or(""))
+    );
+    // Provider identity + moderation reasons are safe to surface; flagged_input
+    // (the user's prompt excerpt) is never read.
+    if let Some(meta) = env.error.metadata.as_ref() {
+        if let Some(provider) = meta.get("provider_name").and_then(|v| v.as_str()) {
+            out.push_str(&format!(" [provider={provider}]"));
+        }
+        if let Some(reasons) = meta.get("reasons").and_then(|v| v.as_array()) {
+            let rs: Vec<&str> = reasons.iter().filter_map(|v| v.as_str()).collect();
+            if !rs.is_empty() {
+                out.push_str(&format!(" [moderation_reasons={}]", rs.join(",")));
+            }
+        }
+    }
+    out
+}
+
+/// A 200 body that failed to decode as a chat/vision completion: if it is in
+/// fact an OpenRouter error envelope (`{"error":...}` with no `choices`),
+/// surface its scrubbed message as a `Provider` error so the candidate chain
+/// advances with a useful, redacted reason; otherwise the ordinary `Decode`
+/// error (whose `Display` carries only a serde offset, never the body).
+fn decode_or_api_error(body: &str, err: serde_json::Error) -> LlmError {
+    let is_api_error = serde_json::from_str::<serde_json::Value>(body)
+        .ok()
+        .and_then(|v| v.get("error").cloned())
+        .is_some();
+    if is_api_error {
+        LlmError::Provider(format!("openrouter 200 error body: {}", scrub_error_body(body)))
+    } else {
+        LlmError::Decode(err)
+    }
+}
+
 /// One-shot image-generation request. The model is expected to return
 /// generated images in `message.images[]` on the wire response.
 #[derive(Debug, Clone, Default)]
@@ -818,14 +902,23 @@ impl OpenRouterClient {
             if !status.is_success() {
                 let text = resp.text().await.unwrap_or_default();
                 tracing::warn!(model = %model, %status, "openrouter: vision attempt failed (status); next");
-                last_err = Some(LlmError::Status(status, text));
+                last_err = Some(LlmError::Status(status, scrub_error_body(&text)));
                 continue;
             }
-            let parsed: WireResponse = match resp.json().await {
+            let body = match resp.text().await {
+                Ok(b) => b,
+                Err(e) => {
+                    tracing::warn!(model = %model, error = %e, "openrouter: vision attempt failed (transport); next");
+                    last_err = Some(e.into());
+                    continue;
+                }
+            };
+            let parsed: WireResponse = match serde_json::from_str::<WireResponse>(&body) {
                 Ok(p) => p,
                 Err(e) => {
-                    tracing::warn!(model = %model, error = %e, "openrouter: vision attempt failed (decode); next");
-                    last_err = Some(e.into());
+                    let err = decode_or_api_error(&body, e);
+                    tracing::warn!(model = %model, error = %err, "openrouter: vision attempt failed (decode); next");
+                    last_err = Some(err);
                     continue;
                 }
             };
@@ -1054,16 +1147,32 @@ impl OpenRouterClient {
         let status = resp.status();
         if !status.is_success() {
             let text = resp.text().await.unwrap_or_default();
-            return Err(LlmError::Status(status, text));
+            return Err(LlmError::Status(status, scrub_error_body(&text)));
         }
 
-        let parsed: WireResponse = resp.json().await?;
+        // Read as text so a 200 body that is actually an error envelope
+        // (`{"error":...}` with no `choices`) surfaces the provider message
+        // instead of a bare "missing field choices" decode error.
+        let body = resp.text().await?;
+        let parsed: WireResponse = match serde_json::from_str::<WireResponse>(&body) {
+            Ok(p) => p,
+            Err(e) => return Err(decode_or_api_error(&body, e)),
+        };
         let first_choice = parsed.choices.into_iter().next();
         let raw = first_choice
             .as_ref()
             .and_then(|c| c.message.content.clone())
             .unwrap_or_default();
         let finish_reason = first_choice.and_then(|c| c.finish_reason);
+        // A non-stream completion that finished with finish_reason="error" is a
+        // mid-generation provider death (Batch A fixed the streaming path only).
+        // Fail the attempt so `execute`'s chain advances rather than returning a
+        // partial reply that callers' validity gates would accept as complete.
+        if finish_reason.as_deref() == Some("error") {
+            return Err(LlmError::Provider(
+                "openrouter: non-stream completion finished with finish_reason=error".into(),
+            ));
+        }
         if crate::byte_bpe::looks_byte_garbled(&raw) {
             tracing::error!(
                 model,
@@ -1133,7 +1242,7 @@ impl OpenRouterClient {
         let status = resp.status();
         if !status.is_success() {
             let text = resp.text().await.unwrap_or_default();
-            return Err(LlmError::Status(status, text));
+            return Err(LlmError::Status(status, scrub_error_body(&text)));
         }
 
         let stream = idle_bounded(resp.bytes_stream(), STREAM_IDLE_TIMEOUT)
@@ -1676,6 +1785,175 @@ mod tests {
         assert!(
             matches!(err, LlmError::Status(s, _) if s.as_u16() == 500),
             "expected last 500, got {err:?}"
+        );
+    }
+
+    // ─── B-err1: bounded + redacted provider error body ─────────────────────
+
+    #[test]
+    fn body_preview_caps_and_flattens() {
+        assert_eq!(body_preview("  hi\nthere\r "), "hi\\nthere");
+        let long: String = "x".repeat(ERROR_PREVIEW_MAX + 50);
+        let out = body_preview(&long);
+        assert_eq!(out.chars().count(), ERROR_PREVIEW_MAX + 1, "capped + ellipsis");
+        assert!(out.ends_with('…'));
+    }
+
+    #[test]
+    fn scrub_error_body_drops_moderation_flagged_input() {
+        // The user's flagged prompt excerpt must never survive into the log line.
+        let raw = serde_json::json!({
+            "error": {
+                "code": "moderation",
+                "message": "flagged",
+                "metadata": {
+                    "reasons": ["sexual"],
+                    "flagged_input": "SECRET USER PROMPT TEXT",
+                    "provider_name": "SomeProvider",
+                    "model_slug": "some/model",
+                }
+            }
+        })
+        .to_string();
+        let out = scrub_error_body(&raw);
+        assert!(!out.contains("SECRET USER PROMPT TEXT"), "flagged_input leaked: {out}");
+        assert!(out.contains("code=\"moderation\""), "keeps code: {out}");
+        assert!(out.contains("provider=SomeProvider"), "keeps provider: {out}");
+        assert!(out.contains("moderation_reasons=sexual"), "keeps reasons: {out}");
+    }
+
+    #[test]
+    fn scrub_error_body_handles_numeric_code_and_non_envelope() {
+        // Numeric code (Value, not i64-restricted) round-trips.
+        let raw = serde_json::json!({"error": {"code": 402, "message": "no credits"}}).to_string();
+        let out = scrub_error_body(&raw);
+        assert!(out.contains("code=402"), "{out}");
+        assert!(out.contains("no credits"), "{out}");
+        // Non-envelope junk falls back to a bounded preview.
+        let junk: String = "boom ".repeat(100);
+        let out = scrub_error_body(&junk);
+        assert!(out.chars().count() <= ERROR_PREVIEW_MAX + 1, "bounded: {}", out.len());
+    }
+
+    #[test]
+    fn decode_or_api_error_surfaces_embedded_error() {
+        // A 200 body that is really an error envelope → Provider (chain advances
+        // with a useful, redacted reason), not a bare Decode.
+        let body = serde_json::json!({"error": {"code": 400, "message": "bad request"}}).to_string();
+        let err = serde_json::from_str::<WireResponse>(&body).expect_err("no choices");
+        match decode_or_api_error(&body, err) {
+            LlmError::Provider(msg) => assert!(msg.contains("bad request"), "{msg}"),
+            other => panic!("expected Provider, got {other:?}"),
+        }
+        // Genuine junk stays a Decode error (no body leak — Display is a serde offset).
+        let junk = "not json at all";
+        let err = serde_json::from_str::<WireResponse>(junk).expect_err("bad json");
+        assert!(matches!(decode_or_api_error(junk, err), LlmError::Decode(_)));
+    }
+
+    #[tokio::test]
+    async fn call_once_status_body_is_scrubbed_in_error() {
+        // A moderation 403 with flagged_input must reach the caller's error
+        // (hence logs) with the prompt excerpt stripped.
+        let server = MockServer::start().await;
+        let moderation = serde_json::json!({
+            "error": {
+                "code": "moderation",
+                "message": "input flagged",
+                "metadata": { "reasons": ["harassment"], "flagged_input": "RAW USER CHAT" }
+            }
+        });
+        Mock::given(path("/api/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(403).set_body_json(moderation))
+            .mount(&server)
+            .await;
+        let client = OpenRouterClient::with_base_url(
+            "test-key".into(),
+            AppAttribution::default(),
+            format!("{}/api/v1/chat/completions", server.uri()),
+        );
+        let err = client
+            .execute(ChatRequest {
+                model: "m".into(),
+                messages: vec![ChatMessage { role: "user".into(), content: "hi".into() }],
+                temperature: 0.0,
+                max_tokens: 16,
+                ..Default::default()
+            })
+            .await
+            .expect_err("403 fails the chain");
+        let shown = err.to_string();
+        assert!(!shown.contains("RAW USER CHAT"), "flagged_input leaked into error: {shown}");
+        assert!(shown.contains("moderation_reasons=harassment"), "{shown}");
+    }
+
+    // ─── B-err2: non-stream finish_reason=="error" fails the attempt ─────────
+
+    #[tokio::test]
+    async fn call_once_finish_reason_error_advances_chain() {
+        let server = MockServer::start().await;
+        // Primary returns 200 with finish_reason:"error" (mid-generation death);
+        // fallback returns a clean reply.
+        Mock::given(path("/api/v1/chat/completions"))
+            .and(wiremock::matchers::body_partial_json(serde_json::json!({"model": "p"})))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "choices": [{ "message": { "content": "partial" }, "finish_reason": "error" }]
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(path("/api/v1/chat/completions"))
+            .and(wiremock::matchers::body_partial_json(serde_json::json!({"model": "f"})))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ok_response()))
+            .mount(&server)
+            .await;
+        let client = OpenRouterClient::with_base_url(
+            "test-key".into(),
+            AppAttribution::default(),
+            format!("{}/api/v1/chat/completions", server.uri()),
+        );
+        let resp = client
+            .execute(ChatRequest {
+                model: "p".into(),
+                fallback_model: vec!["f".into()],
+                messages: vec![ChatMessage { role: "user".into(), content: "hi".into() }],
+                temperature: 0.0,
+                max_tokens: 16,
+                ..Default::default()
+            })
+            .await
+            .expect("fallback serves the clean reply");
+        assert_eq!(resp.reply, "ok", "the finish_reason=error partial must not be returned");
+    }
+
+    // ─── B-err3: 200 body that is an error envelope ─────────────────────────
+
+    #[tokio::test]
+    async fn call_once_200_error_envelope_becomes_provider_error() {
+        let server = MockServer::start().await;
+        Mock::given(path("/api/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "error": { "code": 500, "message": "provider exploded" }
+            })))
+            .mount(&server)
+            .await;
+        let client = OpenRouterClient::with_base_url(
+            "test-key".into(),
+            AppAttribution::default(),
+            format!("{}/api/v1/chat/completions", server.uri()),
+        );
+        let err = client
+            .execute(ChatRequest {
+                model: "m".into(),
+                messages: vec![ChatMessage { role: "user".into(), content: "hi".into() }],
+                temperature: 0.0,
+                max_tokens: 16,
+                ..Default::default()
+            })
+            .await
+            .expect_err("a 200 error envelope must fail, not decode-silently");
+        assert!(
+            matches!(&err, LlmError::Provider(m) if m.contains("provider exploded")),
+            "expected Provider with the embedded message, got {err:?}"
         );
     }
 

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -558,6 +558,11 @@ fn drive_chat_burst(
                             };
                             match item {
                                 Ok(c) => {
+                                    // `execute_stream` filters empty deltas to None
+                                    // (openrouter.rs `.filter(|s| !s.is_empty())`),
+                                    // so a present `content` is always non-empty —
+                                    // ttft records the first *real* token, not a
+                                    // role/terminal empty delta.
                                     if let Some(content) = c.content {
                                         ttft_ms.get_or_insert_with(|| {
                                             attempt_started.elapsed().as_millis() as u64
@@ -872,6 +877,10 @@ fn drive_chat_burst(
                         };
                         match item {
                             Ok(c) => {
+                                // Empty deltas are already filtered to None by
+                                // execute_stream, so a present `content` is a real
+                                // upstream token — ttft is not tripped by role/
+                                // terminal empty frames.
                                 if let Some(content) = c.content {
                                     ttft_ms.get_or_insert_with(|| {
                                         attempt_started.elapsed().as_millis() as u64

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -527,6 +527,12 @@ fn drive_chat_burst(
                 per_model_req.model = model_id.clone();
                 per_model_req.fallback_model = Vec::new();
 
+                // Per-attempt latency observability (spec §4.2). ttft = call →
+                // first content delta; outcome is the terminal disposition.
+                let attempt_started = std::time::Instant::now();
+                let mut ttft_ms: Option<u64> = None;
+                let mut attempt_outcome: &'static str = "served";
+
                 match tokio::time::timeout(
                     STREAM_OPEN_TIMEOUT,
                     state.openrouter.execute_stream(per_model_req),
@@ -546,12 +552,16 @@ fn drive_chat_burst(
                                         STREAM_TOTAL_TIMEOUT.as_secs()
                                     );
                                     truncated = true;
+                                    attempt_outcome = "total_timeout";
                                     break;
                                 }
                             };
                             match item {
                                 Ok(c) => {
                                     if let Some(content) = c.content {
+                                        ttft_ms.get_or_insert_with(|| {
+                                            attempt_started.elapsed().as_millis() as u64
+                                        });
                                         acc.push_str(&content);
                                         yield ProtocolFrame::Delta {
                                             message_id: ulid_string(msg_ulid),
@@ -565,27 +575,32 @@ fn drive_chat_burst(
                                     // rides the same truncation → chain-advance path
                                     // as "length" (parity with the sync path's
                                     // filter_output_invalidity gate).
-                                    if matches!(
-                                        c.finish_reason.as_deref(),
-                                        Some("length") | Some("content_filter")
-                                    ) {
-                                        truncated = true;
+                                    match c.finish_reason.as_deref() {
+                                        Some("length") => { truncated = true; attempt_outcome = "length"; }
+                                        Some("content_filter") => {
+                                            truncated = true;
+                                            attempt_outcome = "content_filter";
+                                        }
+                                        _ => {}
                                     }
                                 }
                                 Err(e) => {
                                     tracing::warn!("stream: upstream chunk err: {e}");
                                     truncated = true;
+                                    attempt_outcome = "chunk_error";
                                     break;
                                 }
                             }
                         }
                         if !truncated && acc.is_empty() {
                             empty_completion = true;
+                            attempt_outcome = "empty";
                         }
                     }
                     Ok(Err(e)) => {
                         tracing::warn!("stream: upstream open err: {e}");
                         truncated = true;
+                        attempt_outcome = "open_error";
                     }
                     Err(_) => {
                         tracing::warn!(
@@ -593,6 +608,7 @@ fn drive_chat_burst(
                             STREAM_OPEN_TIMEOUT.as_secs()
                         );
                         truncated = true;
+                        attempt_outcome = "open_timeout";
                     }
                 }
 
@@ -616,10 +632,21 @@ fn drive_chat_burst(
                     tracing::error!(model = %model_id, "stream: byte-BPE garbled completion (issue #84)");
                     acc = eros_engine_llm::byte_bpe::repair_byte_bpe(&acc);
                     truncated = true;
+                    attempt_outcome = "garbled";
                     if !truncated_before_garble {
                         last_complete_garble = Some(acc.clone());
                     }
                 }
+
+                tracing::info!(
+                    target: "stream_metrics",
+                    model = %model_id,
+                    attempt = idx,
+                    ttft_ms,
+                    total_ms = attempt_started.elapsed().as_millis() as u64,
+                    outcome = attempt_outcome,
+                    "chat stream attempt"
+                );
 
                 // Disposition, computed once up front (spec §5.3): a non-last
                 // empty completion advances to the next model below; only the
@@ -812,6 +839,14 @@ fn drive_chat_burst(
             let mut per_model_req = req.clone();
             per_model_req.model = model_id.clone();
             per_model_req.fallback_model = Vec::new();
+
+            // Per-attempt observability (spec §4.2). In filtered mode the client
+            // sees nothing until the whole reply is rewritten, so ttft_ms here is
+            // time-to-first-UPSTREAM-token (still useful to compare model speed),
+            // not time-to-client.
+            let attempt_started = std::time::Instant::now();
+            let mut ttft_ms: Option<u64> = None;
+            let mut attempt_outcome: &'static str = "served";
             match tokio::time::timeout(
                 STREAM_OPEN_TIMEOUT,
                 state.openrouter.execute_stream(per_model_req),
@@ -831,34 +866,55 @@ fn drive_chat_burst(
                                     STREAM_TOTAL_TIMEOUT.as_secs()
                                 );
                                 truncated = true;
+                                attempt_outcome = "total_timeout";
                                 break;
                             }
                         };
                         match item {
                             Ok(c) => {
-                                if let Some(content) = c.content { acc.push_str(&content); }
+                                if let Some(content) = c.content {
+                                    ttft_ms.get_or_insert_with(|| {
+                                        attempt_started.elapsed().as_millis() as u64
+                                    });
+                                    acc.push_str(&content);
+                                }
                                 if c.usage.is_some() { last_usage = c.usage; }
                                 if c.generation_id.is_some() { last_gen_id = c.generation_id; }
-                                if matches!(c.finish_reason.as_deref(), Some("length") | Some("content_filter")) { truncated = true; }
+                                match c.finish_reason.as_deref() {
+                                    Some("length") => { truncated = true; attempt_outcome = "length"; }
+                                    Some("content_filter") => { truncated = true; attempt_outcome = "content_filter"; }
+                                    _ => {}
+                                }
                             }
-                            Err(e) => { tracing::warn!("stream(filtered): chunk err: {e}"); truncated = true; break; }
+                            Err(e) => {
+                                tracing::warn!("stream(filtered): chunk err: {e}");
+                                truncated = true;
+                                attempt_outcome = "chunk_error";
+                                break;
+                            }
                         }
                     }
-                    if !truncated && acc.is_empty() { empty_completion = true; }
+                    if !truncated && acc.is_empty() { empty_completion = true; attempt_outcome = "empty"; }
                 }
-                Ok(Err(e)) => { tracing::warn!("stream(filtered): open err: {e}"); truncated = true; }
+                Ok(Err(e)) => {
+                    tracing::warn!("stream(filtered): open err: {e}");
+                    truncated = true;
+                    attempt_outcome = "open_error";
+                }
                 Err(_) => {
                     tracing::warn!(
                         "stream(filtered): open timeout ({}s), advancing chain",
                         STREAM_OPEN_TIMEOUT.as_secs()
                     );
                     truncated = true;
+                    attempt_outcome = "open_timeout";
                 }
             }
 
             if eros_engine_llm::byte_bpe::looks_byte_garbled(&acc) {
                 tracing::error!(model = %model_id, "stream(filtered): byte-BPE garbled completion (issue #84)");
                 acc = eros_engine_llm::byte_bpe::repair_byte_bpe(&acc);
+                attempt_outcome = "garbled";
                 // Nothing has been streamed to the client yet, so a COMPLETE garble
                 // is salvaged immediately: the repaired (clean) text flows through
                 // the output filter + persist below. We deliberately do NOT force a
@@ -866,6 +922,17 @@ fn drive_chat_burst(
                 // the later attempt failed. An INCOMPLETE garble is already
                 // `truncated` (length / transport) and handled by the block below.
             }
+
+            tracing::info!(
+                target: "stream_metrics",
+                model = %model_id,
+                attempt = idx,
+                ttft_ms,
+                total_ms = attempt_started.elapsed().as_millis() as u64,
+                outcome = attempt_outcome,
+                filtered = true,
+                "chat stream attempt"
+            );
 
             if empty_completion {
                 if idx + 1 == chain.len() {

--- a/docs/superpowers/specs/2026-07-23-openrouter-stream-latency-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-23-openrouter-stream-latency-hardening-design.md
@@ -222,6 +222,14 @@ tracing::info!(
 
 `outcome` is a `&'static str` assigned where each condition is detected
 (the existing `warn!` lines stay; this event is the aggregate-friendly one).
+The live burst also carries `ttft_ms` as true time-to-client; the filtered
+burst carries it as time-to-first-*upstream*-token (the client sees nothing
+until the rewrite completes) and tags the event `filtered = true`. Scope: the
+event is emitted in the two **companion** bursts (live + filtered) — the
+TTFT-critical paths and Batch C's optimization target. The out-of-character
+**product-QA** executor (a low-volume path Batch C does not touch, with a
+labeled-`continue`/`break` chain walk) keeps its existing per-attempt `warn`
+logs rather than a fragile multi-exit-point structured emit.
 
 ### 4.3 Error-body bounding & redaction (riders folded into B)
 

--- a/docs/superpowers/specs/2026-07-23-openrouter-stream-latency-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-23-openrouter-stream-latency-hardening-design.md
@@ -223,6 +223,67 @@ tracing::info!(
 `outcome` is a `&'static str` assigned where each condition is detected
 (the existing `warn!` lines stay; this event is the aggregate-friendly one).
 
+### 4.3 Error-body bounding & redaction (riders folded into B)
+
+Two independent investigations of the reference SDK
+`realmorrisliu/openrouter-rs` (its `ApiErrorContext` / `is_retryable` /
+`ApiErrorKind` normalization) concluded **PARTIAL**: eros-engine's pipeline is
+*uniform-advance* — the server crate holds **zero** `LlmError` references and
+consumes errors only as a `Display` string in `tracing` logs, so a normalized
+error taxonomy nobody branches on is dead weight, and wiring moderation as a
+"terminal" kind would actively *regress* companion fallback (a laxer model
+down the chain is exactly what you want). Rejected: `ApiErrorContext`,
+`is_retryable`, `ApiErrorKind` control flow, `api_code`, `x-request-id`
+header, `normalize_error_status`, `merge_top_level_metadata`. Adopted here is
+only the subset that closes a **real privacy defect** or a small correctness
+gap. All changes are inside `eros-engine-llm`; `LlmError::Status`'s
+`(StatusCode, String)` shape is unchanged (its existing tests match on status
+only), so nothing in the server crate moves.
+
+**The defect:** `LlmError::Status`'s `Display` is `"non-success status {0}:
+{1}"` where `{1}` is the **full, unbounded provider body**, logged verbatim on
+the chain-advance path (`openrouter.rs` `execute` warn lines; `stream.rs`
+`"upstream open err: {e}"`). OpenRouter's *moderation* error body carries
+`metadata.flagged_input` — an excerpt of the user's flagged message — so today
+a slice of raw user chat content lands in ordinary logs, unbounded. Direct
+violation of the "never echo NSFW content" rule.
+
+- **B-err1 — bound + scrub at the `LlmError::Status` construction sites**
+  (`call_once`, `execute_stream`, `execute_vision`). New helpers in
+  `openrouter.rs`:
+  - `body_preview(&str) -> String`: flatten `\r`/`\n`, cap `ERROR_PREVIEW_MAX
+    = 200` chars with an ellipsis marker.
+  - `scrub_error_body(raw) -> String`: best-effort parse the OpenRouter
+    `{"error":{code,message,metadata}}` envelope; keep `code` (as
+    `serde_json::Value` — satisfies the non-i64 requirement, and is *better*
+    than the reference's `Option<i64>`), a `body_preview`'d `message`, and —
+    from moderation metadata — only `provider_name` + `reasons`, **never
+    `flagged_input`**. Non-envelope bodies fall back to `body_preview(raw)`.
+    Store the scrubbed string in `Status`, so every downstream `%e`/`{e}` log
+    is bounded and redacted with no log-site edits.
+- **B-err2 — close the non-streaming `finish_reason == "error"` gap.** Batch A
+  fixed only the streaming path; `call_once` still returns `Ok` with
+  `finish_reason: Some("error")`, so non-stream callers (PDE / output-filter /
+  affinity / world) accept a partial reply from a mid-generation provider
+  death. Add: `finish_reason == "error"` ⇒ `Err(LlmError::Provider(..))` so
+  `execute`'s chain advances (mirror of the Batch A stream fix), placed before
+  the garble check.
+- **B-err3 — surface an embedded error on a 200-decode failure.** A 200 body
+  that is actually `{"error":...}` with no `choices` currently fails as
+  `Decode("missing field choices")`, discarding the provider's message. In
+  `call_once` and `execute_vision`, read the body as text, `from_str`; on
+  parse failure route through `decode_or_api_error(status, body, err)`: if the
+  body contains a top-level `error` object ⇒ `Provider(scrub_error_body(body))`
+  (chain advances with a useful, redacted reason); otherwise the existing
+  `Decode(err)` (its `Display` carries only a serde offset, not the body — no
+  leak, no new variant).
+
+Skipped from the reference (no consumer / would regress): the whole
+`ApiErrorContext` struct, `is_retryable`/`is_client_error`/`is_server_error`,
+`ApiErrorKind` as control flow, `x-request-id` capture (different key from the
+audit's `generation_id`, which §4.1 already captures), `normalize_error_status`,
+and moderation-as-terminal.
+
 ## 5. Batch C — streaming-safe `output_regex` (the TTFT lever)
 
 ### 5.1 Problem shape


### PR DESCRIPTION
Batch B of the OpenRouter stream-hardening work (spec §4:
`docs/superpowers/specs/2026-07-23-openrouter-stream-latency-hardening-design.md`).
Latency observability, generation-id capture, and — folded in after an
investigation — a small error-body redaction subset. Batches C/D follow.

## Error-handling subset (the investigation result)

Prompted by the reference SDK `realmorrisliu/openrouter-rs`, two independent
audits (one Fable, one Opus) both concluded **PARTIAL**: eros-engine's pipeline
is *uniform-advance* — the server crate holds zero `LlmError` references and
consumes errors only as a `Display` string in logs — so the reference's
`ApiErrorContext` / `is_retryable()` / moderation-vs-provider taxonomy is dead
weight nobody branches on, and moderation-as-terminal would actively *regress*
companion fallback (a laxer model down the chain is what you want). Rejected the
framework; adopted only what closes a real defect:

- **B-err1 — redact + bound the provider error body.** `LlmError::Status`'s
  Display was `"non-success status {0}: {1}"` with `{1}` the **full, unbounded
  provider body**, logged verbatim on the chain-advance path. An OpenRouter
  moderation body carries `metadata.flagged_input` — an excerpt of the user's
  flagged message — so raw chat content was landing in logs unbounded. New
  `scrub_error_body` / `body_preview` at every `Status` construction site keep
  only `code` (as `serde_json::Value`, not i64), a capped `message`, and
  `provider_name` / moderation `reasons`; `flagged_input` is never read. The
  whole assembled string is flattened + capped so provider-controlled fields
  can't inject newlines or blow up log volume. `LlmError::Status`'s shape is
  unchanged.
- **B-err2 — non-stream `finish_reason == "error"` fails the attempt.** Batch A
  fixed the streaming path only; `call_once` still returned `Ok` with a partial
  reply. Now it errors so `execute`'s chain advances.
- **B-err3 — 200 error-envelope surfaces the provider message** via
  `decode_or_api_error`, instead of a bare `Decode("missing field choices")`.

## Observability (original Batch B)

- **B1** — capture `X-Generation-Id` at header-arrival as a synthetic first
  `DeltaChunk` (audit handle survives a stream that dies before its first
  id-bearing body chunk); debug-log stream-open latency + negotiated HTTP
  version (should read HTTP/2.0 post-A3). Prompt content is never logged.
- **B2** — per-attempt `stream_metrics` info event (model, `ttft_ms`,
  `total_ms`, `&'static outcome`) on the live + filtered companion bursts. The
  out-of-character product-QA executor keeps its existing warn logs (low-volume,
  not a TTFT target, labeled-`continue` chain walk not worth a fragile
  multi-exit emit). This instrumentation is what makes Batch C's streaming win
  measurable.

## Testing

`cargo fmt` + `clippy --all-targets -D warnings` clean; full workspace **884
tests green**; openapi no drift. New coverage: helper units, moderation-redaction
(asserts `flagged_input` never survives), hostile-metadata bounding, non-stream
`finish_reason=error`, 200-error-envelope, `X-Generation-Id` present/absent.
Codex review (`--base dev`) surfaced two P2s — one real (unbounded
provider-controlled metadata → fixed) and one false positive (TTFT on empty
deltas — verified `execute_stream` already filters empty content to `None`;
documented the invariant). Final codex pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
