### PR TITLE
feat: OpenRouter stream hardening — Batch D (borrow fallback request, opt-in provider.sort)

### DIFF
--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -369,6 +369,12 @@ pub struct DefaultConfig {
     /// client reads this once at boot. Empty = no exclusion.
     #[serde(default)]
     pub ignore_providers: Vec<String>,
+    /// OpenRouter `provider.sort` routing preference applied on EVERY task:
+    /// `"price"` / `"throughput"` / `"latency"`. `None` (absent) omits the
+    /// field, keeping OpenRouter's default price-based load balancing. Setting
+    /// it trades cost for the chosen axis — a deployer decision, off by default.
+    #[serde(default)]
+    pub provider_sort: Option<String>,
 }
 
 fn default_model_spec() -> ModelSpec {
@@ -3805,6 +3811,25 @@ filter_prompt = "只根据产品资料作答。"
         "#;
         let cfg = ModelConfig::from_toml_str(toml).expect("parse");
         assert!(cfg.defaults.ignore_providers.is_empty());
+    }
+
+    #[test]
+    fn defaults_provider_sort_parses_and_defaults_none() {
+        let with = r#"
+            [defaults]
+            provider_sort = "latency"
+            [tasks.chat_companion]
+            model = "x/y"
+        "#;
+        let cfg = ModelConfig::from_toml_str(with).expect("parse");
+        assert_eq!(cfg.defaults.provider_sort.as_deref(), Some("latency"));
+
+        let without = r#"
+            [tasks.chat_companion]
+            model = "x/y"
+        "#;
+        let cfg = ModelConfig::from_toml_str(without).expect("parse");
+        assert!(cfg.defaults.provider_sort.is_none());
     }
 
     #[test]

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -1203,15 +1203,32 @@ impl OpenRouterClient {
     }
 
     /// Open a streaming chat completion against a single model. Fallback
