### PR TITLE
feat: filter_prompt variants + raw escape for the image-prompt composer

### DIFF
--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -1698,13 +1698,20 @@ impl ModelConfig {
             .filter_prompt
             .as_ref()
             .and_then(|s| s.select(variant));
-        if selected.is_none() && variant.is_some() && task_cfg.filter_prompt.is_some() {
-            tracing::warn!(
+        // The warn/debug decision is a pure function of (selected, variant,
+        // has a filter_prompt at all) — pulled out of the tracing call so it
+        // can be unit-tested directly, without a tracing subscriber, and so a
+        // refactor that accidentally drops a guard shows up as a plain
+        // assertion failure instead of only a missing log line.
+        match compose_variant_log_event(selected, variant, task_cfg.filter_prompt.is_some()) {
+            Some(ComposeVariantLogEvent::Mismatch) => tracing::warn!(
                 variant = %variant.unwrap_or_default(),
                 "image-compose: variant not found; using the built-in prompt"
-            );
-        } else if selected.is_some() && variant.is_some() {
-            tracing::debug!(variant = %variant.unwrap_or_default(), "image-compose: variant selected");
+            ),
+            Some(ComposeVariantLogEvent::Selected) => {
+                tracing::debug!(variant = %variant.unwrap_or_default(), "image-compose: variant selected")
+            }
+            None => {}
         }
         // `trim`/`is_empty` is what makes a blank PLAIN filter_prompt fall
         // through to the built-in prompt. Redundant for the variant shapes
@@ -1735,6 +1742,40 @@ impl ModelConfig {
 fn dedup_keep_first(v: &mut Vec<String>) {
     let mut seen = std::collections::HashSet::new();
     v.retain(|s| seen.insert(s.clone()));
+}
+
+/// What (if anything) `resolve_image_prompt_compose` should log about a
+/// variant lookup. A `warn` on every miss would fire on the common
+/// no-`prompt_variant`-supplied turn, which is silent by design — only an
+/// explicitly-supplied variant that failed to match is worth surfacing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ComposeVariantLogEvent {
+    /// The caller supplied a variant, a `filter_prompt` container exists, and
+    /// nothing matched — falling back to the built-in prompt is surprising
+    /// enough to warn about.
+    Mismatch,
+    /// The caller supplied a variant and something was selected for it
+    /// (worth a breadcrumb at `debug`, not louder).
+    Selected,
+}
+
+/// Pure decision behind the warn/debug logging in
+/// `resolve_image_prompt_compose`, split out so the guard conditions are
+/// unit-testable without a `tracing` subscriber: a refactor that drops the
+/// `variant.is_some()` or `has_filter_prompt` guard changes this function's
+/// return value directly, instead of only silently changing log output.
+fn compose_variant_log_event(
+    selected: Option<&str>,
+    variant: Option<&str>,
+    has_filter_prompt: bool,
+) -> Option<ComposeVariantLogEvent> {
+    if selected.is_none() && variant.is_some() && has_filter_prompt {
+        Some(ComposeVariantLogEvent::Mismatch)
+    } else if selected.is_some() && variant.is_some() {
+        Some(ComposeVariantLogEvent::Selected)
+    } else {
+        None
+    }
 }
 
 /// Build the per-turn image model chain. Returns `None` ⇒ no model anywhere ⇒
@@ -5235,7 +5276,13 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
     }
 
     #[test]
-    fn raw_on_an_absent_compose_task_is_still_none() {
+    fn raw_returns_none_whether_or_not_the_composer_is_configured() {
+        // NOTE: this does NOT pin the "raw check precedes the task lookup"
+        // ordering — `self.tasks.get(COMPOSE_TASK)?` early-returns `None` for
+        // an absent task regardless of which check runs first, so this test
+        // passes under both orderings. It only pins that `raw` still yields
+        // `None` (composer does not run) when the task block is absent, same
+        // as when it's present — a real behavior, just not evidence of order.
         let c = cfg("[tasks.chat_companion]\nmodel = \"m\"\n");
         assert!(c.resolve_image_prompt_compose(Some("raw")).is_none());
         assert!(c.resolve_image_prompt_compose(None).is_none());
@@ -5251,5 +5298,50 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
                 .compose_prompt,
             DEFAULT_COMPOSE_PROMPT
         );
+    }
+
+    #[test]
+    fn raw_variant_is_trimmed_before_the_raw_comparison() {
+        // Pins that the incoming variant is trimmed BEFORE the "raw" match,
+        // not after: `filter_prompt` is a non-blank Plain string here, so if
+        // trimming happened later (or not at all), " raw \n" would fail the
+        // exact `eq_ignore_ascii_case("raw")` comparison, fall through to
+        // normal selection, and this would resolve to `Some(..)` with
+        // compose_prompt = "custom" instead of `None`.
+        let c =
+            cfg("[tasks.chat_image_prompt_compose]\nmodel = \"m\"\nfilter_prompt = \"custom\"\n");
+        assert!(c.resolve_image_prompt_compose(Some(" raw \n")).is_none());
+    }
+
+    // ─── compose_variant_log_event: the warn/debug guards, pinned directly ──
+    // (no tracing subscriber needed — the decision is a pure function)
+
+    #[test]
+    fn compose_variant_log_event_warns_only_on_an_explicit_unmatched_variant() {
+        // The common case: no prompt_variant was supplied at all. Falling
+        // back to the built-in prompt is silent — nothing was asked for, so
+        // nothing failed to be found.
+        assert_eq!(compose_variant_log_event(None, None, true), None);
+        // A container exists but no filter_prompt at all was configured —
+        // can't happen via the public resolver (selected implies a
+        // filter_prompt), but the guard must not fire even so.
+        assert_eq!(compose_variant_log_event(None, Some("z"), false), None);
+        // The one case that DOES warn: a variant was supplied, a
+        // filter_prompt container exists, and nothing matched.
+        assert_eq!(
+            compose_variant_log_event(None, Some("z"), true),
+            Some(ComposeVariantLogEvent::Mismatch)
+        );
+    }
+
+    #[test]
+    fn compose_variant_log_event_debug_only_when_a_variant_was_supplied_and_matched() {
+        assert_eq!(
+            compose_variant_log_event(Some("AAA"), Some("0"), true),
+            Some(ComposeVariantLogEvent::Selected)
+        );
+        // No variant supplied ⇒ nothing to report, even though `selected` is
+        // `Some` (e.g. a Plain filter_prompt, which always resolves).
+        assert_eq!(compose_variant_log_event(Some("AAA"), None, true), None);
     }
 }

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -187,6 +187,16 @@ impl PromptSpec {
     }
 }
 
+/// A task/tier `filter_prompt` as a plain string, or `""`. This is the shape
+/// every non-composer `resolve_*` expects. A variant shape reads as `""`
+/// (i.e. "unset"), so those tasks degrade to "feature off" rather than
+/// misbehaving — a branch `validate_prompt_variants` makes unreachable at boot.
+fn plain_or_empty(spec: Option<&PromptSpec>) -> String {
+    spec.and_then(PromptSpec::as_plain)
+        .unwrap_or_default()
+        .to_string()
+}
+
 /// Client-facing model-name display override (chat `meta.model`). Four TOML
 /// shapes, unambiguous to serde: `false`/`true` (bool), `"name"` (string),
 /// `["a","b"]` (array → random per emit), or `{ "id" = "name", default =
