### PR TITLE
chore(release): v0.9.1 — affinity long-poll + world-reply clamp + stream-hardening follow-ups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,7 +511,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "eros-engine-core"
-version = "0.9.1-dev"
+version = "0.9.1"
 dependencies = [
  "chrono",
  "serde",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-llm"
-version = "0.9.1-dev"
+version = "0.9.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-server"
-version = "0.9.1-dev"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-store"
-version = "0.9.1-dev"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.9.1-dev"
+version = "0.9.1"
 edition = "2021"
 license = "AGPL-3.0-only"
 repository = "https://github.com/etherfunlab/eros-engine"

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ eros-engine-llm   = "0.8"   # only if you want the OpenRouter + Voyage clients
 `linux/amd64` images for `eros-engine-server` are published to GitHub Container Registry for every `v*` tag (need arm64? Build it yourself from `docker/Dockerfile`):
 
 ```bash
-docker pull ghcr.io/etherfunlab/eros-engine:0.9.0
+docker pull ghcr.io/etherfunlab/eros-engine:0.9.1
 # or track the latest tagged release
 docker pull ghcr.io/etherfunlab/eros-engine:latest
 ```
@@ -87,7 +87,7 @@ Minimal run (you bring Postgres + your own `.env`):
 
 ```bash
 docker run --rm -p 8080:8080 --env-file .env \
-  ghcr.io/etherfunlab/eros-engine:0.9.0 serve
+  ghcr.io/etherfunlab/eros-engine:0.9.1 serve
 ```
 
 The `docker/Dockerfile` is the same artifact used to build this image. Deploy it on any container host. See [Deploying](docs/deploying.md).

--- a/crates/eros-engine-llm/Cargo.toml
+++ b/crates/eros-engine-llm/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "openrouter", "voyage", "embeddings", "llm"]
 categories = ["api-bindings"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "0.9.1-dev" }
+eros-engine-core = { path = "../eros-engine-core", version = "0.9.1" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/eros-engine-server/Cargo.toml
+++ b/crates/eros-engine-server/Cargo.toml
@@ -13,9 +13,9 @@ name = "eros-engine"
 path = "src/main.rs"
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "0.9.1-dev" }
-eros-engine-llm  = { path = "../eros-engine-llm", version = "0.9.1-dev" }
-eros-engine-store = { path = "../eros-engine-store", version = "0.9.1-dev" }
+eros-engine-core = { path = "../eros-engine-core", version = "0.9.1" }
+eros-engine-llm  = { path = "../eros-engine-llm", version = "0.9.1" }
+eros-engine-store = { path = "../eros-engine-store", version = "0.9.1" }
 axum = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0-only",
       "identifier": "AGPL-3.0-only"
     },
-    "version": "0.9.1-dev"
+    "version": "0.9.1"
   },
   "servers": [
     {

--- a/crates/eros-engine-store/Cargo.toml
+++ b/crates/eros-engine-store/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "memory", "pgvector", "postgres", "sqlx"]
 categories = ["database"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "0.9.1-dev" }
+eros-engine-core = { path = "../eros-engine-core", version = "0.9.1" }
 sqlx = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
## Summary

Version bump 0.9.1-dev → 0.9.1 for the v0.9.1 stable release.

- 4 Cargo.tomls (workspace + server/llm/store path-dep pins) + Cargo.lock
- `openapi.json` info.version regenerated
- README docker-pull examples 0.9.0 → 0.9.1

Release delta since v0.9.0 (all PRs merged to dev after the v0.9.0 publish):
- #191 feat(affinity): long-poll on `GET /bff/v1/comp/affinity/{session_id}/event` (`?after` + `?wait`) — closes #147
- #190 fix(world): floor reply window one town tick above debounce, warn on clamp — closes #180
- #192 fix(stream): v0.8.4 stream-hardening follow-ups (voice.rs parity, metrics vocabulary, DefaultConfig semver doc, error-body redaction) — closes #188

Pre-release gates: per-PR codex review + CI green; whole-delta Opus review returned NO RELEASE-GATING ISSUES.

🤖 Generated with [Claude Code](https://claude.com/claude-code)