-    /// chain handling is the caller's responsibility (pipeline layer).
+    /// chain handling is the caller's responsibility (pipeline layer). Owns
+    /// its `ChatRequest`; retained as the stable public entry point. In-tree
+    /// fallback loops use [`execute_stream_as`](Self::execute_stream_as) to
+    /// avoid re-cloning the prompt per attempt.
     pub async fn execute_stream(&self, req: ChatRequest) -> Result<DeltaStream, LlmError> {
+        let model = req.model.clone();
+        self.execute_stream_as(&req, &model).await
+    }
+
+    /// Like [`execute_stream`](Self::execute_stream) but borrows the request and
+    /// takes the served `model` separately, so a fallback chain can retry the
+    /// same (large) prompt against each candidate without deep-cloning it per
+    /// attempt. `req.model` / `req.fallback_model` are ignored — `model` is the
+    /// one actually sent.
+    pub async fn execute_stream_as(
+        &self,
+        req: &ChatRequest,
+        model: &str,
+    ) -> Result<DeltaStream, LlmError> {
         use eventsource_stream::Eventsource;
         use futures_util::StreamExt;
 
         if self.api_key.is_empty() {
             return Err(LlmError::Config("openrouter: api key not set".into()));
         }
-        if req.model.is_empty() {
+        if model.is_empty() {
             return Err(LlmError::Config(
                 "openrouter: execute_stream requires a non-empty model".into(),
             ));
@@ -1222,7 +1239,7 @@ impl OpenRouterClient {
         // rejects (400 "expected string, received null"). Sharing WireRequest
         // keeps the skip-None behaviour and stops the two paths from drifting.
         let wire = WireRequest {
-            model: &req.model,
+            model,
             messages: &req.messages,
             temperature: req.temperature,
             top_p: req.top_p,
@@ -1259,7 +1276,7 @@ impl OpenRouterClient {
         // logged — only the model id and timing.
         tracing::debug!(
             target: "openrouter_stream",
-            model = %req.model,
+            model = %model,
             headers_ms = started.elapsed().as_millis() as u64,
             http_version = ?resp.version(),
             "stream opened"
@@ -2565,6 +2582,48 @@ data: [DONE]\n\n";
             matches!(item, Err(LlmError::Provider(_))),
             "finish_reason=error must surface as Provider error, got {item:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn execute_stream_as_sends_the_passed_model_not_req_model() {
+        use futures_util::StreamExt;
+        // The borrowed request's own `model` is ignored — the `model` argument
+        // is what reaches the wire (the fallback-chain contract).
+        let server = MockServer::start().await;
+        Mock::given(path("/api/v1/chat/completions"))
+            .and(wiremock::matchers::body_partial_json(
+                serde_json::json!({"model": "actual/served", "stream": true}),
+            ))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw("data: [DONE]\n\n", "text/event-stream"),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        let client = OpenRouterClient::with_base_url(
+            "test-key".into(),
+            AppAttribution::default(),
+            format!("{}/api/v1/chat/completions", server.uri()),
+        );
+        let req = ChatRequest {
+            model: "ignored/primary".into(),
+            fallback_model: vec!["also/ignored".into()],
+            messages: vec![ChatMessage {
+                role: "user".into(),
+                content: "hi".into(),
+            }],
+            temperature: 0.0,
+            max_tokens: 16,
+            ..Default::default()
+        };
+        let mut stream = client
+            .execute_stream_as(&req, "actual/served")
+            .await
+            .expect("stream opens");
+        // Drain (single [DONE]).
+        while stream.next().await.is_some() {}
     }
 
     // ─── B1: X-Generation-Id header capture ─────────────────────────────────

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -475,12 +475,18 @@ fn is_false(b: &bool) -> bool {
     !*b
 }
 
-/// OpenRouter provider routing preferences. Only `ignore` is used today;
-/// `allow_fallbacks` is omitted so OpenRouter applies its default (true),
-/// i.e. the model is still served by a healthy provider.
+/// OpenRouter provider routing preferences. `allow_fallbacks` is omitted so
+/// OpenRouter applies its default (true), i.e. the model is still served by a
+/// healthy provider. `sort` is opt-in and off by default: an explicit sort
+/// disables OpenRouter's price-based load balancing (a cost decision the
+/// deployer owns), so when unset the field is omitted and the wire body is
+/// byte-identical to before.
 #[derive(Debug, Serialize)]
 struct ProviderPrefs<'a> {
+    #[serde(skip_serializing_if = "<[String]>::is_empty")]
     ignore: &'a [String],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sort: Option<&'a str>,
 }
 
 #[derive(Debug, Serialize)]
@@ -661,6 +667,11 @@ pub struct OpenRouterClient {
     /// OpenRouter provider slugs sent as `provider.ignore` on every call.
     /// Empty by default; set at boot via [`OpenRouterClient::with_ignore_providers`].
     ignore_providers: Vec<String>,
+    /// OpenRouter `provider.sort` preference (`"price"` / `"throughput"` /
+    /// `"latency"`). `None` by default; set at boot via
+    /// [`OpenRouterClient::with_provider_sort`]. When `None` the field is
+    /// omitted, preserving OpenRouter's default price-based load balancing.
+    provider_sort: Option<String>,
 }
 
 impl OpenRouterClient {
@@ -728,6 +739,7 @@ impl OpenRouterClient {
             api_key,
             base_url,
             ignore_providers: Vec::new(),
+            provider_sort: None,
         }
     }
 
@@ -739,14 +751,26 @@ impl OpenRouterClient {
         self
     }
 
-    /// Build the `ProviderPrefs` for a wire body, or `None` when the exclusion
-    /// list is empty (so the `provider` key is omitted entirely).
+    /// Set the global `provider.sort` routing preference (`"price"` /
+    /// `"throughput"` / `"latency"`). Consuming builder, chainable at boot.
+    /// `None` (default) omits the field. Passed through verbatim — OpenRouter
+    /// validates. NOTE: an explicit sort disables OpenRouter's default
+    /// price-based load balancing, a cost/latency tradeoff the deployer owns.
+    pub fn with_provider_sort(mut self, sort: Option<String>) -> Self {
+        self.provider_sort = sort.filter(|s| !s.is_empty());
+        self
+    }
+
+    /// Build the `ProviderPrefs` for a wire body, or `None` when neither the
+    /// exclusion list nor a sort preference is set (so the `provider` key is
+    /// omitted entirely and the body is byte-identical to the no-prefs case).
     fn provider_prefs(&self) -> Option<ProviderPrefs<'_>> {
-        if self.ignore_providers.is_empty() {
+        if self.ignore_providers.is_empty() && self.provider_sort.is_none() {
             None
         } else {
             Some(ProviderPrefs {
                 ignore: &self.ignore_providers,
+                sort: self.provider_sort.as_deref(),
             })
         }
     }
@@ -2806,11 +2830,49 @@ data: [DONE]\n\n";
             session_id: None,
             metadata: None,
             reasoning: None,
-            provider: Some(ProviderPrefs { ignore: &ignore }),
+            provider: Some(ProviderPrefs {
+                ignore: &ignore,
+                sort: None,
+            }),
             response_format: None,
         };
         let body = serde_json::to_value(&wire).unwrap();
         assert_eq!(body["provider"]["ignore"][0], "BadHost");
+        assert!(
+            body["provider"].get("sort").is_none(),
+            "sort omitted when None"
+        );
+    }
+
+    #[test]
+    fn wire_request_emits_provider_sort_when_set_without_ignore() {
+        // sort-only: `ignore` is empty so it is omitted; only `sort` appears.
+        let empty: Vec<String> = Vec::new();
+        let wire = WireRequest {
+            model: "x/y",
+            messages: &[],
+            temperature: 0.8,
+            top_p: None,
+            frequency_penalty: None,
+            presence_penalty: None,
+            max_tokens: 100,
+            stream: false,
+            user: None,
+            session_id: None,
+            metadata: None,
+            reasoning: None,
+            provider: Some(ProviderPrefs {
+                ignore: &empty,
+                sort: Some("latency"),
+            }),
+            response_format: None,
+        };
+        let body = serde_json::to_value(&wire).unwrap();
+        assert_eq!(body["provider"]["sort"], "latency");
+        assert!(
+            body["provider"].get("ignore").is_none(),
+            "empty ignore omitted"
+        );
     }
 
     #[test]
@@ -2823,6 +2885,42 @@ data: [DONE]\n\n";
         .with_ignore_providers(vec!["BadHost".into()]);
         let prefs = c.provider_prefs().expect("prefs present");
         assert_eq!(prefs.ignore, ["BadHost"]);
+        assert!(prefs.sort.is_none());
+    }
+
+    #[test]
+    fn with_provider_sort_sets_prefs_and_composes_with_ignore() {
+        // sort alone → prefs present.
+        let c = OpenRouterClient::with_base_url(
+            "k".into(),
+            AppAttribution::default(),
+            "http://localhost".into(),
+        )
+        .with_provider_sort(Some("throughput".into()));
+        let prefs = c.provider_prefs().expect("prefs present for sort-only");
+        assert_eq!(prefs.sort, Some("throughput"));
+        assert!(prefs.ignore.is_empty());
+
+        // empty string sort → treated as unset (no prefs when nothing else set).
+        let c = OpenRouterClient::with_base_url(
+            "k".into(),
+            AppAttribution::default(),
+            "http://localhost".into(),
+        )
+        .with_provider_sort(Some(String::new()));
+        assert!(c.provider_prefs().is_none(), "empty sort is unset");
+
+        // ignore + sort compose into one prefs object.
+        let c = OpenRouterClient::with_base_url(
+            "k".into(),
+            AppAttribution::default(),
+            "http://localhost".into(),
+        )
+        .with_ignore_providers(vec!["BadHost".into()])
+        .with_provider_sort(Some("latency".into()));
+        let prefs = c.provider_prefs().expect("prefs present");
+        assert_eq!(prefs.ignore, ["BadHost"]);
+        assert_eq!(prefs.sort, Some("latency"));
     }
 
     /// Garbled string used in garble-guard tests. `Ġ`/`Ċ` density is 2/12 ≈ 16.7 % >> 3 % threshold.

--- a/crates/eros-engine-server/src/main.rs
+++ b/crates/eros-engine-server/src/main.rs
@@ -334,11 +334,13 @@ async fn run_server() -> Result<()> {
         Err(msg) => anyhow::bail!(msg),
     };
 
-    // OpenRouter client is constructed after model_config so we can wire in
-    // the global provider exclusion list from [defaults].ignore_providers.
+    // OpenRouter client is constructed after model_config so we can wire in the
+    // global provider routing prefs from [defaults]: the exclusion list and the
+    // optional sort preference (both off by default).
     let openrouter = Arc::new(
         eros_engine_llm::openrouter::OpenRouterClient::new(openrouter_key, attribution)
-            .with_ignore_providers(model_config.defaults.ignore_providers.clone()),
+            .with_ignore_providers(model_config.defaults.ignore_providers.clone())
+            .with_provider_sort(model_config.defaults.provider_sort.clone()),
     );
 
     // Computed once at boot, before model_config is moved into the state

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -536,19 +536,17 @@ fn drive_chat_burst(
                     continues_from: continues_from.map(ulid_string),
                 };
 
-                let mut per_model_req = req.clone();
-                per_model_req.model = model_id.clone();
-                per_model_req.fallback_model = Vec::new();
-
                 // Per-attempt latency observability (spec §4.2). ttft = call →
                 // first content delta; outcome is the terminal disposition.
                 let attempt_started = std::time::Instant::now();
                 let mut ttft_ms: Option<u64> = None;
                 let mut attempt_outcome: &'static str = "served";
 
+                // Borrow the shared request; only the served model differs per
+                // attempt, so no per-fallback clone of the (large) prompt.
                 match tokio::time::timeout(
                     STREAM_OPEN_TIMEOUT,
-                    state.openrouter.execute_stream(per_model_req),
+                    state.openrouter.execute_stream_as(&req, model_id),
                 )
                 .await
                 {
@@ -918,10 +916,6 @@ fn drive_chat_burst(
             let mut truncated = false;
             let mut empty_completion = false;
 
-            let mut per_model_req = req.clone();
-            per_model_req.model = model_id.clone();
-            per_model_req.fallback_model = Vec::new();
-
             // Per-attempt observability (spec §4.2). In filtered mode the client
             // sees nothing until the whole reply is rewritten, so ttft_ms here is
             // time-to-first-UPSTREAM-token (still useful to compare model speed),
@@ -929,9 +923,10 @@ fn drive_chat_burst(
             let attempt_started = std::time::Instant::now();
             let mut ttft_ms: Option<u64> = None;
             let mut attempt_outcome: &'static str = "served";
+            // Borrow the shared request; no per-fallback prompt clone.
             match tokio::time::timeout(
                 STREAM_OPEN_TIMEOUT,
-                state.openrouter.execute_stream(per_model_req),
+                state.openrouter.execute_stream_as(&req, model_id),
             )
             .await
             {
@@ -3105,22 +3100,23 @@ pub fn run_stream(
                 let mut last_gen_id: Option<String> = None;
                 let mut served_model: Option<String> = None;
                 let mut truncated = false;
+                // Built once; only the served model differs per candidate, so
+                // execute_stream_as borrows it (no per-candidate prompt clone).
+                let qa_req = eros_engine_llm::openrouter::ChatRequest {
+                    messages,
+                    temperature: p.temperature as f32,
+                    max_tokens: p.max_tokens,
+                    reasoning: p.reasoning.clone(),
+                    ..Default::default()
+                };
                 'candidates: for model_id in candidates {
                     last_usage = None;
                     last_gen_id = None;
                     served_model = None;
                     truncated = false;
-                    let req = eros_engine_llm::openrouter::ChatRequest {
-                        model: model_id.clone(),
-                        messages: messages.clone(),
-                        temperature: p.temperature as f32,
-                        max_tokens: p.max_tokens,
-                        reasoning: p.reasoning.clone(),
-                        ..Default::default()
-                    };
                     let stream = match tokio::time::timeout(
                         STREAM_OPEN_TIMEOUT,
-                        state.openrouter.execute_stream(req),
+                        state.openrouter.execute_stream_as(&qa_req, &model_id),
                     )
                     .await
                     {

--- a/docs/superpowers/specs/2026-07-23-openrouter-stream-latency-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-23-openrouter-stream-latency-hardening-design.md
@@ -410,17 +410,24 @@ cleared `fallback_model`). The three burst loops switch to
 
 ### 6.2 D2: provider routing `sort` (opt-in)
 
-- `ProviderPrefs` gains `#[serde(skip_serializing_if = "Option::is_none")] sort: Option<&'a str>`.
-- Plumbed like `ignore_providers`: a boot-time
-  `OpenRouterClient::with_provider_sort(Option<String>)` consuming builder,
-  sourced from the same engine config that supplies the exclusion list;
-  absent ⇒ wire body byte-identical to today.
-- Accepted values passed through verbatim (`"latency"` / `"throughput"` /
-  `"price"`); OpenRouter validates. Documented tradeoff: any explicit sort
-  disables OpenRouter's default price load-balancing.
-- Field name/shape verified against the live provider-routing docs at
-  implementation time; if the API differs, adjust to the documented schema
-  rather than this sketch.
+Verified against the live provider-routing docs: `provider.sort` is a top-level
+field on the `provider` object accepting `"price"` / `"throughput"` /
+`"latency"`. Implemented as:
+
+- `ProviderPrefs` gains `#[serde(skip_serializing_if = "Option::is_none")] sort:
+  Option<&'a str>`, and `ignore` gains `skip_serializing_if =
+  "<[String]>::is_empty"` so a sort-only prefs object omits `ignore`. The
+  ignore-only wire body stays byte-identical (ignore is present iff non-empty,
+  as before).
+- Plumbed like `ignore_providers`: `[defaults].provider_sort: Option<String>`
+  in the config, threaded through a boot-time
+  `OpenRouterClient::with_provider_sort(Option<String>)` consuming builder (an
+  empty string is treated as unset). `provider_prefs()` returns `Some` when
+  either the exclusion list is non-empty or a sort is set; absent both ⇒
+  `provider` key omitted, wire body byte-identical to today.
+- Value passed through verbatim; OpenRouter validates. Documented tradeoff (in
+  code and `examples/model_config.toml`): any explicit sort disables
+  OpenRouter's default price-based load balancing.
 
 ## 7. Testing
 

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -12,8 +12,15 @@
 # on every call; allow_fallbacks stays true so the model is still served by a
 # healthy provider. Find the offending slug via OpenRouter's generation API.
 # Empty/unset = no exclusion.
+#
+# `provider_sort` (optional) sets OpenRouter's provider routing sort on EVERY
+# task: "price" | "throughput" | "latency". Unset (default) keeps OpenRouter's
+# price-based load balancing. Setting it trades cost for the chosen axis —
+# "latency" favours TTFT for chat; note it disables price load-balancing, so
+# watch cost and success rate separately.
 #[defaults]
 #ignore_providers = ["some-bad-provider-slug"]
+#provider_sort = "latency"
 #
 # One-off repair of rows already persisted with byte-BPE garble (run manually,
 # NOT a migration — the engine refuses to own downstream prod data). Repairs the


### PR DESCRIPTION
Batch D of the OpenRouter stream-hardening work (spec §6) — the final batch:
cheap tuning, both opt-in / behavior-preserving. Closes the series (A–D).

## D1 — borrow the request across fallback attempts

The three streaming burst loops (live, filtered, product-QA) deep-cloned the
full `ChatRequest` — system prompt + up to ~20 history messages — once **per
fallback candidate**, just to swap the model string. New
`execute_stream_as(&ChatRequest, &str)` sends the passed model while borrowing
the shared request; `execute_stream` becomes a thin wrapper over it. The loops
drop their per-attempt `req.clone()` / `messages.clone()`. No behavior change
(`req.model` / `req.fallback_model` are ignored by the borrow entry point — the
served model is explicit); just fewer allocations under fallback/high-QPS.

## D2 — opt-in `provider.sort`

`[defaults].provider_sort` (`"price"` / `"throughput"` / `"latency"`, verified
against OpenRouter's live provider-routing docs) threads through a boot-time
`with_provider_sort` builder into the `provider.sort` wire field on every call.
**Off by default**: absent ⇒ the `provider` key is omitted and the body is
byte-identical to today, preserving OpenRouter's price-based load balancing.
`ProviderPrefs.ignore` gained `skip_serializing_if` so a sort-only prefs omits
`ignore`; the existing ignore-only body is unchanged. Documented (code +
`examples/model_config.toml`) that an explicit sort trades cost for the chosen
axis — `latency` favours chat TTFT, but disables price load-balancing, so cost
and success rate should be watched separately. Left as a deployer decision, not
a default.

## Testing

`cargo fmt` / `clippy -D warnings` clean; full workspace **896 tests green**;
openapi no drift. New: `execute_stream_as` sends the passed model (ignoring
`req.model`); provider-sort wire serialization (unset omits, sort-only omits
`ignore`, ignore+sort compose, empty-string sort treated as unset);
`[defaults].provider_sort` parse + default-none. Codex review (`--base dev`):
no actionable regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