@@ -401,7 +411,7 @@ pub struct TierConfig {
     #[serde(default)]
     pub output_filter: Option<bool>,
     #[serde(default)]
-    pub filter_prompt: Option<String>,
+    pub filter_prompt: Option<PromptSpec>,
     #[serde(default)]
     pub trigger: Option<OutputFilterTrigger>,
     #[serde(default)]
@@ -572,7 +582,7 @@ pub struct TaskConfig {
     /// rewrite is passed as a SEPARATE user message — this is NOT a template
     /// with placeholder substitution.
     #[serde(default)]
-    pub filter_prompt: Option<String>,
+    pub filter_prompt: Option<PromptSpec>,
     #[serde(default)]
     pub trigger: Option<OutputFilterTrigger>,
     #[serde(default)]
@@ -1307,9 +1317,16 @@ impl ModelConfig {
 
         // filter_prompt / trigger / timing: tier → default block.
         let filter_prompt = tier_cfg
-            .and_then(|t| t.filter_prompt.clone())
-            .or_else(|| task_cfg.filter_prompt.clone())
-            .unwrap_or_default();
+            .and_then(|t| t.filter_prompt.as_ref())
+            .and_then(PromptSpec::as_plain)
+            .or_else(|| {
+                task_cfg
+                    .filter_prompt
+                    .as_ref()
+                    .and_then(PromptSpec::as_plain)
+            })
+            .unwrap_or_default()
+            .to_string();
         if filter_prompt.trim().is_empty() {
             return None; // no usable instruction ⇒ inert
         }
@@ -1381,7 +1398,7 @@ impl ModelConfig {
             return None;
         }
         let task_cfg = self.tasks.get(FILTER_TASK)?;
-        let filter_prompt = task_cfg.filter_prompt.clone().unwrap_or_default();
+        let filter_prompt = plain_or_empty(task_cfg.filter_prompt.as_ref());
         if filter_prompt.trim().is_empty() {
             return None;
         }
@@ -1409,7 +1426,7 @@ impl ModelConfig {
     pub fn resolve_vision(&self) -> Option<ResolvedVision> {
         const VISION_TASK: &str = "chat_vision";
         let task_cfg = self.tasks.get(VISION_TASK)?;
-        let describe_prompt = task_cfg.filter_prompt.clone().unwrap_or_default();
+        let describe_prompt = plain_or_empty(task_cfg.filter_prompt.as_ref());
         if describe_prompt.trim().is_empty() {
             return None;
         }
@@ -1444,7 +1461,9 @@ impl ModelConfig {
         let audio_tags = task_cfg.tts_audio_tags.unwrap_or(false);
         let custom = task_cfg
             .filter_prompt
-            .clone()
+            .as_ref()
+            .and_then(PromptSpec::as_plain)
+            .map(str::to_string)
             .filter(|s| !s.trim().is_empty());
         let directive = match (custom, audio_tags) {
             (Some(c), true) => format!("{c}\n\n{AUDIO_TAGS_ADDENDUM}"),
@@ -1489,7 +1508,7 @@ impl ModelConfig {
     pub fn resolve_pde(&self) -> Option<ResolvedPde> {
         const PDE_TASK: &str = "pde_decision";
         let task_cfg = self.tasks.get(PDE_TASK)?;
-        let decision_prompt = task_cfg.filter_prompt.clone().unwrap_or_default();
+        let decision_prompt = plain_or_empty(task_cfg.filter_prompt.as_ref());
         if decision_prompt.trim().is_empty() {
             return None;
         }
@@ -1517,7 +1536,7 @@ impl ModelConfig {
     pub fn resolve_product_qa(&self) -> Option<ResolvedProductQa> {
         const PRODUCT_QA_TASK: &str = "chat_product_qa";
         let task_cfg = self.tasks.get(PRODUCT_QA_TASK)?;
-        let answer_prompt = task_cfg.filter_prompt.clone().unwrap_or_default();
+        let answer_prompt = plain_or_empty(task_cfg.filter_prompt.as_ref());
         if answer_prompt.trim().is_empty() {
             return None;
         }
@@ -1545,7 +1564,8 @@ impl ModelConfig {
     pub fn product_qa_enabled(&self) -> bool {
         self.tasks
             .get("chat_product_qa")
-            .and_then(|t| t.filter_prompt.as_deref())
+            .and_then(|t| t.filter_prompt.as_ref())
+            .and_then(PromptSpec::as_plain)
             .is_some_and(|p| !p.trim().is_empty())
     }
 
@@ -1556,7 +1576,8 @@ impl ModelConfig {
     pub fn pde_enabled(&self) -> bool {
         self.tasks
             .get("pde_decision")
-            .and_then(|t| t.filter_prompt.as_deref())
+            .and_then(|t| t.filter_prompt.as_ref())
+            .and_then(PromptSpec::as_plain)
             .is_some_and(|p| !p.trim().is_empty())
     }
 
@@ -1614,7 +1635,8 @@ impl ModelConfig {
         let task_cfg = self.tasks.get(COMPOSE_TASK)?;
         let compose_prompt = task_cfg
             .filter_prompt
-            .as_deref()
+            .as_ref()
+            .and_then(PromptSpec::as_plain)
             .map(str::trim)
             .filter(|s| !s.is_empty())
             .map(str::to_string)
@@ -1697,7 +1719,7 @@ impl ModelConfig {
     /// straight from `resolve()` so the call site keeps today's selection semantics.
     fn resolve_extract(&self, task: &str) -> Option<ResolvedExtract> {
         let task_cfg = self.tasks.get(task)?;
-        let extract_prompt = task_cfg.filter_prompt.clone().unwrap_or_default();
+        let extract_prompt = plain_or_empty(task_cfg.filter_prompt.as_ref());
         if extract_prompt.trim().is_empty() {
             return None;
         }
@@ -1717,7 +1739,7 @@ impl ModelConfig {
     /// is absent OR its `filter_prompt` is blank — the sweeper goes inert.
     pub fn resolve_world_director(&self) -> Option<ResolvedWorldDirector> {
         let task_cfg = self.tasks.get("world_director")?;
-        let director_prompt = task_cfg.filter_prompt.clone().unwrap_or_default();
+        let director_prompt = plain_or_empty(task_cfg.filter_prompt.as_ref());
         if director_prompt.trim().is_empty() {
             return None;
         }
@@ -1744,7 +1766,7 @@ impl ModelConfig {
     /// the comment-round path goes inert.
     pub fn resolve_world_comment(&self) -> Option<ResolvedWorldComment> {
         let task_cfg = self.tasks.get("world_comment")?;
-        let comment_prompt = task_cfg.filter_prompt.clone().unwrap_or_default();
+        let comment_prompt = plain_or_empty(task_cfg.filter_prompt.as_ref());
         if comment_prompt.trim().is_empty() {
             return None;
         }
@@ -1774,7 +1796,7 @@ impl ModelConfig {
         const MIN_BAND_SECS: u64 = 30;
 
         let task_cfg = self.tasks.get("world_reply")?;
-        let reply_prompt = task_cfg.filter_prompt.clone().unwrap_or_default();
+        let reply_prompt = plain_or_empty(task_cfg.filter_prompt.as_ref());
         if reply_prompt.trim().is_empty() {
             return None;
         }
@@ -1813,7 +1835,7 @@ impl ModelConfig {
     /// blank — the story claim path goes inert.
     pub fn resolve_world_stories_director(&self) -> Option<ResolvedWorldStories> {
         let task_cfg = self.tasks.get("world_stories_director")?;
-        let director_prompt = task_cfg.filter_prompt.clone().unwrap_or_default();
+        let director_prompt = plain_or_empty(task_cfg.filter_prompt.as_ref());
         if director_prompt.trim().is_empty() {
             return None;
         }
@@ -2322,7 +2344,7 @@ filter_prompt = "Answer product questions from the docs."
         assert!(pde.fallback.is_none());
         assert_eq!(pde.temperature, Some(0.5));
         assert_eq!(
-            pde.filter_prompt.as_deref(),
+            pde.filter_prompt.as_ref().and_then(PromptSpec::as_plain),
             Some("Decide the action and inner_state.")
         );
         assert_eq!(pde.ghosting, Some(false));
@@ -2334,7 +2356,7 @@ filter_prompt = "Answer product questions from the docs."
         assert_eq!(pq.model.as_fixed(), Some("x-ai/grok-4-mini"));
         assert_eq!(pq.retry_depth, Some(1));
         assert_eq!(
-            pq.filter_prompt.as_deref(),
+            pq.filter_prompt.as_ref().and_then(PromptSpec::as_plain),
             Some("Answer product questions from the docs.")
         );
         let rpq = cfg
@@ -2875,7 +2897,10 @@ trigger = { random = 1.0 }
         assert_eq!(cc.tiers["gold"].output_filter, Some(true));
 
         let f = &cfg.tasks["chat_output_filter"];
-        assert_eq!(f.filter_prompt.as_deref(), Some("Rewrite: {x}"));
+        assert_eq!(
+            f.filter_prompt.as_ref().and_then(PromptSpec::as_plain),
+            Some("Rewrite: {x}")
+        );
         assert_eq!(f.retry_depth, Some(2));
         assert_eq!(f.timing, Some(FilterTiming::AfterExtract));
         let trig = f.trigger.clone().unwrap();
@@ -2887,7 +2912,10 @@ trigger = { random = 1.0 }
         // per-tier override parses; tier trigger replaces default wholesale
         assert_eq!(f.tiers["gold"].trigger.clone().unwrap().random, Some(1.0));
         assert_eq!(
-            f.tiers["gold"].filter_prompt.as_deref(),
+            f.tiers["gold"]
+                .filter_prompt
+                .as_ref()
+                .and_then(PromptSpec::as_plain),
             Some("tier prompt")
         );
     }

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -3,7 +3,7 @@
 
 use rand::Rng;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
@@ -129,6 +129,60 @@ impl ModelSpec {
         match self {
             ModelSpec::Fixed(s) => Some(s.as_str()),
             _ => None,
+        }
+    }
+}
+
+/// A task's `filter_prompt`. Accepts three TOML shapes, mirroring `ModelSpec`:
+/// `"xxx"` (plain), `["aaa","bbb"]` (index-keyed variants), or
+/// `{ a = "aaa", b = "bbb" }` (string-keyed variants).
+///
+/// Only `[tasks.chat_image_prompt_compose]` reads variants; every other task —
+/// and every tier block, including the composer's own — must use the plain
+/// shape. Enforced at boot by `ModelConfig::validate_prompt_variants`, because
+/// `TaskConfig` is shared by every `[tasks.*]` section and the type alone
+/// cannot express the restriction.
+///
+/// `BTreeMap` (not `HashMap`) so key ordering in boot-failure messages is
+/// deterministic across restarts.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(untagged)]
+pub enum PromptSpec {
+    Plain(String),
+    Indexed(Vec<String>),
+    Keyed(BTreeMap<String, String>),
+}
+
+impl PromptSpec {
+    /// The prompt as a plain string. `None` for the variant shapes — which,
+    /// after `validate_prompt_variants`, only the composer task can hold.
+    /// Callers treat `None` exactly like an absent `filter_prompt`.
+    pub fn as_plain(&self) -> Option<&str> {
+        match self {
+            PromptSpec::Plain(s) => Some(s.as_str()),
+            _ => None,
+        }
+    }
+
+    /// Pick the variant named by `variant`. `None` ⇒ nothing was selected and
+    /// the caller falls back to its built-in default.
+    ///
+    /// `Plain` ignores `variant` entirely — the string IS the prompt.
+    /// `Indexed` parses `variant` as a `usize` index. `Keyed` looks it up as an
+    /// exact, case-sensitive key (`default` carries no special meaning). Every
+    /// miss in a variant shape — absent, unparseable, out of range, unknown
+    /// key — is `None`.
+    ///
+    /// `raw` is handled by the caller BEFORE this is reached; it never appears
+    /// here.
+    pub fn select(&self, variant: Option<&str>) -> Option<&str> {
+        match self {
+            PromptSpec::Plain(s) => Some(s.as_str()),
+            PromptSpec::Indexed(v) => {
+                let idx: usize = variant?.parse().ok()?;
+                v.get(idx).map(String::as_str)
+            }
+            PromptSpec::Keyed(m) => m.get(variant?).map(String::as_str),
         }
     }
 }
@@ -4762,5 +4816,73 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
         // No stories section at all ⇒ fine either way.
         let cfg = ModelConfig::from_toml_str("").unwrap();
         assert!(cfg.validate_world_prompts(true, true).is_ok());
+    }
+
+    // ─── PromptSpec ──────────────────────────────────────────────────────
+
+    #[derive(Deserialize)]
+    struct SpecWrap {
+        p: PromptSpec,
+    }
+
+    fn spec(src: &str) -> PromptSpec {
+        toml::from_str::<SpecWrap>(src).expect("parse PromptSpec").p
+    }
+
+    #[test]
+    fn prompt_spec_parses_three_shapes() {
+        assert_eq!(spec(r#"p = "xxx""#), PromptSpec::Plain("xxx".into()));
+        assert_eq!(
+            spec(r#"p = ["aaa", "bbb"]"#),
+            PromptSpec::Indexed(vec!["aaa".into(), "bbb".into()])
+        );
+        let mut m = std::collections::BTreeMap::new();
+        m.insert("a".to_string(), "aaa".to_string());
+        m.insert("b".to_string(), "bbb".to_string());
+        assert_eq!(
+            spec(r#"p = { a = "aaa", b = "bbb" }"#),
+            PromptSpec::Keyed(m)
+        );
+    }
+
+    #[test]
+    fn prompt_spec_as_plain_only_for_plain() {
+        assert_eq!(spec(r#"p = "xxx""#).as_plain(), Some("xxx"));
+        assert_eq!(spec(r#"p = ["aaa"]"#).as_plain(), None);
+        assert_eq!(spec(r#"p = { a = "aaa" }"#).as_plain(), None);
+    }
+
+    #[test]
+    fn prompt_spec_plain_ignores_variant() {
+        let s = spec(r#"p = "xxx""#);
+        assert_eq!(s.select(None), Some("xxx"));
+        assert_eq!(s.select(Some("b")), Some("xxx"));
+        assert_eq!(s.select(Some("7")), Some("xxx"));
+    }
+
+    #[test]
+    fn prompt_spec_indexed_selection() {
+        let s = spec(r#"p = ["aaa", "bbb"]"#);
+        assert_eq!(s.select(Some("0")), Some("aaa"));
+        assert_eq!(s.select(Some("1")), Some("bbb"));
+        // "01" parses as 1 — ordinary usize::from_str behavior, not special-cased.
+        assert_eq!(s.select(Some("01")), Some("bbb"));
+        // Every miss is None; the caller substitutes its built-in default.
+        assert_eq!(s.select(None), None, "no variant selects nothing");
+        assert_eq!(s.select(Some("5")), None, "out of range");
+        assert_eq!(s.select(Some("a")), None, "non-numeric");
+        assert_eq!(s.select(Some("-1")), None, "unparseable as usize");
+    }
+
+    #[test]
+    fn prompt_spec_keyed_selection() {
+        let s = spec(r#"p = { a = "aaa", b = "bbb", default = "ccc" }"#);
+        assert_eq!(s.select(Some("a")), Some("aaa"));
+        assert_eq!(s.select(Some("b")), Some("bbb"));
+        // `default` is an ORDINARY key: it wins only on a literal "default".
+        assert_eq!(s.select(Some("default")), Some("ccc"));
+        assert_eq!(s.select(None), None, "no variant selects nothing");
+        assert_eq!(s.select(Some("z")), None, "unknown key");
+        assert_eq!(s.select(Some("A")), None, "key match is case-sensitive");
     }
 }

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -1670,18 +1670,47 @@ impl ModelConfig {
         })
     }
 
-    /// Resolve the image-prompt composer task. `None` (feature off) only when
-    /// `[tasks.chat_image_prompt_compose]` is absent. When the task is present, a
-    /// non-blank `filter_prompt` overrides the built-in `DEFAULT_COMPOSE_PROMPT`;
-    /// a blank/absent one falls back to it. No probability/trigger gate; the
-    /// caller invokes it only after an image action is decided.
-    pub fn resolve_image_prompt_compose(&self) -> Option<ResolvedImagePromptCompose> {
+    /// Resolve the image-prompt composer task. `None` (composer does not run)
+    /// when `[tasks.chat_image_prompt_compose]` is absent, **or** when the
+    /// caller passed the reserved `raw` variant — the two are indistinguishable
+    /// by design, since both mean "use the seed subject verbatim"; `tracing`
+    /// tells them apart.
+    ///
+    /// `variant` is the client's per-turn `image.prompt_variant`, already
+    /// trimmed by the caller. Selection is delegated to `PromptSpec::select`:
+    /// a plain `filter_prompt` ignores it, and any miss in a variant shape
+    /// falls back to the built-in `DEFAULT_COMPOSE_PROMPT`.
+    ///
+    /// No probability/trigger gate; the caller invokes it only after an image
+    /// action is decided.
+    pub fn resolve_image_prompt_compose(
+        &self,
+        variant: Option<&str>,
+    ) -> Option<ResolvedImagePromptCompose> {
         const COMPOSE_TASK: &str = "chat_image_prompt_compose";
+        let variant = variant.map(str::trim).filter(|v| !v.is_empty());
+        if variant.is_some_and(|v| v.eq_ignore_ascii_case("raw")) {
+            tracing::debug!("image-compose: variant \"raw\" — skipping composer");
+            return None;
+        }
         let task_cfg = self.tasks.get(COMPOSE_TASK)?;
-        let compose_prompt = task_cfg
+        let selected = task_cfg
             .filter_prompt
             .as_ref()
-            .and_then(PromptSpec::as_plain)
+            .and_then(|s| s.select(variant));
+        if selected.is_none() && variant.is_some() && task_cfg.filter_prompt.is_some() {
+            tracing::warn!(
+                variant = %variant.unwrap_or_default(),
+                "image-compose: variant not found; using the built-in prompt"
+            );
+        } else if selected.is_some() && variant.is_some() {
+            tracing::debug!(variant = %variant.unwrap_or_default(), "image-compose: variant selected");
+        }
+        // `trim`/`is_empty` is what makes a blank PLAIN filter_prompt fall
+        // through to the built-in prompt. Redundant for the variant shapes
+        // (`validate_prompt_variants` rejects blanks there at boot), but
+        // removing it would regress the plain shape.
+        let compose_prompt = selected
             .map(str::trim)
             .filter(|s| !s.is_empty())
             .map(str::to_string)
@@ -4437,7 +4466,7 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
     #[test]
     fn resolve_image_prompt_compose_none_when_task_absent() {
         let cfg = ModelConfig::from_toml_str("[tasks.chat_companion]\nmodel = \"m\"\n").unwrap();
-        assert!(cfg.resolve_image_prompt_compose().is_none());
+        assert!(cfg.resolve_image_prompt_compose(None).is_none());
     }
 
     #[test]
@@ -4448,14 +4477,16 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
             "[tasks.chat_image_prompt_compose]\nmodel = \"m\"\nfilter_prompt = \"   \"\n",
         )
         .unwrap();
-        let r = cfg.resolve_image_prompt_compose().unwrap();
+        let r = cfg.resolve_image_prompt_compose(None).unwrap();
         assert_eq!(r.compose_prompt, DEFAULT_COMPOSE_PROMPT);
 
         // also true when filter_prompt is omitted entirely
         let cfg2 = ModelConfig::from_toml_str("[tasks.chat_image_prompt_compose]\nmodel = \"m\"\n")
             .unwrap();
         assert_eq!(
-            cfg2.resolve_image_prompt_compose().unwrap().compose_prompt,
+            cfg2.resolve_image_prompt_compose(None)
+                .unwrap()
+                .compose_prompt,
             DEFAULT_COMPOSE_PROMPT
         );
     }
@@ -4467,7 +4498,9 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
         )
         .unwrap();
         assert_eq!(
-            cfg.resolve_image_prompt_compose().unwrap().compose_prompt,
+            cfg.resolve_image_prompt_compose(None)
+                .unwrap()
+                .compose_prompt,
             "custom composer"
         );
     }
@@ -4478,7 +4511,7 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
             "[tasks.chat_image_prompt_compose]\nmodel = \"m\"\nfilter_prompt = \"compose it\"\nfallback = [\"a\", \"b\", \"c\"]\nretry_depth = 1\n",
         )
         .unwrap();
-        let r = cfg.resolve_image_prompt_compose().unwrap();
+        let r = cfg.resolve_image_prompt_compose(None).unwrap();
         assert_eq!(r.compose_prompt, "compose it");
         assert_eq!(r.retry_depth, 1);
         assert_eq!(r.fallback_model.len(), 1);
@@ -5107,5 +5140,116 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
                 .expect_err("reserved key must refuse to boot");
             assert!(e.contains("reserved"), "{e}");
         }
+    }
+
+    // ─── resolve_image_prompt_compose: variants + raw ────────────────────
+
+    #[test]
+    fn compose_indexed_variant_selection() {
+        let c = cfg("[tasks.chat_image_prompt_compose]\nmodel = \"m\"\n\
+                     filter_prompt = [\"AAA\", \"BBB\"]\n");
+        assert_eq!(
+            c.resolve_image_prompt_compose(Some("1"))
+                .unwrap()
+                .compose_prompt,
+            "BBB"
+        );
+        // No variant, and every miss, fall through to the built-in prompt.
+        for v in [None, Some("5"), Some("a"), Some("-1")] {
+            assert_eq!(
+                c.resolve_image_prompt_compose(v).unwrap().compose_prompt,
+                DEFAULT_COMPOSE_PROMPT,
+                "variant {v:?} should fall back to the built-in prompt"
+            );
+        }
+    }
+
+    #[test]
+    fn compose_keyed_variant_selection() {
+        let c = cfg("[tasks.chat_image_prompt_compose]\nmodel = \"m\"\n\
+                     filter_prompt = { a = \"AAA\", default = \"CCC\" }\n");
+        assert_eq!(
+            c.resolve_image_prompt_compose(Some("a"))
+                .unwrap()
+                .compose_prompt,
+            "AAA"
+        );
+        // `default` is an ordinary key — it needs a literal "default" to win.
+        assert_eq!(
+            c.resolve_image_prompt_compose(Some("default"))
+                .unwrap()
+                .compose_prompt,
+            "CCC"
+        );
+        for v in [None, Some("z")] {
+            assert_eq!(
+                c.resolve_image_prompt_compose(v).unwrap().compose_prompt,
+                DEFAULT_COMPOSE_PROMPT
+            );
+        }
+    }
+
+    #[test]
+    fn compose_plain_prompt_ignores_the_variant() {
+        let c = cfg("[tasks.chat_image_prompt_compose]\nmodel = \"m\"\n\
+                     filter_prompt = \"custom composer\"\n");
+        for v in [None, Some("a"), Some("3")] {
+            assert_eq!(
+                c.resolve_image_prompt_compose(v).unwrap().compose_prompt,
+                "custom composer"
+            );
+        }
+    }
+
+    #[test]
+    fn compose_blank_plain_prompt_still_falls_back() {
+        // Pre-existing behavior, unchanged: a blank plain string is "commented
+        // out", not a boot failure.
+        let c = cfg("[tasks.chat_image_prompt_compose]\nmodel = \"m\"\nfilter_prompt = \"   \"\n");
+        assert_eq!(
+            c.resolve_image_prompt_compose(None).unwrap().compose_prompt,
+            DEFAULT_COMPOSE_PROMPT
+        );
+    }
+
+    #[test]
+    fn raw_skips_the_composer_in_every_shape() {
+        let sources = [
+            "[tasks.chat_image_prompt_compose]\nmodel = \"m\"\nfilter_prompt = [\"AAA\"]\n",
+            "[tasks.chat_image_prompt_compose]\nmodel = \"m\"\nfilter_prompt = { a = \"AAA\" }\n",
+            "[tasks.chat_image_prompt_compose]\nmodel = \"m\"\nfilter_prompt = \"custom\"\n",
+            // No filter_prompt at all (built-in prompt) — raw still wins.
+            "[tasks.chat_image_prompt_compose]\nmodel = \"m\"\n",
+        ];
+        for src in sources {
+            let c = cfg(src);
+            for v in ["raw", "Raw", "RAW"] {
+                assert!(
+                    c.resolve_image_prompt_compose(Some(v)).is_none(),
+                    "{v} must skip the composer for: {src}"
+                );
+            }
+            // Sanity: without `raw` the composer is still resolved.
+            assert!(c.resolve_image_prompt_compose(None).is_some(), "{src}");
+        }
+    }
+
+    #[test]
+    fn raw_on_an_absent_compose_task_is_still_none() {
+        let c = cfg("[tasks.chat_companion]\nmodel = \"m\"\n");
+        assert!(c.resolve_image_prompt_compose(Some("raw")).is_none());
+        assert!(c.resolve_image_prompt_compose(None).is_none());
+    }
+
+    #[test]
+    fn blank_variant_string_is_treated_as_absent() {
+        let c = cfg("[tasks.chat_image_prompt_compose]\nmodel = \"m\"\n\
+                     filter_prompt = [\"AAA\", \"BBB\"]\n");
+        assert_eq!(
+            c.resolve_image_prompt_compose(Some("   "))
+                .unwrap()
+                .compose_prompt,
+            DEFAULT_COMPOSE_PROMPT
+        );
     }
 }

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -227,6 +227,13 @@ fn check_variant_shape(task: &str, spec: &PromptSpec) -> Result<(), String> {
                 if k.trim().is_empty() {
                     return refuse("has a blank key".to_string());
                 }
+                if k.trim() != k.as_str() {
+                    return refuse(format!(
+                        "has whitespace-padded key \"{k}\": its trimmed form differs from the raw \
+                         key, but `select` matches a client's `image.prompt_variant` exactly — so \
+                         neither \"{k}\" nor its trimmed form could ever select it"
+                    ));
+                }
                 if k.trim().eq_ignore_ascii_case("raw") {
                     return refuse(format!(
                         "uses the reserved key \"{k}\": \"raw\" is the wire value that skips the \
@@ -1703,13 +1710,23 @@ impl ModelConfig {
         // can be unit-tested directly, without a tracing subscriber, and so a
         // refactor that accidentally drops a guard shows up as a plain
         // assertion failure instead of only a missing log line.
+        // `?` (Debug), not `%` (Display): `variant` is a client-supplied wire
+        // value (`image.prompt_variant`) that nothing on the validation path
+        // bounds — unlike `tier`, which is pattern-and-length checked in
+        // `validate_payload`. Debug escapes/quotes so embedded newlines or
+        // control characters can't smuggle fake log lines, and
+        // `cap_for_log` bounds its length so a pathological value can't blow
+        // up log volume.
         match compose_variant_log_event(selected, variant, task_cfg.filter_prompt.is_some()) {
             Some(ComposeVariantLogEvent::Mismatch) => tracing::warn!(
-                variant = %variant.unwrap_or_default(),
+                variant = ?cap_for_log(variant.unwrap_or_default(), 64),
                 "image-compose: variant not found; using the built-in prompt"
             ),
             Some(ComposeVariantLogEvent::Selected) => {
-                tracing::debug!(variant = %variant.unwrap_or_default(), "image-compose: variant selected")
+                tracing::debug!(
+                    variant = ?cap_for_log(variant.unwrap_or_default(), 64),
+                    "image-compose: variant selected"
+                )
             }
             None => {}
         }
@@ -1742,6 +1759,19 @@ impl ModelConfig {
 fn dedup_keep_first(v: &mut Vec<String>) {
     let mut seen = std::collections::HashSet::new();
     v.retain(|s| seen.insert(s.clone()));
+}
+
+/// Cap a string to at most `max_chars` characters before it reaches a log
+/// line, appending `…` when truncated. Counts/truncates by `char`, never mid
+/// UTF-8 codepoint. Used to bound client-supplied values (e.g. the image
+/// compose `variant`) that no request-validation step already length-limits.
+fn cap_for_log(s: &str, max_chars: usize) -> String {
+    if s.chars().count() <= max_chars {
+        return s.to_string();
+    }
+    let mut out: String = s.chars().take(max_chars).collect();
+    out.push('…');
+    out
 }
 
 /// What (if anything) `resolve_image_prompt_compose` should log about a
@@ -1999,9 +2029,11 @@ impl ModelConfig {
     /// dead config — refuse to boot rather than let it silently no-op.
     ///
     /// Also enforces the structural rules for a variant container: non-empty,
-    /// no blank keys or values, and no reserved `raw` key (`raw` is the wire
-    /// escape that skips the composer, so a config key by that name could
-    /// never be selected).
+    /// no blank or whitespace-padded keys, no blank values, and no reserved
+    /// `raw` key (`raw` is the wire escape that skips the composer, so a
+    /// config key by that name could never be selected — and a padded key
+    /// like `" a "` could never be selected either, since `select` matches a
+    /// client's variant exactly).
     ///
     /// Task names are visited in sorted order so the reported failure is
     /// deterministic across restarts (`self.tasks` is a `HashMap`).
@@ -5183,6 +5215,24 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
         }
     }
 
+    #[test]
+    fn whitespace_padded_keyed_key_refuses_to_boot() {
+        // A key like " a " parses and boots fine as TOML, but `select` matches
+        // a client's (already-trimmed) `image.prompt_variant` exactly — so
+        // neither "a" nor " a " could ever select it. Distinct from the
+        // all-whitespace ("blank key") case above: this key is non-blank,
+        // just padded, and the blank-key check must not misfire on it.
+        let e = cfg("[tasks.chat_image_prompt_compose]\nmodel = \"m\"\n\
+                     filter_prompt = { \" a \" = \"aaa\", b = \"bbb\" }\n")
+        .validate_prompt_variants()
+        .expect_err("whitespace-padded key must refuse to boot");
+        assert!(e.contains("whitespace-padded"), "{e}");
+        assert!(
+            !e.contains("blank key"),
+            "must not be reported as the blank-key case: {e}"
+        );
+    }
+
     // ─── resolve_image_prompt_compose: variants + raw ────────────────────
 
     #[test]
@@ -5343,5 +5393,24 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
         // No variant supplied ⇒ nothing to report, even though `selected` is
         // `Some` (e.g. a Plain filter_prompt, which always resolves).
         assert_eq!(compose_variant_log_event(Some("AAA"), None, true), None);
+    }
+
+    // ─── cap_for_log ──────────────────────────────────────────────────────
+
+    #[test]
+    fn cap_for_log_passes_short_strings_through_unchanged() {
+        assert_eq!(cap_for_log("abc", 64), "abc");
+        assert_eq!(cap_for_log("", 64), "");
+        // Exactly at the cap: no truncation marker.
+        assert_eq!(cap_for_log("aaaa", 4), "aaaa");
+    }
+
+    #[test]
+    fn cap_for_log_truncates_on_a_char_boundary_and_marks_it() {
+        assert_eq!(cap_for_log("aaaaa", 4), "aaaa…");
+        // Multi-byte chars: counted/truncated by char, never mid-codepoint
+        // (which would panic on a byte-index slice).
+        let s = "你好世界和平"; // 6 chars
+        assert_eq!(cap_for_log(s, 3), "你好世…");
     }
 }

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -197,6 +197,51 @@ fn plain_or_empty(spec: Option<&PromptSpec>) -> String {
         .to_string()
 }
 
+/// Structural rules for a variant-shaped `filter_prompt`. `Plain` always
+/// passes — its blank-string leniency ("commented out" ⇒ built-in default) is
+/// deliberate and unchanged. A variant container is a deliberate list, so a
+/// blank inside it is a typo, and silently substituting the generic built-in
+/// prompt would be the hardest class of misconfiguration to notice.
+fn check_variant_shape(task: &str, spec: &PromptSpec) -> Result<(), String> {
+    let refuse = |why: String| {
+        Err(format!(
+            "[tasks.{task}].filter_prompt {why} — eros-engine refuses to boot."
+        ))
+    };
+    match spec {
+        PromptSpec::Plain(_) => Ok(()),
+        PromptSpec::Indexed(v) => {
+            if v.is_empty() {
+                return refuse("is an empty array".to_string());
+            }
+            match v.iter().position(|s| s.trim().is_empty()) {
+                Some(i) => refuse(format!("has a blank entry at index {i}")),
+                None => Ok(()),
+            }
+        }
+        PromptSpec::Keyed(m) => {
+            if m.is_empty() {
+                return refuse("is an empty table".to_string());
+            }
+            for (k, v) in m {
+                if k.trim().is_empty() {
+                    return refuse("has a blank key".to_string());
+                }
+                if k.trim().eq_ignore_ascii_case("raw") {
+                    return refuse(format!(
+                        "uses the reserved key \"{k}\": \"raw\" is the wire value that skips the \
+                         composer entirely, so a prompt stored under it could never be selected"
+                    ));
+                }
+                if v.trim().is_empty() {
+                    return refuse(format!("has a blank value for key \"{k}\""));
+                }
+            }
+            Ok(())
+        }
+    }
+}
+
 /// Client-facing model-name display override (chat `meta.model`). Four TOML
 /// shapes, unambiguous to serde: `false`/`true` (bool), `"name"` (string),
 /// `["a","b"]` (array → random per emit), or `{ "id" = "name", default =
@@ -1873,6 +1918,53 @@ impl ModelConfig {
                      refuses to boot. Set a filter_prompt, or remove the [tasks.{name}] \
                      section to disable {name}."
                 ));
+            }
+        }
+        Ok(())
+    }
+
+    /// Boot gate for `filter_prompt` variant shapes. Variants are read by
+    /// `chat_image_prompt_compose` alone, and never from a tier block (the
+    /// composer resolves with `tier = None`), so a variant anywhere else is
+    /// dead config — refuse to boot rather than let it silently no-op.
+    ///
+    /// Also enforces the structural rules for a variant container: non-empty,
+    /// no blank keys or values, and no reserved `raw` key (`raw` is the wire
+    /// escape that skips the composer, so a config key by that name could
+    /// never be selected).
+    ///
+    /// Task names are visited in sorted order so the reported failure is
+    /// deterministic across restarts (`self.tasks` is a `HashMap`).
+    pub fn validate_prompt_variants(&self) -> Result<(), String> {
+        const COMPOSE_TASK: &str = "chat_image_prompt_compose";
+        let mut names: Vec<&String> = self.tasks.keys().collect();
+        names.sort();
+        for name in names {
+            let task = &self.tasks[name];
+            if let Some(spec) = &task.filter_prompt {
+                if !matches!(spec, PromptSpec::Plain(_)) && name != COMPOSE_TASK {
+                    return Err(format!(
+                        "[tasks.{name}].filter_prompt uses a variant shape (array/table), but \
+                         only [tasks.{COMPOSE_TASK}] reads variants — eros-engine refuses to \
+                         boot. Use a plain string here."
+                    ));
+                }
+                check_variant_shape(name, spec)?;
+            }
+            let mut tier_names: Vec<&String> = task.tiers.keys().collect();
+            tier_names.sort();
+            for tier_name in tier_names {
+                let tier = &task.tiers[tier_name];
+                if let Some(spec) = &tier.filter_prompt {
+                    if !matches!(spec, PromptSpec::Plain(_)) {
+                        return Err(format!(
+                            "[tasks.{name}.tiers.{tier_name}].filter_prompt uses a variant shape \
+                             (array/table), but tier blocks never carry variants — the composer \
+                             resolves with no tier, so it could never be selected. eros-engine \
+                             refuses to boot. Use a plain string here."
+                        ));
+                    }
+                }
             }
         }
         Ok(())
@@ -4912,5 +5004,108 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
         assert_eq!(s.select(None), None, "no variant selects nothing");
         assert_eq!(s.select(Some("z")), None, "unknown key");
         assert_eq!(s.select(Some("A")), None, "key match is case-sensitive");
+    }
+
+    // ─── validate_prompt_variants ────────────────────────────────────────
+
+    fn cfg(src: &str) -> ModelConfig {
+        ModelConfig::from_toml_str(src).expect("parse ModelConfig")
+    }
+
+    #[test]
+    fn variants_allowed_on_the_composer_task_only() {
+        // Composer: array and table both accepted.
+        assert!(cfg("[tasks.chat_image_prompt_compose]\nmodel = \"m\"\n\
+                     filter_prompt = [\"aaa\", \"bbb\"]\n")
+        .validate_prompt_variants()
+        .is_ok());
+        assert!(cfg("[tasks.chat_image_prompt_compose]\nmodel = \"m\"\n\
+                     filter_prompt = { a = \"aaa\", b = \"bbb\" }\n")
+        .validate_prompt_variants()
+        .is_ok());
+        // Any other task: rejected.
+        let e = cfg("[tasks.chat_output_filter]\nmodel = \"m\"\n\
+                     filter_prompt = [\"aaa\", \"bbb\"]\n")
+        .validate_prompt_variants()
+        .expect_err("non-composer variant must refuse to boot");
+        assert!(e.contains("chat_output_filter"), "{e}");
+        assert!(e.contains("refuses to boot"), "{e}");
+    }
+
+    #[test]
+    fn plain_filter_prompts_always_validate() {
+        assert!(cfg(
+            "[tasks.chat_output_filter]\nmodel = \"m\"\nfilter_prompt = \"p\"\n\
+                     [tasks.chat_output_filter.tiers.gold]\nfilter_prompt = \"tier p\"\n\
+                     [tasks.world_reply]\nmodel = \"m\"\nfilter_prompt = \"   \"\n"
+        )
+        .validate_prompt_variants()
+        .is_ok());
+        // No filter_prompt anywhere is also fine.
+        assert!(cfg("[tasks.chat_companion]\nmodel = \"m\"\n")
+            .validate_prompt_variants()
+            .is_ok());
+    }
+
+    #[test]
+    fn tier_blocks_never_carry_variants() {
+        // Rejected even under the composer task, because the composer resolves
+        // with `tier = None` and could never select it.
+        let e = cfg(
+            "[tasks.chat_image_prompt_compose]\nmodel = \"m\"\nfilter_prompt = \"p\"\n\
+                     [tasks.chat_image_prompt_compose.tiers.gold]\n\
+                     filter_prompt = [\"aaa\"]\n",
+        )
+        .validate_prompt_variants()
+        .expect_err("tier variant must refuse to boot");
+        assert!(e.contains("tiers.gold"), "{e}");
+    }
+
+    #[test]
+    fn empty_variant_containers_refuse_to_boot() {
+        for src in [
+            "[tasks.chat_image_prompt_compose]\nmodel = \"m\"\nfilter_prompt = []\n",
+            "[tasks.chat_image_prompt_compose]\nmodel = \"m\"\nfilter_prompt = {}\n",
+        ] {
+            let e = cfg(src)
+                .validate_prompt_variants()
+                .expect_err("empty variant container must refuse to boot");
+            assert!(e.contains("empty"), "{e}");
+        }
+    }
+
+    #[test]
+    fn blank_variant_entries_refuse_to_boot() {
+        let e = cfg("[tasks.chat_image_prompt_compose]\nmodel = \"m\"\n\
+                     filter_prompt = [\"aaa\", \"   \"]\n")
+        .validate_prompt_variants()
+        .expect_err("blank array entry must refuse to boot");
+        assert!(e.contains("index 1"), "{e}");
+
+        let e = cfg("[tasks.chat_image_prompt_compose]\nmodel = \"m\"\n\
+                     filter_prompt = { a = \"aaa\", b = \"  \" }\n")
+        .validate_prompt_variants()
+        .expect_err("blank table value must refuse to boot");
+        assert!(e.contains("blank value for key \"b\""), "{e}");
+
+        let e = cfg("[tasks.chat_image_prompt_compose]\nmodel = \"m\"\n\
+                     filter_prompt = { \"  \" = \"aaa\" }\n")
+        .validate_prompt_variants()
+        .expect_err("blank table key must refuse to boot");
+        assert!(e.contains("blank key"), "{e}");
+    }
+
+    #[test]
+    fn raw_is_a_reserved_key_case_insensitively() {
+        for key in ["raw", "Raw", "RAW"] {
+            let src = format!(
+                "[tasks.chat_image_prompt_compose]\nmodel = \"m\"\n\
+                 filter_prompt = {{ {key} = \"aaa\", b = \"bbb\" }}\n"
+            );
+            let e = cfg(&src)
+                .validate_prompt_variants()
+                .expect_err("reserved key must refuse to boot");
+            assert!(e.contains("reserved"), "{e}");
+        }
     }
 }

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -1750,6 +1750,13 @@
           "mode": {
             "$ref": "#/components/schemas/ImageMode"
           },
+          "prompt_variant": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Which `[tasks.chat_image_prompt_compose].filter_prompt` variant to use\nfor this turn: an index (`\"0\"`, `\"1\"`) for the array shape, or a key\n(`\"a\"`, `\"b\"`) for the table shape. Ignored when that task configures a\nsingle plain prompt.\n\n`\"raw\"` (case-insensitive) is reserved: it skips the composer LLM\nentirely and draws the seed subject as-is, saving one LLM call.\n\nAn unknown index/key falls back to the engine's built-in composer\nprompt — it is never an error."
+          },
           "style": {
             "type": [
               "string",

--- a/crates/eros-engine-server/src/main.rs
+++ b/crates/eros-engine-server/src/main.rs
@@ -290,6 +290,18 @@ async fn run_server() -> Result<()> {
         }
     });
 
+    // Prompt-variant shape gate runs FIRST, before the resolver-based checks
+    // below (extraction / product_qa). Those detect "unset" via
+    // `PromptSpec::as_plain()`, under which a variant shape (array/table)
+    // reads as `None` — so a variant-shaped filter_prompt misplaced under, say,
+    // [tasks.insight_extraction] would otherwise surface as "filter_prompt is
+    // unset" (telling an operator who just set it to set it) instead of the
+    // accurate "uses a variant shape, but only [tasks.chat_image_prompt_compose]
+    // reads variants" from `validate_prompt_variants`.
+    if let Err(msg) = model_config.validate_prompt_variants() {
+        anyhow::bail!(msg);
+    }
+
     // Extraction prompts are required ONLY when the task section exists. A
     // missing [tasks.*_extraction] section means that extraction is off — the
     // engine boots and runs without it. A present section with a blank/absent
@@ -305,10 +317,6 @@ async fn run_server() -> Result<()> {
     }
 
     if let Err(msg) = model_config.validate_product_qa_prompt() {
-        anyhow::bail!(msg);
-    }
-
-    if let Err(msg) = model_config.validate_prompt_variants() {
         anyhow::bail!(msg);
     }
 
@@ -459,6 +467,54 @@ mod tests {
             .expect("shipped example parses");
         cfg.validate_product_qa_prompt()
             .expect("shipped example must pass the product_qa boot gate");
+    }
+
+    /// The shipped example's [tasks.chat_image_prompt_compose] override is
+    /// commented out, and every other task in it uses a plain filter_prompt —
+    /// it MUST pass the variant-shape boot gate, or `main` bails.
+    #[test]
+    fn shipped_model_config_satisfies_prompt_variant_boot_gate() {
+        let text = include_str!("../../../examples/model_config.toml");
+        let cfg = ModelConfig::from_toml_str(text).expect("examples/model_config.toml parses");
+        assert!(
+            cfg.validate_prompt_variants().is_ok(),
+            "shipped config must pass the prompt-variant boot gate: {:?}",
+            cfg.validate_prompt_variants()
+        );
+    }
+
+    /// Regression for the boot-check ordering bug: `validate_extraction_prompts`
+    /// detects "unset" via `PromptSpec::as_plain()`, under which a variant shape
+    /// reads as `None` — so, checked in isolation, it produces a misleading
+    /// "filter_prompt is unset" message for a variant-shaped
+    /// [tasks.insight_extraction], instead of the accurate "uses a variant
+    /// shape" one from `validate_prompt_variants`. `main` must run
+    /// `validate_prompt_variants()` BEFORE `validate_extraction_prompts()` so
+    /// the accurate message is the one an operator actually sees.
+    #[test]
+    fn variant_shaped_extraction_prompt_reports_the_accurate_error() {
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.insight_extraction]\nmodel = \"m\"\nfilter_prompt = [\"a\", \"b\"]\n",
+        )
+        .expect("parses");
+
+        let variant_err = cfg
+            .validate_prompt_variants()
+            .expect_err("variant shape under insight_extraction must refuse to boot");
+        assert!(variant_err.contains("variant shape"), "{variant_err}");
+        assert!(variant_err.contains("insight_extraction"), "{variant_err}");
+        assert!(
+            !variant_err.contains("unset"),
+            "the accurate message must not also claim the prompt is unset: {variant_err}"
+        );
+
+        // Sanity: pins the exact masking bug this ordering fix prevents —
+        // checked on its own (the pre-fix order), the extraction gate sees the
+        // variant shape as "unset" and reports the wrong, misleading reason.
+        let unset_err = cfg
+            .validate_extraction_prompts()
+            .expect_err("extraction gate also errors on this config, but for the wrong reason");
+        assert!(unset_err.contains("unset"), "{unset_err}");
     }
 
     #[test]

--- a/crates/eros-engine-server/src/main.rs
+++ b/crates/eros-engine-server/src/main.rs
@@ -308,6 +308,10 @@ async fn run_server() -> Result<()> {
         anyhow::bail!(msg);
     }
 
+    if let Err(msg) = model_config.validate_prompt_variants() {
+        anyhow::bail!(msg);
+    }
+
     // Skip when the master switch is off — WORLD_DISABLED must be able to
     // isolate a staged/incomplete [tasks.world_director] section (the sweeper
     // won't spawn and injection is gated too, so a blank prompt is harmless).

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -2526,6 +2526,113 @@ async fn run_image_prompt_compose(
     None
 }
 
+/// The three per-turn image inputs, resolved from plan → request → config.
+struct ImageTurnInputs {
+    seed_subject: String,
+    style: eros_engine_llm::model_config::StyleKey,
+    aspect_ratio: Option<String>,
+}
+
+/// Pure: resolve the seed subject, style, and aspect ratio for a delegated
+/// image turn. Precedence per field:
+/// - subject: `plan.image_prompt` → `req_image.image_prompt` → `""`
+/// - style:   `req_image.style` → config `default_style` → type default
+/// - aspect:  `plan.aspect_ratio` → `req_image.aspect_ratio` → config default
+///
+/// Blank strings count as absent at every level.
+fn resolve_image_turn_inputs(
+    plan: &eros_engine_core::types::ActionPlan,
+    req_image: Option<&crate::routes::companion_stream::ImageReplyParams>,
+    resolved_image_gen: Option<&eros_engine_llm::model_config::ResolvedImageGen>,
+) -> ImageTurnInputs {
+    let seed_subject = plan
+        .image_prompt
+        .as_deref()
+        .filter(|s| !s.trim().is_empty())
+        .or_else(|| {
+            req_image
+                .and_then(|i| i.image_prompt.as_deref())
+                .filter(|s| !s.trim().is_empty())
+        })
+        .unwrap_or("")
+        .to_string();
+    let style = req_image
+        .and_then(|i| i.style)
+        .or_else(|| resolved_image_gen.map(|r| r.default_style))
+        .unwrap_or_default();
+    // A per-turn aspect (PDE/plan or per-request) beats the config default.
+    let aspect_ratio = plan
+        .aspect_ratio
+        .as_deref()
+        .filter(|s| !s.trim().is_empty())
+        .or_else(|| {
+            req_image
+                .and_then(|i| i.aspect_ratio.as_deref())
+                .filter(|s| !s.trim().is_empty())
+        })
+        .map(str::to_string)
+        .or_else(|| resolved_image_gen.map(|r| r.default_aspect_ratio.clone()));
+    ImageTurnInputs {
+        seed_subject,
+        style,
+        aspect_ratio,
+    }
+}
+
+/// Everything the two delegated-image call sites need. `style` is deliberately
+/// absent: it is consumed internally by `compose_image_prompt` and neither
+/// caller uses it afterwards.
+struct DelegatedImagePrompt {
+    /// Seed subject — feeds `build_delegated_image_marker`.
+    seed_subject: String,
+    /// Effective aspect ratio — feeds the marker and the wire frame.
+    aspect_ratio: Option<String>,
+    /// Final wire prompt — feeds the wire frame.
+    composed_prompt: String,
+}
+
+/// Resolve the per-turn image inputs, optionally enrich the subject via the
+/// composer LLM, and wrap the result into the final wire prompt.
+///
+/// The composer is skipped entirely when it is not configured. It is fail-open
+/// throughout: a model error, timeout, or empty reply degrades to the seed
+/// subject and never blocks the image turn.
+async fn build_delegated_image_prompt(
+    state: &AppState,
+    persona: &eros_engine_core::persona::CompanionPersona,
+    plan: &eros_engine_core::types::ActionPlan,
+    req_image: Option<&crate::routes::companion_stream::ImageReplyParams>,
+    resolved_image_gen: Option<&eros_engine_llm::model_config::ResolvedImageGen>,
+    pde_transcript: &str,
+) -> DelegatedImagePrompt {
+    let inputs = resolve_image_turn_inputs(plan, req_image, resolved_image_gen);
+    let style_str = serde_json::to_value(inputs.style)
+        .ok()
+        .and_then(|v| v.as_str().map(String::from))
+        .unwrap_or_else(|| "realistic".to_string());
+    let final_subject = match state.model_config.resolve_image_prompt_compose() {
+        Some(c) => run_image_prompt_compose(
+            state,
+            &c,
+            persona,
+            &inputs.seed_subject,
+            pde_transcript,
+            inputs.aspect_ratio.as_deref(),
+            &style_str,
+        )
+        .await
+        .unwrap_or_else(|| inputs.seed_subject.clone()),
+        None => inputs.seed_subject.clone(),
+    };
+    let composed_prompt =
+        crate::pipeline::handlers::compose_image_prompt(inputs.style, persona, &final_subject);
+    DelegatedImagePrompt {
+        seed_subject: inputs.seed_subject,
+        aspect_ratio: inputs.aspect_ratio,
+        composed_prompt,
+    }
+}
+
 /// Try to emit a pseudo-ghost on chain exhaustion.
 ///
 /// Picks a configured fallback phrase from `engine.error_handling_config`,
@@ -3308,56 +3415,18 @@ pub fn run_stream(
                     let msg_ulid = Ulid::new();
                     let msg_uuid: Uuid = msg_ulid.into();
                     let img_mid = ulid_string(msg_ulid);
-                    let subject = plan
-                        .image_prompt
-                        .as_deref()
-                        .filter(|s| !s.trim().is_empty())
-                        .or_else(|| {
-                            req_image
-                                .and_then(|i| i.image_prompt.as_deref())
-                                .filter(|s| !s.trim().is_empty())
-                        })
-                        .unwrap_or("")
-                        .to_string();
-                    let style: eros_engine_llm::model_config::StyleKey = req_image
-                        .and_then(|i| i.style)
-                        .or_else(|| resolved_image_gen.as_ref().map(|r| r.default_style))
-                        .unwrap_or_default();
-                    let style_str = serde_json::to_value(style)
-                        .ok()
-                        .and_then(|v| v.as_str().map(String::from))
-                        .unwrap_or_else(|| "realistic".to_string());
-                    // A per-turn aspect (PDE/plan or per-request) beats the config default.
-                    let aspect: Option<String> = plan
-                        .aspect_ratio
-                        .as_deref()
-                        .filter(|s| !s.trim().is_empty())
-                        .or_else(|| {
-                            req_image
-                                .and_then(|i| i.aspect_ratio.as_deref())
-                                .filter(|s| !s.trim().is_empty())
-                        })
-                        .map(str::to_string)
-                        .or_else(|| resolved_image_gen.as_ref().map(|r| r.default_aspect_ratio.clone()));
-                    let final_subject = match state.model_config.resolve_image_prompt_compose() {
-                        Some(c) => run_image_prompt_compose(
-                            &state,
-                            &c,
-                            &input.persona,
-                            &subject,
-                            &pde_transcript,
-                            aspect.as_deref(),
-                            &style_str,
-                        )
-                        .await
-                        .unwrap_or_else(|| subject.clone()),
-                        None => subject.clone(),
-                    };
-                    let composed_prompt = crate::pipeline::handlers::compose_image_prompt(
-                        style,
+                    let img = build_delegated_image_prompt(
+                        &state,
                         &input.persona,
-                        &final_subject,
-                    );
+                        &plan,
+                        req_image,
+                        resolved_image_gen.as_ref(),
+                        &pde_transcript,
+                    )
+                    .await;
+                    let subject = img.seed_subject;
+                    let aspect = img.aspect_ratio;
+                    let composed_prompt = img.composed_prompt;
                     // Persist an empty-content row carrying ONLY the minimal
                     // marker (seed subject + aspect) so the PDE stays image-aware
                     // (§5); the composed prompt and the draw result live with the
@@ -3668,55 +3737,18 @@ pub fn run_stream(
                     if let Some(last) = produced.last() {
                         let msg_uuid = last.message_id;
                         let img_mid = ulid_string(Ulid::from(msg_uuid));
-                        let subject = plan
-                            .image_prompt
-                            .as_deref()
-                            .filter(|s| !s.trim().is_empty())
-                            .or_else(|| {
-                                req_image
-                                    .and_then(|i| i.image_prompt.as_deref())
-                                    .filter(|s| !s.trim().is_empty())
-                            })
-                            .unwrap_or("")
-                            .to_string();
-                        let style: eros_engine_llm::model_config::StyleKey = req_image
-                            .and_then(|i| i.style)
-                            .or_else(|| resolved_image_gen.as_ref().map(|r| r.default_style))
-                            .unwrap_or_default();
-                        let style_str = serde_json::to_value(style)
-                            .ok()
-                            .and_then(|v| v.as_str().map(String::from))
-                            .unwrap_or_else(|| "realistic".to_string());
-                        let aspect: Option<String> = plan
-                            .aspect_ratio
-                            .as_deref()
-                            .filter(|s| !s.trim().is_empty())
-                            .or_else(|| {
-                                req_image
-                                    .and_then(|i| i.aspect_ratio.as_deref())
-                                    .filter(|s| !s.trim().is_empty())
-                            })
-                            .map(str::to_string)
-                            .or_else(|| resolved_image_gen.as_ref().map(|r| r.default_aspect_ratio.clone()));
-                        let final_subject = match state.model_config.resolve_image_prompt_compose() {
-                            Some(c) => run_image_prompt_compose(
-                                &state,
-                                &c,
-                                &input.persona,
-                                &subject,
-                                &pde_transcript,
-                                aspect.as_deref(),
-                                &style_str,
-                            )
-                            .await
-                            .unwrap_or_else(|| subject.clone()),
-                            None => subject.clone(),
-                        };
-                        let composed_prompt = crate::pipeline::handlers::compose_image_prompt(
-                            style,
+                        let img = build_delegated_image_prompt(
+                            &state,
                             &input.persona,
-                            &final_subject,
-                        );
+                            &plan,
+                            req_image,
+                            resolved_image_gen.as_ref(),
+                            &pde_transcript,
+                        )
+                        .await;
+                        let subject = img.seed_subject;
+                        let aspect = img.aspect_ratio;
+                        let composed_prompt = img.composed_prompt;
                         // Merge ONLY the minimal marker (seed subject + aspect)
                         // onto the already-persisted text row so the PDE stays
                         // image-aware (§5). The text already reached the client;
@@ -4078,6 +4110,110 @@ mod tests {
         assert!(p.contains("on a rooftop"));
         assert!(p.contains("realistic"));
         assert!(p.contains("9:16"));
+    }
+
+    // ─── resolve_image_turn_inputs ───────────────────────────────────────
+
+    fn img_plan(
+        image_prompt: Option<&str>,
+        aspect: Option<&str>,
+    ) -> eros_engine_core::types::ActionPlan {
+        eros_engine_core::types::ActionPlan {
+            action_type: ActionType::ReplyImage,
+            reply_style: eros_engine_core::types::ReplyStyle::Neutral,
+            affinity_deltas: Default::default(),
+            energy_cost: 0.0,
+            context_hints: vec![],
+            reply_tone: None,
+            image_prompt: image_prompt.map(str::to_string),
+            image_ref: eros_engine_core::types::ImageRef::Face,
+            aspect_ratio: aspect.map(str::to_string),
+        }
+    }
+
+    fn img_params(
+        image_prompt: Option<&str>,
+        style: Option<eros_engine_llm::model_config::StyleKey>,
+        aspect: Option<&str>,
+    ) -> crate::routes::companion_stream::ImageReplyParams {
+        crate::routes::companion_stream::ImageReplyParams {
+            image_prompt: image_prompt.map(str::to_string),
+            style,
+            aspect_ratio: aspect.map(str::to_string),
+            ..Default::default()
+        }
+    }
+
+    fn img_gen(
+        style: eros_engine_llm::model_config::StyleKey,
+        aspect: &str,
+    ) -> eros_engine_llm::model_config::ResolvedImageGen {
+        eros_engine_llm::model_config::ResolvedImageGen {
+            model: None,
+            fallback_model: vec![],
+            default_style: style,
+            default_aspect_ratio: aspect.to_string(),
+            default_resolution: None,
+            max_tokens: 4096,
+        }
+    }
+
+    #[test]
+    fn image_turn_subject_prefers_plan_then_request_then_empty() {
+        use eros_engine_llm::model_config::StyleKey;
+        let params = img_params(Some("from request"), None, None);
+
+        // plan wins
+        let r = resolve_image_turn_inputs(&img_plan(Some("from plan"), None), Some(&params), None);
+        assert_eq!(r.seed_subject, "from plan");
+
+        // blank plan subject falls through to the request
+        let r = resolve_image_turn_inputs(&img_plan(Some("   "), None), Some(&params), None);
+        assert_eq!(r.seed_subject, "from request");
+
+        // neither ⇒ empty string
+        let r = resolve_image_turn_inputs(&img_plan(None, None), None, None);
+        assert_eq!(r.seed_subject, "");
+        let _ = StyleKey::Realistic;
+    }
+
+    #[test]
+    fn image_turn_style_prefers_request_then_config_then_default() {
+        use eros_engine_llm::model_config::StyleKey;
+        let gen = img_gen(StyleKey::Anime, "1:1");
+
+        let params = img_params(None, Some(StyleKey::SemiRealistic), None);
+        let r = resolve_image_turn_inputs(&img_plan(None, None), Some(&params), Some(&gen));
+        assert_eq!(r.style, StyleKey::SemiRealistic, "request wins");
+
+        let r = resolve_image_turn_inputs(&img_plan(None, None), None, Some(&gen));
+        assert_eq!(r.style, StyleKey::Anime, "config default");
+
+        let r = resolve_image_turn_inputs(&img_plan(None, None), None, None);
+        assert_eq!(r.style, StyleKey::default(), "no config ⇒ type default");
+    }
+
+    #[test]
+    fn image_turn_aspect_prefers_plan_then_request_then_config() {
+        use eros_engine_llm::model_config::StyleKey;
+        let gen = img_gen(StyleKey::Realistic, "1:1");
+        let params = img_params(None, None, Some("16:9"));
+
+        let r = resolve_image_turn_inputs(&img_plan(None, Some("3:4")), Some(&params), Some(&gen));
+        assert_eq!(r.aspect_ratio.as_deref(), Some("3:4"), "plan wins");
+
+        let r = resolve_image_turn_inputs(&img_plan(None, Some("  ")), Some(&params), Some(&gen));
+        assert_eq!(
+            r.aspect_ratio.as_deref(),
+            Some("16:9"),
+            "blank plan ⇒ request"
+        );
+
+        let r = resolve_image_turn_inputs(&img_plan(None, None), None, Some(&gen));
+        assert_eq!(r.aspect_ratio.as_deref(), Some("1:1"), "config default");
+
+        let r = resolve_image_turn_inputs(&img_plan(None, None), None, None);
+        assert_eq!(r.aspect_ratio, None, "nothing anywhere ⇒ None");
     }
 
     #[test]

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -5956,6 +5956,21 @@ data: [DONE]\n\n";
     /// Shared setup for the two `prompt_variant` tests: a keyed composer
     /// config, a mock that records every outbound call, and a forced
     /// image-only turn. Returns the recorded requests and the emitted frames.
+    ///
+    /// The turn's user content is deliberately kept below
+    /// `post_process::AFFINITY_EVAL_MIN_CHARS` (4 chars). A successful forced
+    /// `ReplyImage` turn `tokio::spawn`s `post_process::run` in the background
+    /// and returns before that task finishes; `post_process::run` unconditionally
+    /// attempts an `affinity_evaluation` LLM call (against this same mock)
+    /// whenever `eval_skip_reason` lets it through — and `resolve()` never
+    /// returns `None` for an unconfigured task, so there is no config-side gate
+    /// to lean on here. A longer message (e.g. "draw me", 7 chars) clears the
+    /// length gate, and because `ReplyImage` proxies the assistant text with
+    /// `plan.image_prompt` (non-blank here), it would also clear the
+    /// empty-assistant gate — so the eval call fires, racing the test's
+    /// `mock.received_requests()` against a `tokio::spawn`ed task. Keeping the
+    /// content short makes "the composer is the only possible call" true by
+    /// construction, not by scheduling luck.
     async fn run_variant_turn(
         pool: &PgPool,
         prompt_variant: Option<&str>,
@@ -5997,7 +6012,7 @@ data: [DONE]\n\n";
         let user_message_id = match chat_repo
             .upsert_user_message_idempotent(
                 session_id,
-                "draw me",
+                "hi",
                 "01J9000000000000000000000A",
                 "user",
                 None,
@@ -6016,7 +6031,7 @@ data: [DONE]\n\n";
                 session_id,
                 user_id,
                 instance_id,
-                content: "draw me".into(),
+                content: "hi".into(),
                 prompt_traits: vec![],
                 audit: None,
                 tier: None,

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -2610,7 +2610,7 @@ async fn build_delegated_image_prompt(
         .ok()
         .and_then(|v| v.as_str().map(String::from))
         .unwrap_or_else(|| "realistic".to_string());
-    let final_subject = match state.model_config.resolve_image_prompt_compose() {
+    let final_subject = match state.model_config.resolve_image_prompt_compose(None) {
         Some(c) => run_image_prompt_compose(
             state,
             &c,

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -2610,7 +2610,8 @@ async fn build_delegated_image_prompt(
         .ok()
         .and_then(|v| v.as_str().map(String::from))
         .unwrap_or_else(|| "realistic".to_string());
-    let final_subject = match state.model_config.resolve_image_prompt_compose(None) {
+    let variant = req_image.and_then(|i| i.prompt_variant.as_deref());
+    let final_subject = match state.model_config.resolve_image_prompt_compose(variant) {
         Some(c) => run_image_prompt_compose(
             state,
             &c,
@@ -5949,6 +5950,151 @@ data: [DONE]\n\n";
             img["prompt"],
             serde_json::json!(composed),
             "the composed wire prompt must not be persisted (only the seed subject)"
+        );
+    }
+
+    /// Shared setup for the two `prompt_variant` tests: a keyed composer
+    /// config, a mock that records every outbound call, and a forced
+    /// image-only turn. Returns the recorded requests and the emitted frames.
+    async fn run_variant_turn(
+        pool: &PgPool,
+        prompt_variant: Option<&str>,
+    ) -> (Vec<wiremock::Request>, Vec<ProtocolFrame>) {
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+        use futures_util::StreamExt;
+        use wiremock::matchers::path as wm_path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        // 500 on every call: the composer fails open to the seed subject. These
+        // tests assert on what was SENT, so the response body is irrelevant.
+        let mock = MockServer::start().await;
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&mock)
+            .await;
+
+        let user_id = Uuid::new_v4();
+        let (_g, instance_id, session_id) = seed_persona_and_session(pool, user_id).await;
+
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = std::sync::Arc::new(
+            eros_engine_llm::model_config::ModelConfig::from_toml_str(
+                "[tasks.chat_companion]\nmodel = \"primary\"\n\
+                 [tasks.chat_image_prompt_compose]\nmodel = \"composer\"\n\
+                 filter_prompt = { a = \"PROMPT_A\", b = \"PROMPT_B\" }\n",
+            )
+            .unwrap(),
+        );
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                eros_engine_llm::openrouter::AppAttribution::default(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+
+        let chat_repo = ChatRepo { pool };
+        let user_message_id = match chat_repo
+            .upsert_user_message_idempotent(
+                session_id,
+                "draw me",
+                "01J9000000000000000000000A",
+                "user",
+                None,
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
+
+        let frames: Vec<ProtocolFrame> = run_stream(
+            std::sync::Arc::new(state),
+            PersistedUserMessage {
+                user_message_id,
+                session_id,
+                user_id,
+                instance_id,
+                content: "draw me".into(),
+                prompt_traits: vec![],
+                audit: None,
+                tier: None,
+                memory_scope: Default::default(),
+                affinity_scope: Default::default(),
+                tips_amount_usd: None,
+                image_url: None,
+                image: Some(crate::routes::companion_stream::ImageReplyParams {
+                    force: true,
+                    mode: crate::routes::companion_stream::ImageMode::ImageOnly,
+                    image_prompt: Some("a beach at sunset".into()),
+                    prompt_variant: prompt_variant.map(str::to_string),
+                    ..Default::default()
+                }),
+                history_anchor: Default::default(),
+            },
+            None,
+        )
+        .collect()
+        .await;
+
+        let reqs = mock.received_requests().await.expect("recorded requests");
+        (reqs, frames)
+    }
+
+    /// `image.prompt_variant = "b"` must send variant b's text as the
+    /// composer's system message — proof the wire value reaches
+    /// `PromptSpec::select`.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn prompt_variant_selects_the_configured_composer_prompt(pool: PgPool) {
+        let (reqs, _frames) = run_variant_turn(&pool, Some("b")).await;
+        assert_eq!(
+            reqs.len(),
+            1,
+            "an image-only turn makes exactly one provider call (the composer)"
+        );
+        let body: serde_json::Value =
+            serde_json::from_slice(&reqs[0].body).expect("composer request body is json");
+        assert_eq!(body["messages"][0]["role"], "system");
+        assert_eq!(
+            body["messages"][0]["content"], "PROMPT_B",
+            "composer must use variant b, got {}",
+            body["messages"][0]["content"]
+        );
+    }
+
+    /// `prompt_variant = "raw"` must make ZERO provider calls and pass the seed
+    /// subject through to the wire prompt verbatim.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn prompt_variant_raw_skips_the_composer(pool: PgPool) {
+        let (reqs, frames) = run_variant_turn(&pool, Some("raw")).await;
+        assert!(
+            reqs.is_empty(),
+            "raw must make no composer call, got {} request(s)",
+            reqs.len()
+        );
+
+        let composed_b64 = frames
+            .iter()
+            .find_map(|f| match f {
+                ProtocolFrame::ImageRequest {
+                    composed_prompt, ..
+                } => Some(composed_prompt.clone()),
+                _ => None,
+            })
+            .expect("image_request present");
+        let composed = {
+            use base64::Engine as _;
+            String::from_utf8(
+                base64::engine::general_purpose::STANDARD
+                    .decode(&composed_b64)
+                    .unwrap(),
+            )
+            .unwrap()
+        };
+        assert!(
+            composed.contains("a beach at sunset"),
+            "raw must pass the seed subject through: {composed}"
         );
     }
 

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -2539,7 +2539,9 @@ struct ImageTurnInputs {
 /// - style:   `req_image.style` → config `default_style` → type default
 /// - aspect:  `plan.aspect_ratio` → `req_image.aspect_ratio` → config default
 ///
-/// Blank strings count as absent at every level.
+/// Blank strings count as absent at the plan and request levels. The config
+/// default (`default_aspect_ratio`) is taken as-is, unfiltered — pre-existing
+/// behavior, unchanged.
 fn resolve_image_turn_inputs(
     plan: &eros_engine_core::types::ActionPlan,
     req_image: Option<&crate::routes::companion_stream::ImageReplyParams>,
@@ -4161,7 +4163,6 @@ mod tests {
 
     #[test]
     fn image_turn_subject_prefers_plan_then_request_then_empty() {
-        use eros_engine_llm::model_config::StyleKey;
         let params = img_params(Some("from request"), None, None);
 
         // plan wins
@@ -4175,7 +4176,13 @@ mod tests {
         // neither ⇒ empty string
         let r = resolve_image_turn_inputs(&img_plan(None, None), None, None);
         assert_eq!(r.seed_subject, "");
-        let _ = StyleKey::Realistic;
+
+        // blank request value, plan absent ⇒ falls through to empty string
+        // too, not the blank string itself (the request-level blank filter
+        // must still fire).
+        let blank_params = img_params(Some("   "), None, None);
+        let r = resolve_image_turn_inputs(&img_plan(None, None), Some(&blank_params), None);
+        assert_eq!(r.seed_subject, "");
     }
 
     #[test]
@@ -4215,6 +4222,16 @@ mod tests {
 
         let r = resolve_image_turn_inputs(&img_plan(None, None), None, None);
         assert_eq!(r.aspect_ratio, None, "nothing anywhere ⇒ None");
+
+        // blank request value, plan absent ⇒ falls through to the config
+        // default (the request-level blank filter must still fire).
+        let blank_params = img_params(None, None, Some("  "));
+        let r = resolve_image_turn_inputs(&img_plan(None, None), Some(&blank_params), Some(&gen));
+        assert_eq!(
+            r.aspect_ratio.as_deref(),
+            Some("1:1"),
+            "blank request ⇒ config default"
+        );
     }
 
     #[test]

--- a/crates/eros-engine-server/src/routes/companion_stream.rs
+++ b/crates/eros-engine-server/src/routes/companion_stream.rs
@@ -99,6 +99,18 @@ pub struct ImageReplyParams {
     pub image_prompt: Option<String>,
     #[serde(default)]
     pub aspect_ratio: Option<String>,
+    /// Which `[tasks.chat_image_prompt_compose].filter_prompt` variant to use
+    /// for this turn: an index (`"0"`, `"1"`) for the array shape, or a key
+    /// (`"a"`, `"b"`) for the table shape. Ignored when that task configures a
+    /// single plain prompt.
+    ///
+    /// `"raw"` (case-insensitive) is reserved: it skips the composer LLM
+    /// entirely and draws the seed subject as-is, saving one LLM call.
+    ///
+    /// An unknown index/key falls back to the engine's built-in composer
+    /// prompt — it is never an error.
+    #[serde(default)]
+    pub prompt_variant: Option<String>,
 }
 
 #[derive(Debug, Deserialize, utoipa::ToSchema)]

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -292,6 +292,7 @@ draws on the chat stream).
 | `style` | `"realistic"` \| `"semi_realistic"` \| `"anime"` | task `default_style` | One of the three engine-owned style presets. |
 | `image_prompt` | `String` | PDE judge / user text | Subject for the forced path. On the PDE path the judge's own `image_prompt` is used. |
 | `aspect_ratio` | `String` | task `default_aspect_ratio` | Allowed: `1:1`, `3:4`, `4:3`, `9:16`, `16:9`. Returns `422` if invalid. |
+| `prompt_variant` | `String` | none | Selects a `[tasks.chat_image_prompt_compose].filter_prompt` variant: an index (`"0"`, `"1"`) or a key (`"a"`, `"b"`), depending on how that task is configured (see [model-config.md](model-config.md)). `"raw"` (case-insensitive) skips the composer LLM entirely and draws the seed subject as-is. An index/key that doesn't match falls back to the engine's built-in composer prompt — never a `422` or other error. Ignored when the task isn't configured, or configures a single plain prompt. |
 
 **Reference selection (`image_ref`).** The PDE verdict carries `image_ref`
 (`"face"` | `"previous"`, default `"face"`) and rides on the `image_request`

--- a/docs/api-reference.zh.md
+++ b/docs/api-reference.zh.md
@@ -267,6 +267,7 @@ curl -N -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/js
 | `style` | `"realistic"` \| `"semi_realistic"` \| `"anime"` | 任务 `default_style` | 引擎内置三种风格预设之一。 |
 | `image_prompt` | `String` | PDE 判断 / 用户文本 | 强制路径的图片主题。PDE 路径使用判断器自己的 `image_prompt`。 |
 | `aspect_ratio` | `String` | 任务 `default_aspect_ratio` | 允许值：`1:1`、`3:4`、`4:3`、`9:16`、`16:9`。非法时返回 `422`。 |
+| `prompt_variant` | `String` | 无 | 选择 `[tasks.chat_image_prompt_compose].filter_prompt` 的一个变体：按下标（`"0"`、`"1"`）或按 key（`"a"`、`"b"`），取决于该任务的配置形态（见 [model-config.zh.md](model-config.zh.md)）。`"raw"`（大小写不敏感）会完全跳过改写器 LLM，直接用种子主题原样出图。下标/key 没命中时回退到引擎内置的改写器提示词——绝不报 `422` 或其他错误。该任务未配置，或配置为单一纯字符串提示词时，此字段被忽略。 |
 
 **参考图选择（`image_ref`）。** PDE verdict 带有 `image_ref`（`"face"` \| `"previous"`，默认 `"face"`），并附带在下方的 `image_request` 帧中——聊天流本身不会把它解析成实际 URL。`previous` 且无可用图时回退到 `face` 的规则，以及 `face_ref_url` / `prev_image_url` 参考图 URL，都属于绘图端点（见其请求体）。持久化的 `metadata.image` 标记只记录种子提示词与画幅，不记录参考类型。
 

--- a/docs/model-config.md
+++ b/docs/model-config.md
@@ -489,11 +489,15 @@ filter_prompt = ["…", "…"]                # pick by index: prompt_variant = 
 filter_prompt = { a = "…", b = "…" }      # pick by key:   prompt_variant = "a" / "b"
 ```
 
-Anything not selected — no `prompt_variant`, an out-of-range index, an unknown
-key — falls back to the **built-in** prompt above (logged at `warn`), never to
-"first entry wins". There is no reserved `default` key: writing `default = "…"`
-defines an ordinary variant, selected only by a literal `prompt_variant =
-"default"`.
+Anything not selected falls back to the **built-in** prompt above, never to
+"first entry wins" — but the two ways of "not selected" are logged
+differently. An **absent** `prompt_variant` falls back silently (the common
+case: no variant was requested, so there is nothing to warn about). An
+**explicitly-supplied** variant that fails to match — an out-of-range index, an
+unknown key — also falls back, but additionally logs at `warn`, since a
+variant the caller asked for and didn't get is worth surfacing. There is no
+reserved `default` key: writing `default = "…"` defines an ordinary variant,
+selected only by a literal `prompt_variant = "default"`.
 
 `prompt_variant = "raw"` (case-insensitive) skips the composer LLM entirely and
 draws the seed subject as-is — one fewer LLM call for that turn. `raw` is

--- a/docs/model-config.md
+++ b/docs/model-config.md
@@ -489,6 +489,20 @@ filter_prompt = ["…", "…"]                # pick by index: prompt_variant = 
 filter_prompt = { a = "…", b = "…" }      # pick by key:   prompt_variant = "a" / "b"
 ```
 
+Composer prompts tend to be long, multi-paragraph strings, and TOML 1.0.0
+discourages breaking an inline table across lines — so the keyed form also
+works as a standard (non-inline) table, one key per section:
+
+```toml
+[tasks.chat_image_prompt_compose.filter_prompt]
+a = """
+…long prompt…
+"""
+b = """
+…another long prompt…
+"""
+```
+
 Anything not selected falls back to the **built-in** prompt above, never to
 "first entry wins" — but the two ways of "not selected" are logged
 differently. An **absent** `prompt_variant` falls back silently (the common

--- a/docs/model-config.md
+++ b/docs/model-config.md
@@ -469,7 +469,7 @@ max_tokens   = 700
 | `temperature` | `f64` | task default | Sampling temperature for the composer call. |
 | `max_tokens` | `u32` | task default | Token cap for the composer call. |
 | `reasoning` | table | absent | Optional reasoning control forwarded to OpenRouter. |
-| `filter_prompt` | `String` | **built-in default** | **Optional** (unlike other tasks). Blank/absent ⇒ the engine's built-in `DEFAULT_COMPOSE_PROMPT`; non-blank ⇒ override. |
+| `filter_prompt` | `String` \| `Array<String>` \| `Table<String, String>` | **built-in default** | **Optional** (unlike other tasks). Blank/absent ⇒ the engine's built-in `DEFAULT_COMPOSE_PROMPT`. See **variants** below for the array/table shapes. |
 
 **Built-in default prompt.** Unlike every other task (whose prompt must come from
 config), the composer ships a generic, **product-identity-free** built-in
@@ -478,6 +478,31 @@ appearance into a detailed prompt and does **not** soften, downgrade, censor, or
 refuse, and adds no content-moderation layer of its own — moderation is delegated
 to the image-model provider and the downstream deployment, not this step. A
 non-blank `filter_prompt` overrides it; a blank/absent one falls back to it.
+
+**Variants.** This is the **only** task whose `filter_prompt` accepts more than a
+plain string. The consumer picks one per chat turn via `image.prompt_variant` on
+the send-message body. Three shapes:
+
+```toml
+filter_prompt = "…"                       # one prompt; prompt_variant is ignored
+filter_prompt = ["…", "…"]                # pick by index: prompt_variant = "0" / "1"
+filter_prompt = { a = "…", b = "…" }      # pick by key:   prompt_variant = "a" / "b"
+```
+
+Anything not selected — no `prompt_variant`, an out-of-range index, an unknown
+key — falls back to the **built-in** prompt above (logged at `warn`), never to
+"first entry wins". There is no reserved `default` key: writing `default = "…"`
+defines an ordinary variant, selected only by a literal `prompt_variant =
+"default"`.
+
+`prompt_variant = "raw"` (case-insensitive) skips the composer LLM entirely and
+draws the seed subject as-is — one fewer LLM call for that turn. `raw` is
+reserved: a table key literally named `raw` (any casing) refuses to boot.
+
+Variants are honored on this task only. An array/table `filter_prompt` on any
+other task, or inside **any** `[tasks.*.tiers.*]` block (this task's own tiers
+included — the composer always resolves with no tier), refuses to boot rather
+than sit there unreachable.
 
 Call site: `crates/eros-engine-server/src/pipeline/stream.rs` via
 `resolve_image_prompt_compose()` in `model_config.rs`.

--- a/docs/model-config.zh.md
+++ b/docs/model-config.zh.md
@@ -409,6 +409,19 @@ filter_prompt = ["…", "…"]                # 按下标选：prompt_variant = 
 filter_prompt = { a = "…", b = "…" }      # 按 key 选：  prompt_variant = "a" / "b"
 ```
 
+改写器提示词通常又长又多段，而 TOML 1.0.0 本就不建议把 inline table 拆成多行——所以按
+key 选的形态也可以写成标准（非 inline）表，一个 key 一个 section：
+
+```toml
+[tasks.chat_image_prompt_compose.filter_prompt]
+a = """
+…较长的提示词…
+"""
+b = """
+…另一个较长的提示词…
+"""
+```
+
 没有命中都会回退到上面的**内置**提示词，不存在"取第一项"这种行为——但两种"没命中"的记录方式不同。**没传** `prompt_variant` 属于静默回退（最常见的情况：既然没人要求选变体，也就没什么好警告的）。**明确传了但没命中**的变体——下标越界、key 不存在——同样回退，但会额外记一条 `warn` 日志，因为调用方指定了变体却没用上，值得被看到。也没有保留的 `default` key：写 `default = "…"` 只是定义了一个普通变体，只有字面量 `prompt_variant = "default"` 才会命中它。
 
 `prompt_variant = "raw"`（大小写不敏感）会完全跳过改写器 LLM，直接用种子主题原样出图——这一轮少一次 LLM 调用。`raw` 是保留字：表里若出现字面量为 `raw` 的 key（任意大小写）会拒绝启动。

--- a/docs/model-config.zh.md
+++ b/docs/model-config.zh.md
@@ -397,9 +397,23 @@ max_tokens   = 700
 | `temperature` | `f64` | 任务默认 | 改写器调用的采样温度。 |
 | `max_tokens` | `u32` | 任务默认 | 改写器调用的 token 上限。 |
 | `reasoning` | 表 | 缺失 | 可选 reasoning 控制，转发给 OpenRouter。 |
-| `filter_prompt` | `String` | **内置默认** | **可选**（不同于其他任务）。空白/缺失 ⇒ 引擎内置的 `DEFAULT_COMPOSE_PROMPT`；非空 ⇒ 覆盖。 |
+| `filter_prompt` | `String` \| `Array<String>` \| `Table<String, String>` | **内置默认** | **可选**（不同于其他任务）。空白/缺失 ⇒ 引擎内置的 `DEFAULT_COMPOSE_PROMPT`。数组/表两种形态见下方"变体"。 |
 
 **内置默认提示词。** 不同于其他每个任务（提示词必须来自配置），改写器自带一个通用、**不含产品身份**的内置默认。它的立场是**只扩写**：忠实地把种子主题和外观扩成详细提示词，**不**软化、不降级、不审查、不拒绝，也不自带内容审核层——审核交给画图模型供应商和下游部署，不在这一步。非空 `filter_prompt` 覆盖它；空白/缺失则回退到它。
+
+**变体（variants）。** 这是**唯一**一个 `filter_prompt` 接受纯字符串以外形态的任务。前端在每个 chat 轮次通过发消息请求体上的 `image.prompt_variant` 挑一个。三种形态：
+
+```toml
+filter_prompt = "…"                       # 单一提示词；prompt_variant 被忽略
+filter_prompt = ["…", "…"]                # 按下标选：prompt_variant = "0" / "1"
+filter_prompt = { a = "…", b = "…" }      # 按 key 选：  prompt_variant = "a" / "b"
+```
+
+没有命中的情况——没传 `prompt_variant`、下标越界、key 不存在——一律回退到上面的**内置**提示词（记 `warn` 日志），不存在"取第一项"这种行为。也没有保留的 `default` key：写 `default = "…"` 只是定义了一个普通变体，只有字面量 `prompt_variant = "default"` 才会命中它。
+
+`prompt_variant = "raw"`（大小写不敏感）会完全跳过改写器 LLM，直接用种子主题原样出图——这一轮少一次 LLM 调用。`raw` 是保留字：表里若出现字面量为 `raw` 的 key（任意大小写）会拒绝启动。
+
+变体只在这一个任务上生效。任何其他任务的数组/表形态 `filter_prompt`，或**任何** `[tasks.*.tiers.*]` 块（包括本任务自己的 tiers——改写器解析时永远不走 tier）里的数组/表形态，都会拒绝启动，而不是留在那里永远选不到。
 
 调用点：`crates/eros-engine-server/src/pipeline/stream.rs`，通过 `model_config.rs` 中的 `resolve_image_prompt_compose()`。
 

--- a/docs/model-config.zh.md
+++ b/docs/model-config.zh.md
@@ -409,7 +409,7 @@ filter_prompt = ["…", "…"]                # 按下标选：prompt_variant = 
 filter_prompt = { a = "…", b = "…" }      # 按 key 选：  prompt_variant = "a" / "b"
 ```
 
-没有命中的情况——没传 `prompt_variant`、下标越界、key 不存在——一律回退到上面的**内置**提示词（记 `warn` 日志），不存在"取第一项"这种行为。也没有保留的 `default` key：写 `default = "…"` 只是定义了一个普通变体，只有字面量 `prompt_variant = "default"` 才会命中它。
+没有命中都会回退到上面的**内置**提示词，不存在"取第一项"这种行为——但两种"没命中"的记录方式不同。**没传** `prompt_variant` 属于静默回退（最常见的情况：既然没人要求选变体，也就没什么好警告的）。**明确传了但没命中**的变体——下标越界、key 不存在——同样回退，但会额外记一条 `warn` 日志，因为调用方指定了变体却没用上，值得被看到。也没有保留的 `default` key：写 `default = "…"` 只是定义了一个普通变体，只有字面量 `prompt_variant = "default"` 才会命中它。
 
 `prompt_variant = "raw"`（大小写不敏感）会完全跳过改写器 LLM，直接用种子主题原样出图——这一轮少一次 LLM 调用。`raw` 是保留字：表里若出现字面量为 `raw` 的 key（任意大小写）会拒绝启动。
 

--- a/docs/superpowers/specs/2026-07-31-image-prompt-compose-variants-design.md
+++ b/docs/superpowers/specs/2026-07-31-image-prompt-compose-variants-design.md
@@ -1,0 +1,342 @@
+# eros-engine — `chat_image_prompt_compose` filter_prompt variants
+
+Lets a deployment configure **several** image-composer prompts under one
+`[tasks.chat_image_prompt_compose].filter_prompt` and lets the downstream
+consumer pick one per turn, plus a reserved `raw` escape that skips the
+composer LLM entirely.
+
+Today `filter_prompt` is a single string: every image turn in a deployment gets
+the same composer instruction, and the only way to skip the composer is to
+remove the whole task block (a deploy-wide, all-or-nothing switch). This design
+adds a per-turn axis without touching either property for deployments that keep
+the plain-string form.
+
+---
+
+## 0. Decisions (settled during brainstorm)
+
+- **Only `chat_image_prompt_compose` gets variants.** `TaskConfig` is one
+  shared struct, so the *type* of `filter_prompt` necessarily widens for every
+  `[tasks.*]` block; "only compose" is therefore enforced at **boot
+  validation**, not by the type system. Any other task written in a variant
+  form refuses to boot.
+- **Variant forms are rejected inside `[tasks.*.tiers.*]` blocks — including
+  compose's own.** `resolve_image_prompt_compose` calls `self.resolve(TASK,
+  None)` and reads `task_cfg.filter_prompt` directly; it never consults tiers.
+  A tier-level variant would be silently dead config, which §1.2 exists to
+  prevent.
+- **Wire location is `image.prompt_variant`** (inside `ImageReplyParams`), not
+  a top-level request field. The composer only runs on image turns, and the
+  presence of the `image` block is already the "this turn may produce an image"
+  signal — so the parameter cannot land somewhere it has no meaning.
+- **Wire type is `Option<String>`.** Numeric variants are written `"0"` /
+  `"1"`. A JSON number is a 400. This keeps the OpenAPI schema a plain string
+  and avoids `1` vs `1.0` vs `01` normalization rules.
+- **Unknown / out-of-range variants fall back silently + `warn`.** The whole
+  composer path is already fail-open (model error, timeout, and empty reply all
+  degrade to the seed subject); a typo in a client-supplied variant name must
+  not take down a chat turn. A 400 would also mean deleting a variant from
+  config instantly breaks already-shipped clients.
+- **Blank values inside a variant form refuse to boot.** The plain-string
+  form's leniency (`"   "` → built-in default) exists so a deployer can comment
+  a prompt out. Once they have deliberately written a *list* of variants, a
+  blank entry is a typo, and silently substituting the generic built-in prompt
+  is the hardest class of bug to notice.
+- **No selected variant ⇒ the built-in `DEFAULT_COMPOSE_PROMPT`.** One rule
+  covers both variant forms and both miss cases (nothing passed / passed but
+  not found). The originally-sketched "index 0" and "`default` key" special
+  cases are both dropped: the engine already ships a fallback prompt, so a
+  second per-form fallback mechanism earns nothing.
+- **`default` is an ordinary key.** In the keyed form it matches only when the
+  client literally sends `"default"`. Documented, not boot-checked — it is a
+  legal key name.
+- **`raw` is a reserved word, matched case-insensitively on both sides.** The
+  client value `raw` skips the composer; a config key `raw` (any casing)
+  refuses to boot. Case-insensitivity on the config side removes the trap where
+  a deployer writes `Raw = "…"`, believes they have defined the escape hatch,
+  and never sees it used.
+- **The selected variant is not persisted.** `tracing` only.
+  `build_delegated_image_marker` stays deliberately minimal (seed subject +
+  aspect ratio), consistent with its existing doc comment and with the
+  `chat_vision` audit's same stance. The value is client-supplied anyway.
+- **The two delegated-image call sites are extracted into one helper first.**
+  They are byte-identical for ~45 lines modulo indentation and one comment that
+  exists in only one copy — evidence the manual sync has already drifted.
+  Landing the variant in both by hand would double that drift surface.
+
+---
+
+## 1. Config layer
+
+### 1.1 `PromptSpec`
+
+New type in `crates/eros-engine-llm/src/model_config.rs`, placed next to
+`ModelSpec` and mirroring its untagged-deserialize pattern
+(`model_config.rs:49`), which already establishes "one field, three TOML
+shapes" in this config file:
+
+```rust
+/// A task's `filter_prompt`. Accepts three TOML shapes, mirroring `ModelSpec`:
+/// `"xxx"` (plain), `["aaa","bbb"]` (index-keyed variants), or
+/// `{ a = "aaa", b = "bbb" }` (string-keyed variants). Only
+/// `chat_image_prompt_compose` may use the variant shapes; see
+/// `validate_prompt_variants`.
+pub enum PromptSpec {
+    Plain(String),
+    Indexed(Vec<String>),
+    Keyed(BTreeMap<String, String>),
+}
+```
+
+Deserialize order `Plain → Indexed → Keyed`; TOML string / array / table are
+unambiguous to serde. `BTreeMap` (not `HashMap`) so key lists in boot-failure
+messages are ordered deterministically.
+
+`TaskConfig.filter_prompt` (`model_config.rs:521`) and
+`TierConfig.filter_prompt` (`model_config.rs:350`) both become
+`Option<PromptSpec>`.
+
+Two accessors:
+
+| Method | Consumer |
+| --- | --- |
+| `as_plain(&self) -> Option<&str>` | The 13 non-compose read sites. Returns `Some` only for `Plain` — and after §1.2 those sites can only ever hold `Plain`. A `None` from a variant shape is indistinguishable from an absent/blank `filter_prompt`, which every one of those sites already handles (almost always: feature off), so the unreachable branch degrades safely rather than panicking. |
+| `select(&self, variant: Option<&str>) -> Option<&str>` | `resolve_image_prompt_compose` only. |
+
+### 1.2 Boot validation
+
+New `ModelConfig::validate_prompt_variants() -> Result<(), String>`, called
+from `main.rs` alongside the existing `validate_*` sequence
+(`main.rs:299-322`), unconditionally — no feature flag gates it, and like its
+neighbours it sits in the serve path only, so `print-openapi` / backfill
+subcommands are unaffected.
+
+It walks every `[tasks.*]` block plus every tier block within them, and refuses
+to boot when:
+
+| Condition | Rationale |
+| --- | --- |
+| A task other than `chat_image_prompt_compose` uses `Indexed` / `Keyed` | Nothing reads variants there |
+| **Any** tier block uses `Indexed` / `Keyed` (compose included) | Compose resolves with `tier = None`; tier variants can never be selected |
+| `[]` or `{}` | Empty container |
+| Any `Indexed` entry blank after trim | §0 zero-tolerance for blanks in variant forms |
+| Any `Keyed` value blank after trim | Same |
+| Any `Keyed` key blank after trim | Same |
+| Any `Keyed` key equal to `raw` (ASCII case-insensitive) | Reserved wire word |
+
+Message format follows the existing convention (`model_config.rs:1519`):
+`[tasks.{name}] … — eros-engine refuses to boot. …`
+
+Key matching is otherwise **case-sensitive and exact**.
+
+---
+
+## 2. Selection semantics
+
+The client value is trimmed first; blank after trim is treated as absent.
+
+### 2.1 `raw` short-circuit
+
+Checked before any shape dispatch: `variant.eq_ignore_ascii_case("raw")` ⇒ the
+composer LLM does not run and the seed subject is used verbatim. This holds for
+**every** shape, including `Plain` and including a compose block with no
+`filter_prompt` at all (built-in prompt).
+
+Implementation: `resolve_image_prompt_compose(variant)` returns `None` on
+`raw`. The existing `None => subject.clone()` arm at the call sites
+(`stream.rs:3353`, `stream.rs:3712`) absorbs it with no new branch. `raw` and
+"feature off" therefore share a code path — deliberate: they produce identical
+output, and the two are distinguished in `tracing`, not in the type.
+
+Skipping the composer does **not** skip `compose_image_prompt`
+(`handlers.rs:276`), the deterministic style-preset + appearance + subject
+wrapper. `raw` saves exactly one LLM call, which is its stated purpose.
+
+### 2.2 `select`
+
+`select(&self, variant: Option<&str>) -> Option<&str>`, where `None` means "no
+variant selected":
+
+| Shape | Behavior |
+| --- | --- |
+| `Plain("xxx")` | Always `Some("xxx")`; the variant parameter is ignored |
+| `Indexed([…])` | `variant.parse::<usize>()` succeeds and is in range ⇒ `Some(entry)`; otherwise `None` |
+| `Keyed({…})` | `variant` matches a key exactly ⇒ `Some(value)`; otherwise `None` |
+
+`None` resolves to `DEFAULT_COMPOSE_PROMPT` one level up. The existing
+`unwrap_or_else` line (`model_config.rs:1567`) is untouched; only the
+expression feeding it changes:
+
+```rust
+let compose_prompt = task_cfg
+    .filter_prompt
+    .as_ref()
+    .and_then(|s| s.select(variant))
+    .map(str::trim)
+    .filter(|s| !s.is_empty())
+    .map(str::to_string)
+    .unwrap_or_else(|| DEFAULT_COMPOSE_PROMPT.to_string());
+```
+
+The `trim` / `is_empty` pair is retained from the current code: it is what makes
+a blank **plain-string** `filter_prompt` fall through to the built-in prompt,
+which an existing test asserts (`model_config.rs:4274`). It is redundant for the
+variant shapes — §1.2 already rejects blanks there at boot — but removing it
+would be a behavior regression for the plain shape.
+
+Misses covered by "otherwise `None`": non-numeric variant against `Indexed`
+(`"a"`), out-of-range (`"5"`), unparseable (`"-1"`), and unknown key against
+`Keyed`. `"01"` parses to `1` — the ordinary `usize::from_str` behavior, not
+special-cased.
+
+### 2.3 Logging
+
+| Level | Event |
+| --- | --- |
+| `debug` | Variant hit (shape + resolved variant) |
+| `debug` | `raw` requested — composer skipped |
+| `warn` | Variant supplied but not found; falling back to the built-in prompt |
+
+---
+
+## 3. Wire and call-site wiring
+
+### 3.1 DTO
+
+`ImageReplyParams` (`companion_stream.rs:90`) gains:
+
+```rust
+/// Which `[tasks.chat_image_prompt_compose].filter_prompt` variant to use this
+/// turn. `"raw"` (case-insensitive) skips the composer LLM entirely and draws
+/// the seed subject as-is. Unknown values fall back to the built-in prompt.
+#[serde(default)]
+pub prompt_variant: Option<String>,
+```
+
+`openapi.json` is regenerated.
+
+`resolve_image_prompt_compose(&self)` becomes
+`resolve_image_prompt_compose(&self, variant: Option<&str>)`.
+
+### 3.2 Commit 1 — extraction (no behavior change)
+
+`stream.rs:3311-3355` (`ReplyImage`) and `stream.rs:3671-3714`
+(`ReplyTextImage`) currently duplicate the computation of `subject`, `style`,
+`style_str`, `aspect`, `final_subject`, and `composed_prompt`. `style` /
+`style_str` are dead after `composed_prompt`, so the two arms need only three
+values from the shared region. Split along the pure/IO seam:
+
+```rust
+struct ImageTurnInputs {
+    seed_subject: String,
+    style: StyleKey,
+    aspect_ratio: Option<String>,
+}
+
+/// Pure: resolve the three per-turn image inputs from plan → request → config.
+fn resolve_image_turn_inputs(
+    plan: &ActionPlan,
+    req_image: Option<&ImageReplyParams>,
+    resolved_image_gen: Option<&ResolvedImageGen>,
+) -> ImageTurnInputs
+
+struct DelegatedImagePrompt {
+    seed_subject: String,          // → build_delegated_image_marker
+    aspect_ratio: Option<String>,  // → marker + frame
+    composed_prompt: String,       // → frame
+}
+
+/// Runs the composer (skipped on `raw`) and wraps the result into the final
+/// wire prompt.
+async fn build_delegated_image_prompt(
+    state: &AppState,
+    persona: &CompanionPersona,
+    plan: &ActionPlan,
+    req_image: Option<&ImageReplyParams>,
+    resolved_image_gen: Option<&ResolvedImageGen>,
+    pde_transcript: &str,
+) -> DelegatedImagePrompt
+```
+
+The pure/IO split is the point: `resolve_image_turn_inputs` holds three
+three-level precedence chains (`plan.image_prompt → req_image.image_prompt →
+""`; `req_image.style → default_style → Default`; `plan.aspect_ratio →
+req_image.aspect_ratio → default_aspect_ratio`) that today have **no unit
+coverage at all**, because they are buried inside `async gen` match arms and
+reachable only through a full mocked pipeline. Precedent for the shape:
+`compose_user_payload` (`stream.rs:2448`, tested at `stream.rs:4068`).
+
+Both match arms shrink to a call plus their divergent tail (insert a new row +
+three frames, versus merge the marker + one frame). This commit must land with
+every existing assertion unchanged.
+
+### 3.3 Commit 2 — variant threading
+
+The variant is read exactly once, inside `build_delegated_image_prompt`, as
+`req_image.and_then(|i| i.prompt_variant.as_deref())`, and passed to
+`resolve_image_prompt_compose`.
+
+`req_image == None` (the PDE chose an image turn without a client `image`
+block) yields `variant = None` — the pre-existing behavior.
+
+Both commits go in one PR.
+
+---
+
+## 4. Testing
+
+**`eros-engine-llm` (`model_config.rs`)**
+
+- `PromptSpec` deserialization for all three shapes.
+- `select`: `Plain` ignores the variant; `Indexed` hit / out-of-range /
+  non-numeric / `"-1"` / `"01"`→`1` / absent; `Keyed` hit / miss / absent;
+  `default` as an ordinary key hits only on a literal `"default"`.
+- `raw`: `resolve_image_prompt_compose(Some("raw"))` ⇒ `None`, for `"RAW"` and
+  `"Raw"` too, and under `Plain` as well as an entirely absent `filter_prompt`.
+- `resolve_image_prompt_compose`: each shape × variant resolves the right
+  `compose_prompt`; every miss resolves `DEFAULT_COMPOSE_PROMPT`.
+- `validate_prompt_variants`: variant on a non-compose task ⇒ `Err`; variant in
+  any tier block ⇒ `Err`; `[]` / `{}` ⇒ `Err`; blank entry / blank value /
+  blank key ⇒ `Err`; `raw` / `Raw` / `RAW` as a key ⇒ `Err`; valid config ⇒
+  `Ok`.
+- **Regression lock:** every existing `resolve_*` test must pass **with no
+  edits**. Their TOML is all plain-string; any required edit means the
+  abstraction leaked.
+
+**`eros-engine-server` (`stream.rs`)**
+
+- Unit tests for `resolve_image_turn_inputs` covering all three precedence
+  chains (new coverage).
+- `sqlx::test` + `wiremock`: a keyed config, a request carrying
+  `image.prompt_variant = "b"`, asserting via `received_requests()` that the
+  composer call's system message is variant `b`'s prompt.
+- `sqlx::test` + `wiremock`: `prompt_variant = "raw"` makes **zero** composer
+  calls, and the `image_request` frame's `composed_prompt` contains the seed
+  subject verbatim.
+
+---
+
+## 5. Documentation
+
+- `examples/model_config.toml`, the compose block (~`258-289`): all three
+  shapes, the `raw` escape, an explicit note that `default` is **not** a
+  reserved key (only a literal `"default"` selects it), and that variants are
+  honored by this task alone and never inside a tier block.
+- `docs/model-config.md:435` and the matching section of
+  `docs/model-config.zh.md` (Simplified Chinese).
+- `docs/api-reference.md` and `docs/api-reference.zh.md`: `prompt_variant` on
+  `ImageReplyParams`.
+- Regenerate `openapi.json`. Run fmt / clippy / test / openapi before the PR.
+
+---
+
+## 6. Non-goals
+
+- The selected variant is not written to `metadata.image` (§0).
+- Variants are not extended to any other task — boot actively rejects them
+  (§1.2).
+- No tier × variant matrix.
+- The `/draw` endpoint is untouched: it receives an already-composed
+  `composed_prompt` and never re-composes.
+- Plain-string `filter_prompt` behavior is unchanged in every respect, so
+  existing deployments are unaffected until they opt in.

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -291,11 +291,14 @@ max_tokens = 4096
 #   filter_prompt = ["…", "…"]                # pick by index: prompt_variant = "0" / "1"
 #   filter_prompt = { a = "…", b = "…" }      # pick by key:   prompt_variant = "a" / "b"
 #
-# Anything not selected — no prompt_variant, an out-of-range index, an unknown
-# key — falls back to the BUILT-IN prompt above (logged at warn). There is no
-# "first entry wins" and no reserved `default` key: writing `default = "…"`
-# defines an ordinary variant that is selected only by a literal
-# prompt_variant = "default".
+# Anything not selected falls back to the BUILT-IN prompt above. That covers
+# both an absent prompt_variant (silent — this is the common case, no LLM was
+# asked to pick anything) and an explicitly-supplied variant that fails to
+# match — an out-of-range index or an unknown key — which additionally logs a
+# warn (a supplied variant that goes unused is worth a human's attention).
+# There is no "first entry wins" and no reserved `default` key: writing
+# `default = "…"` defines an ordinary variant that is selected only by a
+# literal prompt_variant = "default".
 #
 # `prompt_variant = "raw"` (case-insensitive) skips the composer LLM entirely
 # and draws the seed subject as-is — one fewer LLM call for that turn. `raw` is

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -282,8 +282,29 @@ max_tokens = 4096
 #temperature  = 0.7
 #max_tokens   = 700
 #reasoning    = { enabled = false }
-# filter_prompt is OPTIONAL — omit to use the built-in EXPAND-ONLY default, or
-# set it to override:
+#
+# This is the ONLY task whose `filter_prompt` accepts VARIANTS. The consumer
+# picks one per chat turn via `image.prompt_variant` on the send-message body.
+# Three shapes:
+#
+#   filter_prompt = "…"                       # one prompt; prompt_variant is ignored
+#   filter_prompt = ["…", "…"]                # pick by index: prompt_variant = "0" / "1"
+#   filter_prompt = { a = "…", b = "…" }      # pick by key:   prompt_variant = "a" / "b"
+#
+# Anything not selected — no prompt_variant, an out-of-range index, an unknown
+# key — falls back to the BUILT-IN prompt above (logged at warn). There is no
+# "first entry wins" and no reserved `default` key: writing `default = "…"`
+# defines an ordinary variant that is selected only by a literal
+# prompt_variant = "default".
+#
+# `prompt_variant = "raw"` (case-insensitive) skips the composer LLM entirely
+# and draws the seed subject as-is — one fewer LLM call for that turn. `raw` is
+# reserved: a table key named `raw` (any casing) refuses to boot.
+#
+# Variants are honored on THIS task only. An array/table `filter_prompt` on any
+# other task, or inside ANY `[tasks.*.tiers.*]` block (this task's included —
+# the composer resolves with no tier), refuses to boot rather than sit there
+# unreachable.
 #filter_prompt = """
 #…your override here…
 #"""

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -291,6 +291,18 @@ max_tokens = 4096
 #   filter_prompt = ["…", "…"]                # pick by index: prompt_variant = "0" / "1"
 #   filter_prompt = { a = "…", b = "…" }      # pick by key:   prompt_variant = "a" / "b"
 #
+# Composer prompts tend to be long/multi-paragraph, and TOML 1.0.0 discourages
+# breaking an inline table across lines — the keyed form also works as a
+# standard (non-inline) table, one key per section:
+#
+#   [tasks.chat_image_prompt_compose.filter_prompt]
+#   a = """
+#   …long prompt…
+#   """
+#   b = """
+#   …another long prompt…
+#   """
+#
 # Anything not selected falls back to the BUILT-IN prompt above. That covers
 # both an absent prompt_variant (silent — this is the common case, no LLM was
 # asked to pick anything) and an explicitly-supplied variant that fails to


### PR DESCRIPTION
Lets a deployment configure **several** image-composer prompts under one `[tasks.chat_image_prompt_compose].filter_prompt`, lets the consumer pick one per turn via `image.prompt_variant`, and adds a reserved `raw` value that skips the composer LLM entirely.

Design spec: `docs/superpowers/specs/2026-07-31-image-prompt-compose-variants-design.md` (first commit).

## What changed

`filter_prompt` accepts three TOML shapes, mirroring the existing `ModelSpec` idiom in the same file:

```toml
filter_prompt = "…"                    # one prompt; prompt_variant ignored
filter_prompt = ["…", "…"]             # by index: prompt_variant = "0" / "1"
filter_prompt = { a = "…", b = "…" }   # by key:   prompt_variant = "a" / "b"
```

- **Anything unselected falls back to the built-in `DEFAULT_COMPOSE_PROMPT`.** No "index 0 wins", and `default` is an ordinary key selected only by a literal `"default"`.
- **`prompt_variant = "raw"`** (case-insensitive, trimmed) skips the composer LLM — one fewer LLM call that turn. Reserved: a `raw` table key refuses to boot.
- **Variants are honored on this task alone.** `TaskConfig` is shared by every `[tasks.*]` block, so the type system can't express that; `validate_prompt_variants` refuses to boot on a variant shape anywhere else, in any tier block (the composer resolves with `tier = None`, so a tier variant could never be selected), on empty containers, on blanks inside a variant, and on whitespace-padded keys.
- **Misses are fail-open**, matching the composer's existing stance: an unknown index/key logs `warn` and uses the built-in prompt rather than failing the turn.

## Compatibility

**The new boot gate cannot break an existing deployment** — an array/table `filter_prompt` previously failed *deserialization* outright, so every config that booted before still boots. Plain-string behavior is bit-identical, and `prompt_variant` is optional, so existing API clients are unaffected.

⚠️ **Release note for whoever cuts the next version:** this is a breaking change to the published `eros-engine-llm` library — `TaskConfig.filter_prompt` / `TierConfig.filter_prompt` change from `Option<String>` to `Option<PromptSpec>`, and `resolve_image_prompt_compose` gains a parameter. Under cargo's 0.x rules `^0.9.2` permits `0.9.3`, so a downstream `cargo update` would break with no version signal. The break is narrow (only code reading those fields or calling that method), but the version decision should be deliberate.

## Refactor included

`stream.rs`'s `ReplyImage` and `ReplyTextImage` arms carried ~45 byte-identical lines each (already drifted by one comment). Collapsed into `build_delegated_image_prompt`, split along a pure/IO seam so `resolve_image_turn_inputs` — three three-level precedence chains with previously **zero** unit coverage — is directly testable. Landed as its own commit with no behavior change; the pre-existing e2e test passed unedited.

## Verification

fmt · clippy `-D warnings` · **995 tests** (Postgres available, `#[sqlx::test]` cases ran) · openapi snapshot: no drift. All commits signed.

Two `#[sqlx::test]` integration tests prove the feature end-to-end: a keyed variant reaches the composer's system message, and `raw` makes **zero** provider calls.

Docs updated: `examples/model_config.toml`, `docs/model-config{,.zh}.md`, `docs/api-reference{,.zh}.md`, regenerated `openapi.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)