### PR TITLE
feat(world): per-owner custom worldview — hard gating, change-triggered reset, era-scoped town activity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,6 +565,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "sqlx",
  "thiserror 1.0.69",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ tokio = { version = "1.40", features = ["full"] }
 axum = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+sha2 = "0.10"
 sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls", "postgres", "uuid", "chrono", "json"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/eros-engine-server/Cargo.toml
+++ b/crates/eros-engine-server/Cargo.toml
@@ -20,6 +20,7 @@ axum = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+sha2 = { workspace = true }
 sqlx = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -2236,6 +2236,13 @@ mod tests {
             .await
             .unwrap();
         sqlx::query(
+            "INSERT INTO engine.world_worldviews (owner_uid, content) VALUES ($1, '现代都市')",
+        )
+        .bind(owner)
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
             "INSERT INTO engine.world_states (owner_uid, seed, digests) \
              VALUES ($1, '{}'::jsonb, $2)",
         )

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -2279,6 +2279,8 @@ mod tests {
             &[],
             chrono::Utc::now().date_naive(),
             30,
+            "h",
+            false,
             token,
         )
         .await

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -2267,6 +2267,13 @@ mod tests {
             .await
             .unwrap();
         let (_o, token) = claimed[0];
+        let wv_at: chrono::DateTime<chrono::Utc> = sqlx::query_scalar(
+            "SELECT updated_at FROM engine.world_worldviews WHERE owner_uid = $1",
+        )
+        .bind(owner)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
         repo.persist_round(
             owner,
             &serde_json::json!({}),
@@ -2281,6 +2288,7 @@ mod tests {
             30,
             "h",
             false,
+            wv_at,
             token,
         )
         .await

--- a/crates/eros-engine-server/src/pipeline/story.rs
+++ b/crates/eros-engine-server/src/pipeline/story.rs
@@ -41,7 +41,9 @@ backstory 是 canon，不可与之冲突。每轮输出更新后的完整 insigh
 每轮根据 current_time 刷新相对时间表述。\
 5) events：当期发生的具体生活事件（工作进展、感情进展、生活进展等，类目见系统指示），\
 每条一句、自成一体、适合单独召回；避免与近期事件重复。\
-6) digest：1-2 句该角色当前人生近况。";
+6) digest：1-2 句该角色当前人生近况。\
+7) 一切生活设定（职业、居所、日常事件）必须发生在 worldview 描述的世界观内，\
+不得引入与其冲突的元素。";
 
 /// Persona-side life-base schema: superset of COMPANION_INSIGHTS_SCHEMA
 /// (prompt.rs), reworded for the persona, flat (matching preferences
