### PR TITLE
feat(affinity): long-poll on GET /bff/v1/comp/affinity/{session_id}/event

### DIFF
--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -21,7 +21,7 @@
         "tags": [
           "bff-companion"
         ],
-        "summary": "Latest user-turn affinity delta (post-EMA). For per-turn FE observation.\nNOT behind EXPOSE_AFFINITY_DEBUG (the FE owns this surface); still JWT +\nownership checked.",
+        "summary": "Latest user-turn affinity delta (post-EMA). For per-turn FE observation.\nNOT behind EXPOSE_AFFINITY_DEBUG (the FE owns this surface); still JWT +\nownership checked. With `?after=<event_id>` the request long-polls (see\n[`BffAffinityDeltaQuery`]), collapsing the per-turn short-poll loop into\none held request.",
         "operationId": "bff_get_affinity_delta",
         "parameters": [
           {
@@ -32,6 +32,33 @@
             "schema": {
               "type": "string",
               "format": "uuid"
+            }
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "description": "Long-poll baseline: the `event_id` the caller already has. While the\nsession's latest turn event still matches (or none exists yet), the\nrequest is held until a newer event lands or `wait` elapses — the\ntimed-out response returns the unchanged state, same shape as the\nimmediate path. Absent ⇒ return the latest immediately (pre-#147\nbehavior, unchanged).",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "wait",
+            "in": "query",
+            "description": "How long to hold the request open, in milliseconds. Only meaningful\nwith `after`. Default 10000, server-capped at 25000.",
+            "required": false,
+            "schema": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64",
+              "minimum": 0
             }
           }
         ],

--- a/crates/eros-engine-server/src/routes/bff/affinity.rs
+++ b/crates/eros-engine-server/src/routes/bff/affinity.rs
@@ -4,11 +4,11 @@
 //! See docs/superpowers/specs/2026-05-20-affinity-event-delta-design.md §4.
 
 use axum::{
-    extract::{Extension, Path, State},
+    extract::{Extension, Path, Query, State},
     Json,
 };
 use chrono::{DateTime, Utc};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use utoipa_axum::{router::OpenApiRouter, routes};
 use uuid::Uuid;
 
@@ -48,14 +48,45 @@ pub struct BffAffinityDeltaResponse {
     pub event: Option<BffAffinityDelta>,
 }
 
+/// Long-poll knobs for `bff_get_affinity_delta` (issue #147). The affinity
+/// write lands in a post-process task *after* the chat stream's Final frame,
+/// so without these a consumer can only short-poll for the per-turn delta.
+#[derive(Debug, Deserialize, utoipa::IntoParams)]
+pub struct BffAffinityDeltaQuery {
+    /// Long-poll baseline: the `event_id` the caller already has. While the
+    /// session's latest turn event still matches (or none exists yet), the
+    /// request is held until a newer event lands or `wait` elapses — the
+    /// timed-out response returns the unchanged state, same shape as the
+    /// immediate path. Absent ⇒ return the latest immediately (pre-#147
+    /// behavior, unchanged).
+    pub after: Option<Uuid>,
+    /// How long to hold the request open, in milliseconds. Only meaningful
+    /// with `after`. Default 10000, server-capped at 25000.
+    pub wait: Option<u64>,
+}
+
+/// Default / ceiling for `wait` (ms). The cap keeps a held request well under
+/// typical proxy/idle timeouts; a client wanting a longer horizon re-issues.
+const LONG_POLL_DEFAULT_WAIT_MS: u64 = 10_000;
+const LONG_POLL_MAX_WAIT_MS: u64 = 25_000;
+/// Internal re-query cadence while holding. The post-process write commits
+/// within ~a second of the Final frame in the common case, so a held request
+/// resolves on the first tick or two.
+const LONG_POLL_TICK: std::time::Duration = std::time::Duration::from_millis(250);
+
 /// Latest user-turn affinity delta (post-EMA). For per-turn FE observation.
 /// NOT behind EXPOSE_AFFINITY_DEBUG (the FE owns this surface); still JWT +
-/// ownership checked.
+/// ownership checked. With `?after=<event_id>` the request long-polls (see
+/// [`BffAffinityDeltaQuery`]), collapsing the per-turn short-poll loop into
+/// one held request.
 #[utoipa::path(
     get,
     path = "/bff/v1/comp/affinity/{session_id}/event",
     tag = "bff-companion",
