### PR TITLE
fix(stream): apply the v0.8.4 hardening follow-ups deferred in #188

### DIFF
--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -356,6 +356,14 @@ pub struct TierConfig {
     pub retry_depth: Option<u32>,
 }
 
+/// The `[defaults]` section — cross-task fallbacks and provider routing.
+///
+/// **Construct with struct-update syntax** — `DefaultConfig { ignore_providers:
+/// vec![…], ..Default::default() }` — never a bare exhaustive literal. New
+/// optional fields are added here in minor releases (`ignore_providers`
+/// pre-v0.6.1, `provider_sort` v0.8.4) and a bare literal breaks on every such
+/// upgrade; `..Default::default()` is the supported construction pattern
+/// (issue #188).
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct DefaultConfig {
     #[serde(default)]

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -18,6 +18,13 @@ const POOL_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30
 /// Max gap between SSE *bytes* before a live stream is declared dead.
 const STREAM_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(45);
 
+/// Marker prefix of the idle-watchdog error message. Pub so the pipeline's
+/// stream-metrics outcome mapping can recognize an idle timeout after the
+/// message has been stringified through the SSE layer's `Transport error:`
+/// wrapper into `LlmError::Stream` (issue #188 — spec §4.2 lists
+/// `"idle_timeout"` as its own outcome, distinct from `"chunk_error"`).
+pub const STREAM_IDLE_TIMEOUT_MSG: &str = "openrouter stream idle timeout";
+
 /// Gap-bound a fallible stream: an idle period longer than `idle` between
 /// items becomes an io TimedOut error item. Applied to the raw BYTES stream
 /// (before SSE parsing) deliberately: OpenRouter's `: OPENROUTER PROCESSING`
@@ -38,7 +45,7 @@ where
         Err(_elapsed) => Err(std::io::Error::new(
             std::io::ErrorKind::TimedOut,
             format!(
-                "openrouter stream idle timeout: no bytes for {}s",
+                "{STREAM_IDLE_TIMEOUT_MSG}: no bytes for {}s",
                 idle.as_secs()
             ),
         )),
@@ -213,17 +220,6 @@ impl std::fmt::Display for ImageGenError {
 }
 impl std::error::Error for ImageGenError {}
 
-/// Cap a provider error body to a bounded length for persistence/logs.
-fn cap_provider_message(s: &str) -> String {
-    const MAX: usize = 600;
-    let t = s.trim();
-    if t.chars().count() <= MAX {
-        t.to_string()
-    } else {
-        t.chars().take(MAX).collect::<String>() + "…"
-    }
-}
-
 /// Max chars kept from a raw provider error body in ordinary logs. Short by
 /// design: logs are for triage, not forensics — full error forensics live in
 /// OpenRouter's own logs, joined on `generation_id`.
@@ -249,7 +245,11 @@ fn body_preview(s: &str) -> String {
 /// which is an excerpt of the user's flagged prompt that a moderation rejection
 /// echoes back (logging it would leak raw chat content). Non-envelope bodies
 /// fall back to a plain length-capped preview.
-fn scrub_error_body(raw: &str) -> String {
+///
+/// `pub(crate)`: the voyage client reuses this for its own status-error
+/// bodies (issue #188) — the envelope parse simply falls through to the
+/// capped preview for non-OpenRouter shapes.
+pub(crate) fn scrub_error_body(raw: &str) -> String {
     #[derive(Deserialize)]
     struct Env {
         error: ErrBody,
@@ -1087,7 +1087,9 @@ impl OpenRouterClient {
                     variant,
                     outcome: AttemptOutcome::Status {
                         status: status.as_u16(),
-                        message: cap_provider_message(&text),
+                        // scrub, not just cap: a moderation body echoes the
+                        // flagged prompt back (issue #188).
+                        message: scrub_error_body(&text),
                     },
                 });
                 continue;
@@ -3470,5 +3472,47 @@ data: [DONE]\n\n";
         assert_eq!(seen.len(), 2, "on_attempt fires once per planned attempt");
         assert_eq!(seen[0], ("m1".to_string(), PromptVariant::Single, 1, 2));
         assert_eq!(seen[1], ("m2".to_string(), PromptVariant::Single, 2, 2));
+    }
+
+    #[tokio::test]
+    async fn execute_image_inner_scrubs_flagged_input_from_status_attempts() {
+        // A moderation 403 echoes the user's flagged prompt back in
+        // `metadata.flagged_input`; the recorded attempt must keep the code /
+        // provider / reasons but never that excerpt (issue #188 item 4 —
+        // parity with the chat paths' scrub_error_body).
+        let server = MockServer::start().await;
+        let body = r#"{"error":{"code":403,"message":"prompt flagged","metadata":{"provider_name":"prov","reasons":["sexual"],"flagged_input":"SECRET_USER_PROMPT"}}}"#;
+        Mock::given(path("/api/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(403).set_body_raw(body, "application/json"))
+            .mount(&server)
+            .await;
+
+        let client = OpenRouterClient::with_base_url(
+            "test-key".into(),
+            AppAttribution::default(),
+            format!("{}/api/v1/chat/completions", server.uri()),
+        );
+        let req = ImageGenRequest {
+            model: "m1".into(),
+            prompt: "a cat".into(),
+            max_tokens: 4096,
+            ..Default::default()
+        };
+        let result = client.execute_image_inner(req, |_| {}).await;
+        let Err(ImageGenError::ChainExhausted { attempts }) = result else {
+            panic!("expected ChainExhausted, got {result:?}");
+        };
+        let AttemptOutcome::Status { status, message } = &attempts[0].outcome else {
+            panic!("expected Status outcome, got {:?}", attempts[0].outcome);
+        };
+        assert_eq!(*status, 403);
+        assert!(
+            !message.contains("SECRET_USER_PROMPT"),
+            "flagged_input must be scrubbed from the attempt record: {message}"
+        );
+        assert!(
+            message.contains("sexual"),
+            "moderation reasons stay visible for triage: {message}"
+        );
     }
 }

--- a/crates/eros-engine-llm/src/voyage.rs
+++ b/crates/eros-engine-llm/src/voyage.rs
@@ -79,8 +79,9 @@ impl VoyageClient {
         let status = resp.status();
         if !status.is_success() {
             let text = resp.text().await.unwrap_or_default();
-            tracing::warn!("voyage: status={status} body={text}");
-            return Err(LlmError::Status(status, text));
+            let err = status_error(status, &text);
+            tracing::warn!("voyage: {err}");
+            return Err(err);
         }
 
         let parsed: EmbedResponse = resp.json().await?;
@@ -116,11 +117,21 @@ impl VoyageClient {
         let status = resp.status();
         let text = resp.text().await?;
         if !status.is_success() {
-            tracing::warn!("voyage: status={status} body={text}");
-            return Err(LlmError::Status(status, text));
+            let err = status_error(status, &text);
+            tracing::warn!("voyage: {err}");
+            return Err(err);
         }
         parse_embed_batch(&text, texts.len())
     }
+}
+
+/// Build the bounded `LlmError::Status` for a non-success Voyage response.
+/// The raw body never reaches the error (or the log line that mirrors it):
+/// provider bodies are unbounded and may echo input, so they are scrubbed /
+/// capped first — the same bounded-log guarantee the chat client upholds
+/// (issue #188).
+fn status_error(status: reqwest::StatusCode, body: &str) -> LlmError {
+    LlmError::Status(status, crate::openrouter::scrub_error_body(body))
 }
 
 /// Parse a Voyage batch response body into ordered vectors, enforcing that
@@ -180,5 +191,40 @@ mod tests {
     #[test]
     fn parse_embed_batch_rejects_garbage() {
         assert!(parse_embed_batch("not json", 1).is_err());
+    }
+
+    #[test]
+    fn status_error_bounds_and_scrubs_provider_body() {
+        // The stored error body must be bounded and stripped of any echoed
+        // input (issue #188 item 4 — the bounded-log guarantee the v0.8.4
+        // hardening established elsewhere extends to the embedding client).
+        let huge = format!(
+            r#"{{"error":{{"code":400,"message":"{}","metadata":{{"flagged_input":"SECRET"}}}}}}"#,
+            "x".repeat(5000)
+        );
+        let e = status_error(reqwest::StatusCode::BAD_REQUEST, &huge);
+        let LlmError::Status(status, msg) = e else {
+            panic!("expected Status, got {e:?}");
+        };
+        assert_eq!(status, reqwest::StatusCode::BAD_REQUEST);
+        assert!(
+            msg.chars().count() <= 220,
+            "must be bounded, got {} chars",
+            msg.chars().count()
+        );
+        assert!(
+            !msg.contains("SECRET"),
+            "echoed input must be dropped: {msg}"
+        );
+
+        // A plain non-JSON body still comes through, just capped.
+        let e = status_error(
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+            "upstream exploded",
+        );
+        let LlmError::Status(_, msg) = e else {
+            panic!("expected Status, got {e:?}");
+        };
+        assert_eq!(msg, "upstream exploded");
     }
 }

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -608,7 +608,7 @@ fn drive_chat_burst(
                                 Err(e) => {
                                     tracing::warn!("stream: upstream chunk err: {e}");
                                     truncated = true;
-                                    attempt_outcome = "chunk_error";
+                                    attempt_outcome = chunk_err_outcome(&e);
                                     break;
                                 }
                             }
@@ -970,7 +970,7 @@ fn drive_chat_burst(
                             Err(e) => {
                                 tracing::warn!("stream(filtered): chunk err: {e}");
                                 truncated = true;
-                                attempt_outcome = "chunk_error";
+                                attempt_outcome = chunk_err_outcome(&e);
                                 break;
                             }
                         }
@@ -1493,12 +1493,31 @@ const FILTER_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
 
 /// Max wait for a chat stream to OPEN (connect + queue + response headers).
 /// A provider that accepts the socket but never sends headers must not hold
-/// the turn — timeout ⇒ attempt fails ⇒ chain advances.
-const STREAM_OPEN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
+/// the turn — timeout ⇒ attempt fails ⇒ chain advances. `pub(crate)`: the
+/// voice path applies the same caps (issue #188).
+pub(crate) const STREAM_OPEN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
 /// Hard per-attempt cap on one model's whole generation (spec §1.5's 120s).
 /// Byte-level idle liveness is bounded upstream in the llm client; this caps
 /// a stream that keeps trickling forever.
-const STREAM_TOTAL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+pub(crate) const STREAM_TOTAL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+
+/// Spec §4.2 outcome label for an `Err` item mid-consume. Provider error
+/// frames (`LlmError::Provider`) and the byte-level idle watchdog are their
+/// own failure modes — folding them into `"chunk_error"` made dashboards
+/// undercount idle timeouts and blend provider failures into transport drops
+/// (issue #188). Everything else (transport reset, parse) stays
+/// `"chunk_error"`.
+fn chunk_err_outcome(e: &eros_engine_llm::LlmError) -> &'static str {
+    match e {
+        eros_engine_llm::LlmError::Provider(_) => "error_frame",
+        eros_engine_llm::LlmError::Stream(msg)
+            if msg.contains(eros_engine_llm::openrouter::STREAM_IDLE_TIMEOUT_MSG) =>
+        {
+            "idle_timeout"
+        }
+        _ => "chunk_error",
+    }
+}
 
 /// Run the output-filter LLM over `original`, walking the (already
 /// depth-capped) fallback chain one model at a time.  After each successful
@@ -3936,6 +3955,38 @@ pub fn replay_stream(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn chunk_err_outcome_separates_error_frame_and_idle_timeout() {
+        use eros_engine_llm::LlmError;
+        // Provider error frames (a 200 SSE frame carrying `error`) are their
+        // own failure mode, distinct from transport drops (spec §4.2).
+        assert_eq!(
+            chunk_err_outcome(&LlmError::Provider(
+                "openrouter mid-stream error: code=Some(502): upstream".into()
+            )),
+            "error_frame"
+        );
+        // The byte-level idle watchdog's io::Error rides through
+        // eventsource-stream's `Transport error: {inner}` Display into
+        // LlmError::Stream; the shared marker constant is the contract.
+        let idle = LlmError::Stream(format!(
+            "Transport error: {}: no bytes for 45s",
+            eros_engine_llm::openrouter::STREAM_IDLE_TIMEOUT_MSG
+        ));
+        assert_eq!(chunk_err_outcome(&idle), "idle_timeout");
+        // Everything else stays the generic transport/parse label.
+        assert_eq!(
+            chunk_err_outcome(&LlmError::Stream(
+                "Transport error: connection reset by peer".into()
+            )),
+            "chunk_error"
+        );
+        assert_eq!(
+            chunk_err_outcome(&LlmError::StreamParse("not a delta".into())),
+            "chunk_error"
+        );
+    }
 
     #[test]
     fn meta_frame_serializes_with_required_fields() {

--- a/crates/eros-engine-server/src/pipeline/voice.rs
+++ b/crates/eros-engine-server/src/pipeline/voice.rs
@@ -15,7 +15,9 @@ use eros_engine_store::affinity::AffinityRepo;
 use eros_engine_store::chat::ChatRepo;
 use eros_engine_store::persona::PersonaRepo;
 
-use crate::pipeline::stream::{ulid_string, ProtocolFrame, StreamErrorCode};
+use crate::pipeline::stream::{
+    ulid_string, ProtocolFrame, StreamErrorCode, STREAM_OPEN_TIMEOUT, STREAM_TOTAL_TIMEOUT,
+};
 use crate::state::AppState;
 
 /// Assemble the thin voice system prompt: persona + voice directive + one
@@ -149,6 +151,19 @@ pub fn run_voice_turn(
         let mut served_model: Option<String> = None;
         let mut truncated = false;
 
+        // Chain-shared request: `execute_stream_as` borrows it and sends each
+        // candidate's model id, so the prompt is never cloned per attempt
+        // (issue #188 — parity with the text pipeline's loops). `model` here
+        // is a placeholder `execute_stream_as` ignores.
+        let req = ChatRequest {
+            model: String::new(),
+            messages,
+            temperature: resolved.temperature as f32,
+            max_tokens: resolved.max_tokens,
+            reasoning: resolved.reasoning.clone(),
+            ..Default::default()
+        };
+
         'candidates: for model_id in candidates {
             // Per-attempt metadata: reset so an abandoned candidate's usage / gen_id /
             // model / truncated never leaks onto a later fallback's reply.
@@ -156,26 +171,55 @@ pub fn run_voice_turn(
             last_gen_id = None;
             served_model = None;
             truncated = false;
-            let req = ChatRequest {
-                model: model_id.clone(),
-                messages: messages.clone(),
-                temperature: resolved.temperature as f32,
-                max_tokens: resolved.max_tokens,
-                reasoning: resolved.reasoning.clone(),
-                ..Default::default()
-            };
-            let stream = match state.openrouter.execute_stream(req).await {
-                Ok(s) => s,
-                Err(e) => {
+            // Bound the open: a provider that accepts the socket but never
+            // sends response headers must not hold the turn (issue #188 —
+            // the same caps as the text pipeline).
+            let stream = match tokio::time::timeout(
+                STREAM_OPEN_TIMEOUT,
+                state.openrouter.execute_stream_as(&req, &model_id),
+            ).await {
+                Ok(Ok(s)) => s,
+                Ok(Err(e)) => {
                     tracing::warn!(model = %model_id, error = %e, "voice: open stream failed");
+                    if acc.is_empty() { continue 'candidates; }
+                    truncated = true;
+                    break 'candidates;
+                }
+                Err(_) => {
+                    tracing::warn!(
+                        model = %model_id,
+                        "voice: open timeout ({}s)",
+                        STREAM_OPEN_TIMEOUT.as_secs()
+                    );
                     if acc.is_empty() { continue 'candidates; }
                     truncated = true;
                     break 'candidates;
                 }
             };
             futures_util::pin_mut!(stream);
+            // Hard per-attempt cap: byte-level idle liveness is bounded in the
+            // llm client; this caps a stream that keeps trickling forever.
+            let deadline = tokio::time::Instant::now() + STREAM_TOTAL_TIMEOUT;
             loop {
-                match futures_util::StreamExt::next(&mut stream).await {
+                let item = match tokio::time::timeout_at(
+                    deadline,
+                    futures_util::StreamExt::next(&mut stream),
+                )
+                .await
+                {
+                    Ok(item) => item,
+                    Err(_) => {
+                        tracing::warn!(
+                            model = %model_id,
+                            "voice: total timeout ({}s)",
+                            STREAM_TOTAL_TIMEOUT.as_secs()
+                        );
+                        if acc.is_empty() { continue 'candidates; }
+                        truncated = true;
+                        break 'candidates;
+                    }
+                };
+                match item {
                     Some(Ok(chunk)) => {
                         if chunk.usage.is_some() { last_usage = chunk.usage.clone(); }
                         if chunk.generation_id.is_some() { last_gen_id = chunk.generation_id.clone(); }
@@ -184,7 +228,16 @@ pub fn run_voice_turn(
                             acc.push_str(&text);
                             yield ProtocolFrame::Delta { message_id: message_id.clone(), content: text };
                         }
-                        if chunk.finish_reason.as_deref() == Some("length") { truncated = true; }
+                        // "content_filter" = mid-generation safety cut: the
+                        // text is incomplete, so it carries the same
+                        // truncation signal as "length" (issue #188 — parity
+                        // with the text pipeline's gates).
+                        if matches!(
+                            chunk.finish_reason.as_deref(),
+                            Some("length") | Some("content_filter")
+                        ) {
+                            truncated = true;
+                        }
                     }
                     Some(Err(e)) => {
                         tracing::warn!(model = %model_id, error = %e, "voice: mid-stream error");
@@ -925,6 +978,103 @@ data: [DONE]\n\n";
         assert_eq!(
             persisted_usage["cost"], 0.01,
             "DB row must keep the FULL unfiltered usage; got {persisted_usage}"
+        );
+    }
+
+    /// Issue #188 item 1: `content_filter` is a mid-generation safety cut —
+    /// the text is incomplete, so the voice path must mark the turn truncated
+    /// exactly like `length` (parity with the text pipeline's handling).
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn run_voice_turn_content_filter_finish_marks_truncated(pool: sqlx::PgPool) {
+        use eros_engine_llm::model_config::ModelConfig;
+        use futures_util::StreamExt;
+        use wiremock::matchers::path as wm_path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        let body = "\
+data: {\"choices\":[{\"delta\":{\"content\":\"cut short\"}}]}\n\n\
+data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"content_filter\"}],\"id\":\"gen-cf\",\"model\":\"primary\"}\n\n\
+data: [DONE]\n\n";
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+
+        // Seed persona + instance + session.
+        let user_id = Uuid::new_v4();
+        let genome_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata) \
+             VALUES ('V', 'You are V.', '{}'::jsonb) RETURNING id",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let instance_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_instances (genome_id, owner_uid) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(genome_id).bind(user_id).fetch_one(&pool).await.unwrap();
+        let session_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(user_id)
+        .bind(instance_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        let repo = ChatRepo { pool: &pool };
+        let umid = match repo
+            .insert_voice_user_message(session_id, "hello", "01J9000000000000000000VOIC8")
+            .await
+            .unwrap()
+        {
+            eros_engine_store::chat::VoiceUserInsert::Inserted(id) => id,
+            other => panic!("expected Inserted, got {other:?}"),
+        };
+
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = Arc::new(
+            ModelConfig::from_toml_str(
+                "[tasks.chat_voice]\nmodel = \"primary\"\nmax_tokens = 100\n",
+            )
+            .unwrap(),
+        );
+        state.openrouter = Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                eros_engine_llm::openrouter::AppAttribution::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+
+        let resolved = state.model_config.resolve_voice().unwrap();
+        let frames: Vec<ProtocolFrame> = run_voice_turn(
+            Arc::new(state),
+            VoiceTurn {
+                session_id,
+                instance_id,
+                user_message_id: umid,
+            },
+            resolved,
+        )
+        .collect()
+        .await;
+
+        let truncated = frames
+            .iter()
+            .find_map(|f| match f {
+                ProtocolFrame::Done { truncated, .. } => Some(*truncated),
+                _ => None,
+            })
+            .expect("a Done frame");
+        assert!(
+            truncated,
+            "content_filter finish must mark the voice turn truncated; frames={frames:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

Closes #188 — all four deferred items from the v0.8.4 stream-hardening review:

1. **voice.rs parity** — the fourth streaming path now shares the series' hardening: chain-shared request via `execute_stream_as` (no per-candidate prompt clone), `STREAM_OPEN_TIMEOUT` around the open, `STREAM_TOTAL_TIMEOUT` deadline on the consume loop, and `content_filter` treated as truncation like `length`. Closes the residual "socket accepted, headers never sent" + trickling-forever windows.
2. **stream_metrics vocabulary** — the consume loops now label provider error frames `"error_frame"` and the byte-level idle watchdog `"idle_timeout"` per spec §4.2, instead of folding both into `"chunk_error"`. The idle case is recognized via a shared `STREAM_IDLE_TIMEOUT_MSG` constant used both where the watchdog constructs its error and where the pipeline maps outcomes — no free-floating magic string.
3. **DefaultConfig semver** — documents `..Default::default()` struct-update syntax as the supported construction pattern (new optional fields land in minor releases; a bare exhaustive literal breaks on upgrade). Doc-only; no `#[non_exhaustive]` break.
4. **Older error paths** — image-gen status attempts now use `scrub_error_body` (drops moderation `flagged_input`, replacing the plain 600-char cap, which is removed as now-unused), and voyage status errors/logs are scrubbed/bounded instead of storing the raw provider body.

## Testing

TDD red→green for each behavioral item:
- `run_voice_turn_content_filter_finish_marks_truncated` (voice parity; all 7 voice tests green)
- `chunk_err_outcome_separates_error_frame_and_idle_timeout`
- `execute_image_inner_scrubs_flagged_input_from_status_attempts`
- `status_error_bounds_and_scrubs_provider_body` (voyage)

fmt / clippy / full workspace test suite / openapi snapshot (no drift) all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)