@@ -101,6 +103,7 @@ fn story_user_payload(
     recent_events: &[(String, String)],
     affinity: Option<&StoryAffinity>,
     chat_pairs: &[(String, String)],
+    worldview: &str,
 ) -> String {
     let is_init = row.last_run_at.is_none();
     let header = if is_init {
@@ -122,6 +125,7 @@ fn story_user_payload(
         .collect();
     let data = serde_json::json!({
         "current_time": now.to_rfc3339(),
+        "worldview": worldview,
         "persona": {
             "name": persona.name,
             "personality": persona.tip_personality,
@@ -271,6 +275,16 @@ async fn direct_story(
     else {
         return Err("story row missing after claim".into());
     };
+    let world_repo = eros_engine_store::world::WorldRepo { pool: &state.pool };
+    let Some((worldview, _)) = world_repo
+        .worldview_state(owner)
+        .await
+        .map_err(|e| format!("worldview load failed: {e}"))?
+    else {
+        // claim_due (story gate, Task 4) required a worldview; it vanished
+        // between claim and round — release and wait for it to reappear.
+        return Err("worldview missing at story round time".into());
+    };
     let recent = repo
         .recent_events(instance, STORY_RECENT_EVENTS)
         .await
@@ -291,6 +305,7 @@ async fn direct_story(
         &recent,
         affinity.as_ref(),
         &chat,
+        &worldview,
     );
     let req = ChatRequest {
         model: resolved.model.clone(),
@@ -405,6 +420,7 @@ mod tests {
             &[],
             None,
             &[],
+            "现代都市",
         );
         assert!(init.contains("初始化这个角色的人生"));
         assert!(init.contains("咖啡店店主"), "backstory in payload");
@@ -420,10 +436,30 @@ mod tests {
             &[("work".into(), "上周修好了咖啡机".into())],
             None,
             &[("最近好吗".into(), "在忙开店".into())],
+            "现代都市",
         );
         assert!(cont.contains("延续这个角色的人生"));
         assert!(cont.contains("上周修好了咖啡机"));
         assert!(cont.contains("最近好吗"));
+    }
+
+    #[test]
+    fn payload_carries_worldview_and_rule() {
+        let p = story_user_payload(
+            chrono::Utc::now(),
+            &fixture_persona(),
+            &fixture_row(false),
+            &[],
+            None,
+            &[],
+            "古代宫廷",
+        );
+        assert!(p.contains("\"worldview\""));
+        assert!(p.contains("古代宫廷"));
+        assert!(
+            p.contains("必须发生在 worldview"),
+            "worldview rule appended"
+        );
     }
 
     #[test]
@@ -510,6 +546,17 @@ mod tests {
         .unwrap();
         sqlx::query(
             "INSERT INTO engine.world_worldviews (owner_uid, content) VALUES ($1, '现代都市')",
+        )
+        .bind(owner)
+        .execute(&pool)
+        .await
+        .unwrap();
+        // direct_story now fetches WorldRepo::worldview_state, which JOINs
+        // world_states — in production `ensure_states_for_enrollments` backfills
+        // this row every tick before run_stories_scan runs (world.rs), so seed it
+        // here too.
+        sqlx::query(
+            "INSERT INTO engine.world_states (owner_uid, seed, digests) VALUES ($1, '{}', '{}')",
         )
         .bind(owner)
         .execute(&pool)
@@ -623,6 +670,17 @@ mod tests {
         .unwrap();
         sqlx::query(
             "INSERT INTO engine.world_worldviews (owner_uid, content) VALUES ($1, '现代都市')",
+        )
+        .bind(owner)
+        .execute(&pool)
+        .await
+        .unwrap();
+        // direct_story now fetches WorldRepo::worldview_state, which JOINs
+        // world_states — in production `ensure_states_for_enrollments` backfills
+        // this row every tick before run_stories_scan runs (world.rs), so seed it
+        // here too.
+        sqlx::query(
+            "INSERT INTO engine.world_states (owner_uid, seed, digests) VALUES ($1, '{}', '{}')",
         )
         .bind(owner)
         .execute(&pool)

--- a/crates/eros-engine-server/src/pipeline/story.rs
+++ b/crates/eros-engine-server/src/pipeline/story.rs
@@ -276,7 +276,7 @@ async fn direct_story(
         return Err("story row missing after claim".into());
     };
     let world_repo = eros_engine_store::world::WorldRepo { pool: &state.pool };
-    let Some((worldview, _)) = world_repo
+    let Some((worldview, _, _)) = world_repo
         .worldview_state(owner)
         .await
         .map_err(|e| format!("worldview load failed: {e}"))?

--- a/crates/eros-engine-server/src/pipeline/story.rs
+++ b/crates/eros-engine-server/src/pipeline/story.rs
@@ -508,6 +508,13 @@ mod tests {
         .execute(&pool)
         .await
         .unwrap();
+        sqlx::query(
+            "INSERT INTO engine.world_worldviews (owner_uid, content) VALUES ($1, '现代都市')",
+        )
+        .bind(owner)
+        .execute(&pool)
+        .await
+        .unwrap();
         sqlx::query("INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2)")
             .bind(owner)
             .bind(inst)
@@ -609,6 +616,13 @@ mod tests {
         .unwrap();
         sqlx::query(
             "INSERT INTO engine.world_enrollments (owner_uid, stories_enabled) VALUES ($1, true)",
+        )
+        .bind(owner)
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO engine.world_worldviews (owner_uid, content) VALUES ($1, '现代都市')",
         )
         .bind(owner)
         .execute(&pool)

--- a/crates/eros-engine-server/src/pipeline/world.rs
+++ b/crates/eros-engine-server/src/pipeline/world.rs
@@ -215,7 +215,7 @@ async fn direct_world(
         roster.truncate(WORLD_ROSTER_CAP);
     }
 
-    let Some((worldview, stored_hash)) = repo
+    let Some((worldview, stored_hash, worldview_updated_at)) = repo
         .worldview_state(owner)
         .await
         .map_err(|e| format!("worldview load failed: {e}"))?
@@ -388,6 +388,7 @@ async fn direct_world(
         resolved.retention_days,
         &worldview_hash,
         reset,
+        worldview_updated_at,
         token,
     )
     .await

--- a/crates/eros-engine-server/src/pipeline/world.rs
+++ b/crates/eros-engine-server/src/pipeline/world.rs
@@ -707,6 +707,13 @@ mod tests {
             .execute(&pool)
             .await
             .unwrap();
+        sqlx::query(
+            "INSERT INTO engine.world_worldviews (owner_uid, content) VALUES ($1, '现代都市')",
+        )
+        .bind(owner)
+        .execute(&pool)
+        .await
+        .unwrap();
 
         let reply = serde_json::json!({
             "seed": {"arc": "第一幕"},
@@ -805,6 +812,13 @@ mod tests {
             .execute(&pool)
             .await
             .unwrap();
+        sqlx::query(
+            "INSERT INTO engine.world_worldviews (owner_uid, content) VALUES ($1, '现代都市')",
+        )
+        .bind(owner)
+        .execute(&pool)
+        .await
+        .unwrap();
 
         let mock = MockServer::start().await;
         Mock::given(method("POST"))
@@ -893,6 +907,13 @@ mod tests {
         // over this, not just gate on it.
         sqlx::query(
             "INSERT INTO engine.world_enrollments (owner_uid, town_enabled) VALUES ($1, true)",
+        )
+        .bind(owner)
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO engine.world_worldviews (owner_uid, content) VALUES ($1, '现代都市')",
         )
         .bind(owner)
         .execute(&pool)
@@ -1006,6 +1027,13 @@ mod tests {
         .unwrap();
         sqlx::query(
             "INSERT INTO engine.world_enrollments (owner_uid, stories_enabled) VALUES ($1, true)",
+        )
+        .bind(owner)
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO engine.world_worldviews (owner_uid, content) VALUES ($1, '现代都市')",
         )
         .bind(owner)
         .execute(&pool)

--- a/crates/eros-engine-server/src/pipeline/world.rs
+++ b/crates/eros-engine-server/src/pipeline/world.rs
@@ -400,8 +400,9 @@ async fn direct_world(
 /// owners only — memories-only owners see no mention of posts. `recent_life`
 /// is `Some` only for stories-active owners (World System v2, spec §4): each
 /// persona's JSON entry gains a `recent_life` array and
-/// `WORLD_STORIES_WM_RULES` is appended. `None` reproduces the v1 payload
-/// byte-for-byte — no `recent_life` key anywhere, no stories rule.
+/// `WORLD_STORIES_WM_RULES` is appended. `None` adds no `recent_life` key
+/// anywhere and no stories rule — the stories dimension only; every payload
+/// still carries `worldview` and rule 5 regardless (see below).
 /// `worldview` (spec §3) always rides the `data` JSON's `worldview` key and
 /// rule 5 always applies — there is no v1-shaped "no worldview" branch.
 fn director_user_payload(
@@ -1440,5 +1441,145 @@ mod tests {
                 .unwrap();
         assert_eq!(seed["arc"], "第一幕");
         assert_eq!(digests[instance_id.to_string()], "W 在筹备开店");
+    }
+
+    /// spec §7 coverage gap: `recent_life` must be suppressed on a reset
+    /// round even when stories are active and a real `persona_story_events`
+    /// row exists — `direct_world`'s `stories_active && !reset` guard, not
+    /// just the pure-layer unit test's hand-built HashMap. The reset purges
+    /// story data in the same transaction (spec §2 reset inventory), so
+    /// feeding the pre-reset event into this round's payload would leak
+    /// old-era content into the new world.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn direct_world_reset_suppresses_recent_life(pool: sqlx::PgPool) {
+        use wiremock::matchers::{method, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let owner = Uuid::new_v4();
+        let genome_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata) \
+             VALUES ('W','p','{}'::jsonb) RETURNING id",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let instance_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_instances (genome_id, owner_uid) \
+             VALUES ($1,$2) RETURNING id",
+        )
+        .bind(genome_id)
+        .bind(owner)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO engine.world_enrollments (owner_uid, stories_enabled) VALUES ($1, true)",
+        )
+        .bind(owner)
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO engine.world_worldviews (owner_uid, content) VALUES ($1, '现代都市')",
+        )
+        .bind(owner)
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO engine.persona_story_events \
+             (owner_uid, instance_id, category, content, story_date) \
+             VALUES ($1, $2, 'work', '刚拿到新工作的offer', current_date)",
+        )
+        .bind(owner)
+        .bind(instance_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let reply = serde_json::json!({
+            "seed": {"arc": "第一幕"},
+            "personas": [{
+                "instance_id": instance_id,
+                "digest": "W 在筹备开店",
+                "script_fragments": []
+            }]
+        });
+        let mock = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(wm_path("/api/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "gen-world", "model": "w/m",
+                "choices": [{"message": {"content": reply.to_string()}}],
+            })))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = std::sync::Arc::new(
+            eros_engine_llm::model_config::ModelConfig::from_toml_str(
+                "[tasks.world_director]\nmodel=\"w/m\"\nfilter_prompt=\"direct\"\n\
+                 [tasks.world_stories_director]\nmodel=\"w/s\"\nfilter_prompt=\"live\"\n",
+            )
+            .unwrap(),
+        );
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "k".into(),
+                Default::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+        let resolved = state.model_config.resolve_world_director().unwrap();
+        assert!(
+            state
+                .model_config
+                .resolve_world_stories_director()
+                .is_some(),
+            "world_stories_director must resolve for stories_active to be true"
+        );
+
+        let repo = eros_engine_store::world::WorldRepo { pool: &pool };
+        repo.ensure_states_for_enrollments().await.unwrap();
+        // Stamp a DIFFERENT worldview hash than the current content's — this
+        // round must compute a mismatch and take the reset path.
+        sqlx::query("UPDATE engine.world_states SET worldview_hash = $2 WHERE owner_uid = $1")
+            .bind(owner)
+            .bind(worldview_sha256_hex("旧世界观"))
+            .execute(&pool)
+            .await
+            .unwrap();
+        let claimed = repo
+            .claim_due(
+                std::time::Duration::from_secs(24 * 3600),
+                std::time::Duration::from_secs(1800),
+                5,
+            )
+            .await
+            .unwrap();
+        let (owner_claimed, token) = claimed[0];
+        assert_eq!(owner_claimed, owner);
+
+        direct_world(&state, &resolved, owner, token)
+            .await
+            .expect("round ok");
+
+        let reqs = mock.received_requests().await.unwrap();
+        assert_eq!(reqs.len(), 1);
+        let body = String::from_utf8_lossy(&reqs[0].body);
+        assert!(
+            body.contains("初始化这个世界"),
+            "reset forces the init header"
+        );
+        assert!(
+            !body.contains("recent_life"),
+            "reset must suppress recent_life even though stories are active \
+             and a persona_story_events row exists"
+        );
+        assert!(
+            !body.contains("刚拿到新工作的offer"),
+            "the suppressed pre-reset event's content must not leak into the payload"
+        );
     }
 }

--- a/crates/eros-engine-server/src/pipeline/world.rs
+++ b/crates/eros-engine-server/src/pipeline/world.rs
@@ -342,6 +342,9 @@ async fn direct_world(
         &posts,
         script_date,
         resolved.retention_days,
+        // Placeholder until the worldview round flow lands (plan Task 6).
+        "",
+        false,
         token,
     )
     .await

--- a/crates/eros-engine-server/src/pipeline/world.rs
+++ b/crates/eros-engine-server/src/pipeline/world.rs
@@ -45,11 +45,13 @@ const WORLD_DIRECTOR_RULES: &str = "规则：\
 2) seed 描述角色之间的关系图与剧情弧线，供下一轮延续。\
 3) 每个角色输出 digest（该角色视角的世界近况摘要，1-2 句）和 script_fragments\
 （当期发生的具体事件片段，每条一句、自成一体、适合单独召回）。\
-4) 只使用给出的 instance_id。";
+4) 只使用给出的 instance_id。\
+5) 一切设定（时代、科技、地点、职业、事件）必须符合 worldview 描述的世界观，\
+不得引入与其冲突的元素。";
 
 /// Appended to WORLD_DIRECTOR_RULES only for town-enabled owners.
 const WORLD_TOWN_POST_RULES: &str = "\
-5) posts：为部分角色生成朋友圈式贴文（不是每个角色都要发；没有合适内容就输出空数组）。\
+6) posts：为部分角色生成朋友圈式贴文（不是每个角色都要发；没有合适内容就输出空数组）。\
 每条含 instance_id、content（贴文正文，第一人称）、publish_at（ISO-8601 时间戳，\
 安排在未来一个周期内的自然时刻）。";
 
@@ -58,15 +60,22 @@ const WORLD_TOWN_POST_RULES: &str = "\
 /// persona↔user relationship states come from recent_life; the WM-layer
 /// user-grounding rule is restated so the stories doorway can't erode it.
 ///
-/// Numbered 6) — the town rule 5) (`WORLD_TOWN_POST_RULES`) is only
+/// Numbered 7) — the town rule 6) (`WORLD_TOWN_POST_RULES`) is only
 /// conditionally appended, so a stories-active town-disabled owner sees
-/// rules 1,2,3,4,6 (no 5). Harmless: the numbers are cosmetic labels for
+/// rules 1,2,3,4,5,7 (no 6). Harmless: the numbers are cosmetic labels for
 /// the model, not referenced elsewhere. Do not dynamically renumber —
 /// that would alter the payload string for no behavioral gain.
 const WORLD_STORIES_WM_RULES: &str = "\
-6) 各角色的个人生活以其 recent_life 为准，剧本必须与之一致，不可矛盾；\
+7) 各角色的个人生活以其 recent_life 为准，剧本必须与之一致，不可矛盾；\
 角色与用户的关系状态以 recent_life 为准，其他角色可以自然提及，\
 但仍绝不编造用户的言行。";
+
+/// SHA-256 lowercase hex of the (already trimmed) worldview content —
+/// stored in world_states.worldview_hash; mismatch ⇒ reset round (spec §3).
+fn worldview_sha256_hex(content: &str) -> String {
+    use sha2::{Digest, Sha256};
+    format!("{:x}", Sha256::digest(content.as_bytes()))
+}
 
 #[derive(Debug, Deserialize)]
 struct DirectorOutput {
@@ -166,6 +175,14 @@ async fn run_round(
             }
         }
     }
+    match repo.count_enrolled_missing_worldview().await {
+        Ok(0) => {}
+        Ok(n) => tracing::warn!(
+            count = n,
+            "world: enrolled owner(s) have no worldview; skipping until downstream provides one"
+        ),
+        Err(e) => tracing::warn!("world: worldview count failed: {e}"),
+    }
     Ok(count)
 }
 
@@ -197,6 +214,20 @@ async fn direct_world(
         tracing::warn!(%owner, cap = WORLD_ROSTER_CAP, "world: roster truncated");
         roster.truncate(WORLD_ROSTER_CAP);
     }
+
+    let Some((worldview, stored_hash)) = repo
+        .worldview_state(owner)
+        .await
+        .map_err(|e| format!("worldview load failed: {e}"))?
+    else {
+        // claim_due required a worldview; it vanished between claim and
+        // round. Err ⇒ caller releases the claim; the owner is simply not
+        // claimable again until a worldview reappears (no warn spam).
+        return Err("worldview missing at round time".into());
+    };
+    let worldview_hash = worldview_sha256_hex(&worldview);
+    let reset = stored_hash.as_deref() != Some(worldview_hash.as_str());
+
     let town = !state.config.world.town_disabled
         && repo
             .town_enabled(owner)
@@ -212,7 +243,7 @@ async fn direct_world(
             .stories_enabled(owner)
             .await
             .map_err(|e| format!("stories_enabled load failed: {e}"))?;
-    let recent_life = if stories_active {
+    let recent_life = if stories_active && !reset {
         let last_run: Option<chrono::DateTime<chrono::Utc>> =
             sqlx::query_scalar("SELECT last_run_at FROM engine.world_states WHERE owner_uid = $1")
                 .bind(owner)
@@ -232,17 +263,30 @@ async fn direct_world(
         None
     };
 
-    let seed = repo
-        .load_seed(owner)
-        .await
-        .map_err(|e| format!("seed load failed: {e}"))?
-        .unwrap_or_else(|| serde_json::json!({}));
+    // On reset the empty seed is what flips director_user_payload into its
+    // init header + "previous_seed": null branch — the old world's arc must
+    // not leak into the new worldview's first round.
+    let seed = if reset {
+        serde_json::json!({})
+    } else {
+        repo.load_seed(owner)
+            .await
+            .map_err(|e| format!("seed load failed: {e}"))?
+            .unwrap_or_else(|| serde_json::json!({}))
+    };
     let memories = repo
         .recent_extracted_memories(owner, WORLD_FEEDBACK_K)
         .await
         .map_err(|e| format!("memory feedback load failed: {e}"))?;
 
-    let payload = director_user_payload(&seed, &roster, &memories, town, recent_life.as_ref());
+    let payload = director_user_payload(
+        &seed,
+        &roster,
+        &memories,
+        town,
+        recent_life.as_ref(),
+        &worldview,
+    );
     let req = ChatRequest {
         model: resolved.model.clone(),
         fallback_model: resolved.fallback_model.clone(),
@@ -342,9 +386,8 @@ async fn direct_world(
         &posts,
         script_date,
         resolved.retention_days,
-        // Placeholder until the worldview round flow lands (plan Task 6).
-        "",
-        false,
+        &worldview_hash,
+        reset,
         token,
     )
     .await
@@ -352,19 +395,22 @@ async fn direct_world(
 }
 
 /// Assemble the director's user message: framing header + structured JSON of
-/// previous seed / roster / memory feedback + the fixed rules. `town` appends
-/// `WORLD_TOWN_POST_RULES` (the posts rule) for town-enabled owners only —
-/// memories-only owners see no mention of posts. `recent_life` is `Some` only
-/// for stories-active owners (World System v2, spec §4): each persona's JSON
-/// entry gains a `recent_life` array and `WORLD_STORIES_WM_RULES` is
-/// appended. `None` reproduces the v1 payload byte-for-byte — no `recent_life`
-/// key anywhere, no stories rule.
+/// previous seed / roster / memory feedback / worldview + the fixed rules.
+/// `town` appends `WORLD_TOWN_POST_RULES` (the posts rule) for town-enabled
+/// owners only — memories-only owners see no mention of posts. `recent_life`
+/// is `Some` only for stories-active owners (World System v2, spec §4): each
+/// persona's JSON entry gains a `recent_life` array and
+/// `WORLD_STORIES_WM_RULES` is appended. `None` reproduces the v1 payload
+/// byte-for-byte — no `recent_life` key anywhere, no stories rule.
+/// `worldview` (spec §3) always rides the `data` JSON's `worldview` key and
+/// rule 5 always applies — there is no v1-shaped "no worldview" branch.
 fn director_user_payload(
     seed: &serde_json::Value,
     roster: &[RosterEntry],
     memories: &[String],
     town: bool,
     recent_life: Option<&std::collections::HashMap<Uuid, Vec<(String, String)>>>,
+    worldview: &str,
 ) -> String {
     let is_init = seed.as_object().map(|o| o.is_empty()).unwrap_or(false);
     let personas: Vec<serde_json::Value> = roster
@@ -391,6 +437,7 @@ fn director_user_payload(
         })
         .collect();
     let data = serde_json::json!({
+        "worldview": worldview,
         "previous_seed": if is_init { serde_json::Value::Null } else { seed.clone() },
         "personas": personas,
         "recent_user_memories": memories,
@@ -559,7 +606,14 @@ mod tests {
             tip_personality: Some("温柔".into()),
             art_metadata: serde_json::json!({"backstory": "咖啡店店主"}),
         }];
-        let init = director_user_payload(&serde_json::json!({}), &roster, &[], false, None);
+        let init = director_user_payload(
+            &serde_json::json!({}),
+            &roster,
+            &[],
+            false,
+            None,
+            "现代都市",
+        );
         assert!(init.contains("初始化这个世界"));
         assert!(init.contains("\"previous_seed\": null"));
         assert!(init.contains("Aria"));
@@ -571,6 +625,7 @@ mod tests {
             &["用户喜欢旅行".into()],
             false,
             None,
+            "现代都市",
         );
         assert!(cont.contains("延续这个世界"));
         assert!(cont.contains("\"arc\": \"opening\""));
@@ -586,7 +641,14 @@ mod tests {
             tip_personality: None,
             art_metadata: serde_json::json!({}),
         }];
-        let v1 = director_user_payload(&serde_json::json!({}), &roster, &[], false, None);
+        let v1 = director_user_payload(
+            &serde_json::json!({}),
+            &roster,
+            &[],
+            false,
+            None,
+            "现代都市",
+        );
         assert!(
             !v1.contains("recent_life"),
             "v1 payload has no stories trace"
@@ -595,7 +657,14 @@ mod tests {
 
         let mut life = std::collections::HashMap::new();
         life.insert(inst, vec![("work".to_string(), "定了开业日期".to_string())]);
-        let v2 = director_user_payload(&serde_json::json!({}), &roster, &[], false, Some(&life));
+        let v2 = director_user_payload(
+            &serde_json::json!({}),
+            &roster,
+            &[],
+            false,
+            Some(&life),
+            "现代都市",
+        );
         assert!(v2.contains("recent_life"));
         assert!(v2.contains("定了开业日期"));
         assert!(v2.contains("各角色的个人生活"), "stories rule appended");
@@ -674,12 +743,77 @@ mod tests {
             tip_personality: None,
             art_metadata: serde_json::json!({}),
         }];
-        let plain = director_user_payload(&serde_json::json!({}), &roster, &[], false, None);
+        let plain = director_user_payload(
+            &serde_json::json!({}),
+            &roster,
+            &[],
+            false,
+            None,
+            "现代都市",
+        );
         assert!(!plain.contains("posts"), "no posts rule for memories-only");
-        let town = director_user_payload(&serde_json::json!({}), &roster, &[], true, None);
+        let town =
+            director_user_payload(&serde_json::json!({}), &roster, &[], true, None, "现代都市");
         assert!(
             town.contains("posts"),
             "town payload carries the posts rule"
+        );
+    }
+
+    #[test]
+    fn worldview_hash_is_sha256_lowercase_hex() {
+        // Known vector: sha256("a").
+        assert_eq!(
+            worldview_sha256_hex("a"),
+            "ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb"
+        );
+        assert_eq!(worldview_sha256_hex("现代都市").len(), 64);
+        assert_ne!(worldview_sha256_hex("古代"), worldview_sha256_hex("科幻"));
+    }
+
+    #[test]
+    fn director_payload_carries_worldview_and_rule() {
+        let roster = vec![RosterEntry {
+            instance_id: Uuid::new_v4(),
+            name: "Aria".into(),
+            tip_personality: None,
+            art_metadata: serde_json::json!({}),
+        }];
+        let p = director_user_payload(
+            &serde_json::json!({}),
+            &roster,
+            &[],
+            false,
+            None,
+            "赛博朋克近未来都市",
+        );
+        assert!(
+            p.contains("\"worldview\""),
+            "payload data carries the worldview key"
+        );
+        assert!(p.contains("赛博朋克近未来都市"));
+        assert!(p.contains("5) 一切设定"), "worldview rule is rule 5");
+
+        // Renumbering lock: conditional rules follow the new rule 5.
+        let town =
+            director_user_payload(&serde_json::json!({}), &roster, &[], true, None, "现代都市");
+        assert!(town.contains("6) posts"), "town rule renumbered to 6");
+        let mut life = std::collections::HashMap::new();
+        life.insert(
+            roster[0].instance_id,
+            vec![("work".to_string(), "e".to_string())],
+        );
+        let stories = director_user_payload(
+            &serde_json::json!({}),
+            &roster,
+            &[],
+            false,
+            Some(&life),
+            "现代都市",
+        );
+        assert!(
+            stories.contains("7) 各角色的个人生活"),
+            "stories rule renumbered to 7"
         );
     }
 
@@ -789,6 +923,164 @@ mod tests {
         assert_eq!(digests[instance_id.to_string()], "W 在筹备开店");
         assert_eq!(version, 2);
         assert!(claimed.is_none());
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn direct_world_resets_on_worldview_change(pool: sqlx::PgPool) {
+        use wiremock::matchers::{method, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let owner = Uuid::new_v4();
+        let genome_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata) \
+             VALUES ('W','p','{}'::jsonb) RETURNING id",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let instance_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_instances (genome_id, owner_uid) \
+             VALUES ($1,$2) RETURNING id",
+        )
+        .bind(genome_id)
+        .bind(owner)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        sqlx::query("INSERT INTO engine.world_enrollments (owner_uid) VALUES ($1)")
+            .bind(owner)
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO engine.world_worldviews (owner_uid, content) VALUES ($1, '现代都市')",
+        )
+        .bind(owner)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let reply = serde_json::json!({
+            "seed": {"arc": "第一幕"},
+            "personas": [{
+                "instance_id": instance_id,
+                "digest": "W 在筹备开店",
+                "script_fragments": []
+            }]
+        });
+        let mock = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(wm_path("/api/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "gen-world", "model": "w/m",
+                "choices": [{"message": {"content": reply.to_string()}}],
+            })))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = std::sync::Arc::new(
+            eros_engine_llm::model_config::ModelConfig::from_toml_str(
+                "[tasks.world_director]\nmodel=\"w/m\"\nfilter_prompt=\"direct\"\n",
+            )
+            .unwrap(),
+        );
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "k".into(),
+                Default::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+        let resolved = state.model_config.resolve_world_director().unwrap();
+
+        let repo = eros_engine_store::world::WorldRepo { pool: &pool };
+        repo.ensure_states_for_enrollments().await.unwrap();
+
+        // Two extra pre-seeded rows belonging to a DIFFERENT worldview era
+        // than the current '现代都市' row: an old fragment (must be purged)
+        // and a stale seed (must not leak into the payload's previous_seed).
+        let old_embedding = format!("[{}]", vec!["0"; 512].join(","));
+        sqlx::query(
+            "INSERT INTO engine.world_memories (owner_uid, instance_id, content, embedding, script_date) \
+             VALUES ($1, $2, '旧世界片段', $3::vector, current_date)",
+        )
+        .bind(owner)
+        .bind(instance_id)
+        .bind(&old_embedding)
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query("UPDATE engine.world_states SET worldview_hash = $2 WHERE owner_uid = $1")
+            .bind(owner)
+            .bind(worldview_sha256_hex("旧世界观"))
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "UPDATE engine.world_states SET seed = '{\"arc\":\"旧剧情\"}'::jsonb WHERE owner_uid = $1",
+        )
+        .bind(owner)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let claimed = repo
+            .claim_due(
+                std::time::Duration::from_secs(24 * 3600),
+                std::time::Duration::from_secs(1800),
+                5,
+            )
+            .await
+            .unwrap();
+        let (_o, token) = claimed[0];
+
+        direct_world(&state, &resolved, owner, token)
+            .await
+            .expect("round ok");
+
+        let reqs = mock.received_requests().await.unwrap();
+        assert_eq!(reqs.len(), 1);
+        let body = String::from_utf8_lossy(&reqs[0].body);
+        assert!(
+            body.contains("初始化这个世界"),
+            "reset forces the init header even though world_states.seed was non-empty"
+        );
+        assert!(
+            body.contains("现代都市"),
+            "current worldview reaches the payload"
+        );
+        assert!(
+            !body.contains("旧世界片段"),
+            "old-era fragment content must not leak into the payload"
+        );
+        assert!(
+            !body.contains("旧剧情"),
+            "reset drops the stale seed — previous_seed must be null, not the old arc"
+        );
+
+        let frag_contents: Vec<String> =
+            sqlx::query_scalar("SELECT content FROM engine.world_memories WHERE owner_uid = $1")
+                .bind(owner)
+                .fetch_all(&pool)
+                .await
+                .unwrap();
+        assert!(
+            !frag_contents.iter().any(|c| c == "旧世界片段"),
+            "the pre-seeded old-era fragment must be purged on reset"
+        );
+
+        let (hash, set_at): (Option<String>, Option<chrono::DateTime<chrono::Utc>>) =
+            sqlx::query_as(
+                "SELECT worldview_hash, worldview_set_at FROM engine.world_states WHERE owner_uid = $1",
+            )
+            .bind(owner)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(hash, Some(worldview_sha256_hex("现代都市")));
+        assert!(set_at.is_some(), "reset stamps the era start");
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
@@ -1100,6 +1392,15 @@ mod tests {
 
         let repo = eros_engine_store::world::WorldRepo { pool: &pool };
         repo.ensure_states_for_enrollments().await.unwrap();
+        // First-sight-of-worldview is a reset, which suppresses recent_life;
+        // this test exercises the normal continuation path — pre-stamp the
+        // hash the round will compute so it is NOT a reset.
+        sqlx::query("UPDATE engine.world_states SET worldview_hash = $2 WHERE owner_uid = $1")
+            .bind(owner)
+            .bind(worldview_sha256_hex("现代都市"))
+            .execute(&pool)
+            .await
+            .unwrap();
         let claimed = repo
             .claim_due(
                 std::time::Duration::from_secs(24 * 3600),

--- a/crates/eros-engine-server/src/pipeline/world_town.rs
+++ b/crates/eros-engine-server/src/pipeline/world_town.rs
@@ -502,8 +502,15 @@ mod tests {
         .await
         .unwrap();
         sqlx::query(
-            "INSERT INTO engine.world_states (owner_uid, seed, digests) \
-             VALUES ($1, '{\"arc\":\"a\"}'::jsonb, '{}'::jsonb)",
+            "INSERT INTO engine.world_states (owner_uid, seed, digests, worldview_set_at) \
+             VALUES ($1, '{\"arc\":\"a\"}'::jsonb, '{}'::jsonb, now() - interval '1 day')",
+        )
+        .bind(owner)
+        .execute(pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO engine.world_worldviews (owner_uid, content) VALUES ($1, '现代都市')",
         )
         .bind(owner)
         .execute(pool)

--- a/crates/eros-engine-server/src/pipeline/world_town.rs
+++ b/crates/eros-engine-server/src/pipeline/world_town.rs
@@ -156,7 +156,7 @@ async fn run_comment_round(
     }
 
     let world_repo = WorldRepo { pool: &state.pool };
-    let Some((worldview, _)) = world_repo
+    let Some((worldview, _, _)) = world_repo
         .worldview_state(owner)
         .await
         .map_err(|e| format!("worldview load failed: {e}"))?
@@ -269,7 +269,7 @@ async fn run_reply(
         return Ok(()); // silent skip (spec: no failure state on the feed)
     }
     let world_repo = WorldRepo { pool: &state.pool };
-    let Some((worldview, _)) = world_repo
+    let Some((worldview, _, _)) = world_repo
         .worldview_state(cand.owner_uid)
         .await
         .map_err(|e| format!("worldview load failed: {e}"))?
@@ -332,9 +332,15 @@ async fn run_reply(
     if content.is_empty() {
         return Err("world_reply returned empty content".into());
     }
-    repo.insert_reply_comment(cand.post_id, cand.author_instance_id, content)
+    let inserted = repo
+        .insert_reply_comment(cand.post_id, cand.author_instance_id, content)
         .await
-        .map_err(|e| format!("reply insert failed: {e}"))
+        .map_err(|e| format!("reply insert failed: {e}"))?;
+    if !inserted {
+        tracing::warn!(post = %cand.post_id, "world_town: reply dropped — worldview era changed mid-flight");
+        return Ok(());
+    }
+    Ok(())
 }
 
 /// Round payload: seed + roster (valid author ids) + posts with threads.

--- a/crates/eros-engine-server/src/pipeline/world_town.rs
+++ b/crates/eros-engine-server/src/pipeline/world_town.rs
@@ -33,7 +33,8 @@ const TOWN_ROUND_COMMENTS_CAP: usize = 12;
 const WORLD_COMMENT_RULES: &str = "规则：\
 1) 只使用给出的 post_id 和 instance_id；发帖者不评论自己的贴子。\
 2) 评论要符合 seed 里的角色关系；贴子下有用户（user）留言时，角色可以自然回应它。\
-3) 输出 0 到 N 条评论；没有值得评论的就输出空数组。每条评论一两句话，口语化。";
+3) 输出 0 到 N 条评论；没有值得评论的就输出空数组。每条评论一两句话，口语化。\
+4) 评论的语气与内容必须符合 worldview 描述的世界观，不得出现与其冲突的时代或科技元素。";
 
 #[derive(Debug, Deserialize)]
 struct CommentRoundOutput {
@@ -155,6 +156,13 @@ async fn run_comment_round(
     }
 
     let world_repo = WorldRepo { pool: &state.pool };
+    let Some((worldview, _)) = world_repo
+        .worldview_state(owner)
+        .await
+        .map_err(|e| format!("worldview load failed: {e}"))?
+    else {
+        return Ok(()); // candidates are worldview-gated; race window only
+    };
     let seed = world_repo
         .load_seed(owner)
         .await
@@ -168,7 +176,7 @@ async fn run_comment_round(
         return Ok(());
     }
     let posts = repo
-        .feed_page(owner, TOWN_ROUND_POSTS_CAP, None)
+        .round_posts(owner, TOWN_ROUND_POSTS_CAP)
         .await
         .map_err(|e| format!("posts load failed: {e}"))?;
     if posts.is_empty() {
@@ -180,7 +188,7 @@ async fn run_comment_round(
         .await
         .map_err(|e| format!("threads load failed: {e}"))?;
 
-    let payload = comment_round_payload(&seed, &roster, &posts, &comments);
+    let payload = comment_round_payload(&seed, &roster, &posts, &comments, &worldview);
     let req = ChatRequest {
         model: resolved.model.clone(),
         fallback_model: resolved.fallback_model.clone(),
@@ -260,6 +268,14 @@ async fn run_reply(
     if spent >= i64::from(resolved.daily_cap) {
         return Ok(()); // silent skip (spec: no failure state on the feed)
     }
+    let world_repo = WorldRepo { pool: &state.pool };
+    let Some((worldview, _)) = world_repo
+        .worldview_state(cand.owner_uid)
+        .await
+        .map_err(|e| format!("worldview load failed: {e}"))?
+    else {
+        return Ok(()); // candidates are worldview-gated; race window only — never burn the cooldown
+    };
     let cooldown = std::time::Duration::from_secs(resolved.thread_cooldown_secs);
     if !repo
         .claim_reply_cooldown(cand.post_id, cooldown)
@@ -269,7 +285,6 @@ async fn run_reply(
         return Ok(()); // cooling down or another instance owns it
     }
 
-    let world_repo = WorldRepo { pool: &state.pool };
     let seed = world_repo
         .load_seed(cand.owner_uid)
         .await
@@ -297,7 +312,7 @@ async fn run_reply(
             },
             ChatMessage {
                 role: "user".into(),
-                content: reply_payload(&seed, &post, &thread),
+                content: reply_payload(&seed, &post, &thread, &worldview),
             },
         ],
         temperature: resolved.temperature as f32,
@@ -328,6 +343,7 @@ fn comment_round_payload(
     roster: &[eros_engine_store::world::RosterEntry],
     posts: &[FeedPost],
     comments: &[FeedComment],
+    worldview: &str,
 ) -> String {
     let personas: Vec<serde_json::Value> = roster
         .iter()
@@ -365,6 +381,7 @@ fn comment_round_payload(
         "seed": seed,
         "personas": personas,
         "posts": posts_json,
+        "worldview": worldview,
     });
     format!(
         "为这个世界的贴文串生成新一轮评论。\n\n{}\n\n{WORLD_COMMENT_RULES}",
@@ -373,7 +390,12 @@ fn comment_round_payload(
 }
 
 /// Reply payload: the responder speaks as the post's author.
-fn reply_payload(seed: &serde_json::Value, post: &FeedPost, thread: &[FeedComment]) -> String {
+fn reply_payload(
+    seed: &serde_json::Value,
+    post: &FeedPost,
+    thread: &[FeedComment],
+    worldview: &str,
+) -> String {
     let thread_json: Vec<serde_json::Value> = thread
         .iter()
         .map(|c| {
@@ -387,10 +409,12 @@ fn reply_payload(seed: &serde_json::Value, post: &FeedPost, thread: &[FeedCommen
         "seed": seed,
         "post": { "author": post.author_name, "content": post.content },
         "thread": thread_json,
+        "worldview": worldview,
     });
     format!(
         "你是贴文作者「{}」。用户（author 为 user 的留言）在你的贴文下留了言，\
-         请以作者身份自然回应最近的用户留言。只输出评论正文，一两句话，口语化。\n\n{}",
+         请以作者身份自然回应最近的用户留言。只输出评论正文，一两句话，口语化，\
+         语气与内容须符合 worldview 描述的世界观。\n\n{}",
         post.author_name,
         serde_json::to_string_pretty(&data).unwrap_or_default()
     )
@@ -535,6 +559,26 @@ mod tests {
         .fetch_one(&pool)
         .await
         .unwrap();
+        // Old-era post: published before the worldview reset below, so
+        // round_posts (era-scoped) must exclude it from the payload.
+        sqlx::query(
+            "INSERT INTO engine.world_posts \
+                 (owner_uid, instance_id, content, scheduled_at, published_at) \
+             VALUES ($1,$2,'月下旧集市',now() - interval '2 days',now() - interval '2 days')",
+        )
+        .bind(owner)
+        .bind(author)
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "UPDATE engine.world_states SET worldview_set_at = now() - interval '1 hour' \
+             WHERE owner_uid = $1",
+        )
+        .bind(owner)
+        .execute(&pool)
+        .await
+        .unwrap();
 
         let reply = serde_json::json!({
             "comments": [
@@ -573,6 +617,15 @@ mod tests {
         assert_eq!(rows.len(), 1, "only the valid comment landed");
         assert_eq!(rows[0].0, Some(commenter));
         assert_eq!(rows[0].1, "恭喜！");
+
+        let reqs = mock.received_requests().await.unwrap();
+        assert_eq!(reqs.len(), 1);
+        let body = String::from_utf8_lossy(&reqs[0].body);
+        assert!(body.contains("开店了"), "new-era post reaches the payload");
+        assert!(
+            !body.contains("月下旧集市"),
+            "old-era post must not leak into the round payload"
+        );
 
         // Round is stamped: immediately re-running claims nothing and makes
         // no second LLM call (mock .expect(1) enforces it on drop).
@@ -683,5 +736,31 @@ mod tests {
         let fenced = format!("好的：\n```json\n{clean}\n```");
         assert!(parse_comment_output(&fenced).is_some());
         assert!(parse_comment_output("nope").is_none());
+    }
+
+    #[test]
+    fn comment_payload_carries_worldview_and_rule() {
+        let p = comment_round_payload(&serde_json::json!({}), &[], &[], &[], "武侠江湖");
+        assert!(p.contains("\"worldview\""));
+        assert!(p.contains("武侠江湖"));
+        assert!(p.contains("必须符合 worldview"), "worldview rule appended");
+    }
+
+    #[test]
+    fn reply_payload_carries_worldview() {
+        let post = FeedPost {
+            post_id: Uuid::new_v4(),
+            instance_id: Uuid::new_v4(),
+            author_name: "Aria".into(),
+            content: "今日比武".into(),
+            published_at: chrono::Utc::now(),
+        };
+        let p = reply_payload(&serde_json::json!({}), &post, &[], "武侠江湖");
+        assert!(p.contains("\"worldview\""));
+        assert!(p.contains("武侠江湖"));
+        assert!(
+            p.contains("须符合 worldview"),
+            "reply header carries the rule"
+        );
     }
 }

--- a/crates/eros-engine-store/migrations/0039_world_worldviews.sql
+++ b/crates/eros-engine-store/migrations/0039_world_worldviews.sql
@@ -26,11 +26,21 @@ CREATE TABLE engine.world_worldviews (
 -- claim query uses it to detect "worldview touched since last round".
 -- Bump ONLY on content change — content-identical UPDATEs (or explicit
 -- updated_at writes, e.g. in tests) must not register as a touch.
+--
+-- Uses clock_timestamp(), NOT now(): now() is transaction-stable (pinned to
+-- the calling transaction's START), so an UPDATE that blocks on
+-- persist_round's `FOR SHARE` guard and then proceeds after that
+-- transaction commits would otherwise stamp a time from BEFORE the block —
+-- possibly earlier than the just-committed `last_run_at` — silently
+-- defeating claim_due's touch-dueness check (`ww.updated_at >
+-- ws.last_run_at`) a second time. clock_timestamp() reads the actual wall
+-- clock at trigger-execution time, i.e. after the block clears, so the
+-- stamp always reflects when the change really took effect.
 CREATE OR REPLACE FUNCTION engine.touch_world_worldviews()
 RETURNS trigger LANGUAGE plpgsql AS $fn$
 BEGIN
     IF NEW.content IS DISTINCT FROM OLD.content THEN
-        NEW.updated_at := now();
+        NEW.updated_at := clock_timestamp();
     END IF;
     RETURN NEW;
 END

--- a/crates/eros-engine-store/migrations/0039_world_worldviews.sql
+++ b/crates/eros-engine-store/migrations/0039_world_worldviews.sql
@@ -1,0 +1,60 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+--
+-- World Worldview (spec: docs/superpowers/specs/2026-07-28-world-worldview-design.md).
+--
+-- engine.world_worldviews — downstream-managed worldview table. The engine
+-- only ever SELECTs it (over the service_role/owner connection); downstream
+-- INSERTs/UPDATEs/DELETEs rows. The engine ships no default worldview: an
+-- enrolled owner with no row here (or blank content) receives no World
+-- System LLM activity until downstream provides one.
+--
+-- world_states gains two engine-owned columns: worldview_hash (SHA-256 hex
+-- of the content used by the last completed director round; NULL = pre-
+-- worldview world, forces an init-style reset on first sight of a
+-- worldview) and worldview_set_at (start of the current worldview era; Town
+-- AI activity never targets posts published before it).
+
+CREATE TABLE engine.world_worldviews (
+    owner_uid  UUID PRIMARY KEY,
+    content    TEXT NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT worldview_content_len
+        CHECK (char_length(content) BETWEEN 1 AND 10000)
+);
+
+-- Keep updated_at honest even if downstream forgets to set it: the WM
+-- claim query uses it to detect "worldview touched since last round".
+-- Bump ONLY on content change — content-identical UPDATEs (or explicit
+-- updated_at writes, e.g. in tests) must not register as a touch.
+CREATE OR REPLACE FUNCTION engine.touch_world_worldviews()
+RETURNS trigger LANGUAGE plpgsql AS $fn$
+BEGIN
+    IF NEW.content IS DISTINCT FROM OLD.content THEN
+        NEW.updated_at := now();
+    END IF;
+    RETURN NEW;
+END
+$fn$;
+
+CREATE TRIGGER trg_world_worldviews_touch
+    BEFORE UPDATE ON engine.world_worldviews
+    FOR EACH ROW EXECUTE FUNCTION engine.touch_world_worldviews();
+
+ALTER TABLE engine.world_states
+    ADD COLUMN worldview_hash   TEXT,
+    ADD COLUMN worldview_set_at TIMESTAMPTZ;
+
+-- 0013-style lockdown: REVOKE from Supabase browser roles (when present) and
+-- enable policy-less RLS so only owner/service_role connections reach rows.
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
+        REVOKE ALL ON engine.world_worldviews FROM anon;
+    END IF;
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+        REVOKE ALL ON engine.world_worldviews FROM authenticated;
+    END IF;
+END
+$$;
+
+ALTER TABLE engine.world_worldviews ENABLE ROW LEVEL SECURITY;

--- a/crates/eros-engine-store/src/lib.rs
+++ b/crates/eros-engine-store/src/lib.rs
@@ -291,7 +291,9 @@ mod migration_tests {
                 "last_run_at",
                 "claimed_at",
                 "updated_at",
-                "last_comment_round_at"
+                "last_comment_round_at",
+                "worldview_hash",
+                "worldview_set_at"
             ],
         );
 

--- a/crates/eros-engine-store/src/story.rs
+++ b/crates/eros-engine-store/src/story.rs
@@ -162,7 +162,7 @@ impl<'a> StoryRepo<'a> {
                  JOIN engine.world_enrollments we \
                    ON we.owner_uid = psi.owner_uid AND we.stories_enabled \
                  JOIN engine.world_worldviews ww \
-                   ON ww.owner_uid = psi.owner_uid AND btrim(ww.content) <> '' \
+                   ON ww.owner_uid = psi.owner_uid AND btrim(ww.content, E' \\t\\r\\n\\f\\v') <> '' \
                  JOIN engine.persona_instances pi \
                    ON pi.id = psi.instance_id AND pi.status = 'active' \
                  WHERE (psi.last_run_at IS NULL OR psi.last_run_at < $1) \

--- a/crates/eros-engine-store/src/story.rs
+++ b/crates/eros-engine-store/src/story.rs
@@ -139,10 +139,11 @@ impl<'a> StoryRepo<'a> {
     }
 
     /// Claim up to `batch` due instances. Due = past `interval`, not freshly
-    /// claimed, owner still stories-enabled, instance still active, AND the
-    /// activity gate: the pair chatted within `active_window`. Returns
-    /// (instance_id, owner_uid, claimed_at token) — token semantics identical
-    /// to `WorldRepo::claim_due`.
+    /// claimed, owner still stories-enabled, instance still active, owner has
+    /// a non-blank worldview (stories inherit the WM prerequisite — no
+    /// worldview, no story rounds; spec §3), AND the activity gate: the pair
+    /// chatted within `active_window`. Returns (instance_id, owner_uid,
+    /// claimed_at token) — token semantics identical to `WorldRepo::claim_due`.
     pub async fn claim_due(
         &self,
         interval: Duration,
@@ -160,6 +161,8 @@ impl<'a> StoryRepo<'a> {
                  SELECT psi.instance_id FROM engine.persona_story_insights psi \
                  JOIN engine.world_enrollments we \
                    ON we.owner_uid = psi.owner_uid AND we.stories_enabled \
+                 JOIN engine.world_worldviews ww \
+                   ON ww.owner_uid = psi.owner_uid AND btrim(ww.content) <> '' \
                  JOIN engine.persona_instances pi \
                    ON pi.id = psi.instance_id AND pi.status = 'active' \
                  WHERE (psi.last_run_at IS NULL OR psi.last_run_at < $1) \
@@ -579,6 +582,13 @@ mod tests {
         .execute(pool)
         .await
         .unwrap();
+        sqlx::query(
+            "INSERT INTO engine.world_worldviews (owner_uid, content) VALUES ($1, '现代都市')",
+        )
+        .bind(owner)
+        .execute(pool)
+        .await
+        .unwrap();
     }
 
     async fn seed_instance(pool: &PgPool, owner: Uuid, name: &str, status: &str) -> Uuid {
@@ -701,6 +711,46 @@ mod tests {
             .await
             .unwrap()
             .is_empty());
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn claim_due_skips_owner_without_worldview(pool: PgPool) {
+        let repo = StoryRepo { pool: &pool };
+        let owner = Uuid::new_v4();
+        // Raw enrollment — deliberately NOT enroll_stories, which (after
+        // this task) also provides a worldview.
+        sqlx::query(
+            "INSERT INTO engine.world_enrollments (owner_uid, stories_enabled) VALUES ($1, true)",
+        )
+        .bind(owner)
+        .execute(&pool)
+        .await
+        .unwrap();
+        let inst = seed_instance(&pool, owner, "A", "active").await;
+        touch_activity(&pool, owner, inst, "1 hour").await;
+        repo.ensure_insight_rows(8).await.unwrap();
+
+        assert!(
+            repo.claim_due(EIGHT_H, STALE, WINDOW, 8)
+                .await
+                .unwrap()
+                .is_empty(),
+            "no worldview ⇒ story round never claims"
+        );
+
+        sqlx::query(
+            "INSERT INTO engine.world_worldviews (owner_uid, content) VALUES ($1, '现代都市')",
+        )
+        .bind(owner)
+        .execute(&pool)
+        .await
+        .unwrap();
+        let claimed = repo.claim_due(EIGHT_H, STALE, WINDOW, 8).await.unwrap();
+        assert_eq!(
+            claimed.iter().map(|(i, o, _)| (*i, *o)).collect::<Vec<_>>(),
+            vec![(inst, owner)],
+            "worldview present ⇒ claimable again"
+        );
     }
 
     #[sqlx::test(migrations = "./migrations")]

--- a/crates/eros-engine-store/src/world.rs
+++ b/crates/eros-engine-store/src/world.rs
@@ -709,6 +709,49 @@ mod tests {
         );
     }
 
+    /// The trigger must stamp `clock_timestamp()`, not `now()`. `now()` is
+    /// transaction-stable (pinned to this transaction's START), so a
+    /// long-running UPDATE (e.g. one that blocked on `persist_round`'s
+    /// `FOR SHARE` guard and only proceeds after that transaction commits)
+    /// would stamp a time from BEFORE it actually ran, potentially earlier
+    /// than the just-committed `last_run_at` — defeating touch-dueness
+    /// again. `pg_sleep` inside the transaction makes the two clocks
+    /// diverge deterministically: with `clock_timestamp()`, `updated_at` is
+    /// stamped AFTER the sleep and so is later than `now()` (pinned before
+    /// the sleep); with the old `now()` they would be equal and this
+    /// assertion would fail.
+    #[sqlx::test(migrations = "./migrations")]
+    async fn worldview_trigger_stamps_wall_clock_time(pool: PgPool) {
+        let owner = Uuid::new_v4();
+        enroll_without_worldview(&pool, owner).await;
+        set_worldview(&pool, owner, "现代都市").await;
+
+        let mut tx = pool.begin().await.unwrap();
+        sqlx::query("SELECT pg_sleep(0.05)")
+            .execute(&mut *tx)
+            .await
+            .unwrap();
+        sqlx::query("UPDATE engine.world_worldviews SET content = '科幻星际' WHERE owner_uid = $1")
+            .bind(owner)
+            .execute(&mut *tx)
+            .await
+            .unwrap();
+        let stamped_after_now: bool = sqlx::query_scalar(
+            "SELECT updated_at > now() FROM engine.world_worldviews WHERE owner_uid = $1",
+        )
+        .bind(owner)
+        .fetch_one(&mut *tx)
+        .await
+        .unwrap();
+        assert!(
+            stamped_after_now,
+            "trigger must use clock_timestamp() (wall clock at execution time), \
+             not now() (pinned to transaction start) — otherwise a blocked \
+             UPDATE stamps a time from before it actually ran"
+        );
+        tx.rollback().await.unwrap();
+    }
+
     #[sqlx::test(migrations = "./migrations")]
     async fn count_enrolled_missing_worldview_counts_absent_and_blank(pool: PgPool) {
         let repo = WorldRepo { pool: &pool };

--- a/crates/eros-engine-store/src/world.rs
+++ b/crates/eros-engine-store/src/world.rs
@@ -254,19 +254,28 @@ impl<'a> WorldRepo<'a> {
     }
 
     /// Persist one director round in a single transaction (spec §2.4):
-    /// retention delete + fragment inserts + scheduled-post inserts + state
-    /// update (seed_version++, last_run_at=now, claimed_at=NULL).
-    /// All-or-nothing: any failure rolls back and the caller releases the
-    /// claim. `posts` (town-enabled owners only; empty otherwise) ride the
-    /// same transaction and the same claim-ownership-token guard as
-    /// everything else here.
+    /// reset purge (if `reset`) + retention delete + fragment inserts +
+    /// scheduled-post inserts + state update (seed_version++, last_run_at=
+    /// now, claimed_at=NULL, worldview_hash stamped, worldview_set_at
+    /// stamped iff `reset`). All-or-nothing: any failure rolls back and the
+    /// caller releases the claim. `posts` (town-enabled owners only; empty
+    /// otherwise) ride the same transaction and the same claim-ownership-
+    /// token guard as everything else here.
+    ///
+    /// `worldview_hash` is stamped onto `world_states` every round (spec
+    /// §2). `reset` is true exactly when this round's worldview hash
+    /// differs from the previously stored one (or none was stored) —
+    /// caller's job (Task 6); this method just executes the purge + era
+    /// stamp for whatever `reset` it is given. When `reset`, the purge below
+    /// runs first in the same transaction, and `worldview_set_at` is bumped
+    /// to `now()` to mark the new era's start.
     ///
     /// `claimed_at` is the ownership token from `claim_due`. The final state
     /// update is guarded on it (`AND claimed_at = $N`); if a newer sweeper
     /// has since reclaimed this owner the guard matches zero rows and we
     /// return `Err(RowNotFound)` BEFORE committing — the transaction is
-    /// dropped, which rolls back the retention delete, fragment inserts, and
-    /// post inserts too, so a lost-claim round writes nothing.
+    /// dropped, which rolls back the reset purge, retention delete, fragment
+    /// inserts, and post inserts too, so a lost-claim round writes nothing.
     #[allow(clippy::too_many_arguments)]
     pub async fn persist_round(
         &self,
@@ -277,9 +286,43 @@ impl<'a> WorldRepo<'a> {
         posts: &[PostInsert],
         script_date: NaiveDate,
         retention_days: u32,
+        worldview_hash: &str,
+        reset: bool,
         claimed_at: DateTime<Utc>,
     ) -> Result<(), sqlx::Error> {
         let mut tx = self.pool.begin().await?;
+        if reset {
+            // Worldview changed (spec §2 reset inventory): the fictional
+            // world restarts. Old fragments must stop injecting into chat;
+            // scheduled-but-unpublished posts carry stale-era content and
+            // must not surface; published posts + comments stay as the
+            // feed's history. Story rows purge so lives re-derive under the
+            // new worldview — deleting a claimed persona_story_insights row
+            // mid-story-round is safe: that round's token-guarded UPDATE
+            // then matches zero rows and rolls itself back.
+            sqlx::query("DELETE FROM engine.world_memories WHERE owner_uid = $1")
+                .bind(owner_uid)
+                .execute(&mut *tx)
+                .await?;
+            sqlx::query(
+                "DELETE FROM engine.world_posts WHERE owner_uid = $1 AND published_at IS NULL",
+            )
+            .bind(owner_uid)
+            .execute(&mut *tx)
+            .await?;
+            sqlx::query("DELETE FROM engine.persona_story_memories WHERE owner_uid = $1")
+                .bind(owner_uid)
+                .execute(&mut *tx)
+                .await?;
+            sqlx::query("DELETE FROM engine.persona_story_events WHERE owner_uid = $1")
+                .bind(owner_uid)
+                .execute(&mut *tx)
+                .await?;
+            sqlx::query("DELETE FROM engine.persona_story_insights WHERE owner_uid = $1")
+                .bind(owner_uid)
+                .execute(&mut *tx)
+                .await?;
+        }
         let retention_cutoff = script_date - chrono::Days::new(u64::from(retention_days));
         sqlx::query("DELETE FROM engine.world_memories WHERE owner_uid = $1 AND script_date < $2")
             .bind(owner_uid)
@@ -316,13 +359,17 @@ impl<'a> WorldRepo<'a> {
         let res = sqlx::query(
             "UPDATE engine.world_states \
              SET seed = $2, digests = $3, seed_version = seed_version + 1, \
-                 last_run_at = now(), claimed_at = NULL, updated_at = now() \
+                 last_run_at = now(), claimed_at = NULL, updated_at = now(), \
+                 worldview_hash = $5, \
+                 worldview_set_at = CASE WHEN $6 THEN now() ELSE worldview_set_at END \
              WHERE owner_uid = $1 AND claimed_at = $4",
         )
         .bind(owner_uid)
         .bind(seed)
         .bind(digests)
         .bind(claimed_at)
+        .bind(worldview_hash)
+        .bind(reset)
         .execute(&mut *tx)
         .await?;
         if res.rows_affected() == 0 {
@@ -829,9 +876,20 @@ mod tests {
             content: "P 试营业当天把咖啡机弄坏了".into(),
             embedding: unit_embedding(7),
         }];
-        repo.persist_round(owner, &seed, &digests, &frags, &[], today, 30, token)
-            .await
-            .unwrap();
+        repo.persist_round(
+            owner,
+            &seed,
+            &digests,
+            &frags,
+            &[],
+            today,
+            30,
+            "h",
+            false,
+            token,
+        )
+        .await
+        .unwrap();
 
         let contents: Vec<String> =
             sqlx::query_scalar("SELECT content FROM engine.world_memories WHERE owner_uid = $1")
@@ -893,6 +951,8 @@ mod tests {
                 &[],
                 today,
                 30,
+                "h",
+                false,
                 token1,
             )
             .await;
@@ -916,6 +976,245 @@ mod tests {
                 .await
                 .unwrap();
         assert_eq!(n, 0, "fragment insert must roll back too");
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn persist_round_reset_purges_world_and_story_data_keeps_published_posts(pool: PgPool) {
+        let repo = WorldRepo { pool: &pool };
+        let owner = Uuid::new_v4();
+        enroll(&pool, owner).await;
+        repo.ensure_states_for_enrollments().await.unwrap();
+        let inst = seed_instance(&pool, owner, "P", "active").await;
+        let today = Utc::now().date_naive();
+
+        // Old-era data of every purgeable kind.
+        sqlx::query(
+            "INSERT INTO engine.world_memories (owner_uid, instance_id, content, embedding, script_date) \
+             VALUES ($1, $2, '旧剧本', $3::vector, $4)",
+        )
+        .bind(owner).bind(inst).bind(format_vector(&unit_embedding(1))).bind(today)
+        .execute(&pool).await.unwrap();
+        let published: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.world_posts (owner_uid, instance_id, content, scheduled_at, published_at) \
+             VALUES ($1, $2, '旧贴文', now() - interval '1 day', now() - interval '1 day') RETURNING id",
+        )
+        .bind(owner).bind(inst).fetch_one(&pool).await.unwrap();
+        sqlx::query(
+            "INSERT INTO engine.world_post_comments (post_id, author_instance_id, source, content) \
+             VALUES ($1, NULL, NULL, '用户旧评论')",
+        )
+        .bind(published).execute(&pool).await.unwrap();
+        sqlx::query(
+            "INSERT INTO engine.world_posts (owner_uid, instance_id, content, scheduled_at) \
+             VALUES ($1, $2, '未发布贴文', now() + interval '1 hour')",
+        )
+        .bind(owner)
+        .bind(inst)
+        .execute(&pool)
+        .await
+        .unwrap();
+        // persona_story_insights is a flat typed table (no opaque JSONB
+        // stage, per 0038's own comment) — no `insight` column exists.
+        sqlx::query(
+            "INSERT INTO engine.persona_story_insights (instance_id, owner_uid, digest) \
+             VALUES ($1, $2, '旧近况')",
+        )
+        .bind(inst)
+        .bind(owner)
+        .execute(&pool)
+        .await
+        .unwrap();
+        let old_event: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_story_events (owner_uid, instance_id, category, content, story_date) \
+             VALUES ($1, $2, 'work', '旧事件', current_date) RETURNING id",
+        )
+        .bind(owner).bind(inst).fetch_one(&pool).await.unwrap();
+        // persona_story_memories.event_id is NOT NULL (FK to
+        // persona_story_events) — thread the row just inserted above.
+        sqlx::query(
+            "INSERT INTO engine.persona_story_memories (owner_uid, instance_id, event_id, content, embedding, story_date) \
+             VALUES ($1, $2, $3, '旧记忆', $4::vector, current_date)",
+        )
+        .bind(owner).bind(inst).bind(old_event).bind(format_vector(&unit_embedding(2)))
+        .execute(&pool).await.unwrap();
+
+        let claimed = repo.claim_due(DAY, STALE, 5).await.unwrap();
+        let (_o, token) = claimed[0];
+        let frags = vec![FragmentInsert {
+            instance_id: inst,
+            content: "新世界第一幕".into(),
+            embedding: unit_embedding(7),
+        }];
+        repo.persist_round(
+            owner,
+            &serde_json::json!({"arc": "新"}),
+            &serde_json::json!({}),
+            &frags,
+            &[],
+            today,
+            30,
+            "newhash",
+            true,
+            token,
+        )
+        .await
+        .unwrap();
+
+        let frag_contents: Vec<String> =
+            sqlx::query_scalar("SELECT content FROM engine.world_memories WHERE owner_uid = $1")
+                .bind(owner)
+                .fetch_all(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            frag_contents,
+            vec!["新世界第一幕".to_string()],
+            "old fragments purged, new kept"
+        );
+
+        let posts: Vec<String> =
+            sqlx::query_scalar("SELECT content FROM engine.world_posts WHERE owner_uid = $1")
+                .bind(owner)
+                .fetch_all(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            posts,
+            vec!["旧贴文".to_string()],
+            "published kept, unpublished purged"
+        );
+        let comments: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM engine.world_post_comments WHERE post_id = $1",
+        )
+        .bind(published)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(comments, 1, "user comment on published post kept");
+
+        for table in [
+            "persona_story_insights",
+            "persona_story_events",
+            "persona_story_memories",
+        ] {
+            let n: i64 = sqlx::query_scalar(&format!(
+                "SELECT count(*) FROM engine.{table} WHERE owner_uid = $1"
+            ))
+            .bind(owner)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+            assert_eq!(n, 0, "{table} purged on reset");
+        }
+
+        let (hash, set_at): (Option<String>, Option<DateTime<Utc>>) = sqlx::query_as(
+            "SELECT worldview_hash, worldview_set_at FROM engine.world_states WHERE owner_uid = $1",
+        )
+        .bind(owner)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(hash.as_deref(), Some("newhash"));
+        assert!(set_at.is_some(), "reset stamps the era start");
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn persist_round_normal_stamps_hash_without_purge_or_era(pool: PgPool) {
+        let repo = WorldRepo { pool: &pool };
+        let owner = Uuid::new_v4();
+        enroll(&pool, owner).await;
+        repo.ensure_states_for_enrollments().await.unwrap();
+        let inst = seed_instance(&pool, owner, "P", "active").await;
+        let today = Utc::now().date_naive();
+        sqlx::query(
+            "INSERT INTO engine.persona_story_events (owner_uid, instance_id, category, content, story_date) \
+             VALUES ($1, $2, 'work', '既有事件', current_date)",
+        )
+        .bind(owner).bind(inst).execute(&pool).await.unwrap();
+
+        let claimed = repo.claim_due(DAY, STALE, 5).await.unwrap();
+        let (_o, token) = claimed[0];
+        repo.persist_round(
+            owner,
+            &serde_json::json!({}),
+            &serde_json::json!({}),
+            &[],
+            &[],
+            today,
+            30,
+            "h1",
+            false,
+            token,
+        )
+        .await
+        .unwrap();
+
+        let n: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM engine.persona_story_events WHERE owner_uid = $1",
+        )
+        .bind(owner)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(n, 1, "normal round purges nothing");
+        let (hash, set_at): (Option<String>, Option<DateTime<Utc>>) = sqlx::query_as(
+            "SELECT worldview_hash, worldview_set_at FROM engine.world_states WHERE owner_uid = $1",
+        )
+        .bind(owner)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(hash.as_deref(), Some("h1"), "hash stamped every round");
+        assert!(set_at.is_none(), "era untouched on normal rounds");
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn persist_round_reset_rolls_back_purge_on_lost_claim(pool: PgPool) {
+        let repo = WorldRepo { pool: &pool };
+        let owner = Uuid::new_v4();
+        enroll(&pool, owner).await;
+        repo.ensure_states_for_enrollments().await.unwrap();
+        let inst = seed_instance(&pool, owner, "P", "active").await;
+        sqlx::query(
+            "INSERT INTO engine.persona_story_events (owner_uid, instance_id, category, content, story_date) \
+             VALUES ($1, $2, 'work', '必须幸存', current_date)",
+        )
+        .bind(owner).bind(inst).execute(&pool).await.unwrap();
+        let claimed = repo.claim_due(DAY, STALE, 5).await.unwrap();
+        let (_o, token1) = claimed[0];
+        // A newer sweeper reclaims mid-round.
+        sqlx::query(
+            "UPDATE engine.world_states SET claimed_at = now() + interval '1 second' \
+             WHERE owner_uid = $1",
+        )
+        .bind(owner)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let result = repo
+            .persist_round(
+                owner,
+                &serde_json::json!({}),
+                &serde_json::json!({}),
+                &[],
+                &[],
+                Utc::now().date_naive(),
+                30,
+                "h",
+                true,
+                token1,
+            )
+            .await;
+        assert!(result.is_err(), "lost claim must abort the reset");
+        let n: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM engine.persona_story_events WHERE owner_uid = $1",
+        )
+        .bind(owner)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(n, 1, "the purge must roll back with the transaction");
     }
 
     #[sqlx::test]
@@ -967,6 +1266,8 @@ mod tests {
             &posts,
             Utc::now().date_naive(),
             30,
+            "h",
+            false,
             token,
         )
         .await
@@ -1075,6 +1376,8 @@ mod tests {
             &[],
             today,
             30,
+            "h",
+            false,
             token,
         )
         .await

--- a/crates/eros-engine-store/src/world.rs
+++ b/crates/eros-engine-store/src/world.rs
@@ -176,15 +176,19 @@ impl<'a> WorldRepo<'a> {
     }
 
     /// The owner's current worldview (trimmed) plus the hash recorded by the
-    /// last completed round. `None` = no usable worldview (absent row or
-    /// blank content): the caller must not run any World System LLM round
-    /// for this owner (spec §1).
+    /// last completed round, plus the worldview row's own `updated_at`.
+    /// `None` = no usable worldview (absent row or blank content): the
+    /// caller must not run any World System LLM round for this owner (spec
+    /// §1). The caller that runs a director round must thread
+    /// `updated_at` back into `persist_round`'s `worldview_updated_at` —
+    /// that guard is what keeps a mid-round downstream update from
+    /// committing stale output (see `persist_round`).
     pub async fn worldview_state(
         &self,
         owner_uid: Uuid,
-    ) -> Result<Option<(String, Option<String>)>, sqlx::Error> {
-        let row: Option<(String, Option<String>)> = sqlx::query_as(
-            "SELECT ww.content, ws.worldview_hash \
+    ) -> Result<Option<(String, Option<String>, DateTime<Utc>)>, sqlx::Error> {
+        let row: Option<(String, Option<String>, DateTime<Utc>)> = sqlx::query_as(
+            "SELECT ww.content, ws.worldview_hash, ww.updated_at \
              FROM engine.world_worldviews ww \
              JOIN engine.world_states ws USING (owner_uid) \
              WHERE ww.owner_uid = $1",
@@ -192,11 +196,11 @@ impl<'a> WorldRepo<'a> {
         .bind(owner_uid)
         .fetch_optional(self.pool)
         .await?;
-        Ok(row.and_then(|(content, hash)| {
+        Ok(row.and_then(|(content, hash, updated_at)| {
             let trimmed = content
                 .trim_matches(|c: char| c.is_ascii_whitespace())
                 .to_string();
-            (!trimmed.is_empty()).then_some((trimmed, hash))
+            (!trimmed.is_empty()).then_some((trimmed, hash, updated_at))
         }))
     }
 
@@ -278,6 +282,27 @@ impl<'a> WorldRepo<'a> {
     /// return `Err(RowNotFound)` BEFORE committing — the transaction is
     /// dropped, which rolls back the reset purge, retention delete, fragment
     /// inserts, and post inserts too, so a lost-claim round writes nothing.
+    ///
+    /// `worldview_updated_at` is the worldview row's `updated_at` as read by
+    /// the caller alongside the content that produced this round's output
+    /// (`WorldRepo::worldview_state`). Before doing any purge/insert work,
+    /// this method re-checks — `FOR SHARE`, inside this same transaction —
+    /// that the worldview row still has that exact `updated_at`. If it
+    /// doesn't (the worldview changed, or the row vanished, between the
+    /// caller's read and this commit), the round's output was generated
+    /// from now-stale content: we abort with `Err(RowNotFound)` and never
+    /// commit. This matters because `persist_round` also stamps
+    /// `last_run_at = now()`; if a stale round were allowed to commit,
+    /// `last_run_at` would land AFTER the new worldview's `updated_at`, so
+    /// `claim_due`'s touch-dueness condition (`ww.updated_at >
+    /// ws.last_run_at`) would never fire and the fresh worldview would sit
+    /// unprocessed for up to a full `interval_hours`. Aborting instead
+    /// leaves `last_run_at` untouched, so the owner re-claims on the very
+    /// next tick and picks up the new content. `FOR SHARE` also closes the
+    /// race window itself: it blocks a concurrent downstream `UPDATE` on
+    /// that row from committing until this transaction ends, so there is no
+    /// gap between "we checked" and "we committed" for a change to sneak
+    /// through.
     #[allow(clippy::too_many_arguments)]
     pub async fn persist_round(
         &self,
@@ -290,9 +315,26 @@ impl<'a> WorldRepo<'a> {
         retention_days: u32,
         worldview_hash: &str,
         reset: bool,
+        worldview_updated_at: DateTime<Utc>,
         claimed_at: DateTime<Utc>,
     ) -> Result<(), sqlx::Error> {
         let mut tx = self.pool.begin().await?;
+        let still_fresh: Option<i32> = sqlx::query_scalar(
+            "SELECT 1 FROM engine.world_worldviews \
+             WHERE owner_uid = $1 AND updated_at = $2 FOR SHARE",
+        )
+        .bind(owner_uid)
+        .bind(worldview_updated_at)
+        .fetch_optional(&mut *tx)
+        .await?;
+        if still_fresh.is_none() {
+            // The worldview changed (or the row vanished) between the
+            // caller's `worldview_state` read and now: this round's output
+            // is stale. Drop `tx` uncommitted — see the doc comment above
+            // for why aborting here (rather than committing) is what keeps
+            // touch-dueness correct.
+            return Err(sqlx::Error::RowNotFound);
+        }
         if reset {
             // Worldview changed (spec §2 reset inventory): the fictional
             // world restarts. Old fragments must stop injecting into chat;
@@ -457,6 +499,18 @@ mod tests {
         .execute(pool)
         .await
         .unwrap();
+    }
+
+    /// `persist_round`'s freshness guard needs the worldview row's current
+    /// `updated_at` — tests fetch it right after `enroll`/`set_worldview` so
+    /// the value they pass in matches what a real caller would have read
+    /// via `worldview_state` moments earlier.
+    async fn worldview_updated_at(pool: &PgPool, owner: Uuid) -> DateTime<Utc> {
+        sqlx::query_scalar("SELECT updated_at FROM engine.world_worldviews WHERE owner_uid = $1")
+            .bind(owner)
+            .fetch_one(pool)
+            .await
+            .unwrap()
     }
 
     const DAY: Duration = Duration::from_secs(24 * 3600);
@@ -632,7 +686,7 @@ mod tests {
 
         assert!(repo.worldview_state(owner).await.unwrap().is_none());
         set_worldview(&pool, owner, "  古代宫廷  ").await;
-        let (content, hash) = repo.worldview_state(owner).await.unwrap().unwrap();
+        let (content, hash, updated_at1) = repo.worldview_state(owner).await.unwrap().unwrap();
         assert_eq!(content, "古代宫廷", "content is trimmed");
         assert!(hash.is_none(), "no round yet ⇒ no stored hash");
 
@@ -641,8 +695,12 @@ mod tests {
             .execute(&pool)
             .await
             .unwrap();
-        let (_, hash) = repo.worldview_state(owner).await.unwrap().unwrap();
+        let (_, hash, updated_at2) = repo.worldview_state(owner).await.unwrap().unwrap();
         assert_eq!(hash.as_deref(), Some("abc"));
+        assert_eq!(
+            updated_at2, updated_at1,
+            "worldview_hash lives on world_states, not the worldview row — updated_at is untouched"
+        );
 
         set_worldview(&pool, owner, "   ").await;
         assert!(
@@ -720,7 +778,7 @@ mod tests {
             1,
             "full-width-space-only content is claimable (treated as present)"
         );
-        let (content, _hash) = repo
+        let (content, _hash, _updated_at) = repo
             .worldview_state(owner)
             .await
             .unwrap()
@@ -918,6 +976,7 @@ mod tests {
             .await
             .unwrap();
         let (_o, token) = claimed[0];
+        let wv_at = worldview_updated_at(&pool, owner).await;
         let instance = seed_instance(&pool, owner, "P", "active").await;
         let today = Utc::now().date_naive();
 
@@ -951,6 +1010,7 @@ mod tests {
             30,
             "h",
             false,
+            wv_at,
             token,
         )
         .await
@@ -986,6 +1046,7 @@ mod tests {
         enroll(&pool, owner).await;
         repo.ensure_states_for_enrollments().await.unwrap();
         let instance = seed_instance(&pool, owner, "P", "active").await;
+        let wv_at = worldview_updated_at(&pool, owner).await;
         let claimed = repo.claim_due(DAY, STALE, 5).await.unwrap();
         let (_o, token1) = claimed[0];
 
@@ -1018,6 +1079,7 @@ mod tests {
                 30,
                 "h",
                 false,
+                wv_at,
                 token1,
             )
             .await;
@@ -1103,6 +1165,7 @@ mod tests {
         .bind(owner).bind(inst).bind(old_event).bind(format_vector(&unit_embedding(2)))
         .execute(&pool).await.unwrap();
 
+        let wv_at = worldview_updated_at(&pool, owner).await;
         let claimed = repo.claim_due(DAY, STALE, 5).await.unwrap();
         let (_o, token) = claimed[0];
         let frags = vec![FragmentInsert {
@@ -1120,6 +1183,7 @@ mod tests {
             30,
             "newhash",
             true,
+            wv_at,
             token,
         )
         .await
@@ -1197,6 +1261,7 @@ mod tests {
         )
         .bind(owner).bind(inst).execute(&pool).await.unwrap();
 
+        let wv_at = worldview_updated_at(&pool, owner).await;
         let claimed = repo.claim_due(DAY, STALE, 5).await.unwrap();
         let (_o, token) = claimed[0];
         repo.persist_round(
@@ -1209,6 +1274,7 @@ mod tests {
             30,
             "h1",
             false,
+            wv_at,
             token,
         )
         .await
@@ -1245,6 +1311,7 @@ mod tests {
              VALUES ($1, $2, 'work', '必须幸存', current_date)",
         )
         .bind(owner).bind(inst).execute(&pool).await.unwrap();
+        let wv_at = worldview_updated_at(&pool, owner).await;
         let claimed = repo.claim_due(DAY, STALE, 5).await.unwrap();
         let (_o, token1) = claimed[0];
         // A newer sweeper reclaims mid-round.
@@ -1268,6 +1335,7 @@ mod tests {
                 30,
                 "h",
                 true,
+                wv_at,
                 token1,
             )
             .await;
@@ -1280,6 +1348,90 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(n, 1, "the purge must roll back with the transaction");
+    }
+
+    /// The P1 fix: a downstream worldview UPDATE that lands between the
+    /// caller's `worldview_state` read and `persist_round`'s commit must
+    /// abort the round rather than commit stale output — and, crucially,
+    /// must leave `last_run_at` untouched so `claim_due`'s touch-dueness
+    /// condition (`ww.updated_at > ws.last_run_at`) fires on the very next
+    /// scan instead of waiting out the full interval.
+    #[sqlx::test(migrations = "./migrations")]
+    async fn persist_round_aborts_when_worldview_touched_mid_round(pool: PgPool) {
+        let repo = WorldRepo { pool: &pool };
+        let owner = Uuid::new_v4();
+        enroll(&pool, owner).await;
+        repo.ensure_states_for_enrollments().await.unwrap();
+        let inst = seed_instance(&pool, owner, "P", "active").await;
+        let claimed = repo.claim_due(DAY, STALE, 5).await.unwrap();
+        let (_o, token) = claimed[0];
+        // The stale value: what a caller would have read at round start,
+        // BEFORE the downstream update below.
+        let stale_wv_at = worldview_updated_at(&pool, owner).await;
+
+        // Downstream changes the worldview mid-round (trigger bumps
+        // updated_at because content actually changed).
+        set_worldview(&pool, owner, "科幻星际").await;
+        let fresh_wv_at = worldview_updated_at(&pool, owner).await;
+        assert!(
+            fresh_wv_at > stale_wv_at,
+            "content change must bump updated_at"
+        );
+
+        let frags = vec![FragmentInsert {
+            instance_id: inst,
+            content: "stale-content fragment".into(),
+            embedding: unit_embedding(11),
+        }];
+        let result = repo
+            .persist_round(
+                owner,
+                &serde_json::json!({"arc": "stale"}),
+                &serde_json::json!({}),
+                &frags,
+                &[],
+                Utc::now().date_naive(),
+                30,
+                "stalehash",
+                false,
+                stale_wv_at,
+                token,
+            )
+            .await;
+        assert!(
+            result.is_err(),
+            "a worldview touched mid-round must abort persist_round"
+        );
+
+        let version: i32 =
+            sqlx::query_scalar("SELECT seed_version FROM engine.world_states WHERE owner_uid = $1")
+                .bind(owner)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(version, 1, "state update must roll back");
+        let n: i64 =
+            sqlx::query_scalar("SELECT count(*) FROM engine.world_memories WHERE owner_uid = $1")
+                .bind(owner)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(n, 0, "fragment insert must roll back too");
+
+        // Mirror the real caller (pipeline/world.rs `direct_world`): on a
+        // persist_round error it releases the claim so the owner isn't
+        // stuck behind WORLD_CLAIM_STALE.
+        repo.release_claim(owner, token).await.unwrap();
+
+        // The point of the fix: last_run_at was never advanced, so the
+        // owner is immediately due again under the touch-dueness rule —
+        // no waiting out DAY-length interval.
+        let reclaimed = repo.claim_due(DAY, STALE, 5).await.unwrap();
+        assert_eq!(
+            reclaimed.iter().map(|(o, _)| *o).collect::<Vec<_>>(),
+            vec![owner],
+            "aborted round must not blunt touch-dueness — owner re-claims next tick"
+        );
     }
 
     #[sqlx::test]
@@ -1316,6 +1468,7 @@ mod tests {
             .await
             .unwrap();
         let (_o, token) = claimed[0];
+        let wv_at = worldview_updated_at(&pool, owner).await;
 
         let at = Utc::now() + chrono::Duration::hours(3);
         let posts = vec![PostInsert {
@@ -1333,6 +1486,7 @@ mod tests {
             30,
             "h",
             false,
+            wv_at,
             token,
         )
         .await
@@ -1413,6 +1567,7 @@ mod tests {
         let a = seed_instance(&pool, owner, "A", "active").await;
         let b = seed_instance(&pool, owner, "B", "active").await;
         let today = Utc::now().date_naive();
+        let wv_at = worldview_updated_at(&pool, owner).await;
         let claimed = repo.claim_due(DAY, STALE, 5).await.unwrap();
         let (_o, token) = claimed[0];
 
@@ -1443,6 +1598,7 @@ mod tests {
             30,
             "h",
             false,
+            wv_at,
             token,
         )
         .await

--- a/crates/eros-engine-store/src/world.rs
+++ b/crates/eros-engine-store/src/world.rs
@@ -84,7 +84,7 @@ impl<'a> WorldRepo<'a> {
                  SELECT ws.owner_uid FROM engine.world_states ws \
                  JOIN engine.world_enrollments we USING (owner_uid) \
                  JOIN engine.world_worldviews ww USING (owner_uid) \
-                 WHERE btrim(ww.content) <> '' \
+                 WHERE btrim(ww.content, E' \\t\\r\\n\\f\\v') <> '' \
                    AND (ws.last_run_at IS NULL OR ws.last_run_at < $1 \
                         OR ww.updated_at > ws.last_run_at) \
                    AND (ws.claimed_at IS NULL OR ws.claimed_at < $2) \
@@ -193,7 +193,9 @@ impl<'a> WorldRepo<'a> {
         .fetch_optional(self.pool)
         .await?;
         Ok(row.and_then(|(content, hash)| {
-            let trimmed = content.trim().to_string();
+            let trimmed = content
+                .trim_matches(|c: char| c.is_ascii_whitespace())
+                .to_string();
             (!trimmed.is_empty()).then_some((trimmed, hash))
         }))
     }
@@ -205,7 +207,7 @@ impl<'a> WorldRepo<'a> {
         sqlx::query_scalar(
             "SELECT count(*) FROM engine.world_enrollments we \
              LEFT JOIN engine.world_worldviews ww USING (owner_uid) \
-             WHERE ww.owner_uid IS NULL OR btrim(ww.content) = ''",
+             WHERE ww.owner_uid IS NULL OR btrim(ww.content, E' \\t\\r\\n\\f\\v') = ''",
         )
         .fetch_one(self.pool)
         .await
@@ -661,6 +663,69 @@ mod tests {
         set_worldview(&pool, blank, " ").await;
 
         assert_eq!(repo.count_enrolled_missing_worldview().await.unwrap(), 2);
+    }
+
+    /// SQL `btrim` and Rust `str::trim_matches(is_ascii_whitespace)` must
+    /// agree on what "blank" means — otherwise content like a lone "\n"
+    /// passes the DDL CHECK and claim_due's plain `btrim(...) <> ''` gate
+    /// (which only strips spaces) while `worldview_state`'s old `.trim()`
+    /// (which strips all Unicode whitespace) reads it as missing: per-tick
+    /// claim churn plus a `worldview missing at round time` warn that the
+    /// aggregate count also misses. Both sides now use the same ASCII
+    /// whitespace charset (space, tab, CR, LF, FF), so a Unicode-only
+    /// whitespace character like U+3000 (outside that charset) is
+    /// consistently treated as PRESENT content on both sides.
+    #[sqlx::test(migrations = "./migrations")]
+    async fn blank_worldview_definition_agrees_between_sql_and_rust(pool: PgPool) {
+        let repo = WorldRepo { pool: &pool };
+        let owner = Uuid::new_v4();
+        enroll_without_worldview(&pool, owner).await;
+        repo.ensure_states_for_enrollments().await.unwrap();
+
+        // A lone newline passes the DDL CHECK (non-empty) but is blank under
+        // the ASCII-whitespace definition on both sides.
+        set_worldview(&pool, owner, "\n").await;
+        assert!(
+            repo.claim_due(DAY, STALE, 5).await.unwrap().is_empty(),
+            "newline-only content must not be claimable"
+        );
+        assert_eq!(
+            repo.count_enrolled_missing_worldview().await.unwrap(),
+            1,
+            "newline-only content must count toward the aggregate warn"
+        );
+        assert!(
+            repo.worldview_state(owner).await.unwrap().is_none(),
+            "newline-only content must read as no worldview"
+        );
+
+        // Real content self-heals immediately.
+        set_worldview(&pool, owner, "现代都市").await;
+        let claimed = repo.claim_due(DAY, STALE, 5).await.unwrap();
+        assert_eq!(claimed.len(), 1, "real content becomes claimable");
+        let (_, token) = claimed[0];
+        assert_eq!(repo.count_enrolled_missing_worldview().await.unwrap(), 0);
+        // Release so the next claim_due call below isn't blocked by the
+        // fresh claim just taken — this test checks claimability, not the
+        // claim-token lifecycle (covered elsewhere).
+        repo.release_claim(owner, token).await.unwrap();
+
+        // Full-width space (U+3000) IS Unicode whitespace but is outside the
+        // ASCII charset both sides now trim on — it must read as PRESENT,
+        // not blank, consistently.
+        set_worldview(&pool, owner, "\u{3000}").await;
+        let claimed = repo.claim_due(DAY, STALE, 5).await.unwrap();
+        assert_eq!(
+            claimed.len(),
+            1,
+            "full-width-space-only content is claimable (treated as present)"
+        );
+        let (content, _hash) = repo
+            .worldview_state(owner)
+            .await
+            .unwrap()
+            .expect("full-width-space-only content must read as PRESENT");
+        assert_eq!(content, "\u{3000}");
     }
 
     #[sqlx::test(migrations = "./migrations")]

--- a/crates/eros-engine-store/src/world.rs
+++ b/crates/eros-engine-store/src/world.rs
@@ -55,13 +55,18 @@ impl<'a> WorldRepo<'a> {
         Ok(res.rows_affected())
     }
 
-    /// Atomically claim up to `batch` due owners (enrolled AND past their
-    /// interval AND not freshly claimed). Same statement shape as the
-    /// dreaming picker: concurrent sweepers see disjoint sets. Returns each
-    /// owner alongside the `claimed_at` timestamp just written — the caller's
-    /// ownership token, threaded back into `release_claim`/`mark_ran`/
-    /// `persist_round` so a worker that outlives the stale window can never
-    /// clobber a newer sweeper's claim on the same owner.
+    /// Atomically claim up to `batch` due owners: enrolled AND has a
+    /// non-blank worldview AND (past their interval OR the worldview was
+    /// touched since the last run) AND not freshly claimed. Same statement
+    /// shape as the dreaming picker: concurrent sweepers see disjoint sets.
+    /// A content-identical touch (trigger only bumps `updated_at` on real
+    /// change, see Task 1) still costs at most one extra normal round —
+    /// `mark_ran`/`persist_round` advance `last_run_at` past it, so it
+    /// converges. Returns each owner alongside the `claimed_at` timestamp
+    /// just written — the caller's ownership token, threaded back into
+    /// `release_claim`/`mark_ran`/`persist_round` so a worker that outlives
+    /// the stale window can never clobber a newer sweeper's claim on the
+    /// same owner.
     pub async fn claim_due(
         &self,
         interval: Duration,
@@ -78,7 +83,10 @@ impl<'a> WorldRepo<'a> {
              WHERE owner_uid IN ( \
                  SELECT ws.owner_uid FROM engine.world_states ws \
                  JOIN engine.world_enrollments we USING (owner_uid) \
-                 WHERE (ws.last_run_at IS NULL OR ws.last_run_at < $1) \
+                 JOIN engine.world_worldviews ww USING (owner_uid) \
+                 WHERE btrim(ww.content) <> '' \
+                   AND (ws.last_run_at IS NULL OR ws.last_run_at < $1 \
+                        OR ww.updated_at > ws.last_run_at) \
                    AND (ws.claimed_at IS NULL OR ws.claimed_at < $2) \
                  ORDER BY ws.last_run_at ASC NULLS FIRST \
                  LIMIT $3 \
@@ -165,6 +173,42 @@ impl<'a> WorldRepo<'a> {
         .fetch_optional(self.pool)
         .await?;
         Ok(v.unwrap_or(false))
+    }
+
+    /// The owner's current worldview (trimmed) plus the hash recorded by the
+    /// last completed round. `None` = no usable worldview (absent row or
+    /// blank content): the caller must not run any World System LLM round
+    /// for this owner (spec §1).
+    pub async fn worldview_state(
+        &self,
+        owner_uid: Uuid,
+    ) -> Result<Option<(String, Option<String>)>, sqlx::Error> {
+        let row: Option<(String, Option<String>)> = sqlx::query_as(
+            "SELECT ww.content, ws.worldview_hash \
+             FROM engine.world_worldviews ww \
+             JOIN engine.world_states ws USING (owner_uid) \
+             WHERE ww.owner_uid = $1",
+        )
+        .bind(owner_uid)
+        .fetch_optional(self.pool)
+        .await?;
+        Ok(row.and_then(|(content, hash)| {
+            let trimmed = content.trim().to_string();
+            (!trimmed.is_empty()).then_some((trimmed, hash))
+        }))
+    }
+
+    /// Enrolled owners with no usable worldview — the sweeper's aggregate
+    /// warn counter (spec §3). Worldview-less owners are excluded from every
+    /// claim/candidate query, so this count is the only place they surface.
+    pub async fn count_enrolled_missing_worldview(&self) -> Result<i64, sqlx::Error> {
+        sqlx::query_scalar(
+            "SELECT count(*) FROM engine.world_enrollments we \
+             LEFT JOIN engine.world_worldviews ww USING (owner_uid) \
+             WHERE ww.owner_uid IS NULL OR btrim(ww.content) = ''",
+        )
+        .fetch_one(self.pool)
+        .await
     }
 
     /// The owner's active persona roster (earliest-created first) joined to
@@ -342,6 +386,28 @@ mod tests {
             .execute(pool)
             .await
             .unwrap();
+        set_worldview(pool, owner, "现代都市").await;
+    }
+
+    /// Enrollment WITHOUT a worldview — the skip case (spec §1).
+    async fn enroll_without_worldview(pool: &PgPool, owner: Uuid) {
+        sqlx::query("INSERT INTO engine.world_enrollments (owner_uid) VALUES ($1)")
+            .bind(owner)
+            .execute(pool)
+            .await
+            .unwrap();
+    }
+
+    async fn set_worldview(pool: &PgPool, owner: Uuid, content: &str) {
+        sqlx::query(
+            "INSERT INTO engine.world_worldviews (owner_uid, content) VALUES ($1, $2) \
+             ON CONFLICT (owner_uid) DO UPDATE SET content = EXCLUDED.content",
+        )
+        .bind(owner)
+        .bind(content)
+        .execute(pool)
+        .await
+        .unwrap();
     }
 
     const DAY: Duration = Duration::from_secs(24 * 3600);
@@ -425,6 +491,16 @@ mod tests {
         // Enrolled but ran 1h ago with a 24h interval → not due.
         let recent = Uuid::new_v4();
         enroll(&pool, recent).await;
+        // Pin the worldview BEFORE the last run so this owner tests pure
+        // time-dueness, not the worldview-touch path.
+        sqlx::query(
+            "UPDATE engine.world_worldviews SET updated_at = now() - interval '2 hours' \
+             WHERE owner_uid = $1",
+        )
+        .bind(recent)
+        .execute(&pool)
+        .await
+        .unwrap();
         sqlx::query(
             "INSERT INTO engine.world_states (owner_uid, seed, digests, last_run_at) \
              VALUES ($1, '{}'::jsonb, '{}'::jsonb, now() - interval '1 hour')",
@@ -436,6 +512,108 @@ mod tests {
 
         let claimed = repo.claim_due(DAY, STALE, 5).await.unwrap();
         assert!(claimed.is_empty(), "orphan + not-due must both be skipped");
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn claim_due_skips_enrolled_owner_without_worldview(pool: PgPool) {
+        let repo = WorldRepo { pool: &pool };
+        let owner = Uuid::new_v4();
+        enroll_without_worldview(&pool, owner).await;
+        repo.ensure_states_for_enrollments().await.unwrap();
+
+        assert!(
+            repo.claim_due(DAY, STALE, 5).await.unwrap().is_empty(),
+            "no worldview ⇒ never claimed"
+        );
+        // Blank (whitespace-only) content passes the DDL CHECK but must
+        // still be treated as missing.
+        set_worldview(&pool, owner, "  ").await;
+        assert!(
+            repo.claim_due(DAY, STALE, 5).await.unwrap().is_empty(),
+            "blank worldview ⇒ never claimed"
+        );
+        // Providing one self-heals on the next scan.
+        set_worldview(&pool, owner, "古代仙侠").await;
+        let claimed = repo.claim_due(DAY, STALE, 5).await.unwrap();
+        assert_eq!(claimed.len(), 1);
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn claim_due_treats_worldview_touch_as_due(pool: PgPool) {
+        let repo = WorldRepo { pool: &pool };
+        let owner = Uuid::new_v4();
+        enroll(&pool, owner).await;
+        // Ran 1h ago (24h interval ⇒ not time-due), worldview from before
+        // that run ⇒ not due at all.
+        sqlx::query(
+            "INSERT INTO engine.world_states (owner_uid, seed, digests, last_run_at) \
+             VALUES ($1, '{}'::jsonb, '{}'::jsonb, now() - interval '1 hour')",
+        )
+        .bind(owner)
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "UPDATE engine.world_worldviews SET updated_at = now() - interval '2 hours' \
+             WHERE owner_uid = $1",
+        )
+        .bind(owner)
+        .execute(&pool)
+        .await
+        .unwrap();
+        assert!(repo.claim_due(DAY, STALE, 5).await.unwrap().is_empty());
+
+        // Touch the worldview (trigger bumps updated_at past last_run_at)
+        // ⇒ due ahead of the interval (spec §3: change lands within one tick).
+        set_worldview(&pool, owner, "科幻星际").await;
+        let claimed = repo.claim_due(DAY, STALE, 5).await.unwrap();
+        assert_eq!(
+            claimed.iter().map(|(o, _)| *o).collect::<Vec<_>>(),
+            vec![owner],
+            "worldview touched after last run ⇒ immediately due"
+        );
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn worldview_state_trims_and_carries_hash(pool: PgPool) {
+        let repo = WorldRepo { pool: &pool };
+        let owner = Uuid::new_v4();
+        enroll_without_worldview(&pool, owner).await;
+        repo.ensure_states_for_enrollments().await.unwrap();
+
+        assert!(repo.worldview_state(owner).await.unwrap().is_none());
+        set_worldview(&pool, owner, "  古代宫廷  ").await;
+        let (content, hash) = repo.worldview_state(owner).await.unwrap().unwrap();
+        assert_eq!(content, "古代宫廷", "content is trimmed");
+        assert!(hash.is_none(), "no round yet ⇒ no stored hash");
+
+        sqlx::query("UPDATE engine.world_states SET worldview_hash = 'abc' WHERE owner_uid = $1")
+            .bind(owner)
+            .execute(&pool)
+            .await
+            .unwrap();
+        let (_, hash) = repo.worldview_state(owner).await.unwrap().unwrap();
+        assert_eq!(hash.as_deref(), Some("abc"));
+
+        set_worldview(&pool, owner, "   ").await;
+        assert!(
+            repo.worldview_state(owner).await.unwrap().is_none(),
+            "blank content reads as missing"
+        );
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn count_enrolled_missing_worldview_counts_absent_and_blank(pool: PgPool) {
+        let repo = WorldRepo { pool: &pool };
+        let with = Uuid::new_v4();
+        let without = Uuid::new_v4();
+        let blank = Uuid::new_v4();
+        enroll(&pool, with).await;
+        enroll_without_worldview(&pool, without).await;
+        enroll_without_worldview(&pool, blank).await;
+        set_worldview(&pool, blank, " ").await;
+
+        assert_eq!(repo.count_enrolled_missing_worldview().await.unwrap(), 2);
     }
 
     #[sqlx::test(migrations = "./migrations")]

--- a/crates/eros-engine-store/src/world_town.rs
+++ b/crates/eros-engine-store/src/world_town.rs
@@ -90,6 +90,38 @@ impl<'a> WorldTownRepo<'a> {
         .await
     }
 
+    /// Posts fed to a comment round: same shape as `feed_page` but
+    /// restricted to the current worldview era (posts published at/after
+    /// `world_states.worldview_set_at`). Old-era posts stay user-visible
+    /// history but receive no new AI activity (spec §5). A NULL era (no
+    /// worldview round yet) yields no posts — AI activity waits for the
+    /// first reset round.
+    pub async fn round_posts(
+        &self,
+        owner_uid: Uuid,
+        limit: i64,
+    ) -> Result<Vec<FeedPost>, sqlx::Error> {
+        sqlx::query_as(
+            "SELECT p.id AS post_id, p.instance_id, pg.name AS author_name, \
+                    p.content, p.published_at \
+             FROM engine.world_posts p \
+             JOIN engine.world_enrollments we \
+               ON we.owner_uid = p.owner_uid AND we.town_enabled \
+             JOIN engine.world_states ws ON ws.owner_uid = p.owner_uid \
+             JOIN engine.persona_instances pi ON pi.id = p.instance_id \
+             JOIN engine.persona_genomes pg ON pg.id = pi.genome_id \
+             WHERE p.owner_uid = $1 AND p.published_at IS NOT NULL \
+               AND ws.worldview_set_at IS NOT NULL \
+               AND p.published_at >= ws.worldview_set_at \
+             ORDER BY p.published_at DESC, p.id DESC \
+             LIMIT $2",
+        )
+        .bind(owner_uid)
+        .bind(limit)
+        .fetch_all(self.pool)
+        .await
+    }
+
     /// All comments for a page of posts, thread order (spec §4: threads are
     /// small by construction; no comment pagination in v1).
     pub async fn list_comments_for_posts(
@@ -150,7 +182,9 @@ impl<'a> WorldTownRepo<'a> {
         sqlx::query_scalar(
             "SELECT ws.owner_uid FROM engine.world_states ws \
              JOIN engine.world_enrollments we USING (owner_uid) \
+             JOIN engine.world_worldviews ww USING (owner_uid) \
              WHERE we.town_enabled \
+               AND btrim(ww.content) <> '' \
                AND (ws.last_comment_round_at IS NULL \
                     OR ws.last_comment_round_at < now() - make_interval(secs => $1))",
         )
@@ -267,10 +301,15 @@ impl<'a> WorldTownRepo<'a> {
                    ON we.owner_uid = p.owner_uid AND we.town_enabled \
                  JOIN engine.persona_instances pi \
                    ON pi.id = p.instance_id AND pi.status = 'active' \
+                 JOIN engine.world_states ws ON ws.owner_uid = p.owner_uid \
+                 JOIN engine.world_worldviews ww \
+                   ON ww.owner_uid = p.owner_uid AND btrim(ww.content) <> '' \
                  WHERE p.last_user_comment_at > now() - make_interval(secs => $1) \
                    AND p.last_user_comment_at <= now() - make_interval(secs => $2) \
                    AND (p.last_reply_at IS NULL \
                         OR p.last_reply_at < now() - make_interval(secs => $3)) \
+                   AND ws.worldview_set_at IS NOT NULL \
+                   AND p.published_at >= ws.worldview_set_at \
                    AND NOT EXISTS ( \
                        SELECT 1 FROM engine.world_post_comments a \
                        WHERE a.post_id = p.id AND a.author_instance_id IS NOT NULL \
@@ -361,7 +400,12 @@ impl<'a> WorldTownRepo<'a> {
 mod tests {
     use super::*;
 
-    /// genome + instance + world enrollment (town on) + world_states backfill.
+    const T_WINDOW: Duration = Duration::from_secs(3600);
+    const T_DEBOUNCE: Duration = Duration::from_secs(60);
+    const T_COOLDOWN: Duration = Duration::from_secs(600);
+
+    /// genome + instance + world enrollment (town on) + world_states backfill
+    /// + worldview with an era that started yesterday.
     pub(super) async fn seed_town_owner(pool: &PgPool) -> (Uuid, Uuid) {
         let owner = Uuid::new_v4();
         let genome: Uuid = sqlx::query_scalar(
@@ -388,8 +432,15 @@ mod tests {
         .await
         .unwrap();
         sqlx::query(
-            "INSERT INTO engine.world_states (owner_uid, seed, digests) \
-             VALUES ($1, '{}'::jsonb, '{}'::jsonb)",
+            "INSERT INTO engine.world_states (owner_uid, seed, digests, worldview_set_at) \
+             VALUES ($1, '{}'::jsonb, '{}'::jsonb, now() - interval '1 day')",
+        )
+        .bind(owner)
+        .execute(pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO engine.world_worldviews (owner_uid, content) VALUES ($1, '现代都市')",
         )
         .bind(owner)
         .execute(pool)
@@ -419,6 +470,121 @@ mod tests {
         .fetch_one(pool)
         .await
         .unwrap()
+    }
+
+    #[sqlx::test]
+    async fn town_scans_require_worldview(pool: PgPool) {
+        let (owner, inst) = seed_town_owner(&pool).await;
+        let post = seed_post(&pool, owner, inst, "p", true).await;
+        // Settled user comment: inside the window, past the debounce.
+        sqlx::query(
+            "UPDATE engine.world_posts SET last_user_comment_at = now() - interval '2 minutes' \
+             WHERE id = $1",
+        )
+        .bind(post)
+        .execute(&pool)
+        .await
+        .unwrap();
+        let repo = WorldTownRepo { pool: &pool };
+        let round = Duration::from_secs(3600);
+        assert!(repo
+            .list_round_candidates(round)
+            .await
+            .unwrap()
+            .contains(&owner));
+        assert_eq!(
+            repo.list_reply_candidates(T_WINDOW, T_DEBOUNCE, T_COOLDOWN, 10)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+
+        sqlx::query("DELETE FROM engine.world_worldviews WHERE owner_uid = $1")
+            .bind(owner)
+            .execute(&pool)
+            .await
+            .unwrap();
+        assert!(
+            !repo
+                .list_round_candidates(round)
+                .await
+                .unwrap()
+                .contains(&owner),
+            "no worldview ⇒ no comment rounds"
+        );
+        assert!(
+            repo.list_reply_candidates(T_WINDOW, T_DEBOUNCE, T_COOLDOWN, 10)
+                .await
+                .unwrap()
+                .is_empty(),
+            "no worldview ⇒ no replies"
+        );
+    }
+
+    #[sqlx::test]
+    async fn reply_candidates_and_round_posts_stay_inside_the_era(pool: PgPool) {
+        let (owner, inst) = seed_town_owner(&pool).await; // era started 1 day ago
+                                                          // Pre-era post: published 3 days ago, and its user comment is OLDER
+                                                          // than the new post's — without the era filter, DISTINCT ON
+                                                          // (oldest-first) would pick THIS one, so the assertion below proves
+                                                          // the filter, not tie-breaking luck.
+        let old = seed_post(&pool, owner, inst, "旧纪元贴文", true).await;
+        sqlx::query(
+            "UPDATE engine.world_posts \
+             SET published_at = now() - interval '3 days', \
+                 last_user_comment_at = now() - interval '3 minutes' \
+             WHERE id = $1",
+        )
+        .bind(old)
+        .execute(&pool)
+        .await
+        .unwrap();
+        let fresh = seed_post(&pool, owner, inst, "新纪元贴文", true).await;
+        sqlx::query(
+            "UPDATE engine.world_posts SET last_user_comment_at = now() - interval '2 minutes' \
+             WHERE id = $1",
+        )
+        .bind(fresh)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let repo = WorldTownRepo { pool: &pool };
+        let cands = repo
+            .list_reply_candidates(T_WINDOW, T_DEBOUNCE, T_COOLDOWN, 10)
+            .await
+            .unwrap();
+        assert_eq!(cands.len(), 1);
+        assert_eq!(cands[0].post_id, fresh, "pre-era post gets no AI reply");
+
+        let round_view: Vec<String> = repo
+            .round_posts(owner, 10)
+            .await
+            .unwrap()
+            .iter()
+            .map(|p| p.content.clone())
+            .collect();
+        assert_eq!(round_view, vec!["新纪元贴文".to_string()]);
+        assert_eq!(
+            repo.feed_page(owner, 10, None).await.unwrap().len(),
+            2,
+            "user-facing feed keeps full history"
+        );
+
+        // NULL era (worldview present but no reset round yet) ⇒ AI activity
+        // waits for the first worldview round.
+        sqlx::query("UPDATE engine.world_states SET worldview_set_at = NULL WHERE owner_uid = $1")
+            .bind(owner)
+            .execute(&pool)
+            .await
+            .unwrap();
+        assert!(repo.round_posts(owner, 10).await.unwrap().is_empty());
+        assert!(repo
+            .list_reply_candidates(T_WINDOW, T_DEBOUNCE, T_COOLDOWN, 10)
+            .await
+            .unwrap()
+            .is_empty());
     }
 
     #[sqlx::test]

--- a/crates/eros-engine-store/src/world_town.rs
+++ b/crates/eros-engine-store/src/world_town.rs
@@ -184,7 +184,7 @@ impl<'a> WorldTownRepo<'a> {
              JOIN engine.world_enrollments we USING (owner_uid) \
              JOIN engine.world_worldviews ww USING (owner_uid) \
              WHERE we.town_enabled \
-               AND btrim(ww.content) <> '' \
+               AND btrim(ww.content, E' \\t\\r\\n\\f\\v') <> '' \
                AND (ws.last_comment_round_at IS NULL \
                     OR ws.last_comment_round_at < now() - make_interval(secs => $1))",
         )
@@ -303,7 +303,7 @@ impl<'a> WorldTownRepo<'a> {
                    ON pi.id = p.instance_id AND pi.status = 'active' \
                  JOIN engine.world_states ws ON ws.owner_uid = p.owner_uid \
                  JOIN engine.world_worldviews ww \
-                   ON ww.owner_uid = p.owner_uid AND btrim(ww.content) <> '' \
+                   ON ww.owner_uid = p.owner_uid AND btrim(ww.content, E' \\t\\r\\n\\f\\v') <> '' \
                  WHERE p.last_user_comment_at > now() - make_interval(secs => $1) \
                    AND p.last_user_comment_at <= now() - make_interval(secs => $2) \
                    AND (p.last_reply_at IS NULL \

--- a/crates/eros-engine-store/src/world_town.rs
+++ b/crates/eros-engine-store/src/world_town.rs
@@ -242,8 +242,14 @@ impl<'a> WorldTownRepo<'a> {
 
     /// Insert one hourly-round persona comment with validation folded into
     /// the INSERT (spec §3.2): post belongs to the owner and is published,
-    /// author is one of the owner's ACTIVE instances, and the round path
-    /// never self-replies. `false` = rejected (caller warns + drops).
+    /// author is one of the owner's ACTIVE instances, the round path never
+    /// self-replies, and (P2 fix) the post's era is revalidated at insert
+    /// time — `p.published_at >= ws.worldview_set_at` — so a worldview reset
+    /// that commits while this round's LLM call was in flight can't land
+    /// fresh AI content on a now-pre-era post; `round_posts` already fed the
+    /// round from the era current at fetch time, but the era can move
+    /// between that fetch and this INSERT. `false` = rejected (caller warns
+    /// + drops).
     pub async fn insert_round_comment(
         &self,
         owner_uid: Uuid,
@@ -258,8 +264,11 @@ impl<'a> WorldTownRepo<'a> {
              FROM engine.world_posts p \
              JOIN engine.persona_instances pi \
                ON pi.id = $3 AND pi.owner_uid = p.owner_uid AND pi.status = 'active' \
+             JOIN engine.world_states ws ON ws.owner_uid = p.owner_uid \
              WHERE p.id = $1 AND p.owner_uid = $2 \
-               AND p.published_at IS NOT NULL AND p.instance_id <> $3",
+               AND p.published_at IS NOT NULL AND p.instance_id <> $3 \
+               AND ws.worldview_set_at IS NOT NULL \
+               AND p.published_at >= ws.worldview_set_at",
         )
         .bind(post_id)
         .bind(owner_uid)
@@ -359,25 +368,35 @@ impl<'a> WorldTownRepo<'a> {
         Ok(res.rows_affected() > 0)
     }
 
-    /// Insert the responder's comment (source = 'reply'). Validation already
-    /// happened in `list_reply_candidates` + the cooldown CAS.
+    /// Insert the responder's comment (source = 'reply'). Most validation
+    /// already happened in `list_reply_candidates` + the cooldown CAS, but
+    /// (P2 fix) the era is revalidated here too — `p.published_at >=
+    /// ws.worldview_set_at` — because the candidate scan and this insert
+    /// bracket an LLM call: a worldview reset can commit while that call is
+    /// in flight, and without this guard the reply would land on a post
+    /// that is now pre-era. `false` = rejected (caller warns + drops).
     pub async fn insert_reply_comment(
         &self,
         post_id: Uuid,
         author_instance_id: Uuid,
         content: &str,
-    ) -> Result<(), sqlx::Error> {
-        sqlx::query(
+    ) -> Result<bool, sqlx::Error> {
+        let res = sqlx::query(
             "INSERT INTO engine.world_post_comments \
                  (post_id, author_instance_id, source, content) \
-             VALUES ($1, $2, 'reply', $3)",
+             SELECT p.id, $2, 'reply', $3 \
+             FROM engine.world_posts p \
+             JOIN engine.world_states ws ON ws.owner_uid = p.owner_uid \
+             WHERE p.id = $1 AND p.published_at IS NOT NULL \
+               AND ws.worldview_set_at IS NOT NULL \
+               AND p.published_at >= ws.worldview_set_at",
         )
         .bind(post_id)
         .bind(author_instance_id)
         .bind(content)
         .execute(self.pool)
         .await?;
-        Ok(())
+        Ok(res.rows_affected() > 0)
     }
 
     /// One post with author name, for the reply-responder payload.
@@ -874,7 +893,7 @@ mod tests {
         assert_eq!(cands[0].author_instance_id, inst);
 
         // Persona reply after the user comment clears the candidate.
-        repo.insert_reply_comment(post, inst, "在的").await.unwrap();
+        assert!(repo.insert_reply_comment(post, inst, "在的").await.unwrap());
         assert!(repo
             .list_reply_candidates(window, debounce, cooldown, 10)
             .await
@@ -923,9 +942,10 @@ mod tests {
         // Persona comments (round + reply) must NOT move the stamp.
         repo.insert_round_comment_unchecked_for_test(post, inst, "round", "r")
             .await;
-        repo.insert_reply_comment(post, inst, "reply")
+        assert!(repo
+            .insert_reply_comment(post, inst, "reply")
             .await
-            .unwrap();
+            .unwrap());
         let stamp2: Option<DateTime<Utc>> =
             sqlx::query_scalar("SELECT last_user_comment_at FROM engine.world_posts WHERE id = $1")
                 .bind(post)
@@ -1004,9 +1024,10 @@ mod tests {
         assert_eq!(repo.count_replies_today(owner).await.unwrap(), 0);
         repo.insert_round_comment_unchecked_for_test(post, inst, "round", "round row")
             .await;
-        repo.insert_reply_comment(post, inst, "reply row")
+        assert!(repo
+            .insert_reply_comment(post, inst, "reply row")
             .await
-            .unwrap();
+            .unwrap());
         // User rows never count either.
         repo.insert_user_comment(owner, post, "user row")
             .await
@@ -1221,6 +1242,91 @@ mod tests {
                 .unwrap()
                 .is_empty(),
             "a round comment after the user comment suppresses the reply"
+        );
+    }
+
+    /// The P2 fix: both town insert paths revalidate the era at write time,
+    /// not just at candidate-scan time. Simulates a worldview reset landing
+    /// mid-flight (between the scan that picked this post and the insert
+    /// that follows an LLM call) by moving `worldview_set_at` forward past
+    /// the post's `published_at` in between two otherwise-identical calls.
+    #[sqlx::test]
+    async fn town_inserts_reject_pre_era_posts(pool: PgPool) {
+        let (owner, inst) = seed_town_owner(&pool).await; // era started 1 day ago
+                                                          // A second active persona to author the round comment (the round
+                                                          // path rejects self-replies, so it can't reuse `inst`).
+        let genome: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata) \
+             VALUES ('Rin','p','{}'::jsonb) RETURNING id",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let commenter: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_instances (genome_id, owner_uid) VALUES ($1,$2) RETURNING id",
+        )
+        .bind(genome)
+        .bind(owner)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let post = seed_post(&pool, owner, inst, "hello", true).await;
+        let repo = WorldTownRepo { pool: &pool };
+
+        // Published "now", era started 1 day ago ⇒ inside the era: both
+        // insert paths succeed.
+        assert!(
+            repo.insert_round_comment(owner, post, commenter, "不错")
+                .await
+                .unwrap(),
+            "post inside the era accepts a round comment"
+        );
+        assert!(
+            repo.insert_reply_comment(post, inst, "谢谢").await.unwrap(),
+            "post inside the era accepts a reply"
+        );
+        let before: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM engine.world_post_comments WHERE post_id = $1",
+        )
+        .bind(post)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(before, 2);
+
+        // The era rolls forward past the post's published_at — in
+        // production terms, a worldview reset committed while a
+        // comment/reply LLM call for this post was in flight.
+        sqlx::query("UPDATE engine.world_states SET worldview_set_at = now() WHERE owner_uid = $1")
+            .bind(owner)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        assert!(
+            !repo
+                .insert_round_comment(owner, post, commenter, "迟到的评论")
+                .await
+                .unwrap(),
+            "pre-era post must reject a round comment"
+        );
+        assert!(
+            !repo
+                .insert_reply_comment(post, inst, "迟到的回复")
+                .await
+                .unwrap(),
+            "pre-era post must reject a reply"
+        );
+        let after: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM engine.world_post_comments WHERE post_id = $1",
+        )
+        .bind(post)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            after, before,
+            "rejected inserts must not grow the comment count"
         );
     }
 

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -211,6 +211,12 @@ a config + data decision, not a deploy change:
    `service_role` / owner connection (the engine only reads this table); set
    `town_enabled = true` per owner to also enable the feed.
 
+- `engine.world_worldviews` — per-owner worldview text (1..=10000 chars).
+  Downstream-written, engine-read. The engine ships no default: enrolled
+  owners without a row (or with blank content) get **no** World System LLM
+  activity until one is provided. Updating the content resets that owner's
+  world on the next tick (published town posts are kept as history).
+
 Operational switches, all optional:
 
 | Variable | Effect |

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -226,9 +226,11 @@ Operational switches, all optional:
 | `WORLD_TICK_SECS` | Director sweeper tick (default 300; `0` disables) |
 | `WORLD_TOWN_DISABLED=true` | Town only: no post generation, no town sweeper; memories keep running |
 
-Cost shape: one director call per enrolled owner per `interval_hours`, plus
-(town only) activity-gated hourly comment rounds and per-owner-capped replies.
-A world nobody interacts with costs exactly the director call. Details,
+Cost shape: one director call per enrolled owner **with a usable worldview**
+per `interval_hours`, plus (town only) activity-gated hourly comment rounds
+and per-owner-capped replies. Owners without a worldview (see above) are
+skipped entirely and cost nothing. A world nobody interacts with costs
+exactly the director call. Details,
 data model, and the boot-validation rules are in [World system](world-system.md).
 
 - **Health probe:** `GET /healthz` returns 200 with `{ status: "ok", service, version, timestamp }`. Wire this into your platform's health check.

--- a/docs/superpowers/specs/2026-07-28-world-worldview-design.md
+++ b/docs/superpowers/specs/2026-07-28-world-worldview-design.md
@@ -1,0 +1,289 @@
+# eros-engine — World Worldview (per-owner custom worldview; World System v2)
+
+**Status**: design, pending implementation plan
+**Target release**: `0.9.x` dev track. **Migration: 0039** (one new table + two `world_states` columns).
+**Scope**: let each user supply a custom worldview background (sci-fi, modern,
+ancient, …) as a single free-text document that every World System director
+round must honor — the WM director writes scripts inside it, the Stories
+director simulates persona lives inside it, and Town comments/replies stay in
+voice. The engine ships **no default worldview**: providing one (its own
+default text, or forcing the user to write one) is entirely the downstream's
+job, and an enrolled owner without a worldview gets **no** World System LLM
+activity at all.
+
+Companion specs: `2026-07-21-world-memories-design.md` (v1 base),
+`2026-07-21-world-town-design.md`, `2026-07-23-world-stories-design.md`.
+Worldview is a new **input** to all three layers; it adds no fourth layer and
+no new LLM task.
+
+---
+
+## 0. Motivation & research
+
+Today the world runs worldview-less: the WM director improvises a background
+from persona `art_metadata` alone, so every deployment gets an implicit
+"whatever the model assumes" setting, and users cannot ask for 古代 or 科幻.
+
+Survey of the AI-tavern ecosystem (SillyTavern World Info, NovelAI Lorebook,
+Character Card V2/V3 `character_book`, Agnai, Backyard AI, KoboldAI Lite)
+shows two lineages:
+
+- **Lineage A** — a single `scenario` / world-description text injected
+  unconditionally.
+- **Lineage B** — a lorebook: many keyed entries, keyword-scanned against the
+  recent chat window, injected on demand under a token budget (interchange
+  standard: CCv2 `character_book`).
+
+Lineage B's machinery exists to protect **per-turn chat prompts** from large
+static lore. Our primary consumer is different: the directors are background
+sweeper calls (24 h / 8 h / hourly cadence) with no token pressure, and they
+need the worldview **wholesale**, not keyword-sliced. Chat already receives
+the worldview indirectly through the script fragments the director writes.
+So this design is deliberately Lineage A — one text, whole, into every
+director payload — with the data model shaped so a Lineage B entries table
+can be added later without migration breakage (lorebook A = constant-only
+degenerate form of B).
+
+Sources: docs.sillytavern.app World Info; malfoyslastname/character-card-spec-v2;
+kwaroran/character-card-spec-v3; backyard.ai lorebook docs; docs.novelai.net
+lorebook; agnai memory docs.
+
+---
+
+## 1. Decisions (settled during brainstorm)
+
+- **Single free text, lorebook-reserved.** One `content` text (1..=10 000
+  chars) per owner. Future lorebook = a sibling `world_worldview_entries`
+  table; nothing in this design would migrate.
+- **Downstream-writes-table, engine-reads-only** — the `world_enrollments`
+  pattern, verbatim: `service_role` writes, engine only SELECTs, zero HTTP
+  surface, 0013-style lockdown. Upload UX, default-worldview policy, and
+  content moderation are downstream concerns.
+- **Missing worldview = hard prerequisite, skip loudly.** An enrolled owner
+  without a worldview is excluded from **every** World System LLM task (WM
+  rounds, Stories scans, Town comment/reply rounds). The sweeper logs an
+  aggregate `warn!` per tick while any such owner exists. No LLM call is ever
+  made worldview-less. Rationale: matches the engine's
+  present-but-blank-refuses-to-boot convention for config, and avoids
+  producing scripts that contradict a worldview set five minutes later.
+- **Worldview change = world reset.** The engine hashes the content it used
+  (SHA-256, hex) into `world_states.worldview_hash` each round. Hash mismatch
+  (including `NULL` → first hash) makes the next round an **init-style
+  reset**: fresh seed, no `previous_seed`, no stale `recent_life`, and a
+  same-transaction purge of old-worldview data (see §2 for the exact
+  inventory). Consequence, accepted: **existing worlds reset once** after the
+  upgrade backfill, because their `worldview_hash` is `NULL`.
+- **Reset keeps the Town feed as history.** `world_posts` +
+  `world_post_comments` (including user comments) survive resets as a
+  read-only past; what is purged is `world_memories` fragments and all three
+  Stories tables. To keep eras separate, new AI activity (comment rounds,
+  replies) never targets posts published before the current worldview era
+  (§5).
+- **Worldview feeds WM + Stories + Town, not chat.** All four director-side
+  payloads gain a `worldview` field. The chat prompt is untouched — no new
+  block, byte-identical guarantees preserved; worldview reaches chat only
+  through fragments, as today.
+- **Change takes effect within one tick.** A changed worldview makes the
+  owner immediately due for a WM round (claim condition: interval elapsed OR
+  `worldview.updated_at > last_run_at`), so a new worldview lands in
+  ≤ `WORLD_TICK_SECS` (default 300 s), not up to 24 h.
+- **Zero new config surface.** No env vars, no model-config fields, no HTTP
+  routes, no `openapi.json` drift. `WORLD_DISABLED` / `WORLD_TOWN_DISABLED` /
+  `WORLD_STORIES_DISABLED` and the filter-prompt boot gates are unchanged.
+
+---
+
+## 2. Data model (migration 0039)
+
+```sql
+-- Downstream-managed worldview table. The engine only ever SELECTs it
+-- (over the service_role/owner connection); downstream INSERTs/UPDATEs/
+-- DELETEs rows. The engine ships no default worldview: an enrolled owner
+-- with no row here (or a blank content) receives no World System LLM
+-- activity until downstream provides one.
+CREATE TABLE engine.world_worldviews (
+    owner_uid  UUID PRIMARY KEY,
+    content    TEXT NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT worldview_content_len
+        CHECK (char_length(content) BETWEEN 1 AND 10000)
+);
+
+-- 0013-style lockdown: REVOKE ALL from anon/authenticated; RLS enabled
+-- with no policies (service_role bypasses).
+
+ALTER TABLE engine.world_states
+    ADD COLUMN worldview_hash   TEXT,         -- SHA-256 hex of content used last round
+    ADD COLUMN worldview_set_at TIMESTAMPTZ;  -- start of the current worldview era
+```
+
+Both new `world_states` columns are engine-owned and engine-written; `NULL`
+means "pre-worldview world" and forces a reset on first sight of a worldview.
+
+**Reset inventory** (executed inside the `persist_round` transaction of the
+reset round, scoped to the owner):
+
+| Purged | Kept |
+|---|---|
+| `world_memories` (old-worldview fragments must stop injecting into chat) | `world_enrollments`, `world_worldviews` |
+| `persona_story_insights`, `persona_story_events`, `persona_story_memories` | **published** `world_posts` + their `world_post_comments` (historical feed) |
+| scheduled-but-unpublished `world_posts` (stale-era pipeline, §5) | everything outside the World System (`companion_memories`, affinity, …) |
+| `world_states.seed` / `digests` (replaced by the init round's output) | |
+
+Atomicity: purge + new seed/digests/fragments + `worldview_hash` +
+`worldview_set_at` land in one transaction. Any failure (LLM, parse, embed,
+DB, lost claim) rolls back the whole round — the old world stays intact and
+the next tick retries. This is the existing `persist_round` failure contract,
+extended with the purge statements.
+
+Validation: the DDL `CHECK` blocks oversize/empty at the write site. The
+engine additionally trims on read and treats blank-after-trim as missing
+(defense in depth). No control-character policing: the content enters JSON
+payloads via serde, so serialization is injection-safe by construction
+(unlike `prompt_traits`, which renders into prompt bullets and does police).
+
+---
+
+## 3. Sweeper behavior
+
+**Claim gating.** `claim_due` joins `world_worldviews` and considers an owner
+due when `worldview present AND (interval elapsed OR ww.updated_at >
+ws.last_run_at)`. Owners without a worldview are excluded in SQL — no claim
+churn, no per-owner log spam. No hashing in SQL (would need pgcrypto): the
+timestamp only decides *dueness*; the engine hashes the fetched content
+inside the claimed round, and that comparison against `worldview_hash` is
+what decides *reset vs normal*. A content-identical touch (downstream
+rewrites the same text) therefore costs exactly one extra **normal** round —
+`mark_ran` bumps `last_run_at`, so it converges immediately, and no reset
+fires.
+
+**Aggregate warn.** Each world tick additionally counts enrolled owners with
+no (or blank) worldview and, if `> 0`, logs one
+`warn!("world: {n} enrolled owner(s) have no worldview; skipping")`. Loud,
+non-spammy per owner, self-heals the tick after downstream backfills.
+
+**Reset round assembly.** When the claimed round sees a hash mismatch:
+
+- header: the existing **init** variant（「初始化这个世界…」）, even though a
+  previous seed exists;
+- payload: no `previous_seed`, no `recent_life` (old-world evidence);
+  `recent_user_memories` **is** kept — user-profile facts are real-world,
+  worldview-independent;
+- persist: reset inventory (§2) + fresh seed/digests/fragments + new
+  `worldview_hash` + `worldview_set_at = now()`.
+
+A normal (hash-matching) round changes nothing relative to today except the
+added `worldview` payload field.
+
+**Stories & Town gating.** The Stories scan (phase 2 of the world tick) and
+the Town sweeper's comment-round and reply-candidate queries all join
+`world_worldviews` and skip worldview-less owners. Ordering note: on a reset
+tick, the WM round purges Stories data first (phase 1 transaction), then the
+phase-2 Stories scan re-derives insights already under the new worldview.
+
+**Concurrency.** The hash stored by `persist_round` is the hash of the
+content actually used to assemble the payload. If downstream updates the
+worldview mid-round, the next tick sees a fresh mismatch and resets again —
+benign, converges. Lost-claim semantics unchanged (`RowNotFound`, no commit).
+
+---
+
+## 4. Payload & rules changes (four LLM tasks, chat untouched)
+
+- **WM director** — `director_user_payload` gains a top-level
+  `"worldview": "<content>"` as the **first** field (it frames everything
+  after it). `WORLD_DIRECTOR_RULES` gains one always-on rule:
+  「一切设定（时代、科技、地点、职业、事件）必须符合 worldview 描述的世界观，
+  不得引入与其冲突的元素。」 The conditional rule constants
+  (`WORLD_TOWN_POST_RULES`, `WORLD_STORIES_WM_RULES`) are renumbered to
+  follow it.
+- **Stories director** — payload gains `worldview`;
+  `STORY_DIRECTOR_RULES` gains one rule: 生活推演（职业、居所、日常事件）必须
+  发生在 worldview 设定的世界内. The 25-field
+  `PERSONA_STORY_INSIGHTS_SCHEMA` is **unchanged** — the field list is the
+  engine's contract; worldview steers content, never the list.
+- **Town comment & reply** — both payloads gain `worldview`;
+  `WORLD_COMMENT_RULES` and the reply header each gain one line: 评论/回复的
+  语气与内容须符合 worldview（不得出现与世界观冲突的时代元素）.
+- **Chat prompt** — zero change. `[world_memories]` / `[world_stories]`
+  blocks, ordering, and empty-context byte-identical guarantees are all
+  untouched.
+
+---
+
+## 5. Town history isolation
+
+Because resets keep the feed, a mixed-era feed exists by design. What must
+not happen is **new** AI activity on old-era posts (a sci-fi persona
+commenting on an 古代 post). Rule: comment rounds and reply candidacy only
+consider posts with `published_at >= world_states.worldview_set_at`. The
+feed GET serves full history unchanged. One asymmetry: posts scheduled by a
+pre-reset director round but **not yet published** carry old-worldview
+content that would otherwise surface *after* the reset, so the reset purge
+deletes unpublished rows while keeping published ones. Published = history;
+unpublished = pipeline, and the pipeline must not leak a stale era.
+
+---
+
+## 6. Upgrade path
+
+1. Deploy migration 0039 + new binary. From the first tick, every enrolled
+   owner lacking a worldview is skipped (aggregate warn fires). **World
+   System activity pauses deployment-wide until backfill** — this is the
+   designed force-function, not an accident.
+2. Downstream backfills `world_worldviews` (its own default text, or
+   user-collected input) — one INSERT per owner.
+3. Next tick: each backfilled owner is immediately due (hash `NULL` ≠ new
+   hash) → one-time init-style reset per owner, staggered only by claim
+   concurrency. Old published Town posts remain as history; fragments and
+   Stories data re-derive under the new worldview.
+
+Downstream contract addition (docs): `world_worldviews` joins
+`world_enrollments` in the "downstream-managed tables" list. Flipping
+`town_enabled` / `stories_enabled` flags keeps its existing semantics
+(stop simulation, keep data) — unrelated to worldview.
+
+---
+
+## 7. Testing
+
+- **Store**: `claim_due` excludes missing/blank-worldview owners;
+  `ww.updated_at > ws.last_run_at` makes an owner due ahead of interval;
+  engine-side hash mismatch (incl. `NULL`) marks the round as reset while a
+  content-identical touch yields a normal round; `persist_round` reset
+  path purges exactly the §2 inventory + stamps hash/set_at atomically;
+  induced failure rolls back purge and stamps together (old world intact);
+  unpublished-post purge vs published-post retention; aggregate count query.
+- **Pipeline**: all four payloads carry `worldview`; reset round uses the
+  init header and omits `previous_seed`/`recent_life` while keeping
+  `recent_user_memories`; rule-constant renumbering locked by snapshot
+  tests.
+- **Town**: comment/reply candidate queries exclude posts with
+  `published_at < worldview_set_at`.
+- **Chat**: existing byte-identical prompt suite runs unchanged (no chat
+  edits in this design — the suite is the proof).
+
+---
+
+## 8. Docs
+
+- `docs/world-system.md` + `docs/world-system.zh.md` (new sections in 简体中文
+  per current convention): a "Worldview" section — data contract, missing =
+  skip + warn, change = reset (feed kept), and the explicit statement:
+  **the engine ships no default worldview; downstream must provide one**
+  (its own default, or by forcing user input).
+- `docs/deploying.md`: add `world_worldviews` to the downstream-written
+  tables.
+
+---
+
+## 9. Out of scope
+
+- Lorebook entries (keys / constant / budget / recursion / CCv2 import) —
+  reserved via the sibling-table shape, not built.
+- Worldview in the chat system prompt — chat inherits it via fragments only.
+- Any engine-owned upload/read HTTP API for worldviews.
+- Per-persona or per-session worldviews — the worldview is per-owner, same
+  granularity as the world itself.
+- Fixing the pre-existing `docs/model-config.md` gap (world task sections
+  undocumented there) — noted, separate chore.

--- a/docs/superpowers/specs/2026-07-28-world-worldview-design.md
+++ b/docs/superpowers/specs/2026-07-28-world-worldview-design.md
@@ -183,8 +183,21 @@ phase-2 Stories scan re-derives insights already under the new worldview.
 
 **Concurrency.** The hash stored by `persist_round` is the hash of the
 content actually used to assemble the payload. If downstream updates the
-worldview mid-round, the next tick sees a fresh mismatch and resets again —
-benign, converges. Lost-claim semantics unchanged (`RowNotFound`, no commit).
+worldview mid-round, a naive commit would land output generated from the old
+content while stamping `last_run_at = now()` — which lands *after* the new
+row's `updated_at`, so the touch-dueness condition (`ww.updated_at >
+ws.last_run_at`) would never fire and the change would sit unprocessed for up
+to a full `interval_hours`. `persist_round` closes this instead of tolerating
+it: before doing any purge/insert work, it re-checks — `FOR SHARE`, inside the
+same transaction — that the worldview row's `updated_at` still matches the
+value read at round start. A mismatch (content changed, or the row vanished)
+aborts the round (`RowNotFound`, no commit) without touching `last_run_at`, so
+the owner re-claims on the very next tick and the retried round picks up the
+fresh content. `FOR SHARE` also closes the race window itself: it blocks a
+concurrent downstream `UPDATE` on that row from committing until the round's
+transaction ends, so there is no gap between the check and the commit for a
+change to sneak through. Lost-claim semantics unchanged (`RowNotFound`, no
+commit).
 
 ---
 
@@ -224,7 +237,12 @@ feed GET serves full history unchanged. One asymmetry: posts scheduled by a
 pre-reset director round but **not yet published** carry old-worldview
 content that would otherwise surface *after* the reset, so the reset purge
 deletes unpublished rows while keeping published ones. Published = history;
-unpublished = pipeline, and the pipeline must not leak a stale era.
+unpublished = pipeline, and the pipeline must not leak a stale era. The same
+race exists at smaller scale within a single round: a reset can commit while
+a comment/reply LLM call for an in-era post is still in flight. To close it,
+`insert_round_comment` and `insert_reply_comment` both revalidate the era at
+write time (not just at candidate-scan time), so a reset committing mid-flight
+cannot land AI activity on a post that is now pre-era.
 
 ---
 

--- a/docs/superpowers/specs/2026-07-28-world-worldview-design.md
+++ b/docs/superpowers/specs/2026-07-28-world-worldview-design.md
@@ -191,8 +191,11 @@ benign, converges. Lost-claim semantics unchanged (`RowNotFound`, no commit).
 ## 4. Payload & rules changes (four LLM tasks, chat untouched)
 
 - **WM director** — `director_user_payload` gains a top-level
-  `"worldview": "<content>"` as the **first** field (it frames everything
-  after it). `WORLD_DIRECTOR_RULES` gains one always-on rule:
+  `"worldview": "<content>"` field (serialization order is serde-determined —
+  the workspace's `serde_json` has no `preserve_order` feature, so keys
+  serialize alphabetically here; the framing intent is carried by the
+  always-on worldview rule below, not by field position).
+  `WORLD_DIRECTOR_RULES` gains one always-on rule:
   「一切设定（时代、科技、地点、职业、事件）必须符合 worldview 描述的世界观，
   不得引入与其冲突的元素。」 The conditional rule constants
   (`WORLD_TOWN_POST_RULES`, `WORLD_STORIES_WM_RULES`) are renumbered to

--- a/docs/world-system.md
+++ b/docs/world-system.md
@@ -59,6 +59,38 @@ World Town additionally needs **all** of:
    individually optional — a missing section disables just that path).
 6. `WORLD_TOWN_DISABLED` is not set.
 
+## Worldview
+
+Every world runs inside a per-owner **worldview** — a free-text setting
+document (sci-fi, modern, ancient, …) stored in `engine.world_worldviews`
+(`owner_uid` PK, `content` 1..=10000 chars, `updated_at`). Like
+`world_enrollments`, the table is **downstream-managed**: the engine only
+ever SELECTs it; downstream INSERTs/UPDATEs/DELETEs rows over the
+service_role/owner connection. **The engine ships no default worldview** —
+providing one (a deployment default, or forcing the user to write their own)
+is entirely the downstream's job.
+
+Semantics:
+
+- **Missing/blank worldview = no World System LLM activity.** An enrolled
+  owner without a usable worldview is excluded from WM director rounds,
+  story rounds, and town comment/reply scans; the world sweeper logs one
+  aggregate warn per tick while any such owner exists. Backfilling the
+  table self-heals on the next tick.
+- **Change = reset.** The engine stores the SHA-256 of the content each
+  round (`world_states.worldview_hash`). A changed worldview makes the
+  owner due within one tick and turns the next round into an init-style
+  reset: fresh seed, purged script fragments, purged story data
+  (insights/events/memories), purged *unpublished* posts. Published posts
+  and their comments are kept as read-only feed history, but AI activity
+  (comment rounds, replies) only ever targets posts published after the
+  current era start (`world_states.worldview_set_at`).
+- **Payloads.** The WM director, stories director, and town comment/reply
+  payloads all carry the worldview verbatim plus a fixed rule binding all
+  settings (era, technology, places, occupations, events) to it. The chat
+  prompt is unchanged — chat inherits the worldview through script
+  fragments only.
+
 ## World Memories
 
 ### The director round

--- a/docs/world-system.md
+++ b/docs/world-system.md
@@ -332,7 +332,8 @@ while its feature is switched off.
 | Table | Written by | Holds |
 |-------|-----------|-------|
 | `engine.world_enrollments` | downstream | opt-in rows + `town_enabled` + `stories_enabled` flags |
-| `engine.world_states` | engine | seed, digests, director + comment-round scheduling state |
+| `engine.world_worldviews` | downstream | per-owner worldview text (`owner_uid` PK, `content` 1..=10000 chars, `updated_at`) |
+| `engine.world_states` | engine | seed, digests, director + comment-round scheduling state, `worldview_hash` (SHA-256 of the content used last round) + `worldview_set_at` (current era start, gates Town AI activity) |
 | `engine.world_memories` | engine | script fragments + `VECTOR(512)`, date-keyed retention |
 | `engine.world_posts` | engine | scheduled/published posts, reply-cooldown + last-user-comment stamps |
 | `engine.world_post_comments` | engine + user route | threads; `author_instance_id IS NULL` = the user |
@@ -342,7 +343,7 @@ while its feature is switched off.
 
 `stories_enabled` (migration 0038) is downstream-written on the same
 `world_enrollments` row as `town_enabled` — identical opt-in contract. All
-eight tables get the 0013 lockdown treatment (REVOKE from Supabase browser
+nine tables get the 0013 lockdown treatment (REVOKE from Supabase browser
 roles + policy-less RLS). Unenrolling (or flipping a flag off) stops
 simulation and injection immediately but keeps accumulated data —
 re-enrolling resumes the same world/life.
@@ -355,10 +356,13 @@ the shared world sentinel user `11111111-1111-1111-1111-111111111112`;
 `11111111-1111-1111-1111-111111111113` (dreaming = `…111`, world = `…112`,
 stories = `…113` — per-subsystem spend attribution; see
 [LLM / OpenRouter audit](llm-audit.md)). Steady-state cost per enrolled owner
-per day is bounded by: 1 director call + at most `24h/round_secs` comment
-rounds (only those with activity) + at most `daily_cap` replies + up to
-`24h/interval_hours` story calls per **actively-chatted** instance — and a
-world nobody touches still costs exactly one director call.
+**with a worldview** per day is bounded by: 1 director call + at most
+`24h/round_secs` comment rounds (only those with activity) + at most
+`daily_cap` replies + up to `24h/interval_hours` story calls per
+**actively-chatted** instance — and a world nobody touches still costs
+exactly one director call. An enrolled owner **without** a usable worldview
+costs zero LLM calls — excluded entirely from WM director rounds, story
+rounds, and town scans until downstream backfills `engine.world_worldviews`.
 
 ## Current limits
 

--- a/docs/world-system.md
+++ b/docs/world-system.md
@@ -381,3 +381,4 @@ Design documents (decision history and full edge-case tables):
 - [`docs/superpowers/specs/2026-07-21-world-memories-design.md`](superpowers/specs/2026-07-21-world-memories-design.md)
 - [`docs/superpowers/specs/2026-07-21-world-town-design.md`](superpowers/specs/2026-07-21-world-town-design.md)
 - [`docs/superpowers/specs/2026-07-23-world-stories-design.md`](superpowers/specs/2026-07-23-world-stories-design.md)
+- [`docs/superpowers/specs/2026-07-28-world-worldview-design.md`](superpowers/specs/2026-07-28-world-worldview-design.md)

--- a/docs/world-system.zh.md
+++ b/docs/world-system.zh.md
@@ -336,3 +336,4 @@ WM director 回合、故事回合、小镇扫描之外，直到下游回填
 - [`docs/superpowers/specs/2026-07-21-world-memories-design.md`](superpowers/specs/2026-07-21-world-memories-design.md)
 - [`docs/superpowers/specs/2026-07-21-world-town-design.md`](superpowers/specs/2026-07-21-world-town-design.md)
 - [`docs/superpowers/specs/2026-07-23-world-stories-design.md`](superpowers/specs/2026-07-23-world-stories-design.md)
+- [`docs/superpowers/specs/2026-07-28-world-worldview-design.md`](superpowers/specs/2026-07-28-world-worldview-design.md)

--- a/docs/world-system.zh.md
+++ b/docs/world-system.zh.md
@@ -48,6 +48,32 @@ World Town 额外需要**全部**满足：
    独立可选——缺哪个 section 就只关哪条路径）。
 6. 未设置 `WORLD_TOWN_DISABLED`。
 
+## 世界观（Worldview）
+
+每个世界都运行在一份 per-owner 的**世界观**里——一段自由文本的背景设定
+（科幻、现代、古代……），存放于 `engine.world_worldviews`（`owner_uid`
+主键，`content` 1..=10000 字符，`updated_at`）。与 `world_enrollments`
+一样，这张表**由下游管理**：引擎只做 SELECT；下游通过 service_role/owner
+连接执行 INSERT/UPDATE/DELETE。**引擎不内置任何默认世界观**——提供默认
+文本、或强制用户填写，完全是下游的职责。
+
+语义：
+
+- **缺失/空白世界观 = 世界系统零 LLM 活动。** 已入世但没有可用世界观的
+  用户，会被 WM director、故事轮、小镇评论/回复扫描全部排除；只要存在
+  这样的用户，world sweeper 每个 tick 记录一条聚合 warn。回填表数据后
+  下一个 tick 即自愈。
+- **变更 = 重置。** 引擎每轮记录内容的 SHA-256（`world_states.
+  worldview_hash`）。世界观变更会让该用户在一个 tick 内到期，并把下一轮
+  变成 init 式重置：seed 重新推演，剧本片段、故事数据（insights/events/
+  memories）、**未发布**贴文全部清除。已发布贴文及其评论保留为只读历史，
+  但 AI 活动（评论轮、回复）只会作用于当前纪元起点（`world_states.
+  worldview_set_at`）之后发布的贴文。
+- **Payload。** WM director、故事 director、小镇评论/回复的 payload 都
+  原样携带世界观全文，并附一条固定规则：一切设定（时代、科技、地点、
+  职业、事件）必须与之相符。聊天 prompt 不变——世界观只通过剧本片段
+  间接进入聊天。
+
 ## World Memories
 
 ### 导演回合

--- a/docs/world-system.zh.md
+++ b/docs/world-system.zh.md
@@ -292,7 +292,8 @@ context_days = 7            # 每轮喂给导演的聊天/亲密度证据窗口
 | 表 | 写入方 | 内容 |
 |----|--------|------|
 | `engine.world_enrollments` | 下游 | 注册行 + `town_enabled` + `stories_enabled` 开关 |
-| `engine.world_states` | 引擎 | 种子、摘要、导演 + 评论轮调度状态 |
+| `engine.world_worldviews` | 下游 | per-owner 世界观文本（`owner_uid` 主键，`content` 1..=10000 字符，`updated_at`） |
+| `engine.world_states` | 引擎 | 种子、摘要、导演 + 评论轮调度状态，`worldview_hash`（上一轮所用内容的 SHA-256）+ `worldview_set_at`（当前纪元起点，决定 Town AI 活动的作用范围） |
 | `engine.world_memories` | 引擎 | 剧本片段 + `VECTOR(512)`，按日期保留 |
 | `engine.world_posts` | 引擎 | 定时/已发布贴文、回复冷却戳 + 最新用户留言戳 |
 | `engine.world_post_comments` | 引擎 + 用户路由 | 评论串；`author_instance_id IS NULL` = 用户本人 |
@@ -301,7 +302,7 @@ context_days = 7            # 每轮喂给导演的聊天/亲密度证据窗口
 | `engine.persona_story_memories` | 引擎 | 事件的 1:1 嵌入镜像（`event_id` 外键）+ `VECTOR(512)`，按日期保留 |
 
 `stories_enabled`（migration 0038）与 `town_enabled` 写在同一张
-`world_enrollments` 行上，下游写入，同一套开关约定。八张表都套用 0013 锁定
+`world_enrollments` 行上，下游写入，同一套开关约定。九张表都套用 0013 锁定
 （对 Supabase 浏览器角色 REVOKE + 无策略 RLS）。取消注册（或关掉某个开关）
 立即停止模拟与注入，但保留已积累的数据——重新注册会续上同一个世界/人生。
 
@@ -311,10 +312,13 @@ World Memories / Town 三个任务都以共享的世界哨兵用户
 `11111111-1111-1111-1111-111111111112` 把 token 用量记为 tracing 字段；
 `world_stories_director` 用自己的哨兵 `11111111-1111-1111-1111-111111111113`
 （dreaming = `…111`、world = `…112`、stories = `…113`——按子系统分摊花费；见
-[LLM / OpenRouter 审计](llm-audit.zh.md)）。稳态下每个注册 owner 每天的成本
-上界是：1 次导演调用 + 至多 `24h/round_secs` 次评论轮（且只有有活动的那些）
-+ 至多 `daily_cap` 条回复 + 每个**近期有聊天的**instance 至多
-`24h/interval_hours` 次故事回合——没人碰的世界依然恰好只花一次导演调用。
+[LLM / OpenRouter 审计](llm-audit.zh.md)）。稳态下每个**已配置世界观**的
+注册 owner 每天的成本上界是：1 次导演调用 + 至多 `24h/round_secs` 次评论轮
+（且只有有活动的那些）+ 至多 `daily_cap` 条回复 + 每个**近期有聊天的**
+instance 至多 `24h/interval_hours` 次故事回合——没人碰的世界依然恰好只花
+一次导演调用。没有可用世界观的注册 owner 则零 LLM 成本——被完全排除在
+WM director 回合、故事回合、小镇扫描之外，直到下游回填
+`engine.world_worldviews`。
 
 ## 当前限制
 


### PR DESCRIPTION
## Summary

Adds a per-owner **worldview** (自定义世界观) to World System v2, per the committed spec `docs/superpowers/specs/2026-07-28-world-worldview-design.md`:

- **New table `engine.world_worldviews`** (migration 0039): downstream-written / engine-read (world_enrollments pattern, 0013-style lockdown), `content` 1..=10000 chars, content-change-only `updated_at` trigger. **The engine ships no default worldview** — providing one is the downstream's job.
- **Missing/blank worldview = hard prerequisite**: WM rounds, Stories scans, and Town comment/reply scans all skip that owner in SQL; one aggregate `warn!` per tick while any such owner exists.
- **Worldview change = init-style world reset**: SHA-256 recorded in `world_states.worldview_hash`; mismatch (incl. `NULL` legacy worlds) makes the owner due within one tick and the round re-inits — same-transaction purge of script fragments, Stories tables, and unpublished posts; **published posts + comments are kept as feed history**; `worldview_set_at` stamps the era and Town AI activity never targets pre-era posts (user-facing feed unchanged).
- **All four director payloads** (WM / Stories / Town comment / Town reply) carry the worldview verbatim plus one fixed rule each (WM rules renumbered 5/6/7). **Chat prompt path untouched** — byte-identical guarantees preserved.
- Zero new env vars / model-config fields / HTTP routes; `openapi.json` has no drift.
- Docs: new Worldview sections in `world-system.md` / `.zh.md`, downstream contract in `deploying.md`, adjacent cost/data-model sections reconciled.

## Test plan

- Full workspace suite green: 961 passed / 0 failed (`cargo test --workspace`), fmt clean, clippy `-D warnings` clean, openapi drift check empty.
- New coverage: claim gating (absent/blank/self-heal), worldview-touch dueness, SQL↔Rust blank-definition agreement (incl. `"\n"` and U+3000), reset purge inventory + lost-claim rollback, reset round init-assembly (suppresses `recent_life`, mutation-tested), era filters (adversarially constructed DISTINCT ON case), payload/rule snapshot locks for all four tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)