### PR TITLE
fix(world): floor reply window one town tick above debounce, warn on clamp

### DIFF
--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -1703,6 +1703,14 @@ impl ModelConfig {
     /// Resolve the world-town reply-responder bundle. `None` when
     /// `[tasks.world_reply]` is absent OR its `filter_prompt` is blank.
     pub fn resolve_world_reply(&self) -> Option<ResolvedWorldReply> {
+        // Minimum width of the reply-eligibility band (`window - debounce`),
+        // pinned to one town-sweeper tick (`TOWN_TICK` in
+        // eros-engine-server/src/pipeline/world_town.rs). A narrower band
+        // falls between two 30s scans, so a misconfigured
+        // `reply_window_secs <= debounce_secs` would silently near-disable
+        // replies instead of surfacing the misconfig (issue #180).
+        const MIN_BAND_SECS: u64 = 30;
+
         let task_cfg = self.tasks.get("world_reply")?;
         let reply_prompt = task_cfg.filter_prompt.clone().unwrap_or_default();
         if reply_prompt.trim().is_empty() {
@@ -1710,6 +1718,19 @@ impl ModelConfig {
         }
         let m = self.resolve("world_reply", None);
         let debounce_secs = task_cfg.debounce_secs.unwrap_or(90);
+        let configured_window = task_cfg.reply_window_secs.unwrap_or(604_800);
+        let reply_window_secs = configured_window.max(debounce_secs + MIN_BAND_SECS);
+        if reply_window_secs != configured_window {
+            tracing::warn!(
+                configured_window,
+                debounce_secs,
+                clamped_to = reply_window_secs,
+                "world_reply: reply_window_secs leaves an eligibility band \
+                 narrower than one 30s sweeper tick — clamped; fix \
+                 [tasks.world_reply].reply_window_secs (must exceed \
+                 debounce_secs by at least 30s)"
+            );
+        }
         Some(ResolvedWorldReply {
             model: m.model,
             fallback_model: m.fallback_model,
@@ -1721,10 +1742,7 @@ impl ModelConfig {
             debounce_secs,
             thread_cooldown_secs: task_cfg.thread_cooldown_secs.unwrap_or(600),
             daily_cap: task_cfg.daily_cap.unwrap_or(20),
-            reply_window_secs: task_cfg
-                .reply_window_secs
-                .unwrap_or(604_800)
-                .max(debounce_secs + 1),
+            reply_window_secs,
         })
     }
 
@@ -4580,8 +4598,11 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
             259_200
         );
 
-        // A window <= debounce leaves no eligible range ⇒ clamped strictly
-        // above the resolved debounce.
+        // A window <= debounce leaves no eligible range ⇒ clamped to at least
+        // one town-sweeper tick above the resolved debounce, so the eligible
+        // band can never be narrower than the 30s tick that samples it
+        // (issue #180: a +1s floor was almost always missed by the sweeper —
+        // replies silently near-disabled instead of loudly misconfigured).
         let cfg = ModelConfig::from_toml_str(
             "[tasks.world_reply]\nmodel = \"w/r\"\nfilter_prompt = \"p\"\n\
              debounce_secs = 100\nreply_window_secs = 50\n",
@@ -4589,9 +4610,25 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
         .unwrap();
         assert_eq!(
             cfg.resolve_world_reply().unwrap().reply_window_secs,
-            101,
-            "clamped to debounce + 1"
+            130,
+            "clamped to debounce + one 30s town tick"
         );
+
+        // A window inside the tick-wide band is floored too.
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.world_reply]\nmodel = \"w/r\"\nfilter_prompt = \"p\"\n\
+             debounce_secs = 100\nreply_window_secs = 110\n",
+        )
+        .unwrap();
+        assert_eq!(cfg.resolve_world_reply().unwrap().reply_window_secs, 130);
+
+        // A sane window (> debounce + tick) is untouched.
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.world_reply]\nmodel = \"w/r\"\nfilter_prompt = \"p\"\n\
+             debounce_secs = 100\nreply_window_secs = 131\n",
+        )
+        .unwrap();
+        assert_eq!(cfg.resolve_world_reply().unwrap().reply_window_secs, 131);
     }
 
     #[test]

--- a/docs/superpowers/specs/2026-07-21-world-town-reply-window-design.md
+++ b/docs/superpowers/specs/2026-07-21-world-town-reply-window-design.md
@@ -150,15 +150,24 @@ daily_cap = 20
 reply_window_secs = 604800   # NEW: reply-eligibility window after a user comment (default 7d)
 ```
 
-- **Default 604800 (7 days).** The only post the window can permanently drop is
+- **Default 604800 (7 days).** The main post the window can permanently drop is
   one whose user comment never got answered *and* then stayed silent past the
   window — which happens only when `daily_cap` / cooldown deferred the reply.
   `daily_cap` resets each UTC day, so a capped post waits at most ~1 day for
   fresh budget; 7 days leaves comfortable margin while pinning the scan to
-  "posts with a user comment in the last week."
+  "posts with a user comment in the last week." A pending reply is also
+  permanently dropped when the deferral *spans the whole window* for other
+  reasons: the post's author instance goes inactive (`status != 'active'`) and
+  is only reactivated past the window, `town_enabled` is toggled off then back
+  on across it, or the engine is down longer than the window. All of these are
+  preferable to firing a stale necro-reply, so they are accepted, not guarded
+  against (issue #180).
 - **Floored above the debounce window.** A `reply_window_secs <= debounce_secs`
   would make the eligible range (`> now()-window AND <= now()-debounce`) empty;
-  the resolver clamps it to strictly exceed the resolved `debounce_secs`.
+  the resolver clamps the window to `debounce_secs + 30` — at least one
+  town-sweeper tick (`TOWN_TICK`) wide, so the band can never be narrower than
+  the scan that samples it — and `warn!`s when the clamp engages (issue #180;
+  originally `debounce_secs + 1`, a band the 30s sweeper almost always missed).
 - Added to `ResolvedWorldReply` and `resolve_world_reply()` in
   `model_config.rs`, alongside the existing three.
 


### PR DESCRIPTION
## Summary

Closes #180 — both deferred polish items from the v0.8.3 reply-window review:

- **Clamp floor**: `resolve_world_reply` now floors `reply_window_secs` at `debounce_secs + 30` (one `TOWN_TICK`) instead of `debounce_secs + 1`. A misconfigured `reply_window_secs <= debounce_secs` used to leave a 1-second eligibility band the 30s town sweeper almost always missed — replies silently near-disabled. The band can now never be narrower than the scan that samples it, and a `warn!` fires when the clamp engages (the resolver is called once at sweeper startup, so no log spam).
- **Design-doc §4 completeness**: the "only post the window can permanently drop" claim now also names the other drop cases spanning the window (author instance inactive → reactivated, `town_enabled` toggled off/on, engine downtime > window) — all preferable to a stale necro-reply, accepted rather than guarded against.

## Testing

- Extended `resolve_world_reply_defaults_and_overrides` (clamped-below, in-band, and sane-window cases), TDD red→green.
- fmt / clippy / full workspace test suite / openapi snapshot all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)