-    params(("session_id" = Uuid, Path, description = "Chat session id")),
+    params(
+        ("session_id" = Uuid, Path, description = "Chat session id"),
+        BffAffinityDeltaQuery
+    ),
     responses(
         (status = 200, body = BffAffinityDeltaResponse),
         (status = 401, description = "missing or invalid bearer"),
@@ -67,32 +98,51 @@ pub struct BffAffinityDeltaResponse {
 async fn bff_get_affinity_delta(
     State(state): State<AppState>,
     Path(session_id): Path<Uuid>,
+    Query(query): Query<BffAffinityDeltaQuery>,
     Extension(AuthUser(user_id)): Extension<AuthUser>,
 ) -> Result<Json<BffAffinityDeltaResponse>, AppError> {
     require_session_for_user(&state, session_id, user_id).await?;
 
-    let event = AffinityRepo { pool: &state.pool }
-        .latest_turn_event(session_id)
-        .await?
-        .and_then(|r| {
-            // Pre-0014 rows have NULL effective_deltas → omit (don't fabricate).
-            let effective = r.effective_deltas?;
-            let effective_deltas: AffinityDeltasDto = serde_json::from_value(effective).ok()?;
-            let effective_deltas_computed = r
-                .effective_line_deltas
-                .and_then(|v| serde_json::from_value::<BondChemistryDeltas>(v).ok());
-            let label_changes = r
-                .label_changes
-                .and_then(|v| serde_json::from_value::<TurnLabelChangesDto>(v).ok());
-            Some(BffAffinityDelta {
-                event_id: r.id,
-                event_type: r.event_type,
-                effective_deltas,
-                effective_deltas_computed,
-                label_changes,
-                created_at: r.created_at,
-            })
-        });
+    let repo = AffinityRepo { pool: &state.pool };
+    let mut row = repo.latest_turn_event(session_id).await?;
+
+    if let Some(after) = query.after {
+        let wait = query
+            .wait
+            .unwrap_or(LONG_POLL_DEFAULT_WAIT_MS)
+            .min(LONG_POLL_MAX_WAIT_MS);
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(wait);
+        // Hold while there is nothing newer than the caller's baseline: the
+        // latest event still IS the baseline, or no turn event exists yet.
+        while row.as_ref().map(|r| r.id) == Some(after) || row.is_none() {
+            let now = tokio::time::Instant::now();
+            if now >= deadline {
+                break;
+            }
+            tokio::time::sleep(LONG_POLL_TICK.min(deadline - now)).await;
+            row = repo.latest_turn_event(session_id).await?;
+        }
+    }
+
+    let event = row.and_then(|r| {
+        // Pre-0014 rows have NULL effective_deltas → omit (don't fabricate).
+        let effective = r.effective_deltas?;
+        let effective_deltas: AffinityDeltasDto = serde_json::from_value(effective).ok()?;
+        let effective_deltas_computed = r
+            .effective_line_deltas
+            .and_then(|v| serde_json::from_value::<BondChemistryDeltas>(v).ok());
+        let label_changes = r
+            .label_changes
+            .and_then(|v| serde_json::from_value::<TurnLabelChangesDto>(v).ok());
+        Some(BffAffinityDelta {
+            event_id: r.id,
+            event_type: r.event_type,
+            effective_deltas,
+            effective_deltas_computed,
+            label_changes,
+            created_at: r.created_at,
+        })
+    });
 
     Ok(Json(BffAffinityDeltaResponse { session_id, event }))
 }
@@ -140,19 +190,20 @@ mod tests {
         event_type: &str,
         eff_warmth: f64,
         secs_ago: i64,
-    ) {
-        sqlx::query(
+    ) -> Uuid {
+        sqlx::query_scalar(
             "INSERT INTO engine.companion_affinity_events \
                (affinity_id, event_type, deltas, effective_deltas, created_at) \
-             VALUES ($1, $2, '{}'::jsonb, $3, now() - make_interval(secs => $4))",
+             VALUES ($1, $2, '{}'::jsonb, $3, now() - make_interval(secs => $4)) \
+             RETURNING id",
         )
         .bind(affinity_id)
         .bind(event_type)
         .bind(json!({ "warmth": eff_warmth }))
         .bind(secs_ago as f64)
-        .execute(pool)
+        .fetch_one(pool)
         .await
-        .unwrap();
+        .unwrap()
     }
 
     fn req(token: &str, sid: Uuid) -> Request<Body> {
@@ -299,6 +350,127 @@ mod tests {
                 < 1e-9
         );
         assert_eq!(ev["label_changes"]["bond"]["to"], "friend");
+    }
+
+    fn req_longpoll(token: &str, sid: Uuid, after: Uuid, wait_ms: u64) -> Request<Body> {
+        Request::builder()
+            .method("GET")
+            .uri(format!(
+                "/bff/v1/comp/affinity/{sid}/event?after={after}&wait={wait_ms}"
+            ))
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn bff_affinity_longpoll_stale_after_returns_immediately(pool: PgPool) {
+        // `after` differing from the latest event_id ⇒ the caller is behind;
+        // return the latest event at once, no hold.
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+        let aid = seed_affinity(&pool, session_id, user_id, instance_id).await;
+        seed_event(&pool, aid, "message", 0.05, 10).await;
+
+        let state = test_state(pool);
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+        let started = std::time::Instant::now();
+        let (status, body) = send_request(
+            &mut app,
+            req_longpoll(&token, session_id, Uuid::new_v4(), 5_000),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "body={body}");
+        assert_eq!(body["event"]["event_type"], "message");
+        assert!(
+            started.elapsed() < std::time::Duration::from_millis(2_000),
+            "stale `after` must not hold the request"
+        );
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn bff_affinity_longpoll_returns_new_event_when_it_lands(pool: PgPool) {
+        // `after` == latest ⇒ hold; a newer event landing mid-hold is returned
+        // well before the requested wait elapses.
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+        let aid = seed_affinity(&pool, session_id, user_id, instance_id).await;
+        let baseline = seed_event(&pool, aid, "message", 0.05, 10).await;
+
+        let state = test_state(pool.clone());
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        let inserter = tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+            seed_event(&pool, aid, "gift", 0.12, 0).await
+        });
+
+        let started = std::time::Instant::now();
+        let (status, body) =
+            send_request(&mut app, req_longpoll(&token, session_id, baseline, 10_000)).await;
+        let new_id = inserter.await.unwrap();
+        assert_eq!(status, StatusCode::OK, "body={body}");
+        assert_eq!(body["event"]["event_type"], "gift");
+        assert_eq!(body["event"]["event_id"], new_id.to_string());
+        assert!(
+            started.elapsed() < std::time::Duration::from_millis(8_000),
+            "must return on the new event, not the full wait"
+        );
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn bff_affinity_longpoll_timeout_returns_unchanged(pool: PgPool) {
+        // Nothing new within `wait` ⇒ hold for ~wait, then return the (stale)
+        // latest event unchanged — same shape as the immediate path.
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+        let aid = seed_affinity(&pool, session_id, user_id, instance_id).await;
+        let baseline = seed_event(&pool, aid, "message", 0.05, 10).await;
+
+        let state = test_state(pool);
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+        let started = std::time::Instant::now();
+        let (status, body) =
+            send_request(&mut app, req_longpoll(&token, session_id, baseline, 500)).await;
+        assert_eq!(status, StatusCode::OK, "body={body}");
+        assert_eq!(body["event"]["event_id"], baseline.to_string());
+        assert!(
+            started.elapsed() >= std::time::Duration::from_millis(450),
+            "matching `after` must hold until the wait elapses"
+        );
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn bff_affinity_longpoll_no_event_times_out_null(pool: PgPool) {
+        // No turn event at all: `after` (a client can only guess a sentinel
+        // here) holds until timeout, then returns event: null as today.
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+        seed_affinity(&pool, session_id, user_id, instance_id).await;
+
+        let state = test_state(pool);
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+        let started = std::time::Instant::now();
+        let (status, body) = send_request(
+            &mut app,
+            req_longpoll(&token, session_id, Uuid::new_v4(), 400),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "body={body}");
+        assert!(body["event"].is_null());
+        assert!(started.elapsed() >= std::time::Duration::from_millis(350));
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]


### PR DESCRIPTION
## Summary

Closes #147 — optional long-poll semantics on the BFF affinity delta endpoint, fully backward-compatible:

- `?after=<event_id>` — the caller's baseline. While the session's latest turn event still matches (or none exists yet), the handler holds the request, re-querying the repo every 250ms, until a newer event lands or the wait elapses.
- `?wait=<ms>` — hold duration; default 10s, server-capped at 25s (kept under typical proxy idle timeouts).
- Timed-out hold returns the unchanged latest event in the same response shape — the client keeps comparing `event_id`, no new semantics. No `after` ⇒ behavior unchanged.

Collapses the FE's ~3–6 short-polls per turn into one held request and surfaces the per-turn delta as soon as the post-process write commits, instead of on the next poll tick. No schema change; `event_id` was already the documented freshness/dedup key.

## Testing

- Four new sqlx tests (TDD red→green): stale-`after` returns immediately; a mid-hold insert returns the new event before the wait elapses; timeout returns the unchanged event after ~wait; no-event + `after` holds then returns `event: null`.
- OpenAPI snapshot regenerated (`print-openapi`).
- fmt / clippy / full workspace test suite green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)