### PR TITLE
chore(release): v0.9.1 — affinity long-poll + world-reply clamp + stream-hardening follow-ups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,7 +511,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "eros-engine-core"
-version = "0.9.1-dev"
+version = "0.9.1"
 dependencies = [
  "chrono",
  "serde",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-llm"
-version = "0.9.1-dev"
+version = "0.9.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-server"
-version = "0.9.1-dev"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-store"
-version = "0.9.1-dev"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,7 +511,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "eros-engine-core"
-version = "0.9.0"
+version = "0.9.1-dev"
 dependencies = [
  "chrono",
  "serde",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-llm"
-version = "0.9.0"
+version = "0.9.1-dev"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-server"
-version = "0.9.0"
+version = "0.9.1-dev"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-store"
-version = "0.9.0"
+version = "0.9.1-dev"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1-dev"
 edition = "2021"
 license = "AGPL-3.0-only"
 repository = "https://github.com/etherfunlab/eros-engine"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.9.1-dev"
+version = "0.9.1"
 edition = "2021"
 license = "AGPL-3.0-only"
 repository = "https://github.com/etherfunlab/eros-engine"

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ eros-engine-llm   = "0.8"   # only if you want the OpenRouter + Voyage clients
 `linux/amd64` images for `eros-engine-server` are published to GitHub Container Registry for every `v*` tag (need arm64? Build it yourself from `docker/Dockerfile`):
 
 ```bash
-docker pull ghcr.io/etherfunlab/eros-engine:0.9.0
+docker pull ghcr.io/etherfunlab/eros-engine:0.9.1
 # or track the latest tagged release
 docker pull ghcr.io/etherfunlab/eros-engine:latest
 ```
@@ -87,7 +87,7 @@ Minimal run (you bring Postgres + your own `.env`):
 
 ```bash
 docker run --rm -p 8080:8080 --env-file .env \
-  ghcr.io/etherfunlab/eros-engine:0.9.0 serve
+  ghcr.io/etherfunlab/eros-engine:0.9.1 serve
 ```
 
 The `docker/Dockerfile` is the same artifact used to build this image. Deploy it on any container host. See [Deploying](docs/deploying.md).

--- a/crates/eros-engine-llm/Cargo.toml
+++ b/crates/eros-engine-llm/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "openrouter", "voyage", "embeddings", "llm"]
 categories = ["api-bindings"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "0.9.0" }
+eros-engine-core = { path = "../eros-engine-core", version = "0.9.1-dev" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/eros-engine-llm/Cargo.toml
+++ b/crates/eros-engine-llm/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "openrouter", "voyage", "embeddings", "llm"]
 categories = ["api-bindings"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "0.9.1-dev" }
+eros-engine-core = { path = "../eros-engine-core", version = "0.9.1" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -1703,6 +1703,14 @@ impl ModelConfig {
     /// Resolve the world-town reply-responder bundle. `None` when
     /// `[tasks.world_reply]` is absent OR its `filter_prompt` is blank.
     pub fn resolve_world_reply(&self) -> Option<ResolvedWorldReply> {
+        // Minimum width of the reply-eligibility band (`window - debounce`),
+        // pinned to one town-sweeper tick (`TOWN_TICK` in
+        // eros-engine-server/src/pipeline/world_town.rs). A narrower band
+        // falls between two 30s scans, so a misconfigured
+        // `reply_window_secs <= debounce_secs` would silently near-disable
+        // replies instead of surfacing the misconfig (issue #180).
+        const MIN_BAND_SECS: u64 = 30;
+
         let task_cfg = self.tasks.get("world_reply")?;
         let reply_prompt = task_cfg.filter_prompt.clone().unwrap_or_default();
         if reply_prompt.trim().is_empty() {
@@ -1710,6 +1718,19 @@ impl ModelConfig {
         }
         let m = self.resolve("world_reply", None);
         let debounce_secs = task_cfg.debounce_secs.unwrap_or(90);
+        let configured_window = task_cfg.reply_window_secs.unwrap_or(604_800);
+        let reply_window_secs = configured_window.max(debounce_secs + MIN_BAND_SECS);
+        if reply_window_secs != configured_window {
+            tracing::warn!(
+                configured_window,
+                debounce_secs,
+                clamped_to = reply_window_secs,
+                "world_reply: reply_window_secs leaves an eligibility band \
+                 narrower than one 30s sweeper tick — clamped; fix \
+                 [tasks.world_reply].reply_window_secs (must exceed \
+                 debounce_secs by at least 30s)"
+            );
+        }
         Some(ResolvedWorldReply {
             model: m.model,
             fallback_model: m.fallback_model,
@@ -1721,10 +1742,7 @@ impl ModelConfig {
             debounce_secs,
             thread_cooldown_secs: task_cfg.thread_cooldown_secs.unwrap_or(600),
             daily_cap: task_cfg.daily_cap.unwrap_or(20),
-            reply_window_secs: task_cfg
-                .reply_window_secs
-                .unwrap_or(604_800)
-                .max(debounce_secs + 1),
+            reply_window_secs,
         })
     }
 
@@ -4580,8 +4598,11 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
             259_200
         );
 
-        // A window <= debounce leaves no eligible range ⇒ clamped strictly
-        // above the resolved debounce.
+        // A window <= debounce leaves no eligible range ⇒ clamped to at least
+        // one town-sweeper tick above the resolved debounce, so the eligible
+        // band can never be narrower than the 30s tick that samples it
+        // (issue #180: a +1s floor was almost always missed by the sweeper —
+        // replies silently near-disabled instead of loudly misconfigured).
         let cfg = ModelConfig::from_toml_str(
             "[tasks.world_reply]\nmodel = \"w/r\"\nfilter_prompt = \"p\"\n\
              debounce_secs = 100\nreply_window_secs = 50\n",
@@ -4589,9 +4610,25 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
         .unwrap();
         assert_eq!(
             cfg.resolve_world_reply().unwrap().reply_window_secs,
-            101,
-            "clamped to debounce + 1"
+            130,
+            "clamped to debounce + one 30s town tick"
         );
+
+        // A window inside the tick-wide band is floored too.
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.world_reply]\nmodel = \"w/r\"\nfilter_prompt = \"p\"\n\
+             debounce_secs = 100\nreply_window_secs = 110\n",
+        )
+        .unwrap();
+        assert_eq!(cfg.resolve_world_reply().unwrap().reply_window_secs, 130);
+
+        // A sane window (> debounce + tick) is untouched.
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.world_reply]\nmodel = \"w/r\"\nfilter_prompt = \"p\"\n\
+             debounce_secs = 100\nreply_window_secs = 131\n",
+        )
+        .unwrap();
+        assert_eq!(cfg.resolve_world_reply().unwrap().reply_window_secs, 131);
     }
 
     #[test]

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -356,6 +356,14 @@ pub struct TierConfig {
     pub retry_depth: Option<u32>,
 }
 
