### PR TITLE
feat: OpenRouter stream hardening — Batch C (streaming-safe output_regex, the TTFT lever)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,6 +530,7 @@ dependencies = [
  "futures-util",
  "rand 0.8.6",
  "regex",
+ "regex-syntax",
  "reqwest",
  "serde",
  "serde_json",

--- a/crates/eros-engine-llm/Cargo.toml
+++ b/crates/eros-engine-llm/Cargo.toml
@@ -23,6 +23,7 @@ tokio = { workspace = true }
 toml = "0.8"
 rand = "0.8"
 regex = "1"
+regex-syntax = "0.8"
 eventsource-stream = { workspace = true }
 futures-util       = { workspace = true }
 tokio-stream       = { workspace = true }

--- a/crates/eros-engine-llm/src/lib.rs
+++ b/crates/eros-engine-llm/src/lib.rs
@@ -5,6 +5,7 @@ pub mod byte_bpe;
 pub mod error;
 pub mod model_config;
 pub mod openrouter;
+pub mod stream_scrub;
 pub mod voyage;
 
 pub use error::LlmError;

--- a/crates/eros-engine-llm/src/stream_scrub.rs
+++ b/crates/eros-engine-llm/src/stream_scrub.rs
@@ -20,7 +20,7 @@
 //! degrade to full buffering (correct for any rule, just no TTFT win), so a
 //! downstream deployment with an exotic pattern loses nothing versus today.
 
-use regex_syntax::hir::{Hir, HirKind, Look};
+use regex_syntax::hir::{Class, Hir, HirKind, Look};
 
 use crate::model_config::CompiledRegexRule;
 
@@ -57,6 +57,23 @@ fn single_char_literal(hir: &Hir) -> Option<char> {
     None
 }
 
+/// True iff `hir` is exactly the Unicode class `[^close]` — every scalar except
+/// `close`. Verified by negating the class and checking the result is precisely
+/// the single char `close`. This is what makes `SpanTransform`'s `open`→`close`
+/// scan equivalent to the regex: the run between the delimiters must be
+/// "anything but the close char" (not `.`, which excludes newline, and not a
+/// bounded/other class).
+fn class_is_not_char(hir: &Hir, close: char) -> bool {
+    if let HirKind::Class(Class::Unicode(cls)) = hir.kind() {
+        let mut negated = cls.clone();
+        negated.negate();
+        let ranges = negated.ranges();
+        ranges.len() == 1 && ranges[0].start() == close && ranges[0].end() == close
+    } else {
+        false
+    }
+}
+
 /// Classify a rule's regex pattern into a streaming strategy. Uses the parsed
 /// HIR so the decision is structural, not string-guessing.
 pub fn classify(pattern: &str) -> RuleShape {
@@ -67,15 +84,23 @@ pub fn classify(pattern: &str) -> RuleShape {
     if hir.properties().look_set_prefix().contains(Look::Start) {
         return RuleShape::Head;
     }
-    // `open [^close]* close` decodes to Concat[Literal(open), Repetition, Literal(close)].
+    // A span rule must be EXACTLY `open [^close]* close`: Concat of a literal
+    // open, a `*` (min 0, unbounded) repetition of the negated-close class, and
+    // a literal close. Anything looser (`a.+b`, `a.*b`, a bounded `{2,5}`, a
+    // capture group) is NOT what SpanTransform implements, so it stays Opaque
+    // (buffered) rather than risk diverging from apply_output_regex on the wire.
     if let HirKind::Concat(parts) = hir.kind() {
         if parts.len() == 3 {
-            if let (Some(open), HirKind::Repetition(_), Some(close)) = (
+            if let (Some(open), HirKind::Repetition(rep), Some(close)) = (
                 single_char_literal(&parts[0]),
                 parts[1].kind(),
                 single_char_literal(&parts[2]),
             ) {
-                if open != close {
+                if open != close
+                    && rep.min == 0
+                    && rep.max.is_none()
+                    && class_is_not_char(&rep.sub, close)
+                {
                     return RuleShape::Span { open, close };
                 }
             }
@@ -134,6 +159,9 @@ impl Transform for HeadTransform {
 /// [`SPAN_HOLDBACK_CAP`] chars accumulate with no close (flush the held text
 /// verbatim — a lone unterminated `open`).
 struct SpanTransform {
+    /// The full rule regex, run on the completed span so any replacement
+    /// (including `$0`/capture expansion) matches apply_output_regex exactly.
+    regex: regex::Regex,
     open: char,
     close: char,
     replacement: String,
@@ -148,9 +176,12 @@ impl SpanTransform {
         for ch in input.chars() {
             if self.in_span {
                 if ch == self.close {
-                    // Complete span: emit the replacement, drop the held region.
-                    out.push_str(&self.replacement);
-                    self.held.clear();
+                    // Complete span: run the regex over the matched text so the
+                    // replacement is expanded exactly as replace_all would, then
+                    // drop the held region.
+                    let mut full = std::mem::take(&mut self.held);
+                    full.push(ch);
+                    out.push_str(&self.regex.replace(&full, self.replacement.as_str()));
                     self.in_span = false;
                 } else {
                     self.held.push(ch);
@@ -232,6 +263,7 @@ impl StreamScrubber {
                     done: false,
                 }),
                 RuleShape::Span { open, close } => Box::new(SpanTransform {
+                    regex: rule.regex.clone(),
                     open,
                     close,
                     replacement: rule.replacement.clone(),
@@ -313,6 +345,48 @@ mod tests {
         );
         assert_eq!(classify(r"(?s)<think>.*?</think>\s*"), RuleShape::Opaque);
         assert_eq!(classify(r"foo"), RuleShape::Opaque);
+    }
+
+    #[test]
+    fn classify_rejects_non_span_three_part_concats() {
+        // `.+` / `.*` are NOT `[^close]*` (a.+b needs ≥1 char; `.` excludes \n),
+        // a bounded repetition is not `*`, and a capture group breaks the shape.
+        // All must be Opaque so SpanTransform never mis-strips them.
+        assert_eq!(classify(r"a.+b"), RuleShape::Opaque);
+        assert_eq!(classify(r"a.*b"), RuleShape::Opaque);
+        assert_eq!(classify(r"\[[^\]]{2,5}\]"), RuleShape::Opaque);
+        assert_eq!(classify(r"\[([^\]]*)\]"), RuleShape::Opaque);
+        // But the exact production shape stays Span.
+        assert_eq!(
+            classify(r"\[[^\]]*\]"),
+            RuleShape::Span {
+                open: '[',
+                close: ']'
+            }
+        );
+    }
+
+    #[test]
+    fn span_replacement_expansion_matches_whole_text_apply() {
+        // A span rule with a non-empty $0-expanding replacement must stream the
+        // same text apply_output_regex produces (the whole match, wrapped).
+        let rules = vec![CompiledRegexRule {
+            models: vec!["m".to_string()],
+            regex: regex::Regex::new(r"\[[^\]]*\]").unwrap(),
+            replacement: "<$0>".to_string(),
+        }];
+        let text = "a[x]b[y]c";
+        let expected = apply_output_regex(&rules, "m", text).cleaned;
+        for split in 0..=text.chars().count() {
+            let chars: Vec<char> = text.chars().collect();
+            let mut s = StreamScrubber::new(&rules, "m");
+            let a: String = chars[..split].iter().collect();
+            let b: String = chars[split..].iter().collect();
+            let mut got = s.push(&a);
+            got.push_str(&s.push(&b));
+            got.push_str(&s.finish());
+            assert_eq!(got, expected, "split={split}");
+        }
     }
 
     /// The load-bearing guarantee: for every chunk-split point, the scrubbed

--- a/crates/eros-engine-llm/src/stream_scrub.rs
+++ b/crates/eros-engine-llm/src/stream_scrub.rs
@@ -1,0 +1,402 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! Streaming-safe application of `output_regex` rules.
+//!
+//! The pipeline used to buffer a whole reply whenever any model in the chain
+//! had any `output_regex` rule, because [`crate::model_config::apply_output_regex`]
+//! needs the complete text. With the real production config every chat model is
+//! targeted by the bracket-strip rule, so *every* chat turn buffered and TTFT
+//! became full-generation time.
+//!
+//! This module streams through those rules with a bounded holdback. Each rule
+//! becomes a small streaming [`Transform`]; the transforms are chained in
+//! declaration order, so the composition is exactly the sequential
+//! `replace_all`-per-rule that `apply_output_regex` performs — respecting rule
+//! order (e.g. a leading `[artifact]嗯…` has the bracket stripped first, then
+//! the `^嗯` head rule sees the exposed `嗢…`). The load-bearing guarantee is
+//! that concatenating everything a scrubber emits equals `apply_output_regex`
+//! over the same full text; see the property test in this module.
+//!
+//! Rules whose shape isn't a recognized head-anchored or bracket-span pattern
+//! degrade to full buffering (correct for any rule, just no TTFT win), so a
+//! downstream deployment with an exotic pattern loses nothing versus today.
+
+use regex_syntax::hir::{Hir, HirKind, Look};
+
+use crate::model_config::CompiledRegexRule;
+
+/// First-N chars held while a `^`-anchored (head) rule might still match. A
+/// head match longer than this streams before the rule can fire — the persist
+/// path re-runs the whole-text apply, so only the wire briefly shows it
+/// (fail-open, same philosophy as [`SPAN_HOLDBACK_CAP`]).
+const HEAD_HOLDBACK: usize = 64;
+/// Max chars held across an unterminated span open delimiter before flushing it
+/// verbatim (a lone `[` in prose, never closed). Bounds the holdback window.
+const SPAN_HOLDBACK_CAP: usize = 256;
+
+/// The streaming strategy inferred for one compiled rule.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RuleShape {
+    /// `^`-anchored (start-of-haystack): can only match a leading prefix.
+    Head,
+    /// A `open [^close]* close` bracket span (delete/replace a bounded region).
+    Span { open: char, close: char },
+    /// Anything else — must buffer fully to apply safely.
+    Opaque,
+}
+
+/// Decode a HIR `Literal` that is exactly one `char`.
+fn single_char_literal(hir: &Hir) -> Option<char> {
+    if let HirKind::Literal(lit) = hir.kind() {
+        let s = std::str::from_utf8(&lit.0).ok()?;
+        let mut it = s.chars();
+        let c = it.next()?;
+        if it.next().is_none() {
+            return Some(c);
+        }
+    }
+    None
+}
+
+/// Classify a rule's regex pattern into a streaming strategy. Uses the parsed
+/// HIR so the decision is structural, not string-guessing.
+pub fn classify(pattern: &str) -> RuleShape {
+    let Ok(hir) = regex_syntax::parse(pattern) else {
+        return RuleShape::Opaque;
+    };
+    // A `^` (non-multiline) anchors every match to the start of the haystack.
+    if hir.properties().look_set_prefix().contains(Look::Start) {
+        return RuleShape::Head;
+    }
+    // `open [^close]* close` decodes to Concat[Literal(open), Repetition, Literal(close)].
+    if let HirKind::Concat(parts) = hir.kind() {
+        if parts.len() == 3 {
+            if let (Some(open), HirKind::Repetition(_), Some(close)) = (
+                single_char_literal(&parts[0]),
+                parts[1].kind(),
+                single_char_literal(&parts[2]),
+            ) {
+                if open != close {
+                    return RuleShape::Span { open, close };
+                }
+            }
+        }
+    }
+    RuleShape::Opaque
+}
+
+/// One streaming transform. `push` returns the text now safe to hand downstream;
+/// `finish` flushes whatever remains held. The invariant every transform keeps:
+/// the concatenation of all `push` outputs plus `finish` equals its regex
+/// applied (via `replace_all`) to the concatenation of all `push` inputs.
+trait Transform: Send {
+    fn push(&mut self, input: &str) -> String;
+    fn finish(&mut self) -> String;
+}
+
+/// `^`-anchored rule: hold the first [`HEAD_HOLDBACK`] chars, apply once (a
+/// start-anchored rule matches at most the leading prefix), then pass the rest
+/// through untouched.
+struct HeadTransform {
+    regex: regex::Regex,
+    replacement: String,
+    head: String,
+    done: bool,
+}
+
+impl Transform for HeadTransform {
+    fn push(&mut self, input: &str) -> String {
+        if self.done {
+            return input.to_string();
+        }
+        self.head.push_str(input);
+        if self.head.chars().count() < HEAD_HOLDBACK {
+            return String::new();
+        }
+        self.done = true;
+        self.regex
+            .replace_all(&std::mem::take(&mut self.head), self.replacement.as_str())
+            .into_owned()
+    }
+
+    fn finish(&mut self) -> String {
+        if self.done {
+            return String::new();
+        }
+        self.done = true;
+        self.regex
+            .replace_all(&std::mem::take(&mut self.head), self.replacement.as_str())
+            .into_owned()
+    }
+}
+
+/// `open [^close]* close` rule: pass through until an `open`, then hold until the
+/// matching `close` (emit the replacement for the whole span) or until
+/// [`SPAN_HOLDBACK_CAP`] chars accumulate with no close (flush the held text
+/// verbatim — a lone unterminated `open`).
+struct SpanTransform {
+    open: char,
+    close: char,
+    replacement: String,
+    /// Text held since an unmatched `open` (includes the `open`). Empty when
+    /// not inside a span.
+    held: String,
+    in_span: bool,
+}
+
+impl SpanTransform {
+    fn feed(&mut self, input: &str, out: &mut String) {
+        for ch in input.chars() {
+            if self.in_span {
+                if ch == self.close {
+                    // Complete span: emit the replacement, drop the held region.
+                    out.push_str(&self.replacement);
+                    self.held.clear();
+                    self.in_span = false;
+                } else {
+                    self.held.push(ch);
+                    if self.held.chars().count() > SPAN_HOLDBACK_CAP {
+                        // Unterminated: fail open — flush the held text verbatim
+                        // and resume scanning (a later `open` can start a span).
+                        out.push_str(&self.held);
+                        self.held.clear();
+                        self.in_span = false;
+                    }
+                }
+            } else if ch == self.open {
+                self.in_span = true;
+                self.held.push(ch);
+            } else {
+                out.push(ch);
+            }
+        }
+    }
+}
+
+impl Transform for SpanTransform {
+    fn push(&mut self, input: &str) -> String {
+        let mut out = String::new();
+        self.feed(input, &mut out);
+        out
+    }
+
+    fn finish(&mut self) -> String {
+        // An open span never closed: emit the held text verbatim (the regex
+        // requires a close, so an unterminated open is not a match).
+        std::mem::take(&mut self.held)
+    }
+}
+
+/// Fallback for any rule shape not safe to stream: buffer all input, apply the
+/// regex over the whole at `finish`.
+struct OpaqueTransform {
+    regex: regex::Regex,
+    replacement: String,
+    buf: String,
+}
+
+impl Transform for OpaqueTransform {
+    fn push(&mut self, input: &str) -> String {
+        self.buf.push_str(input);
+        String::new()
+    }
+
+    fn finish(&mut self) -> String {
+        self.regex
+            .replace_all(&std::mem::take(&mut self.buf), self.replacement.as_str())
+            .into_owned()
+    }
+}
+
+/// Applies a model's `output_regex` rules to a delta stream incrementally.
+/// Build once per attempt with the rules that target the served model; feed
+/// each delta through [`push`](Self::push) and flush with [`finish`](Self::finish).
+pub struct StreamScrubber {
+    transforms: Vec<Box<dyn Transform>>,
+}
+
+impl StreamScrubber {
+    /// Build a scrubber for `model_id` from the full compiled rule set. Rules
+    /// that don't target the model are skipped; the rest become transforms in
+    /// declaration order. With no matching rule the scrubber is pure passthrough.
+    pub fn new(rules: &[CompiledRegexRule], model_id: &str) -> Self {
+        let mut transforms: Vec<Box<dyn Transform>> = Vec::new();
+        for rule in rules {
+            if !rule.models.iter().any(|m| m == model_id) {
+                continue;
+            }
+            let t: Box<dyn Transform> = match classify(rule.regex.as_str()) {
+                RuleShape::Head => Box::new(HeadTransform {
+                    regex: rule.regex.clone(),
+                    replacement: rule.replacement.clone(),
+                    head: String::new(),
+                    done: false,
+                }),
+                RuleShape::Span { open, close } => Box::new(SpanTransform {
+                    open,
+                    close,
+                    replacement: rule.replacement.clone(),
+                    held: String::new(),
+                    in_span: false,
+                }),
+                RuleShape::Opaque => Box::new(OpaqueTransform {
+                    regex: rule.regex.clone(),
+                    replacement: rule.replacement.clone(),
+                    buf: String::new(),
+                }),
+            };
+            transforms.push(t);
+        }
+        Self { transforms }
+    }
+
+    /// Feed one delta; returns the text now safe to emit to the client (may be
+    /// empty while text is held back).
+    pub fn push(&mut self, delta: &str) -> String {
+        let mut cur = delta.to_string();
+        for t in &mut self.transforms {
+            cur = t.push(&cur);
+        }
+        cur
+    }
+
+    /// Stream ended: flush every transform's held state, cascading each one's
+    /// flush through the transforms after it.
+    pub fn finish(&mut self) -> String {
+        let mut cur = String::new();
+        for t in &mut self.transforms {
+            let pushed = t.push(&cur);
+            let finished = t.finish();
+            cur = pushed + &finished;
+        }
+        cur
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model_config::{apply_output_regex, CompiledRegexRule};
+
+    fn compile(patterns: &[&str]) -> Vec<CompiledRegexRule> {
+        patterns
+            .iter()
+            .map(|p| CompiledRegexRule {
+                models: vec!["m".to_string()],
+                regex: regex::Regex::new(p).unwrap(),
+                replacement: String::new(),
+            })
+            .collect()
+    }
+
+    /// The real production patterns (from eros-engine-web/infra/engine/model_config.toml).
+    fn production_rules() -> Vec<CompiledRegexRule> {
+        compile(&[
+            r"\[[^\]]*\]",
+            r"^嗯(?:\.{3,6}|…{1,2})\s*",
+            r"^(?:[(（][^)）]*[)）]|\.{3,6}\s*|…{1,2}\s*)",
+        ])
+    }
+
+    #[test]
+    fn classify_production_patterns() {
+        assert_eq!(classify(r"^嗯(?:\.{3,6}|…{1,2})\s*"), RuleShape::Head);
+        assert_eq!(
+            classify(r"^(?:[(（][^)）]*[)）]|\.{3,6}\s*|…{1,2}\s*)"),
+            RuleShape::Head
+        );
+        assert_eq!(
+            classify(r"\[[^\]]*\]"),
+            RuleShape::Span {
+                open: '[',
+                close: ']'
+            }
+        );
+        assert_eq!(classify(r"(?s)<think>.*?</think>\s*"), RuleShape::Opaque);
+        assert_eq!(classify(r"foo"), RuleShape::Opaque);
+    }
+
+    /// The load-bearing guarantee: for every chunk-split point, the scrubbed
+    /// stream concatenation equals the whole-text apply (modulo the whitespace
+    /// collapse apply_output_regex does at the persist layer, which the scrubber
+    /// deliberately does not — see the trailing-artifact case).
+    #[test]
+    fn scrubbed_stream_equals_whole_text_apply_for_every_split() {
+        let rules = production_rules();
+        let cases = [
+            "你好呀[你给对方发送了一张照片：海边]今天如何",
+            "嗯......其实我在想你",
+            "（轻轻靠近）说吧",
+            "[你给对方发送了一张照片：自拍]",
+            "多个[a]中间[b]结尾",
+            "[bracket]嗯...紧接着说", // order: span strips bracket, then head sees 嗯
+            "no artifacts here at all",
+        ];
+        for text in cases {
+            let expected = apply_output_regex(&rules, "m", text).cleaned;
+            let chars: Vec<char> = text.chars().collect();
+            for split in 0..=chars.len() {
+                let mut s = StreamScrubber::new(&rules, "m");
+                let a: String = chars[..split].iter().collect();
+                let b: String = chars[split..].iter().collect();
+                let mut got = s.push(&a);
+                got.push_str(&s.push(&b));
+                got.push_str(&s.finish());
+                assert_eq!(got, expected, "text={text:?} split={split}");
+            }
+        }
+    }
+
+    #[test]
+    fn artifact_only_reply_streams_to_empty() {
+        let rules = production_rules();
+        let mut s = StreamScrubber::new(&rules, "m");
+        let mut got = s.push("[你给对方发送了一张照片：自拍]");
+        got.push_str(&s.finish());
+        assert_eq!(got, "", "an artifact-only reply must emit nothing");
+    }
+
+    #[test]
+    fn trailing_artifact_keeps_body() {
+        // apply_output_regex collapses a whitespace-only *stripped* result to
+        // empty at the persist layer; the scrubber keeps real body text.
+        let rules = production_rules();
+        let mut s = StreamScrubber::new(&rules, "m");
+        let mut got = s.push("正文[你给对方发送了一张照片：床上]");
+        got.push_str(&s.finish());
+        assert_eq!(got, "正文");
+    }
+
+    #[test]
+    fn unterminated_bracket_flushes_verbatim() {
+        let rules = production_rules();
+        // A lone `[` with a very long tail and no `]` must fail open, not hang.
+        let text = format!("start[{}", "x".repeat(SPAN_HOLDBACK_CAP + 50));
+        let expected = apply_output_regex(&rules, "m", &text).cleaned;
+        let mut s = StreamScrubber::new(&rules, "m");
+        let mut got = s.push(&text);
+        got.push_str(&s.finish());
+        assert_eq!(got, expected);
+        assert!(got.contains('['), "unterminated open flushes verbatim");
+    }
+
+    #[test]
+    fn non_targeted_model_is_passthrough() {
+        let rules = production_rules();
+        let mut s = StreamScrubber::new(&rules, "other/model");
+        let got = s.push("verbatim [not stripped] text");
+        assert_eq!(got, "verbatim [not stripped] text");
+    }
+
+    #[test]
+    fn opaque_rule_matches_whole_text_apply() {
+        let rules = compile(&[r"(?s)<think>.*?</think>\s*"]);
+        let text = "before<think>hidden</think>after";
+        let expected = apply_output_regex(&rules, "m", text).cleaned;
+        let mut s = StreamScrubber::new(&rules, "m");
+        // Everything buffers; nothing emitted until finish.
+        assert_eq!(s.push("before<think>hid"), "");
+        let mut got = s.push("den</think>after");
+        got.push_str(&s.finish());
+        assert_eq!(got, expected);
+    }
+}

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -641,6 +641,10 @@ fn drive_chat_burst(
                 // sent then superseded, same as the raw deltas already were.
                 let scrub_tail = scrubber.finish();
                 if !scrub_tail.is_empty() {
+                    // For a short reply fully held until now (head transform
+                    // holds ≤64 chars; Opaque buffers all), this tail is the
+                    // FIRST client-visible content — record ttft here too.
+                    ttft_ms.get_or_insert_with(|| attempt_started.elapsed().as_millis() as u64);
                     yield ProtocolFrame::Delta {
                         message_id: ulid_string(msg_ulid),
                         content: scrub_tail,

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -457,17 +457,18 @@ fn drive_chat_burst(
         }
 
         let tag_refs: Vec<&str> = trait_tags.iter().map(String::as_str).collect();
-        // A turn buffers (no live deltas) if the LLM output_filter's turn-level
-        // predicates pass, OR any output_regex rule targets a model in this
-        // turn's resolved chain (so the artifact can be stripped before emit).
-        let regex_targets_chain = chain.iter().any(|m| {
-            state.output_regex.iter().any(|r| r.models.iter().any(|rm| rm == m))
-        });
+        // A turn buffers (no live deltas) ONLY when the LLM output_filter's
+        // turn-level predicates pass — an LLM rewrite is inherently un-streamable
+        // (the filtered text must be produced before any of it is safe to send).
+        // `output_regex` no longer forces buffering: the live burst streams
+        // through the rules incrementally with a bounded holdback
+        // (`StreamScrubber`), so a regex-only chain (the common production case)
+        // now gets true streaming TTFT instead of full-generation buffering.
         let llm_filter_arms = filter
             .as_ref()
             .map(|f| f.trigger.turn_level_pass(random_draw, &tag_refs))
             .unwrap_or(false);
-        let filtered_mode = llm_filter_arms || regex_targets_chain;
+        let filtered_mode = llm_filter_arms;
 
         // Build the assistant row metadata bag: always includes prompt_traits +
         // resolved memory_scope / affinity_scope (the POST-resolve values
@@ -500,7 +501,12 @@ fn drive_chat_burst(
         };
 
         if !filtered_mode {
-            // ===== LIVE MODE (preserved verbatim from the pre-filter burst) =====
+            // ===== LIVE MODE =====
+            // Streams deltas as they arrive, scrubbing output_regex artifacts
+            // incrementally via StreamScrubber (bounded holdback). `acc` keeps
+            // the RAW text; the wire carries the scrubbed text; the served
+            // attempt's persist re-runs the whole-text apply_output_regex so the
+            // DB row + regex audit are byte-identical to the old buffered path.
             let mut continues_from: Option<Ulid> = None;
             // Repaired text of the latest COMPLETE garbled attempt seen across the
             // whole chain. Used as the last-resort replacement when the chain
@@ -515,6 +521,13 @@ fn drive_chat_burst(
                 let mut last_gen_id: Option<String> = None;
                 let mut truncated = false;
                 let mut empty_completion = false;
+                // Scrubs output_regex artifacts out of the wire deltas as they
+                // stream; `acc` still accumulates the raw text for the persist
+                // apply below. Empty rule set ⇒ pure passthrough.
+                let mut scrubber = eros_engine_llm::stream_scrub::StreamScrubber::new(
+                    &state.output_regex,
+                    model_id,
+                );
 
                 yield ProtocolFrame::Meta {
                     message_id: ulid_string(msg_ulid),
@@ -560,18 +573,23 @@ fn drive_chat_burst(
                                 Ok(c) => {
                                     // `execute_stream` filters empty deltas to None
                                     // (openrouter.rs `.filter(|s| !s.is_empty())`),
-                                    // so a present `content` is always non-empty —
-                                    // ttft records the first *real* token, not a
-                                    // role/terminal empty delta.
+                                    // so a present `content` is always a real token.
                                     if let Some(content) = c.content {
-                                        ttft_ms.get_or_insert_with(|| {
-                                            attempt_started.elapsed().as_millis() as u64
-                                        });
                                         acc.push_str(&content);
-                                        yield ProtocolFrame::Delta {
-                                            message_id: ulid_string(msg_ulid),
-                                            content,
-                                        };
+                                        // Scrub artifacts before they hit the wire;
+                                        // ttft counts the first *client-visible*
+                                        // token (a leading artifact is held, so the
+                                        // first emit can lag the first raw token).
+                                        let emit = scrubber.push(&content);
+                                        if !emit.is_empty() {
+                                            ttft_ms.get_or_insert_with(|| {
+                                                attempt_started.elapsed().as_millis() as u64
+                                            });
+                                            yield ProtocolFrame::Delta {
+                                                message_id: ulid_string(msg_ulid),
+                                                content: emit,
+                                            };
+                                        }
                                     }
                                     if c.usage.is_some()         { last_usage = c.usage; }
                                     if c.generation_id.is_some() { last_gen_id = c.generation_id; }
@@ -615,6 +633,18 @@ fn drive_chat_burst(
                         truncated = true;
                         attempt_outcome = "open_timeout";
                     }
+                }
+
+                // Flush any text the scrubber held at end-of-stream (a completed
+                // prefix under the head window, or a trailing unterminated span).
+                // Empty scrubber ⇒ "". On a truncated attempt this partial is
+                // sent then superseded, same as the raw deltas already were.
+                let scrub_tail = scrubber.finish();
+                if !scrub_tail.is_empty() {
+                    yield ProtocolFrame::Delta {
+                        message_id: ulid_string(msg_ulid),
+                        content: scrub_tail,
+                    };
                 }
 
                 // Byte-BPE garble guard (issue #84). A high Ġ/Ċ density means the
@@ -667,19 +697,56 @@ fn drive_chat_burst(
                     truncated = true;
                 }
 
+                // Layer 0: apply output_regex to the RAW acc, but ONLY for the
+                // attempt actually served (`!truncated`). A truncated/superseded
+                // partial must not match a rule and mislabel the turn (mirrors the
+                // filtered burst's same guard). The wire already emitted this same
+                // scrubbed text incrementally; here it governs the persisted row +
+                // regex audit + the strip-to-empty ghost, byte-identical to the
+                // old buffered path.
+                let (persist_content, filter_audit, regex_ghost) = if truncated {
+                    (acc.clone(), None, false)
+                } else {
+                    let strip = eros_engine_llm::model_config::apply_output_regex(
+                        &state.output_regex,
+                        model_id,
+                        &acc,
+                    );
+                    let audit = if strip.matched_rules.is_empty() {
+                        None
+                    } else {
+                        outcome.lock().unwrap().filtered = true;
+                        Some(eros_engine_store::chat::FilterAudit {
+                            pre_filter_content: acc.clone(),
+                            filter_model: "<regex>".to_string(),
+                            filter_triggers: serde_json::json!({ "regex": strip.matched_rules }),
+                            f_client_msg_id: format!("f_{}", Ulid::new()),
+                            f_generation_id: None,
+                        })
+                    };
+                    // Artifact-only reply: the strip emptied a non-empty completion.
+                    // Terminal ghost (does NOT advance the chain), matching the
+                    // filtered burst's regex-strip-to-empty semantics.
+                    let ghost = !strip.matched_rules.is_empty() && strip.cleaned.is_empty();
+                    (strip.cleaned, audit, ghost)
+                };
+                let effective_ghost = is_ghost_fallback || regex_ghost;
+
                 // Persist BEFORE yielding Done (spec §2.3 risk R7).
                 let row = eros_engine_store::chat::AssistantInsert {
                     id: msg_uuid,
-                    content: acc.clone(),
+                    content: persist_content.clone(),
                     assistant_action_type: persist_action.into(),
                     continues_from_message_id: continues_from.map(Into::into),
                     truncated,
                     model: Some(model_id.clone()),
                     usage: last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok()),
                     generation_id: last_gen_id.clone(),
-                    filter_audit: None,
+                    filter_audit,
                     metadata: if is_ghost_fallback {
                         ghost_fallback_metadata(build_metadata(None), "empty_completion")
+                    } else if regex_ghost {
+                        ghost_fallback_metadata(build_metadata(None), "regex_strip")
                     } else {
                         build_metadata(None)
                     },
@@ -692,7 +759,7 @@ fn drive_chat_burst(
                 }
                 outcome.lock().unwrap().produced.push(crate::pipeline::post_process::ProducedMessage {
                     message_id: msg_uuid,
-                    full_text: acc.clone(),
+                    full_text: persist_content.clone(),
                     action: plan_action,
                 });
 
@@ -706,7 +773,7 @@ fn drive_chat_burst(
                     truncated,
                     usage: wire_usage,
                     generation_id: last_gen_id,
-                    ghost_fallback: is_ghost_fallback,
+                    ghost_fallback: effective_ghost,
                 };
 
                 if is_ghost_fallback {
@@ -738,6 +805,12 @@ fn drive_chat_burst(
                     // state alongside the reply the user actually saw.
                     o.produced.retain(|m| m.message_id == msg_uuid);
                     o.retries_chat = idx as u32;
+                    // An artifact-only reply (regex stripped to empty) is a served
+                    // ghost: keep affinity's ghost accounting consistent with the
+                    // Done frame's ghost_fallback and the filtered burst.
+                    if regex_ghost {
+                        o.ghost_fallback = true;
+                    }
                     return;
                 }
                 if idx + 1 == chain.len() {
@@ -10135,11 +10208,16 @@ data: [DONE]\n\n";
         use wiremock::matchers::path as wm_path;
         use wiremock::{Mock, MockServer, ResponseTemplate};
 
-        // ── 1. Mock OpenRouter: returns "hello world" for model "mock/euryale" ──
+        // ── 1. Mock OpenRouter: returns "hello world" across TWO deltas ──
         let mock = MockServer::start().await;
-        // SSE body: one delta with "hello world", then a usage chunk, then [DONE].
+        // Two separate content deltas. `\bNOPE\b` is a complex pattern (word
+        // boundaries → Opaque in StreamScrubber), so the turn still buffers: a
+        // multi-chunk stream must collapse to exactly ONE Delta bubble. (A
+        // stream-safe pattern would emit per-chunk here — see
+        // `regex_span_pattern_streams_live_across_chunks`.)
         let chat_body = "\
-data: {\"choices\":[{\"delta\":{\"content\":\"hello world\"}}],\
+data: {\"choices\":[{\"delta\":{\"content\":\"hello \"}}],\"id\":\"gen-t5\",\"model\":\"mock/euryale\"}\n\n\
+data: {\"choices\":[{\"delta\":{\"content\":\"world\"}}],\
 \"usage\":{\"prompt_tokens\":2,\"completion_tokens\":2,\"total_tokens\":4},\
 \"id\":\"gen-t5\",\"model\":\"mock/euryale\"}\n\n\
 data: [DONE]\n\n";
@@ -10263,14 +10341,16 @@ data: [DONE]\n\n";
             !deltas.is_empty(),
             "regex-targeted turn must produce a Reply bubble (ghosting disabled); got {frames:?}",
         );
-        // Buffered mode emits exactly ONE Delta bubble (the whole reply at once),
-        // proving the turn buffered rather than streaming live per-chunk.
+        // `\bNOPE\b` is Opaque (word boundaries), so the turn buffers: the two
+        // upstream deltas must collapse to exactly ONE Delta bubble. A
+        // stream-safe pattern would have emitted two here — that divergence is
+        // exactly what this asserts.
         assert_eq!(
             deltas.len(),
             1,
-            "buffered mode must emit exactly one Delta bubble; got {deltas:?}",
+            "an Opaque-pattern turn must buffer to one Delta bubble; got {deltas:?}",
         );
-        // Content is the raw reply, unchanged (no strip yet — Task 6).
+        // Content is the raw reply, unchanged (pattern doesn't match).
         assert_eq!(
             deltas[0], "hello world",
             "unmatched regex must not alter the reply; got {:?}",
@@ -10297,6 +10377,187 @@ data: [DONE]\n\n";
             pre_filter.is_none(),
             "pre_filter_content must be NULL for a regex-only buffered turn (no LLM filter ran); \
              got {pre_filter:?}",
+        );
+    }
+
+    /// Batch C: a stream-safe SPAN pattern (the production `\[[^\]]*\]`) streams
+    /// LIVE — the client gets multiple Delta bubbles as pre-artifact text
+    /// arrives, the bracketed artifact is stripped mid-stream (no delta for it),
+    /// and the persisted row + regex audit are byte-identical to the old
+    /// buffered path. This is the whole point of Batch C: regex-targeted chat
+    /// turns get TTFT back instead of buffering the whole reply.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn regex_span_pattern_streams_live_across_chunks(pool: PgPool) {
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+        use futures_util::StreamExt;
+        use wiremock::matchers::path as wm_path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        // Four separate content deltas; the third is the whole bracket artifact.
+        let chat_body = concat!(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"你好\"}}],\"id\":\"gen-s\",\"model\":\"mock/euryale\"}\n\n",
+            "data: {\"choices\":[{\"delta\":{\"content\":\"呀\"}}],\"id\":\"gen-s\",\"model\":\"mock/euryale\"}\n\n",
+            "data: {\"choices\":[{\"delta\":{\"content\":\"[你给对方发送了一张照片：海边]\"}}],\"id\":\"gen-s\",\"model\":\"mock/euryale\"}\n\n",
+            "data: {\"choices\":[{\"delta\":{\"content\":\"今天如何\"}}],",
+            "\"usage\":{\"prompt_tokens\":2,\"completion_tokens\":6,\"total_tokens\":8},",
+            "\"id\":\"gen-s\",\"model\":\"mock/euryale\"}\n\n",
+            "data: [DONE]\n\n"
+        );
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(chat_body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+
+        let user_id = uuid::Uuid::new_v4();
+        let (_g, _instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        // Production span pattern (unanchored bracket) → StreamScrubber Span.
+        // Single-quoted TOML literal: backslashes reach `regex` verbatim, so the
+        // Rust `\\` (one backslash) is exactly the regex escape wanted.
+        let regex_cfg = eros_engine_llm::model_config::ModelConfig::from_toml_str(
+            "[tasks.chat_companion]\nmodel=\"mock/euryale\"\n\
+             [[tasks.chat_companion.output_regex]]\n\
+             models=[\"mock/euryale\"]\n\
+             pattern='\\[[^\\]]*\\]'\n",
+        )
+        .unwrap();
+        state.output_regex = std::sync::Arc::new(
+            regex_cfg
+                .compile_output_regex()
+                .expect("span pattern compiles"),
+        );
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                eros_engine_llm::openrouter::AppAttribution::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+        let state = std::sync::Arc::new(state);
+
+        let chat_repo = ChatRepo { pool: &pool };
+        let user_message_id = match chat_repo
+            .upsert_user_message_idempotent(
+                session_id,
+                "hi",
+                "01JSPANSTREAM0000000000A",
+                "user",
+                None,
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
+
+        let req = eros_engine_llm::openrouter::ChatRequest {
+            model: "mock/euryale".into(),
+            fallback_model: vec![],
+            messages: vec![eros_engine_llm::openrouter::ChatMessage {
+                role: "user".into(),
+                content: "hi".into(),
+            }],
+            temperature: 0.0,
+            max_tokens: 64,
+            ..Default::default()
+        };
+        let outcome = std::sync::Arc::new(std::sync::Mutex::new(BurstOutcome::default()));
+        let burst = drive_chat_burst(
+            state.clone(),
+            session_id,
+            user_message_id,
+            FrameActionType::Reply,
+            "reply",
+            ActionType::ReplyText,
+            req,
+            None,
+            None, // regex-only turn
+            vec![],
+            None,
+            Default::default(),
+            Default::default(),
+            None,
+            outcome.clone(),
+        );
+        let frames: Vec<ProtocolFrame> = Box::pin(burst).collect().await;
+
+        let deltas: Vec<&str> = frames
+            .iter()
+            .filter_map(|f| match f {
+                ProtocolFrame::Delta { content, .. } => Some(content.as_str()),
+                _ => None,
+            })
+            .collect();
+
+        // LIVE: more than one Delta bubble (a buffered turn would emit exactly
+        // one) — the pre-artifact text streamed per-chunk.
+        assert!(
+            deltas.len() > 1,
+            "a span-pattern turn must stream multiple Delta bubbles, not buffer; got {deltas:?}",
+        );
+        // The bracket artifact never reaches the client; the visible text is the
+        // cleaned reply.
+        assert_eq!(
+            deltas.concat(),
+            "你好呀今天如何",
+            "concatenated deltas must equal the artifact-stripped reply; got {deltas:?}",
+        );
+        assert!(
+            !deltas.iter().any(|d| d.contains('[')),
+            "no delta may carry the bracket artifact; got {deltas:?}",
+        );
+
+        // produced (extract/memory input) is the cleaned text.
+        {
+            let o = outcome.lock().unwrap();
+            assert_eq!(
+                o.produced.len(),
+                1,
+                "one produced message; got {:?}",
+                o.produced
+            );
+            assert_eq!(o.produced[0].full_text, "你好呀今天如何");
+            assert!(
+                o.filtered,
+                "outcome.filtered must be true when a rule fired"
+            );
+        }
+
+        // DB row: cleaned content, raw on pre_filter_content, regex audit.
+        let (content, pre_filter, filter_model, filter_triggers): (
+            String,
+            Option<String>,
+            Option<String>,
+            Option<serde_json::Value>,
+        ) = sqlx::query_as(
+            "SELECT content, pre_filter_content, filter_model, filter_triggers \
+             FROM engine.chat_messages \
+             WHERE session_id = $1 AND role = 'assistant' \
+             ORDER BY sent_at DESC LIMIT 1",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            content, "你好呀今天如何",
+            "persisted content is the stripped text"
+        );
+        assert_eq!(
+            pre_filter.as_deref(),
+            Some("你好呀[你给对方发送了一张照片：海边]今天如何"),
+            "pre_filter_content is the raw original",
+        );
+        assert_eq!(filter_model.as_deref(), Some("<regex>"));
+        assert_eq!(
+            filter_triggers,
+            Some(serde_json::json!({ "regex": [0usize] }))
         );
     }
 

--- a/docs/superpowers/specs/2026-07-23-openrouter-stream-latency-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-23-openrouter-stream-latency-hardening-design.md
@@ -322,26 +322,34 @@ impl StreamScrubber {
 }
 ```
 
-- **Classification** (at `Self::new`, via `regex-syntax`'s HIR — already a
-  transitive dep of `regex`): a rule whose HIR is start-anchored
-  (`look_set_prefix` contains `Look::Start`) is a **head rule**; a rule whose
-  possible matches all start with a literal `[` (prefix-literal extraction)
-  is a **span rule** with open `[` / close `]`. Any other shape makes the
-  scrubber **degenerate to full buffering** for this attempt (emit nothing
-  from `push`, everything from `finish` after a whole-text
-  `apply_output_regex`) — correct for arbitrary rules, just without the TTFT
-  win; downstream deployments with exotic patterns lose nothing vs today.
-- **Head phase:** hold the first `HEAD_HOLDBACK = 64` chars; once exceeded
-  (or at `finish`), apply the head rules to the held prefix once, emit, and
-  leave head phase permanently.
-- **Span phase (steady state):** emit passthrough until an un-emitted `[`
-  appears; hold from there; on `]`, run the span rule over the held segment,
-  emit the cleaned remainder; if `SPAN_HOLDBACK_CAP = 256` chars accumulate
-  with no `]`, flush held text verbatim (fail-open) and resume scanning
-  *after* it.
-- Char-boundary safe (operates on `char` indices, never splits a CJK
-  scalar); a marker straddling any chunk boundary must be stripped
-  identically to the whole-text result (test matrix below).
+- **Classification** (`classify(pattern) -> RuleShape`, via `regex-syntax`'s
+  HIR — a direct dep pinned to `regex`'s minor): a rule whose HIR
+  `look_set_prefix` contains `Look::Start` is **`Head`**; a rule whose HIR is
+  exactly `Concat[Literal(open), Repetition(_), Literal(close)]` with distinct
+  single-char `open`/`close` is **`Span { open, close }`** (this matches
+  `\[[^\]]*\]`); anything else is **`Opaque`**.
+- **Transform pipeline (not a phase-split).** Each matching rule becomes a
+  small streaming `Transform`, and the transforms are chained **in declaration
+  order** — the composition is exactly `apply_output_regex`'s sequential
+  `replace_all`-per-rule. This is what makes rule *order* correct: a leading
+  `[artifact]嗯…` has the span transform strip the bracket first, so the
+  downstream `^嗯` head transform sees the exposed `嗢…` (a naive
+  head-then-span phase-split would miss this, since the raw head starts with
+  `[`). `push` feeds a delta through the chain; `finish` cascades each
+  transform's flush into the next.
+  - **`HeadTransform`:** hold the first `HEAD_HOLDBACK = 64` chars, apply the
+    regex once (a start-anchored rule matches at most the leading prefix),
+    then pass the rest through. A head match longer than 64 chars is not
+    caught on the wire (fail-open; persist re-applies).
+  - **`SpanTransform`:** pass through until an `open`; hold from there; on
+    `close` emit the replacement (drop the span); if `SPAN_HOLDBACK_CAP = 256`
+    chars accumulate with no `close`, flush verbatim (fail-open, a lone `[`).
+  - **`OpaqueTransform`:** buffer everything, apply at `finish` — preserves
+    today's full-buffering behavior for any exotic pattern (no TTFT win, no
+    correctness loss).
+- Char-boundary safe (iterates `char`s, never splits a scalar); a marker
+  straddling any chunk boundary strips identically to the whole-text result
+  (property test below).
 
 ### 5.3 Pipeline rewiring (`stream.rs`)
 
@@ -351,15 +359,17 @@ impl StreamScrubber {
   accumulates the **raw** text; `ProtocolFrame::Delta` carries the scrubbed
   `emit` (skip the frame when empty). After the loop, `scrubber.finish()`
   emits the tail.
-- Persist path (unchanged semantics, new location): before the
-  `AssistantInsert`, run the existing whole-text
-  `apply_output_regex(&state.output_regex, model_id, &acc)`; persist
-  `cleaned`, carry the regex audit exactly as the filtered path does today
-  (raw on the audit field when rules matched), and port the
-  **strip-to-empty ⇒ ghost-fallback** branch (`ghost_fallback_metadata`
-  with the regex reason) into the live burst. The whitespace-only-deltas
-  edge (raw `"\n\n[...]"` streams two blank deltas, then strips to empty ⇒
-  ghost) is accepted — clients render nothing for whitespace.
+- Persist path: run `apply_output_regex(&state.output_regex, model_id, &acc)`
+  **only on the served attempt** (`!truncated`) — a truncated/superseded
+  partial must not match a rule and mislabel the turn (same guard the filtered
+  burst uses). Persist `cleaned`, write the regex audit (`filter_model =
+  "<regex>"`, `{regex: indices}`, raw on `pre_filter_content`), feed `cleaned`
+  to `produced`, and set `filtered = true` when a rule fired. An artifact-only
+  reply (`cleaned` empty after a match) is a **terminal** served ghost
+  (`ghost_fallback_metadata(.., "regex_strip")`, does not advance the chain) —
+  matching the filtered burst. The whitespace-only-deltas edge (raw
+  `"\n\n[...]"` streams blank deltas, then persist strips to empty ⇒ ghost) is
+  accepted — clients render nothing for whitespace.
 - Filtered burst (LLM output_filter armed): completely unchanged — it
   already buffers for the rewrite and applies regex on the buffered text.
 - Beta-tier turns (output_filter trigger passing) therefore still buffer —


### PR DESCRIPTION
Batch C of the OpenRouter stream-hardening work (spec §5) — **the TTFT lever**.
Batch D (fallback borrow + provider.sort) follows.

## The problem

`filtered_mode = llm_filter_arms || regex_targets_chain` buffered the whole
reply whenever *any* chain model had *any* `output_regex` rule. With the real
downstream config, the bracket-strip rule lists **every** production chat
model — so **100% of chat turns buffered**, and TTFT was full-generation time
on turns that only needed a deterministic artifact strip, not an LLM rewrite.

## The change

The gate drops to `filtered_mode = llm_filter_arms` — only an LLM
`output_filter` still buffers (inherent to a rewrite). `output_regex` now
streams through a new **`StreamScrubber`** (`eros-engine-llm`): each rule is
classified from its parsed regex HIR into a streaming strategy, and each
matching rule becomes a small streaming transform chained **in declaration
order**, so the composition equals `apply_output_regex`'s sequential
`replace_all` — including rule order (a leading `[artifact]嗯…` has the bracket
stripped first, exposing the `^嗯` head rule).

- **`Head`** (`^`-anchored): hold the first 64 chars, apply once, then stream.
- **`Span`** (exactly `open [^close]* close`): stream until `open`, hold to
  `close` (strip), or flush verbatim past a 256-char cap (fail-open).
- **`Opaque`** (anything else): buffer fully — preserves today's behavior for
  exotic patterns, no correctness loss.

The live burst keeps the **raw** `acc`; the wire carries scrubbed deltas; the
**served attempt's** persist re-runs the whole-text `apply_output_regex`, so
the DB row, regex audit (`filter_model="<regex>"`, `{regex:[…]}`, raw on
`pre_filter_content`), and strip-to-empty ghost are **byte-identical** to the
old buffered path. Only the wire changes: one buffered bubble → live per-chunk
deltas. Result: production chat flips to true streaming TTFT, measurable via
Batch B's `stream_metrics.ttft_ms`.

## Testing

`StreamScrubber` has a property test asserting the scrubbed stream equals the
whole-text apply at **every chunk-split point** for the real production
patterns; plus classification, artifact-only→empty, trailing-artifact,
unterminated-bracket fail-open, Opaque-buffering, and replacement-expansion
tests. New integration test `regex_span_pattern_streams_live_across_chunks`
proves multiple deltas stream, the bracket is stripped on the wire, and
persist/audit match. Existing Opaque-pattern tests still buffer correctly
(clarified). `cargo fmt`/`clippy -D warnings` clean; full workspace **892
tests green**; openapi no drift.

Codex review (`--base dev`, 3 passes): two P1s (Span classification too
permissive for `a.+b`/`a.*b`; replacement expansion) and one P2 (TTFT missing
on the tail flush) — all fixed and re-verified; final pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