+/// The `[defaults]` section — cross-task fallbacks and provider routing.
+///
+/// **Construct with struct-update syntax** — `DefaultConfig { ignore_providers:
+/// vec![…], ..Default::default() }` — never a bare exhaustive literal. New
+/// optional fields are added here in minor releases (`ignore_providers`
+/// pre-v0.6.1, `provider_sort` v0.8.4) and a bare literal breaks on every such
+/// upgrade; `..Default::default()` is the supported construction pattern
+/// (issue #188).
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct DefaultConfig {
     #[serde(default)]

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -18,6 +18,13 @@ const POOL_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30
 /// Max gap between SSE *bytes* before a live stream is declared dead.
 const STREAM_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(45);
 
+/// Marker prefix of the idle-watchdog error message. Pub so the pipeline's
+/// stream-metrics outcome mapping can recognize an idle timeout after the
+/// message has been stringified through the SSE layer's `Transport error:`
+/// wrapper into `LlmError::Stream` (issue #188 — spec §4.2 lists
+/// `"idle_timeout"` as its own outcome, distinct from `"chunk_error"`).
+pub const STREAM_IDLE_TIMEOUT_MSG: &str = "openrouter stream idle timeout";
+
 /// Gap-bound a fallible stream: an idle period longer than `idle` between
 /// items becomes an io TimedOut error item. Applied to the raw BYTES stream
 /// (before SSE parsing) deliberately: OpenRouter's `: OPENROUTER PROCESSING`
@@ -38,7 +45,7 @@ where
         Err(_elapsed) => Err(std::io::Error::new(
             std::io::ErrorKind::TimedOut,
             format!(
-                "openrouter stream idle timeout: no bytes for {}s",
+                "{STREAM_IDLE_TIMEOUT_MSG}: no bytes for {}s",
                 idle.as_secs()
             ),
         )),
@@ -213,17 +220,6 @@ impl std::fmt::Display for ImageGenError {
 }
 impl std::error::Error for ImageGenError {}
 
-/// Cap a provider error body to a bounded length for persistence/logs.
-fn cap_provider_message(s: &str) -> String {
-    const MAX: usize = 600;
-    let t = s.trim();
-    if t.chars().count() <= MAX {
-        t.to_string()
-    } else {
-        t.chars().take(MAX).collect::<String>() + "…"
-    }
-}
-
 /// Max chars kept from a raw provider error body in ordinary logs. Short by
 /// design: logs are for triage, not forensics — full error forensics live in
 /// OpenRouter's own logs, joined on `generation_id`.
@@ -249,7 +245,11 @@ fn body_preview(s: &str) -> String {
 /// which is an excerpt of the user's flagged prompt that a moderation rejection
 /// echoes back (logging it would leak raw chat content). Non-envelope bodies
 /// fall back to a plain length-capped preview.
-fn scrub_error_body(raw: &str) -> String {
+///
+/// `pub(crate)`: the voyage client reuses this for its own status-error
+/// bodies (issue #188) — the envelope parse simply falls through to the
+/// capped preview for non-OpenRouter shapes.
+pub(crate) fn scrub_error_body(raw: &str) -> String {
     #[derive(Deserialize)]
     struct Env {
         error: ErrBody,
@@ -1087,7 +1087,9 @@ impl OpenRouterClient {
                     variant,
                     outcome: AttemptOutcome::Status {
                         status: status.as_u16(),
-                        message: cap_provider_message(&text),
+                        // scrub, not just cap: a moderation body echoes the
+                        // flagged prompt back (issue #188).
+                        message: scrub_error_body(&text),
                     },
                 });
                 continue;
@@ -3470,5 +3472,47 @@ data: [DONE]\n\n";
         assert_eq!(seen.len(), 2, "on_attempt fires once per planned attempt");
         assert_eq!(seen[0], ("m1".to_string(), PromptVariant::Single, 1, 2));
         assert_eq!(seen[1], ("m2".to_string(), PromptVariant::Single, 2, 2));
+    }
+
+    #[tokio::test]
+    async fn execute_image_inner_scrubs_flagged_input_from_status_attempts() {
+        // A moderation 403 echoes the user's flagged prompt back in
+        // `metadata.flagged_input`; the recorded attempt must keep the code /
+        // provider / reasons but never that excerpt (issue #188 item 4 —
+        // parity with the chat paths' scrub_error_body).
+        let server = MockServer::start().await;
+        let body = r#"{"error":{"code":403,"message":"prompt flagged","metadata":{"provider_name":"prov","reasons":["sexual"],"flagged_input":"SECRET_USER_PROMPT"}}}"#;
+        Mock::given(path("/api/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(403).set_body_raw(body, "application/json"))
+            .mount(&server)
+            .await;
+
+        let client = OpenRouterClient::with_base_url(
+            "test-key".into(),
+            AppAttribution::default(),
+            format!("{}/api/v1/chat/completions", server.uri()),
+        );
+        let req = ImageGenRequest {
+            model: "m1".into(),
+            prompt: "a cat".into(),
+            max_tokens: 4096,
+            ..Default::default()
+        };
+        let result = client.execute_image_inner(req, |_| {}).await;
+        let Err(ImageGenError::ChainExhausted { attempts }) = result else {
+            panic!("expected ChainExhausted, got {result:?}");
+        };
+        let AttemptOutcome::Status { status, message } = &attempts[0].outcome else {
+            panic!("expected Status outcome, got {:?}", attempts[0].outcome);
+        };
+        assert_eq!(*status, 403);
+        assert!(
+            !message.contains("SECRET_USER_PROMPT"),
+            "flagged_input must be scrubbed from the attempt record: {message}"
+        );
+        assert!(
+            message.contains("sexual"),
+            "moderation reasons stay visible for triage: {message}"
+        );
     }
 }

--- a/crates/eros-engine-llm/src/voyage.rs
+++ b/crates/eros-engine-llm/src/voyage.rs
@@ -79,8 +79,9 @@ impl VoyageClient {
         let status = resp.status();
         if !status.is_success() {
             let text = resp.text().await.unwrap_or_default();
-            tracing::warn!("voyage: status={status} body={text}");
-            return Err(LlmError::Status(status, text));
+            let err = status_error(status, &text);
+            tracing::warn!("voyage: {err}");
+            return Err(err);
         }
 
         let parsed: EmbedResponse = resp.json().await?;
@@ -116,11 +117,21 @@ impl VoyageClient {
         let status = resp.status();
         let text = resp.text().await?;
         if !status.is_success() {
-            tracing::warn!("voyage: status={status} body={text}");
-            return Err(LlmError::Status(status, text));
+            let err = status_error(status, &text);
+            tracing::warn!("voyage: {err}");
+            return Err(err);
         }
         parse_embed_batch(&text, texts.len())
     }
+}
+
+/// Build the bounded `LlmError::Status` for a non-success Voyage response.
+/// The raw body never reaches the error (or the log line that mirrors it):
+/// provider bodies are unbounded and may echo input, so they are scrubbed /
+/// capped first — the same bounded-log guarantee the chat client upholds
+/// (issue #188).
+fn status_error(status: reqwest::StatusCode, body: &str) -> LlmError {
+    LlmError::Status(status, crate::openrouter::scrub_error_body(body))
 }
 
 /// Parse a Voyage batch response body into ordered vectors, enforcing that
@@ -180,5 +191,40 @@ mod tests {
     #[test]
     fn parse_embed_batch_rejects_garbage() {
         assert!(parse_embed_batch("not json", 1).is_err());
+    }
+
+    #[test]
+    fn status_error_bounds_and_scrubs_provider_body() {
+        // The stored error body must be bounded and stripped of any echoed
+        // input (issue #188 item 4 — the bounded-log guarantee the v0.8.4
+        // hardening established elsewhere extends to the embedding client).
+        let huge = format!(
+            r#"{{"error":{{"code":400,"message":"{}","metadata":{{"flagged_input":"SECRET"}}}}}}"#,
+            "x".repeat(5000)
+        );
+        let e = status_error(reqwest::StatusCode::BAD_REQUEST, &huge);
+        let LlmError::Status(status, msg) = e else {
+            panic!("expected Status, got {e:?}");
+        };
+        assert_eq!(status, reqwest::StatusCode::BAD_REQUEST);
+        assert!(
+            msg.chars().count() <= 220,
+            "must be bounded, got {} chars",
+            msg.chars().count()
+        );
+        assert!(
+            !msg.contains("SECRET"),
+            "echoed input must be dropped: {msg}"
+        );
+
+        // A plain non-JSON body still comes through, just capped.
+        let e = status_error(
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+            "upstream exploded",
+        );
+        let LlmError::Status(_, msg) = e else {
+            panic!("expected Status, got {e:?}");
+        };
+        assert_eq!(msg, "upstream exploded");
     }
 }

--- a/crates/eros-engine-server/Cargo.toml
+++ b/crates/eros-engine-server/Cargo.toml
@@ -13,9 +13,9 @@ name = "eros-engine"
 path = "src/main.rs"
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "0.9.1-dev" }
-eros-engine-llm  = { path = "../eros-engine-llm", version = "0.9.1-dev" }
-eros-engine-store = { path = "../eros-engine-store", version = "0.9.1-dev" }
+eros-engine-core = { path = "../eros-engine-core", version = "0.9.1" }
+eros-engine-llm  = { path = "../eros-engine-llm", version = "0.9.1" }
+eros-engine-store = { path = "../eros-engine-store", version = "0.9.1" }
 axum = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/eros-engine-server/Cargo.toml
+++ b/crates/eros-engine-server/Cargo.toml
@@ -13,9 +13,9 @@ name = "eros-engine"
 path = "src/main.rs"
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "0.9.0" }
-eros-engine-llm  = { path = "../eros-engine-llm", version = "0.9.0" }
-eros-engine-store = { path = "../eros-engine-store", version = "0.9.0" }
+eros-engine-core = { path = "../eros-engine-core", version = "0.9.1-dev" }
+eros-engine-llm  = { path = "../eros-engine-llm", version = "0.9.1-dev" }
+eros-engine-store = { path = "../eros-engine-store", version = "0.9.1-dev" }
 axum = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0-only",
       "identifier": "AGPL-3.0-only"
     },
-    "version": "0.9.0"
+    "version": "0.9.1-dev"
   },
   "servers": [
     {

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0-only",
       "identifier": "AGPL-3.0-only"
     },
-    "version": "0.9.1-dev"
+    "version": "0.9.1"
   },
   "servers": [
     {

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -21,7 +21,7 @@
         "tags": [
           "bff-companion"
         ],
-        "summary": "Latest user-turn affinity delta (post-EMA). For per-turn FE observation.\nNOT behind EXPOSE_AFFINITY_DEBUG (the FE owns this surface); still JWT +\nownership checked.",
+        "summary": "Latest user-turn affinity delta (post-EMA). For per-turn FE observation.\nNOT behind EXPOSE_AFFINITY_DEBUG (the FE owns this surface); still JWT +\nownership checked. With `?after=<event_id>` the request long-polls (see\n[`BffAffinityDeltaQuery`]), collapsing the per-turn short-poll loop into\none held request.",
         "operationId": "bff_get_affinity_delta",
         "parameters": [
           {
@@ -32,6 +32,33 @@
             "schema": {
               "type": "string",
               "format": "uuid"
+            }
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "description": "Long-poll baseline: the `event_id` the caller already has. While the\nsession's latest turn event still matches (or none exists yet), the\nrequest is held until a newer event lands or `wait` elapses — the\ntimed-out response returns the unchanged state, same shape as the\nimmediate path. Absent ⇒ return the latest immediately (pre-#147\nbehavior, unchanged).",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "wait",
+            "in": "query",
+            "description": "How long to hold the request open, in milliseconds. Only meaningful\nwith `after`. Default 10000, server-capped at 25000.",
+            "required": false,
+            "schema": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64",
+              "minimum": 0
             }
           }
         ],

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -608,7 +608,7 @@ fn drive_chat_burst(
                                 Err(e) => {
                                     tracing::warn!("stream: upstream chunk err: {e}");
                                     truncated = true;
-                                    attempt_outcome = "chunk_error";
+                                    attempt_outcome = chunk_err_outcome(&e);
                                     break;
                                 }
                             }
@@ -970,7 +970,7 @@ fn drive_chat_burst(
                             Err(e) => {
                                 tracing::warn!("stream(filtered): chunk err: {e}");
                                 truncated = true;
-                                attempt_outcome = "chunk_error";
+                                attempt_outcome = chunk_err_outcome(&e);
                                 break;
                             }
                         }
@@ -1493,12 +1493,31 @@ const FILTER_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
 
 /// Max wait for a chat stream to OPEN (connect + queue + response headers).
 /// A provider that accepts the socket but never sends headers must not hold
-/// the turn — timeout ⇒ attempt fails ⇒ chain advances.
-const STREAM_OPEN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
+/// the turn — timeout ⇒ attempt fails ⇒ chain advances. `pub(crate)`: the
+/// voice path applies the same caps (issue #188).
+pub(crate) const STREAM_OPEN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
 /// Hard per-attempt cap on one model's whole generation (spec §1.5's 120s).
 /// Byte-level idle liveness is bounded upstream in the llm client; this caps
 /// a stream that keeps trickling forever.
-const STREAM_TOTAL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+pub(crate) const STREAM_TOTAL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+
+/// Spec §4.2 outcome label for an `Err` item mid-consume. Provider error
+/// frames (`LlmError::Provider`) and the byte-level idle watchdog are their
+/// own failure modes — folding them into `"chunk_error"` made dashboards
+/// undercount idle timeouts and blend provider failures into transport drops
+/// (issue #188). Everything else (transport reset, parse) stays
+/// `"chunk_error"`.
+fn chunk_err_outcome(e: &eros_engine_llm::LlmError) -> &'static str {
+    match e {
+        eros_engine_llm::LlmError::Provider(_) => "error_frame",
+        eros_engine_llm::LlmError::Stream(msg)
+            if msg.contains(eros_engine_llm::openrouter::STREAM_IDLE_TIMEOUT_MSG) =>
+        {
+            "idle_timeout"
+        }
+        _ => "chunk_error",
+    }
+}
 
 /// Run the output-filter LLM over `original`, walking the (already
 /// depth-capped) fallback chain one model at a time.  After each successful
@@ -3936,6 +3955,38 @@ pub fn replay_stream(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn chunk_err_outcome_separates_error_frame_and_idle_timeout() {
+        use eros_engine_llm::LlmError;
+        // Provider error frames (a 200 SSE frame carrying `error`) are their
+        // own failure mode, distinct from transport drops (spec §4.2).
+        assert_eq!(
+            chunk_err_outcome(&LlmError::Provider(
+                "openrouter mid-stream error: code=Some(502): upstream".into()
+            )),
+            "error_frame"
+        );
+        // The byte-level idle watchdog's io::Error rides through
+        // eventsource-stream's `Transport error: {inner}` Display into
+        // LlmError::Stream; the shared marker constant is the contract.
+        let idle = LlmError::Stream(format!(
+            "Transport error: {}: no bytes for 45s",
+            eros_engine_llm::openrouter::STREAM_IDLE_TIMEOUT_MSG
+        ));
+        assert_eq!(chunk_err_outcome(&idle), "idle_timeout");
+        // Everything else stays the generic transport/parse label.
+        assert_eq!(
+            chunk_err_outcome(&LlmError::Stream(
+                "Transport error: connection reset by peer".into()
+            )),
+            "chunk_error"
+        );
+        assert_eq!(
+            chunk_err_outcome(&LlmError::StreamParse("not a delta".into())),
+            "chunk_error"
+        );
+    }
 
     #[test]
     fn meta_frame_serializes_with_required_fields() {

--- a/crates/eros-engine-server/src/pipeline/voice.rs
+++ b/crates/eros-engine-server/src/pipeline/voice.rs
@@ -15,7 +15,9 @@ use eros_engine_store::affinity::AffinityRepo;
 use eros_engine_store::chat::ChatRepo;
 use eros_engine_store::persona::PersonaRepo;
 
-use crate::pipeline::stream::{ulid_string, ProtocolFrame, StreamErrorCode};
+use crate::pipeline::stream::{
+    ulid_string, ProtocolFrame, StreamErrorCode, STREAM_OPEN_TIMEOUT, STREAM_TOTAL_TIMEOUT,
+};
 use crate::state::AppState;
 
 /// Assemble the thin voice system prompt: persona + voice directive + one
@@ -149,6 +151,19 @@ pub fn run_voice_turn(
         let mut served_model: Option<String> = None;
         let mut truncated = false;
 
+        // Chain-shared request: `execute_stream_as` borrows it and sends each
+        // candidate's model id, so the prompt is never cloned per attempt
+        // (issue #188 — parity with the text pipeline's loops). `model` here
+        // is a placeholder `execute_stream_as` ignores.
+        let req = ChatRequest {
+            model: String::new(),
+            messages,
+            temperature: resolved.temperature as f32,
+            max_tokens: resolved.max_tokens,
+            reasoning: resolved.reasoning.clone(),
+            ..Default::default()
+        };
+
         'candidates: for model_id in candidates {
             // Per-attempt metadata: reset so an abandoned candidate's usage / gen_id /
             // model / truncated never leaks onto a later fallback's reply.
@@ -156,26 +171,55 @@ pub fn run_voice_turn(
             last_gen_id = None;
             served_model = None;
             truncated = false;
-            let req = ChatRequest {
-                model: model_id.clone(),
-                messages: messages.clone(),
-                temperature: resolved.temperature as f32,
-                max_tokens: resolved.max_tokens,
-                reasoning: resolved.reasoning.clone(),
-                ..Default::default()
-            };
-            let stream = match state.openrouter.execute_stream(req).await {
-                Ok(s) => s,
-                Err(e) => {
+            // Bound the open: a provider that accepts the socket but never
+            // sends response headers must not hold the turn (issue #188 —
+            // the same caps as the text pipeline).
+            let stream = match tokio::time::timeout(
+                STREAM_OPEN_TIMEOUT,
+                state.openrouter.execute_stream_as(&req, &model_id),
+            ).await {
+                Ok(Ok(s)) => s,
+                Ok(Err(e)) => {
                     tracing::warn!(model = %model_id, error = %e, "voice: open stream failed");
+                    if acc.is_empty() { continue 'candidates; }
+                    truncated = true;
+                    break 'candidates;
+                }
+                Err(_) => {
+                    tracing::warn!(
+                        model = %model_id,
+                        "voice: open timeout ({}s)",
+                        STREAM_OPEN_TIMEOUT.as_secs()
+                    );
                     if acc.is_empty() { continue 'candidates; }
                     truncated = true;
                     break 'candidates;
                 }
             };
             futures_util::pin_mut!(stream);
+            // Hard per-attempt cap: byte-level idle liveness is bounded in the
+            // llm client; this caps a stream that keeps trickling forever.
+            let deadline = tokio::time::Instant::now() + STREAM_TOTAL_TIMEOUT;
             loop {
-                match futures_util::StreamExt::next(&mut stream).await {
+                let item = match tokio::time::timeout_at(
+                    deadline,
+                    futures_util::StreamExt::next(&mut stream),
+                )
+                .await
+                {
+                    Ok(item) => item,
+                    Err(_) => {
+                        tracing::warn!(
+                            model = %model_id,
+                            "voice: total timeout ({}s)",
+                            STREAM_TOTAL_TIMEOUT.as_secs()
+                        );
+                        if acc.is_empty() { continue 'candidates; }
+                        truncated = true;
+                        break 'candidates;
+                    }
+                };
+                match item {
                     Some(Ok(chunk)) => {
                         if chunk.usage.is_some() { last_usage = chunk.usage.clone(); }
                         if chunk.generation_id.is_some() { last_gen_id = chunk.generation_id.clone(); }
@@ -184,7 +228,16 @@ pub fn run_voice_turn(
                             acc.push_str(&text);
                             yield ProtocolFrame::Delta { message_id: message_id.clone(), content: text };
                         }
-                        if chunk.finish_reason.as_deref() == Some("length") { truncated = true; }
+                        // "content_filter" = mid-generation safety cut: the
+                        // text is incomplete, so it carries the same
+                        // truncation signal as "length" (issue #188 — parity
+                        // with the text pipeline's gates).
+                        if matches!(
+                            chunk.finish_reason.as_deref(),
+                            Some("length") | Some("content_filter")
+                        ) {
+                            truncated = true;
+                        }
                     }
                     Some(Err(e)) => {
                         tracing::warn!(model = %model_id, error = %e, "voice: mid-stream error");
@@ -925,6 +978,103 @@ data: [DONE]\n\n";
         assert_eq!(
             persisted_usage["cost"], 0.01,
             "DB row must keep the FULL unfiltered usage; got {persisted_usage}"
+        );
+    }
+
+    /// Issue #188 item 1: `content_filter` is a mid-generation safety cut —
+    /// the text is incomplete, so the voice path must mark the turn truncated
+    /// exactly like `length` (parity with the text pipeline's handling).
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn run_voice_turn_content_filter_finish_marks_truncated(pool: sqlx::PgPool) {
+        use eros_engine_llm::model_config::ModelConfig;
+        use futures_util::StreamExt;
+        use wiremock::matchers::path as wm_path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        let body = "\
+data: {\"choices\":[{\"delta\":{\"content\":\"cut short\"}}]}\n\n\
+data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"content_filter\"}],\"id\":\"gen-cf\",\"model\":\"primary\"}\n\n\
+data: [DONE]\n\n";
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+
+        // Seed persona + instance + session.
+        let user_id = Uuid::new_v4();
+        let genome_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata) \
+             VALUES ('V', 'You are V.', '{}'::jsonb) RETURNING id",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let instance_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_instances (genome_id, owner_uid) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(genome_id).bind(user_id).fetch_one(&pool).await.unwrap();
+        let session_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(user_id)
+        .bind(instance_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        let repo = ChatRepo { pool: &pool };
+        let umid = match repo
+            .insert_voice_user_message(session_id, "hello", "01J9000000000000000000VOIC8")
+            .await
+            .unwrap()
+        {
+            eros_engine_store::chat::VoiceUserInsert::Inserted(id) => id,
+            other => panic!("expected Inserted, got {other:?}"),
+        };
+
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = Arc::new(
+            ModelConfig::from_toml_str(
+                "[tasks.chat_voice]\nmodel = \"primary\"\nmax_tokens = 100\n",
+            )
+            .unwrap(),
+        );
+        state.openrouter = Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                eros_engine_llm::openrouter::AppAttribution::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+
+        let resolved = state.model_config.resolve_voice().unwrap();
+        let frames: Vec<ProtocolFrame> = run_voice_turn(
+            Arc::new(state),
+            VoiceTurn {
+                session_id,
+                instance_id,
+                user_message_id: umid,
+            },
+            resolved,
+        )
+        .collect()
+        .await;
+
+        let truncated = frames
+            .iter()
+            .find_map(|f| match f {
+                ProtocolFrame::Done { truncated, .. } => Some(*truncated),
+                _ => None,
+            })
+            .expect("a Done frame");
+        assert!(
+            truncated,
+            "content_filter finish must mark the voice turn truncated; frames={frames:?}"
         );
     }
 

--- a/crates/eros-engine-server/src/routes/bff/affinity.rs
+++ b/crates/eros-engine-server/src/routes/bff/affinity.rs
@@ -4,11 +4,11 @@
 //! See docs/superpowers/specs/2026-05-20-affinity-event-delta-design.md §4.
 
 use axum::{
-    extract::{Extension, Path, State},
+    extract::{Extension, Path, Query, State},
     Json,
 };
 use chrono::{DateTime, Utc};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use utoipa_axum::{router::OpenApiRouter, routes};
 use uuid::Uuid;
 
@@ -48,14 +48,45 @@ pub struct BffAffinityDeltaResponse {
     pub event: Option<BffAffinityDelta>,
 }
 
+/// Long-poll knobs for `bff_get_affinity_delta` (issue #147). The affinity
+/// write lands in a post-process task *after* the chat stream's Final frame,
+/// so without these a consumer can only short-poll for the per-turn delta.
+#[derive(Debug, Deserialize, utoipa::IntoParams)]
+pub struct BffAffinityDeltaQuery {
+    /// Long-poll baseline: the `event_id` the caller already has. While the
+    /// session's latest turn event still matches (or none exists yet), the
+    /// request is held until a newer event lands or `wait` elapses — the
+    /// timed-out response returns the unchanged state, same shape as the
+    /// immediate path. Absent ⇒ return the latest immediately (pre-#147
+    /// behavior, unchanged).
+    pub after: Option<Uuid>,
+    /// How long to hold the request open, in milliseconds. Only meaningful
+    /// with `after`. Default 10000, server-capped at 25000.
+    pub wait: Option<u64>,
+}
+
+/// Default / ceiling for `wait` (ms). The cap keeps a held request well under
+/// typical proxy/idle timeouts; a client wanting a longer horizon re-issues.
+const LONG_POLL_DEFAULT_WAIT_MS: u64 = 10_000;
+const LONG_POLL_MAX_WAIT_MS: u64 = 25_000;
+/// Internal re-query cadence while holding. The post-process write commits
+/// within ~a second of the Final frame in the common case, so a held request
+/// resolves on the first tick or two.
+const LONG_POLL_TICK: std::time::Duration = std::time::Duration::from_millis(250);
+
 /// Latest user-turn affinity delta (post-EMA). For per-turn FE observation.
 /// NOT behind EXPOSE_AFFINITY_DEBUG (the FE owns this surface); still JWT +
-/// ownership checked.
+/// ownership checked. With `?after=<event_id>` the request long-polls (see
+/// [`BffAffinityDeltaQuery`]), collapsing the per-turn short-poll loop into
+/// one held request.
 #[utoipa::path(
     get,
     path = "/bff/v1/comp/affinity/{session_id}/event",
     tag = "bff-companion",
-    params(("session_id" = Uuid, Path, description = "Chat session id")),
+    params(
+        ("session_id" = Uuid, Path, description = "Chat session id"),
+        BffAffinityDeltaQuery
+    ),
     responses(
         (status = 200, body = BffAffinityDeltaResponse),
         (status = 401, description = "missing or invalid bearer"),
@@ -67,32 +98,51 @@ pub struct BffAffinityDeltaResponse {
 async fn bff_get_affinity_delta(
     State(state): State<AppState>,
     Path(session_id): Path<Uuid>,
+    Query(query): Query<BffAffinityDeltaQuery>,
     Extension(AuthUser(user_id)): Extension<AuthUser>,
 ) -> Result<Json<BffAffinityDeltaResponse>, AppError> {
     require_session_for_user(&state, session_id, user_id).await?;
 
-    let event = AffinityRepo { pool: &state.pool }
-        .latest_turn_event(session_id)
-        .await?
-        .and_then(|r| {
-            // Pre-0014 rows have NULL effective_deltas → omit (don't fabricate).
-            let effective = r.effective_deltas?;
-            let effective_deltas: AffinityDeltasDto = serde_json::from_value(effective).ok()?;
-            let effective_deltas_computed = r
-                .effective_line_deltas
-                .and_then(|v| serde_json::from_value::<BondChemistryDeltas>(v).ok());
-            let label_changes = r
-                .label_changes
-                .and_then(|v| serde_json::from_value::<TurnLabelChangesDto>(v).ok());
-            Some(BffAffinityDelta {
-                event_id: r.id,
-                event_type: r.event_type,
-                effective_deltas,
-                effective_deltas_computed,
-                label_changes,
-                created_at: r.created_at,
-            })
-        });
+    let repo = AffinityRepo { pool: &state.pool };
+    let mut row = repo.latest_turn_event(session_id).await?;
+
+    if let Some(after) = query.after {
+        let wait = query
+            .wait
+            .unwrap_or(LONG_POLL_DEFAULT_WAIT_MS)
+            .min(LONG_POLL_MAX_WAIT_MS);
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(wait);
+        // Hold while there is nothing newer than the caller's baseline: the
+        // latest event still IS the baseline, or no turn event exists yet.
+        while row.as_ref().map(|r| r.id) == Some(after) || row.is_none() {
+            let now = tokio::time::Instant::now();
+            if now >= deadline {
+                break;
+            }
+            tokio::time::sleep(LONG_POLL_TICK.min(deadline - now)).await;
+            row = repo.latest_turn_event(session_id).await?;
+        }
+    }
+
+    let event = row.and_then(|r| {
+        // Pre-0014 rows have NULL effective_deltas → omit (don't fabricate).
+        let effective = r.effective_deltas?;
+        let effective_deltas: AffinityDeltasDto = serde_json::from_value(effective).ok()?;
+        let effective_deltas_computed = r
+            .effective_line_deltas
+            .and_then(|v| serde_json::from_value::<BondChemistryDeltas>(v).ok());
+        let label_changes = r
+            .label_changes
+            .and_then(|v| serde_json::from_value::<TurnLabelChangesDto>(v).ok());
+        Some(BffAffinityDelta {
+            event_id: r.id,
+            event_type: r.event_type,
+            effective_deltas,
+            effective_deltas_computed,
+            label_changes,
+            created_at: r.created_at,
+        })
+    });
 
     Ok(Json(BffAffinityDeltaResponse { session_id, event }))
 }
@@ -140,19 +190,20 @@ mod tests {
         event_type: &str,
         eff_warmth: f64,
         secs_ago: i64,
-    ) {
-        sqlx::query(
+    ) -> Uuid {
+        sqlx::query_scalar(
             "INSERT INTO engine.companion_affinity_events \
                (affinity_id, event_type, deltas, effective_deltas, created_at) \
-             VALUES ($1, $2, '{}'::jsonb, $3, now() - make_interval(secs => $4))",
+             VALUES ($1, $2, '{}'::jsonb, $3, now() - make_interval(secs => $4)) \
+             RETURNING id",
         )
         .bind(affinity_id)
         .bind(event_type)
         .bind(json!({ "warmth": eff_warmth }))
         .bind(secs_ago as f64)
-        .execute(pool)
+        .fetch_one(pool)
         .await
-        .unwrap();
+        .unwrap()
     }
 
     fn req(token: &str, sid: Uuid) -> Request<Body> {
@@ -299,6 +350,127 @@ mod tests {
                 < 1e-9
         );
         assert_eq!(ev["label_changes"]["bond"]["to"], "friend");
+    }
+
+    fn req_longpoll(token: &str, sid: Uuid, after: Uuid, wait_ms: u64) -> Request<Body> {
+        Request::builder()
+            .method("GET")
+            .uri(format!(
+                "/bff/v1/comp/affinity/{sid}/event?after={after}&wait={wait_ms}"
+            ))
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn bff_affinity_longpoll_stale_after_returns_immediately(pool: PgPool) {
+        // `after` differing from the latest event_id ⇒ the caller is behind;
+        // return the latest event at once, no hold.
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+        let aid = seed_affinity(&pool, session_id, user_id, instance_id).await;
+        seed_event(&pool, aid, "message", 0.05, 10).await;
+
+        let state = test_state(pool);
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+        let started = std::time::Instant::now();
+        let (status, body) = send_request(
+            &mut app,
+            req_longpoll(&token, session_id, Uuid::new_v4(), 5_000),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "body={body}");
+        assert_eq!(body["event"]["event_type"], "message");
+        assert!(
+            started.elapsed() < std::time::Duration::from_millis(2_000),
+            "stale `after` must not hold the request"
+        );
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn bff_affinity_longpoll_returns_new_event_when_it_lands(pool: PgPool) {
+        // `after` == latest ⇒ hold; a newer event landing mid-hold is returned
+        // well before the requested wait elapses.
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+        let aid = seed_affinity(&pool, session_id, user_id, instance_id).await;
+        let baseline = seed_event(&pool, aid, "message", 0.05, 10).await;
+
+        let state = test_state(pool.clone());
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        let inserter = tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+            seed_event(&pool, aid, "gift", 0.12, 0).await
+        });
+
+        let started = std::time::Instant::now();
+        let (status, body) =
+            send_request(&mut app, req_longpoll(&token, session_id, baseline, 10_000)).await;
+        let new_id = inserter.await.unwrap();
+        assert_eq!(status, StatusCode::OK, "body={body}");
+        assert_eq!(body["event"]["event_type"], "gift");
+        assert_eq!(body["event"]["event_id"], new_id.to_string());
+        assert!(
+            started.elapsed() < std::time::Duration::from_millis(8_000),
+            "must return on the new event, not the full wait"
+        );
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn bff_affinity_longpoll_timeout_returns_unchanged(pool: PgPool) {
+        // Nothing new within `wait` ⇒ hold for ~wait, then return the (stale)
+        // latest event unchanged — same shape as the immediate path.
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+        let aid = seed_affinity(&pool, session_id, user_id, instance_id).await;
+        let baseline = seed_event(&pool, aid, "message", 0.05, 10).await;
+
+        let state = test_state(pool);
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+        let started = std::time::Instant::now();
+        let (status, body) =
+            send_request(&mut app, req_longpoll(&token, session_id, baseline, 500)).await;
+        assert_eq!(status, StatusCode::OK, "body={body}");
+        assert_eq!(body["event"]["event_id"], baseline.to_string());
+        assert!(
+            started.elapsed() >= std::time::Duration::from_millis(450),
+            "matching `after` must hold until the wait elapses"
+        );
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn bff_affinity_longpoll_no_event_times_out_null(pool: PgPool) {
+        // No turn event at all: `after` (a client can only guess a sentinel
+        // here) holds until timeout, then returns event: null as today.
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+        seed_affinity(&pool, session_id, user_id, instance_id).await;
+
+        let state = test_state(pool);
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+        let started = std::time::Instant::now();
+        let (status, body) = send_request(
+            &mut app,
+            req_longpoll(&token, session_id, Uuid::new_v4(), 400),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "body={body}");
+        assert!(body["event"].is_null());
+        assert!(started.elapsed() >= std::time::Duration::from_millis(350));
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/crates/eros-engine-store/Cargo.toml
+++ b/crates/eros-engine-store/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "memory", "pgvector", "postgres", "sqlx"]
 categories = ["database"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "0.9.0" }
+eros-engine-core = { path = "../eros-engine-core", version = "0.9.1-dev" }
 sqlx = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/eros-engine-store/Cargo.toml
+++ b/crates/eros-engine-store/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "memory", "pgvector", "postgres", "sqlx"]
 categories = ["database"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "0.9.1-dev" }
+eros-engine-core = { path = "../eros-engine-core", version = "0.9.1" }
 sqlx = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/docs/superpowers/specs/2026-07-21-world-town-reply-window-design.md
+++ b/docs/superpowers/specs/2026-07-21-world-town-reply-window-design.md
@@ -150,15 +150,24 @@ daily_cap = 20
 reply_window_secs = 604800   # NEW: reply-eligibility window after a user comment (default 7d)
 ```
 
-- **Default 604800 (7 days).** The only post the window can permanently drop is
+- **Default 604800 (7 days).** The main post the window can permanently drop is
   one whose user comment never got answered *and* then stayed silent past the
   window — which happens only when `daily_cap` / cooldown deferred the reply.
   `daily_cap` resets each UTC day, so a capped post waits at most ~1 day for
   fresh budget; 7 days leaves comfortable margin while pinning the scan to
-  "posts with a user comment in the last week."
+  "posts with a user comment in the last week." A pending reply is also
+  permanently dropped when the deferral *spans the whole window* for other
+  reasons: the post's author instance goes inactive (`status != 'active'`) and
+  is only reactivated past the window, `town_enabled` is toggled off then back
+  on across it, or the engine is down longer than the window. All of these are
+  preferable to firing a stale necro-reply, so they are accepted, not guarded
+  against (issue #180).
 - **Floored above the debounce window.** A `reply_window_secs <= debounce_secs`
   would make the eligible range (`> now()-window AND <= now()-debounce`) empty;
-  the resolver clamps it to strictly exceed the resolved `debounce_secs`.
+  the resolver clamps the window to `debounce_secs + 30` — at least one
+  town-sweeper tick (`TOWN_TICK`) wide, so the band can never be narrower than
+  the scan that samples it — and `warn!`s when the clamp engages (issue #180;
+  originally `debounce_secs + 1`, a band the 30s sweeper almost always missed).
 - Added to `ResolvedWorldReply` and `resolve_world_reply()` in
   `model_config.rs`, alongside the existing three.
 


### PR DESCRIPTION
## Summary

Promote dev → main as the v0.9.1 stable release.

Release delta since v0.9.0 (every PR merged into dev after the v0.9.0 publish):

- #191 feat(affinity): long-poll on `GET /bff/v1/comp/affinity/{session_id}/event` (`?after=<event_id>` + `?wait=<ms>`, default 10s / cap 25s) — collapses the FE's per-turn short-poll loop into one held request; fully backward-compatible. Closes #147
- #190 fix(world): floor the reply-window eligibility band at one `TOWN_TICK` (30s) above debounce and `warn!` on clamp — a misconfig used to silently near-disable replies. Design doc §4 drop-cases completed. Closes #180
- #192 fix(stream): v0.8.4 stream-hardening follow-ups — voice.rs open/total timeouts + `execute_stream_as` + `content_filter` parity; `stream_metrics` `error_frame`/`idle_timeout` outcome split; `DefaultConfig` construction doc; `scrub_error_body` in image-gen + voyage. Closes #188
- #193 chore(release): version bump 0.9.1-dev → 0.9.1 (4 Cargo.tomls + Cargo.lock + openapi.json + README docker examples)

Gates: per-PR codex review + CI green; whole-delta Opus review — NO RELEASE-GATING ISSUES.

🤖 Generated with [Claude Code](https://claude.com/claude-code)