### PR TITLE
feat: multiple LLM providers — [providers] block + model@provider routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,17 @@ DATABASE_URL=postgres://postgres:<password>@<host>:5432/postgres
 # OpenRouter (chat completions). Same key works for both apps.
 OPENROUTER_API_KEY=sk-or-...
 
+# Optional. Override the built-in OpenRouter endpoint (e.g. an
+# OpenRouter-dialect proxy). Full URL including path; empty counts as unset
+# and keeps the pinned https://openrouter.ai/api/v1/chat/completions.
+# OPENROUTER_BASE_URL=
+
+# Per-provider API keys for the model-config [providers] block (multi-provider
+# routing — see docs/model-config.md). Each [providers] entry `name` reads
+# `<NAME>_API_KEY` (name uppercased): [providers].venice → VENICE_API_KEY.
+# Required only for providers actually referenced by some model slug.
+# VENICE_API_KEY=
+
 # OpenRouter app attribution (optional). When set, the engine adds
 # these headers to every outbound OpenRouter call so the deployment
 # shows up on OpenRouter's app analytics dashboard. Leave unset to

--- a/README.ja.md
+++ b/README.ja.md
@@ -99,7 +99,7 @@ docker run --rm -p 8080:8080 --env-file .env \
 - [Ghost mechanics](docs/ghost-mechanics.md) — スコア式、保護ルール、例。
 - [Memory layers](docs/memory-layers.md) — プロフィール記憶と関係記憶、Voyage、pgvector による検索。
 - [World system](docs/world-system.md) — 実験的なオーナー単位のペルソナワールド：World Memories のシミュレーションとリコール注入、World Town のソーシャルフィード。
-- [Model config](docs/model-config.md) — `model_config.toml` schema、すべてのタスク（chat、vision、image generation、PDE、filters、extraction）、モデル選択、0.x の安定性に関する方針。
+- [Model config](docs/model-config.md) — `model_config.toml` schema、すべてのタスク（chat、vision、image generation、PDE、filters、extraction）、モデル選択、マルチプロバイダールーティング（`[providers]`）、0.x の安定性に関する方針。
 - [Prompt traits](docs/prompt-traits.md) — リクエスト単位の system prompt 注入と tier の許可リスト。
 - [LLM / OpenRouter audit](docs/llm-audit.md) — ユーザー単位 / セッション単位の attribution の受け渡し。
 - [Deploying](docs/deploying.md) — Docker、独自の Postgres / IdP、運用向け環境変数。

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The `docker/Dockerfile` is the same artifact used to build this image. Deploy it
 - [Ghost mechanics](docs/ghost-mechanics.md) — score formula, protection rules, examples.
 - [Memory layers](docs/memory-layers.md) — profile vs relationship memory, Voyage, pgvector retrieval.
 - [World system](docs/world-system.md) — experimental per-owner persona worlds: World Memories (relationship simulation + recall injection), World Town (social feed), and World Stories (per-instance persona life simulation feeding both).
-- [Model config](docs/model-config.md) — `model_config.toml` schema, every task (chat, vision, image generation, PDE, filters, extraction), model selection, 0.x stability commitments.
+- [Model config](docs/model-config.md) — `model_config.toml` schema, every task (chat, vision, image generation, PDE, filters, extraction), model selection, multi-provider routing (`[providers]`), 0.x stability commitments.
 - [Prompt traits](docs/prompt-traits.md) — per-request system-prompt injection and tier allow-lists.
 - [LLM / OpenRouter audit](docs/llm-audit.md) — per-user / per-session attribution passthrough.
 - [Deploying](docs/deploying.md) — Docker, bring-your-own Postgres / IdP, operational env vars.

--- a/README.zh.md
+++ b/README.zh.md
@@ -99,7 +99,7 @@ docker run --rm -p 8080:8080 --env-file .env \
 - [ghost 机制](docs/ghost-mechanics.zh.md)——评分公式、保护规则、示例。
 - [记忆分层](docs/memory-layers.zh.md)——画像记忆 vs 关系记忆、Voyage、pgvector 检索。
 - [世界系统](docs/world-system.zh.md)——实验性的按 owner 角色世界：World Memories 模拟 + 召回注入，以及 World Town 社交动态流。
-- [模型配置](docs/model-config.zh.md)——`model_config.toml` schema、各任务（chat、vision、图像生成、PDE、过滤器、抽取）、选模型规则、0.x 稳定性承诺。
+- [模型配置](docs/model-config.zh.md)——`model_config.toml` schema、各任务（chat、vision、图像生成、PDE、过滤器、抽取）、选模型规则、多 provider 路由（`[providers]`）、0.x 稳定性承诺。
 - [Prompt traits](docs/prompt-traits.zh.md)——按请求注入系统 prompt 与 tier 白名单。
 - [LLM / OpenRouter 审计](docs/llm-audit.zh.md)——按用户 / 按会话的归因透传。
 - [部署](docs/deploying.zh.md)——Docker、自带 Postgres / IdP、运行期环境变量。

--- a/crates/eros-engine-llm/src/lib.rs
+++ b/crates/eros-engine-llm/src/lib.rs
@@ -5,6 +5,7 @@ pub mod byte_bpe;
 pub mod error;
 pub mod model_config;
 pub mod openrouter;
+pub mod provider;
 pub mod stream_scrub;
 pub mod voyage;
 

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -315,7 +315,7 @@ impl DisplayOverride {
 /// omitted from the wire. Common uses: `{ enabled = false }` to disable
 /// reasoning entirely, or `{ exclude = true }` to keep reasoning but drop it
 /// from the response. (Extend with `effort`/`max_tokens` here if ever needed.)
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
 pub struct ReasoningConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -31,6 +31,19 @@ impl FallbackSpec {
             FallbackSpec::Multiple(v) => v.into_iter().filter(|s| !s.is_empty()).collect(),
         }
     }
+
+    /// Every literal candidate id, non-empty only (see `ModelSpec::candidate_ids`).
+    fn candidate_ids(&self) -> Vec<&str> {
+        match self {
+            FallbackSpec::Single(s) if s.is_empty() => Vec::new(),
+            FallbackSpec::Single(s) => vec![s.as_str()],
+            FallbackSpec::Multiple(v) => v
+                .iter()
+                .filter(|s| !s.is_empty())
+                .map(String::as_str)
+                .collect(),
+        }
+    }
 }
 
 /// A task/tier's primary `model`. Accepts three TOML shapes:
@@ -102,6 +115,19 @@ impl ModelSpec {
                 Some(pick_weighted(entries, position).to_string())
             }
             _ => None,
+        }
+    }
+
+    /// Every literal candidate id in this spec, non-empty entries only. Boot
+    /// validation must see ALL candidates: a weighted table picks at random
+    /// per call, so validating only `select()`'s output would let a
+    /// misconfigured entry lie dormant until an unlucky draw.
+    fn candidate_ids(&self) -> Vec<&str> {
+        match self {
+            ModelSpec::Fixed(s) if s.is_empty() => Vec::new(),
+            ModelSpec::Fixed(s) => vec![s.as_str()],
+            ModelSpec::RoundRobin { models, .. } => models.iter().map(String::as_str).collect(),
+            ModelSpec::Weighted(entries) => entries.iter().map(|(m, _)| m.as_str()).collect(),
         }
     }
 }
@@ -718,6 +744,14 @@ pub struct TaskConfig {
 pub struct ModelConfig {
     #[serde(default)]
     pub defaults: DefaultConfig,
+    /// The `[providers]` block — custom OpenAI-compatible endpoints keyed by
+    /// name (spec 2026-07-31-multi-llm-providers). Value is the COMPLETE
+    /// chat-completions URL, posted verbatim (no path joining). The API key
+    /// comes from env as `<NAME_UPPERCASED>_API_KEY`. Under MODEL_CONFIG_DIR
+    /// this merges as one whole top-level key (like `[defaults]`, unlike
+    /// `[tasks]`): all providers live in one file.
+    #[serde(default)]
+    pub providers: HashMap<String, String>,
     #[serde(default)]
     pub tasks: HashMap<String, TaskConfig>,
 }
@@ -2070,6 +2104,154 @@ impl ModelConfig {
             }
         }
         Ok(())
+    }
+
+    /// Boot gate for the `[providers]` block and every `@provider` model slug
+    /// (multi-provider spec §7). Checks, in order: provider-table shape
+    /// (charset, reserved name, non-empty URL), then a LITERAL full scan of
+    /// every candidate slug — `[defaults].fallback_model`, every task's and
+    /// tier's `model`/`fallback`, including every round-robin element and
+    /// weighted-table key. Referenced providers must have a non-empty
+    /// `<NAME>_API_KEY` in the environment (loud-fail, like VOYAGE_API_KEY).
+    pub fn validate_providers(&self) -> Result<(), String> {
+        self.validate_providers_with(|k| std::env::var(k).ok())
+    }
+
+    /// Testable core: `env` abstracts `std::env::var` so tests inject keys
+    /// without process-global mutation.
+    fn validate_providers_with(&self, env: impl Fn(&str) -> Option<String>) -> Result<(), String> {
+        const IMG_TASK: &str = "chat_image_generation";
+
+        // 1. Provider table shape. Sorted for deterministic messages.
+        let mut names: Vec<&String> = self.providers.keys().collect();
+        names.sort();
+        for name in names {
+            if name == "openrouter" {
+                return Err(
+                    "[providers]: `openrouter` is reserved — override the built-in \
+                     endpoint with the OPENROUTER_BASE_URL env var, not a [providers] \
+                     entry"
+                        .to_string(),
+                );
+            }
+            if name.is_empty()
+                || !name
+                    .chars()
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+            {
+                return Err(format!(
+                    "[providers].{name}: provider names must match [a-z0-9_]+ — the name \
+                     is uppercased into the `<NAME>_API_KEY` env var, so use underscores"
+                ));
+            }
+            if self.providers[name].is_empty() {
+                return Err(format!("[providers].{name}: base URL is empty"));
+            }
+        }
+
+        // 2. Literal full scan of every candidate slug.
+        let mut slugs: Vec<(String, &str, bool)> = Vec::new();
+        if let Some(fb) = self.defaults.fallback_model.as_deref() {
+            if !fb.is_empty() {
+                slugs.push(("[defaults].fallback_model".to_string(), fb, false));
+            }
+        }
+        let mut task_names: Vec<&String> = self.tasks.keys().collect();
+        task_names.sort();
+        for name in task_names {
+            let task = &self.tasks[name];
+            let draw = name == IMG_TASK;
+            for id in task.model.candidate_ids() {
+                slugs.push((format!("[tasks.{name}].model"), id, draw));
+            }
+            if let Some(fb) = &task.fallback {
+                for id in fb.candidate_ids() {
+                    slugs.push((format!("[tasks.{name}].fallback"), id, draw));
+                }
+            }
+            let mut tier_names: Vec<&String> = task.tiers.keys().collect();
+            tier_names.sort();
+            for tier in tier_names {
+                let t = &task.tiers[tier];
+                if let Some(m) = &t.model {
+                    for id in m.candidate_ids() {
+                        slugs.push((format!("[tasks.{name}.tiers.{tier}].model"), id, draw));
+                    }
+                }
+                if let Some(fb) = &t.fallback {
+                    for id in fb.candidate_ids() {
+                        slugs.push((format!("[tasks.{name}.tiers.{tier}].fallback"), id, draw));
+                    }
+                }
+            }
+        }
+
+        for (at, slug, draw) in slugs {
+            if draw {
+                // The draw endpoint speaks OpenRouter's modalities extension —
+                // not OpenAI-compatible in either direction, so no routing (and
+                // therefore no escape) is meaningful here at all.
+                if slug.contains('@') {
+                    return Err(format!(
+                        "{at}: `{slug}` — image generation sends OpenRouter's `modalities` \
+                         extension, which OpenAI-compatible providers do not accept; \
+                         `@provider` routing is not supported on [tasks.{IMG_TASK}]"
+                    ));
+                }
+                continue;
+            }
+            let (_, provider) =
+                crate::provider::split_model_slug(slug).map_err(|e| format!("{at}: {e}"))?;
+            if let Some(p) = provider {
+                if !self.providers.contains_key(p) {
+                    let mut declared: Vec<&str> =
+                        self.providers.keys().map(String::as_str).collect();
+                    declared.sort();
+                    return Err(format!(
+                        "{at}: `{slug}` names provider `{p}`, which is not declared in \
+                         [providers] (declared: {declared:?}). If the `@` is part of the \
+                         model id, escape it as `\\@` (in TOML double quotes: `\"\\\\@\"`)."
+                    ));
+                }
+                let var = format!("{}_API_KEY", p.to_uppercase());
+                if env(&var).is_none_or(|v| v.is_empty()) {
+                    return Err(format!(
+                        "{at}: `{slug}` routes to provider `{p}` but ${var} is unset or \
+                         empty — eros-engine refuses to boot rather than fail at request \
+                         time"
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Build the name → endpoint map handed to `OpenRouterClient` at boot.
+    /// NO checks here — runs only after `validate_providers` passed. Every
+    /// declared entry is included; an unreferenced entry without a key gets an
+    /// empty api_key (unreachable at runtime, and `resolve_endpoint` guards
+    /// it anyway).
+    pub fn build_providers(&self) -> HashMap<String, crate::provider::ProviderEndpoint> {
+        self.build_providers_with(|k| std::env::var(k).ok())
+    }
+
+    fn build_providers_with(
+        &self,
+        env: impl Fn(&str) -> Option<String>,
+    ) -> HashMap<String, crate::provider::ProviderEndpoint> {
+        self.providers
+            .iter()
+            .map(|(name, url)| {
+                let key = env(&format!("{}_API_KEY", name.to_uppercase())).unwrap_or_default();
+                (
+                    name.clone(),
+                    crate::provider::ProviderEndpoint {
+                        base_url: url.clone(),
+                        api_key: key,
+                    },
+                )
+            })
+            .collect()
     }
 
     /// Boot gate, mirroring `validate_extraction_prompts`: any present world
@@ -5412,5 +5594,206 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
         // (which would panic on a byte-index slice).
         let s = "你好世界和平"; // 6 chars
         assert_eq!(cap_for_log(s, 3), "你好世…");
+    }
+
+    // ---- [providers] block + validate_providers (multi-provider spec §1/§7) ----
+
+    /// env closure: no provider key exists.
+    fn no_env(_: &str) -> Option<String> {
+        None
+    }
+
+    #[test]
+    fn providers_block_parses() {
+        let cfg = ModelConfig::from_toml_str(
+            "[providers]\nvenice = \"https://api.venice.ai/api/v1/chat/completions\"\n",
+        )
+        .unwrap();
+        assert_eq!(
+            cfg.providers.get("venice").map(String::as_str),
+            Some("https://api.venice.ai/api/v1/chat/completions")
+        );
+    }
+
+    #[test]
+    fn providers_absent_is_empty_and_valid() {
+        let cfg = ModelConfig::from_toml_str("[tasks.chat_companion]\nmodel=\"m\"\n").unwrap();
+        assert!(cfg.providers.is_empty());
+        assert!(cfg.validate_providers_with(no_env).is_ok());
+    }
+
+    #[test]
+    fn provider_name_openrouter_is_reserved() {
+        let cfg =
+            ModelConfig::from_toml_str("[providers]\nopenrouter = \"https://x/v1\"\n").unwrap();
+        let msg = cfg.validate_providers_with(no_env).unwrap_err();
+        assert!(msg.contains("reserved"));
+        assert!(msg.contains("OPENROUTER_BASE_URL"));
+    }
+
+    #[test]
+    fn provider_name_charset_is_constrained() {
+        // Dash is rejected: the name uppercases into an env var, no mangling.
+        let cfg =
+            ModelConfig::from_toml_str("[providers]\n\"venice-ai\" = \"https://x/v1\"\n").unwrap();
+        let msg = cfg.validate_providers_with(no_env).unwrap_err();
+        assert!(msg.contains("a-z0-9_"), "should state the charset: {msg}");
+    }
+
+    #[test]
+    fn provider_empty_url_refuses_boot() {
+        let cfg = ModelConfig::from_toml_str("[providers]\nvenice = \"\"\n").unwrap();
+        assert!(cfg
+            .validate_providers_with(no_env)
+            .unwrap_err()
+            .contains("empty"));
+    }
+
+    #[test]
+    fn unreferenced_provider_needs_no_key() {
+        // The examples/ config ships a sample [providers] entry; deployments
+        // that copy it without using it must still boot.
+        let cfg = ModelConfig::from_toml_str(
+            "[providers]\nvenice = \"https://x/v1\"\n[tasks.chat_companion]\nmodel=\"plain/m\"\n",
+        )
+        .unwrap();
+        assert!(cfg.validate_providers_with(no_env).is_ok());
+    }
+
+    #[test]
+    fn referenced_provider_missing_key_refuses_boot() {
+        let cfg = ModelConfig::from_toml_str(
+            "[providers]\nvenice = \"https://x/v1\"\n[tasks.chat_companion]\nmodel=\"m@venice\"\n",
+        )
+        .unwrap();
+        let msg = cfg.validate_providers_with(no_env).unwrap_err();
+        assert!(
+            msg.contains("VENICE_API_KEY"),
+            "must name the env var: {msg}"
+        );
+    }
+
+    #[test]
+    fn referenced_provider_empty_key_refuses_boot() {
+        let cfg = ModelConfig::from_toml_str(
+            "[providers]\nvenice = \"https://x/v1\"\n[tasks.chat_companion]\nmodel=\"m@venice\"\n",
+        )
+        .unwrap();
+        let env = |k: &str| (k == "VENICE_API_KEY").then(String::new);
+        assert!(cfg.validate_providers_with(env).is_err());
+    }
+
+    #[test]
+    fn referenced_provider_with_key_is_green() {
+        let cfg = ModelConfig::from_toml_str(
+            "[providers]\nvenice = \"https://x/v1\"\n[tasks.chat_companion]\nmodel=\"m@venice\"\nfallback=[\"other/m\"]\n",
+        )
+        .unwrap();
+        let env = |k: &str| (k == "VENICE_API_KEY").then(|| "sk-v".to_string());
+        assert!(cfg.validate_providers_with(env).is_ok());
+    }
+
+    #[test]
+    fn undeclared_provider_in_slug_refuses_boot() {
+        // Also the escape-typo case: "aaa@bb" points at the \@ escape.
+        let cfg = ModelConfig::from_toml_str("[tasks.chat_companion]\nmodel=\"aaa@bb\"\n").unwrap();
+        let msg = cfg.validate_providers_with(no_env).unwrap_err();
+        assert!(msg.contains("`bb`"));
+        assert!(msg.contains("\\@"), "should teach the escape: {msg}");
+    }
+
+    #[test]
+    fn slug_grammar_error_propagates_with_location() {
+        let cfg =
+            ModelConfig::from_toml_str("[tasks.chat_companion]\nmodel=\"a@b@venice\"\n").unwrap();
+        let msg = cfg.validate_providers_with(no_env).unwrap_err();
+        assert!(
+            msg.contains("[tasks.chat_companion].model"),
+            "location: {msg}"
+        );
+    }
+
+    #[test]
+    fn weighted_table_keys_are_all_scanned() {
+        // resolve() picks at random — validation must see every key.
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.chat_companion]\nmodel = { \"good/m\" = 0.9, \"bad@nope\" = 0.1 }\n",
+        )
+        .unwrap();
+        assert!(cfg
+            .validate_providers_with(no_env)
+            .unwrap_err()
+            .contains("nope"));
+    }
+
+    #[test]
+    fn tier_fallback_is_scanned() {
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.chat_companion]\nmodel=\"m\"\n[tasks.chat_companion.tiers.premium]\nfallback=[\"x@nope\"]\n",
+        )
+        .unwrap();
+        let msg = cfg.validate_providers_with(no_env).unwrap_err();
+        assert!(msg.contains("[tasks.chat_companion.tiers.premium].fallback"));
+    }
+
+    #[test]
+    fn defaults_fallback_model_is_scanned() {
+        let cfg = ModelConfig::from_toml_str("[defaults]\nfallback_model=\"x@nope\"\n").unwrap();
+        let msg = cfg.validate_providers_with(no_env).unwrap_err();
+        assert!(msg.contains("[defaults].fallback_model"));
+    }
+
+    #[test]
+    fn image_generation_rejects_any_at() {
+        // Draw endpoint speaks OpenRouter's modalities extension (spec §7).
+        let cfg = ModelConfig::from_toml_str(
+            "[providers]\nvenice = \"https://x/v1\"\n[tasks.chat_image_generation]\nmodel=\"img@venice\"\n",
+        )
+        .unwrap();
+        let env = |k: &str| (k == "VENICE_API_KEY").then(|| "sk-v".to_string());
+        let msg = cfg.validate_providers_with(env).unwrap_err();
+        assert!(msg.contains("modalities"), "should explain why: {msg}");
+
+        // Even an ESCAPED @ is rejected there — no routing, no escape need.
+        let cfg2 =
+            ModelConfig::from_toml_str("[tasks.chat_image_generation]\nmodel=\"img\\\\@x\"\n")
+                .unwrap();
+        assert!(cfg2.validate_providers_with(no_env).is_err());
+    }
+
+    #[test]
+    fn image_generation_fallback_is_also_literal_checked() {
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.chat_image_generation]\nmodel=\"img/m\"\nfallback=[\"img@venice\"]\n",
+        )
+        .unwrap();
+        assert!(cfg.validate_providers_with(no_env).is_err());
+    }
+
+    #[test]
+    fn compose_task_accepts_provider_suffix() {
+        // Pins spec §9: the draw-endpoint restriction must never widen to the
+        // compose task — it is an ordinary chat-shaped task.
+        let cfg = ModelConfig::from_toml_str(
+            "[providers]\nvenice = \"https://x/v1\"\n[tasks.chat_image_prompt_compose]\nmodel=\"m@venice\"\nfilter_prompt=\"compose it\"\n",
+        )
+        .unwrap();
+        let env = |k: &str| (k == "VENICE_API_KEY").then(|| "sk-v".to_string());
+        assert!(cfg.validate_providers_with(env).is_ok());
+    }
+
+    #[test]
+    fn build_providers_maps_declared_entries() {
+        let cfg = ModelConfig::from_toml_str(
+            "[providers]\nvenice = \"https://x/v1\"\nother = \"https://y/v1\"\n",
+        )
+        .unwrap();
+        let env = |k: &str| (k == "VENICE_API_KEY").then(|| "sk-v".to_string());
+        let map = cfg.build_providers_with(env);
+        assert_eq!(map["venice"].base_url, "https://x/v1");
+        assert_eq!(map["venice"].api_key, "sk-v");
+        // Unreferenced/keyless entry still present, with an empty key —
+        // resolve_endpoint's runtime guard covers the (unreachable) miss.
+        assert_eq!(map["other"].api_key, "");
     }
 }

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -1123,12 +1123,14 @@ impl OpenRouterClient {
             }
             // §6: a custom row self-identifies as <echo>@<provider> so a failed
             // eros-audit join on generation_id explains itself from the model
-            // column. OpenRouter rows are byte-identical to before.
+            // column. OpenRouter rows are byte-identical to before. The echo /
+            // bare id is escaped so a literal `@` in it doesn't produce a
+            // second unescaped `@`, which `split_model_slug` would reject.
             let model_out = match ep.name {
                 None => parsed.model,
                 Some(p) => Some(match parsed.model {
-                    Some(echo) => format!("{echo}@{p}"),
-                    None => format!("{bare_model}@{p}"),
+                    Some(echo) => format!("{}@{p}", crate::provider::escape_model_id(&echo)),
+                    None => format!("{}@{p}", crate::provider::escape_model_id(&bare_model)),
                 }),
             };
             return Ok(ChatResponse {
@@ -1374,12 +1376,14 @@ impl OpenRouterClient {
         }
         // §6: a custom row self-identifies as <echo>@<provider> so a failed
         // eros-audit join on generation_id explains itself from the model
-        // column. OpenRouter rows are byte-identical to before.
+        // column. OpenRouter rows are byte-identical to before. The echo /
+        // bare id is escaped so a literal `@` in it doesn't produce a
+        // second unescaped `@`, which `split_model_slug` would reject.
         let model_out = match ep.name {
             None => parsed.model,
             Some(p) => Some(match parsed.model {
-                Some(echo) => format!("{echo}@{p}"),
-                None => format!("{bare_model}@{p}"),
+                Some(echo) => format!("{}@{p}", crate::provider::escape_model_id(&echo)),
+                None => format!("{}@{p}", crate::provider::escape_model_id(&bare_model)),
             }),
         };
         Ok(ChatResponse {
@@ -4149,6 +4153,53 @@ data: [DONE]\n\n";
         for k in ["session_id", "metadata", "reasoning", "provider"] {
             assert!(body.get(k).is_none(), "body field {k} leaked");
         }
+    }
+
+    #[tokio::test]
+    async fn custom_echo_with_literal_at_is_escaped_in_audit_slug() {
+        let server_b = MockServer::start().await;
+        Mock::given(path("/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "v-gen-3",
+                "model": "weird@vendor/m",
+                "choices": [{ "message": { "content": "ok" } }]
+            })))
+            .expect(1)
+            .mount(&server_b)
+            .await;
+        let client = OpenRouterClient::with_base_url(
+            "or-key".into(),
+            AppAttribution::default(),
+            "https://unused.test/v1".into(),
+        )
+        .with_providers(std::collections::HashMap::from([(
+            "venice".to_string(),
+            crate::provider::ProviderEndpoint {
+                base_url: format!("{}/v1/chat/completions", server_b.uri()),
+                api_key: "v-key".into(),
+            },
+        )]));
+        let resp = client
+            .execute(ChatRequest {
+                model: "weird\\@vendor/m@venice".into(),
+                messages: vec![ChatMessage {
+                    role: "user".into(),
+                    content: "hi".into(),
+                }],
+                temperature: 0.0,
+                max_tokens: 16,
+                ..Default::default()
+            })
+            .await
+            .expect("custom call succeeds");
+        // The echoed id contains a literal `@`; it must be escaped before the
+        // `@venice` suffix so the persisted slug has exactly one unescaped
+        // `@` and is parseable again.
+        assert_eq!(resp.model.as_deref(), Some("weird\\@vendor/m@venice"));
+        assert_eq!(
+            crate::provider::bare_model_id(resp.model.as_deref().unwrap()),
+            "weird@vendor/m"
+        );
     }
 
     #[tokio::test]

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -1040,6 +1040,14 @@ impl OpenRouterClient {
                         body["provider"] = v;
                     }
                 }
+            } else {
+                // Custom `[providers]` endpoints get a strict OpenAI subset
+                // (spec §4) — `reasoning` is an OpenRouter-specific extension
+                // that `build_vision_body` bakes in unconditionally, so strip
+                // it back out here, mirroring `WireRequest::for_endpoint`.
+                if let Some(o) = body.as_object_mut() {
+                    o.remove("reasoning");
+                }
             }
             let resp = match ep
                 .http
@@ -3560,7 +3568,10 @@ data: [DONE]\n\n";
                 caption: None,
                 temperature: 0.0,
                 max_tokens: 64,
-                reasoning: None,
+                reasoning: Some(ReasoningConfig {
+                    enabled: Some(false),
+                    ..Default::default()
+                }),
             })
             .await
             .expect("vision call succeeds");
@@ -3576,6 +3587,10 @@ data: [DONE]\n\n";
         assert!(
             body.get("provider").is_none(),
             "provider prefs leaked to custom vision"
+        );
+        assert!(
+            body.get("reasoning").is_none(),
+            "OpenRouter-only reasoning object leaked to custom vision"
         );
     }
 

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -149,6 +149,19 @@ fn build_vision_body(req: &VisionRequest, model: &str) -> serde_json::Value {
     body
 }
 
+/// Strip the OpenRouter-specific fields `build_vision_body` bakes in
+/// unconditionally, for a custom `[providers]` endpoint (spec §4). Mirrors
+/// `WireRequest::for_endpoint`'s drop list, but operates on the raw
+/// `serde_json::Value` since the vision body isn't a typed wire struct. A
+/// named helper (rather than inlining the strip at each call site) so the
+/// `execute_vision` production path and its subset-lock test can never drift
+/// apart.
+fn strip_openrouter_vision_fields(body: &mut serde_json::Value) {
+    if let Some(o) = body.as_object_mut() {
+        o.remove("reasoning");
+    }
+}
+
 /// Which prompt variant an image attempt used. `Single` = no compose retry
 /// (compose off, or it left the subject unchanged); `Composed`/`Original` =
 /// the two variants tried per model when compose rewrote the subject.
@@ -1045,9 +1058,7 @@ impl OpenRouterClient {
                 // (spec §4) — `reasoning` is an OpenRouter-specific extension
                 // that `build_vision_body` bakes in unconditionally, so strip
                 // it back out here, mirroring `WireRequest::for_endpoint`.
-                if let Some(o) = body.as_object_mut() {
-                    o.remove("reasoning");
-                }
+                strip_openrouter_vision_fields(&mut body);
             }
             let resp = match ep
                 .http
@@ -3970,6 +3981,52 @@ data: [DONE]\n\n";
             assert!(
                 ALLOW.contains(&k.as_str()),
                 "OpenRouter-specific field `{k}` leaked to a custom provider"
+            );
+        }
+    }
+
+    #[test]
+    fn custom_endpoint_vision_body_is_strict_openai_subset() {
+        // Finding 1 (final review): the WireRequest lock above only covers
+        // the typed chat/stream path (`call_once` / `execute_stream_as`).
+        // `execute_vision` instead builds a raw `serde_json::Value` via
+        // `build_vision_body` and strips OpenRouter-only fields with
+        // `strip_openrouter_vision_fields` — the exact helper `execute_vision`
+        // calls for a custom endpoint — so it needs its own lock, driving both
+        // together the same way production does. This can't drift from
+        // `execute_vision`'s custom-endpoint path because both call the same
+        // helper.
+        let req = VisionRequest {
+            model: "ignored".into(),
+            fallback_model: vec!["ignored-2".into()],
+            system_prompt: "sys".into(),
+            image_url: "https://x/y.png".into(),
+            caption: Some("a caption".into()),
+            temperature: 0.5,
+            max_tokens: 10,
+            reasoning: Some(ReasoningConfig {
+                enabled: Some(false),
+                ..Default::default()
+            }),
+        };
+        let mut body = build_vision_body(&req, "m");
+        strip_openrouter_vision_fields(&mut body);
+        const ALLOW: [&str; 10] = [
+            "model",
+            "messages",
+            "temperature",
+            "top_p",
+            "frequency_penalty",
+            "presence_penalty",
+            "max_tokens",
+            "stream",
+            "user",
+            "response_format",
+        ];
+        for k in body.as_object().unwrap().keys() {
+            assert!(
+                ALLOW.contains(&k.as_str()),
+                "OpenRouter-specific field `{k}` leaked to a custom provider via the vision body"
             );
         }
     }

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -4216,4 +4216,66 @@ data: [DONE]\n\n";
             .expect("chain advances past the unresolvable candidate");
         assert_eq!(resp.reply, "ok");
     }
+
+    #[tokio::test]
+    async fn draw_endpoint_never_routes_a_provider_suffix() {
+        let server_a = MockServer::start().await; // built-in endpoint
+        let server_b = MockServer::start().await; // configured provider — must stay silent
+        Mock::given(path("/or/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "gen-img",
+                "model": "x@venice",
+                "choices": [{ "message": { "content": "", "images": [
+                    { "image_url": { "url": "data:image/png;base64,AAAA" } }
+                ] } }]
+            })))
+            .expect(1)
+            .mount(&server_a)
+            .await;
+        let client = OpenRouterClient::with_base_url(
+            "or-key".into(),
+            AppAttribution::default(),
+            format!("{}/or/chat/completions", server_a.uri()),
+        )
+        .with_providers(std::collections::HashMap::from([(
+            "venice".to_string(),
+            crate::provider::ProviderEndpoint {
+                base_url: format!("{}/v1/chat/completions", server_b.uri()),
+                api_key: "v-key".into(),
+            },
+        )]));
+        // "x@venice" simulates a hostile/typo client req_model reaching the
+        // draw chain. It must go to the BUILT-IN endpoint as a verbatim —
+        // nonsense — model id, never to the configured provider.
+        let resp = client
+            .execute_image(ImageGenRequest {
+                model: "x@venice".into(),
+                fallback_model: vec![],
+                prompt: "a cat".into(),
+                face_ref_url: None,
+                aspect_ratio: None,
+                resolution: None,
+                max_tokens: 1024,
+                prompt_original: None,
+            })
+            .await
+            .expect("image call succeeds against the built-in endpoint");
+        assert_eq!(resp.images.len(), 1);
+        let req_a = &server_a.received_requests().await.unwrap()[0];
+        assert_eq!(
+            req_a
+                .headers
+                .get("authorization")
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "Bearer or-key"
+        );
+        let body: serde_json::Value = serde_json::from_slice(&req_a.body).unwrap();
+        assert_eq!(body["model"], "x@venice", "slug must pass through verbatim");
+        assert!(
+            server_b.received_requests().await.unwrap().is_empty(),
+            "draw endpoint must NEVER post to a [providers] host"
+        );
+    }
 }

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -520,6 +520,24 @@ struct WireRequest<'a> {
     response_format: Option<&'a serde_json::Value>,
 }
 
+impl<'a> WireRequest<'a> {
+    /// Strip the OpenRouter-specific fields for a custom endpoint (spec §4):
+    /// custom providers receive a strict OpenAI chat-completions subset. All
+    /// four fields carry `skip_serializing_if`, so `None` removes them from
+    /// the wire entirely — one serialization path, no drift. NOTE: when
+    /// adding a field to WireRequest, decide its fate here; the
+    /// `custom_endpoint_wire_is_strict_openai_subset` test enforces it.
+    fn for_endpoint(mut self, ep: &Endpoint<'_>) -> Self {
+        if ep.name.is_some() {
+            self.session_id = None;
+            self.metadata = None;
+            self.reasoning = None;
+            self.provider = None;
+        }
+        self
+    }
+}
+
 #[derive(Debug, Deserialize)]
 struct WireImageUrl {
     url: String,
@@ -683,7 +701,6 @@ pub struct OpenRouterClient {
     /// for every custom-provider post. The three attribution headers are
     /// baked into `http` at construction and cannot be withdrawn per-request
     /// (spec §3); same connect/pool bounds as `http`.
-    #[allow(dead_code)] // consumed by Task 4-6
     plain_http: reqwest::Client,
 }
 
@@ -807,7 +824,6 @@ impl OpenRouterClient {
 /// `name: None` ⇒ the built-in OpenRouter endpoint (attribution headers,
 /// full wire); `Some(name)` ⇒ a `[providers]` entry (plain client, strict
 /// OpenAI wire subset, audit model suffixed `@name`).
-#[allow(dead_code)] // consumed by Task 4-6
 struct Endpoint<'a> {
     url: &'a str,
     api_key: &'a str,
@@ -823,7 +839,6 @@ impl OpenRouterClient {
     /// `LlmError::Config`, which advances the caller's candidate chain
     /// instead of panicking (unreachable for config slugs post-boot, but
     /// `execute_stream_as` receives arbitrary server strings).
-    #[allow(dead_code)] // consumed by Task 4-6
     fn resolve_endpoint<'s>(&'s self, slug: &str) -> Result<(String, Endpoint<'s>), LlmError> {
         let (bare, provider) = crate::provider::split_model_slug(slug)
             .map_err(|e| LlmError::Config(format!("openrouter: {e}")))?;
@@ -1254,12 +1269,9 @@ impl OpenRouterClient {
         req_reasoning: Option<&ReasoningConfig>,
         req_response_format: Option<&serde_json::Value>,
     ) -> Result<ChatResponse, LlmError> {
-        if self.api_key.is_empty() {
-            return Err(LlmError::Config("openrouter: api key not set".into()));
-        }
-
+        let (bare_model, ep) = self.resolve_endpoint(model)?;
         let wire = WireRequest {
-            model,
+            model: &bare_model,
             messages,
             temperature,
             top_p,
@@ -1273,12 +1285,13 @@ impl OpenRouterClient {
             reasoning: req_reasoning,
             provider: self.provider_prefs(),
             response_format: req_response_format,
-        };
+        }
+        .for_endpoint(&ep);
 
-        let resp = self
+        let resp = ep
             .http
-            .post(&self.base_url)
-            .bearer_auth(&self.api_key)
+            .post(ep.url)
+            .bearer_auth(ep.api_key)
             .json(&wire)
             .send()
             .await?;
@@ -1324,10 +1337,20 @@ impl OpenRouterClient {
                 finish_reason,
             });
         }
+        // §6: a custom row self-identifies as <echo>@<provider> so a failed
+        // eros-audit join on generation_id explains itself from the model
+        // column. OpenRouter rows are byte-identical to before.
+        let model_out = match ep.name {
+            None => parsed.model,
+            Some(p) => Some(match parsed.model {
+                Some(echo) => format!("{echo}@{p}"),
+                None => format!("{bare_model}@{p}"),
+            }),
+        };
         Ok(ChatResponse {
             reply: clean_response(raw.trim()),
             generation_id: parsed.id,
-            model: parsed.model,
+            model: model_out,
             usage: parsed.usage,
             finish_reason,
         })
@@ -3718,5 +3741,331 @@ data: [DONE]\n\n";
             message.contains("sexual"),
             "moderation reasons stay visible for triage: {message}"
         );
+    }
+
+    // ---- multi-provider routing: non-stream wire (spec §4/§6) ----
+
+    /// A WireRequest with EVERY optional field set — the worst case for leaks.
+    /// Returns owned parts; tests borrow from them.
+    fn full_wire_parts() -> (
+        Vec<ChatMessage>,
+        serde_json::Map<String, serde_json::Value>,
+        ReasoningConfig,
+        serde_json::Value,
+        Vec<String>,
+    ) {
+        let messages = vec![ChatMessage {
+            role: "user".into(),
+            content: "hi".into(),
+        }];
+        let mut meta = serde_json::Map::new();
+        meta.insert("k".into(), serde_json::json!("v"));
+        let reasoning = ReasoningConfig {
+            enabled: Some(false),
+            ..Default::default()
+        };
+        let response_format = serde_json::json!({ "type": "json_object" });
+        let ignore = vec!["bad-provider".to_string()];
+        (messages, meta, reasoning, response_format, ignore)
+    }
+
+    #[test]
+    fn custom_endpoint_wire_is_strict_openai_subset() {
+        // THE allow-list lock (spec §4): a custom-endpoint body's keys must be
+        // a SUBSET of the OpenAI chat-completions surface. Subset, not
+        // equality — several fields are legitimately skipped when None/false.
+        // If this test fails on a field you just added to WireRequest, add it
+        // to WireRequest::for_endpoint's drop list (or the allow list, if it
+        // is standard OpenAI).
+        let (messages, meta, reasoning, response_format, ignore) = full_wire_parts();
+        let http = reqwest::Client::new();
+        let ep = Endpoint {
+            url: "https://x",
+            api_key: "k",
+            http: &http,
+            name: Some("venice"),
+        };
+        let wire = WireRequest {
+            model: "m",
+            messages: &messages,
+            temperature: 0.5,
+            top_p: Some(0.9),
+            frequency_penalty: Some(0.1),
+            presence_penalty: Some(0.1),
+            max_tokens: 10,
+            stream: true,
+            user: Some("u"),
+            session_id: Some("s"),
+            metadata: Some(&meta),
+            reasoning: Some(&reasoning),
+            provider: Some(ProviderPrefs {
+                ignore: &ignore,
+                sort: Some("latency"),
+            }),
+            response_format: Some(&response_format),
+        }
+        .for_endpoint(&ep);
+        let v = serde_json::to_value(&wire).unwrap();
+        const ALLOW: [&str; 10] = [
+            "model",
+            "messages",
+            "temperature",
+            "top_p",
+            "frequency_penalty",
+            "presence_penalty",
+            "max_tokens",
+            "stream",
+            "user",
+            "response_format",
+        ];
+        for k in v.as_object().unwrap().keys() {
+            assert!(
+                ALLOW.contains(&k.as_str()),
+                "OpenRouter-specific field `{k}` leaked to a custom provider"
+            );
+        }
+    }
+
+    #[test]
+    fn openrouter_endpoint_wire_keeps_all_fields() {
+        // Regression lock: for_endpoint on the built-in endpoint drops NOTHING.
+        let (messages, meta, reasoning, response_format, ignore) = full_wire_parts();
+        let http = reqwest::Client::new();
+        let ep = Endpoint {
+            url: "https://x",
+            api_key: "k",
+            http: &http,
+            name: None,
+        };
+        let wire = WireRequest {
+            model: "m",
+            messages: &messages,
+            temperature: 0.5,
+            top_p: None,
+            frequency_penalty: None,
+            presence_penalty: None,
+            max_tokens: 10,
+            stream: false,
+            user: None,
+            session_id: Some("s"),
+            metadata: Some(&meta),
+            reasoning: Some(&reasoning),
+            provider: Some(ProviderPrefs {
+                ignore: &ignore,
+                sort: None,
+            }),
+            response_format: Some(&response_format),
+        }
+        .for_endpoint(&ep);
+        let v = serde_json::to_value(&wire).unwrap();
+        let obj = v.as_object().unwrap();
+        for k in ["session_id", "metadata", "reasoning", "provider"] {
+            assert!(
+                obj.contains_key(k),
+                "`{k}` must survive on the OpenRouter path"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn custom_provider_gets_bare_model_own_key_no_attribution() {
+        let server_b = MockServer::start().await;
+        Mock::given(path("/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "v-gen-1",
+                "model": "venice-echo",
+                "choices": [{ "message": { "content": "ok" } }]
+            })))
+            .expect(1)
+            .mount(&server_b)
+            .await;
+        // Attribution + prefs configured — none of it may reach the custom host.
+        let client = OpenRouterClient::with_base_url(
+            "or-key".into(),
+            AppAttribution {
+                referer: Some("https://eros.example".into()),
+                title: Some("Eros".into()),
+                categories: Some("roleplay".into()),
+            },
+            "https://unused-openrouter.test/v1".into(),
+        )
+        .with_ignore_providers(vec!["bad".into()])
+        .with_provider_sort(Some("latency".into()))
+        .with_providers(std::collections::HashMap::from([(
+            "venice".to_string(),
+            crate::provider::ProviderEndpoint {
+                base_url: format!("{}/v1/chat/completions", server_b.uri()),
+                api_key: "v-key".into(),
+            },
+        )]));
+        let mut meta = serde_json::Map::new();
+        meta.insert("k".into(), serde_json::json!("v"));
+        let resp = client
+            .execute(ChatRequest {
+                model: "venice-model@venice".into(),
+                messages: vec![ChatMessage {
+                    role: "user".into(),
+                    content: "hi".into(),
+                }],
+                temperature: 0.5,
+                max_tokens: 16,
+                session_id: Some("sess".into()),
+                metadata: Some(meta),
+                reasoning: Some(ReasoningConfig {
+                    enabled: Some(false),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            })
+            .await
+            .expect("custom call succeeds");
+
+        // §6: audit model = upstream echo + @provider; generation_id verbatim.
+        assert_eq!(resp.model.as_deref(), Some("venice-echo@venice"));
+        assert_eq!(resp.generation_id.as_deref(), Some("v-gen-1"));
+
+        let req = &server_b.received_requests().await.unwrap()[0];
+        // Bearer is the provider's own key.
+        assert_eq!(
+            req.headers.get("authorization").unwrap().to_str().unwrap(),
+            "Bearer v-key"
+        );
+        // No attribution headers on a custom host (spec §4).
+        for h in [
+            "HTTP-Referer",
+            "X-OpenRouter-Title",
+            "X-OpenRouter-Categories",
+        ] {
+            assert!(req.headers.get(h).is_none(), "header {h} leaked");
+        }
+        // Bare model id + none of the four OpenRouter-only body fields.
+        let body: serde_json::Value = serde_json::from_slice(&req.body).unwrap();
+        assert_eq!(body["model"], "venice-model");
+        for k in ["session_id", "metadata", "reasoning", "provider"] {
+            assert!(body.get(k).is_none(), "body field {k} leaked");
+        }
+    }
+
+    #[tokio::test]
+    async fn custom_echo_missing_falls_back_to_bare_at_name() {
+        let server_b = MockServer::start().await;
+        Mock::given(path("/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ok_response()))
+            .expect(1)
+            .mount(&server_b)
+            .await;
+        let client = OpenRouterClient::with_base_url(
+            "or-key".into(),
+            AppAttribution::default(),
+            "https://unused.test/v1".into(),
+        )
+        .with_providers(std::collections::HashMap::from([(
+            "venice".to_string(),
+            crate::provider::ProviderEndpoint {
+                base_url: format!("{}/v1/chat/completions", server_b.uri()),
+                api_key: "v-key".into(),
+            },
+        )]));
+        let resp = client
+            .execute(ChatRequest {
+                model: "vm@venice".into(),
+                messages: vec![ChatMessage {
+                    role: "user".into(),
+                    content: "hi".into(),
+                }],
+                temperature: 0.0,
+                max_tokens: 16,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        // ok_response() has no "model" field → bare@name.
+        assert_eq!(resp.model.as_deref(), Some("vm@venice"));
+    }
+
+    #[tokio::test]
+    async fn mixed_chain_falls_back_from_custom_to_openrouter() {
+        let server_a = MockServer::start().await; // built-in
+        let server_b = MockServer::start().await; // venice — down
+        Mock::given(path("/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(1)
+            .mount(&server_b)
+            .await;
+        Mock::given(path("/or/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ok_response()))
+            .expect(1)
+            .mount(&server_a)
+            .await;
+        let client = OpenRouterClient::with_base_url(
+            "or-key".into(),
+            AppAttribution::default(),
+            format!("{}/or/chat/completions", server_a.uri()),
+        )
+        .with_providers(std::collections::HashMap::from([(
+            "venice".to_string(),
+            crate::provider::ProviderEndpoint {
+                base_url: format!("{}/v1/chat/completions", server_b.uri()),
+                api_key: "v-key".into(),
+            },
+        )]));
+        let resp = client
+            .execute(ChatRequest {
+                model: "m@venice".into(),
+                fallback_model: vec!["or/fallback".into()],
+                messages: vec![ChatMessage {
+                    role: "user".into(),
+                    content: "hi".into(),
+                }],
+                temperature: 0.0,
+                max_tokens: 16,
+                ..Default::default()
+            })
+            .await
+            .expect("fallback serves");
+        assert_eq!(resp.reply, "ok");
+        // The OpenRouter attempt used its own key and the fallback's bare id.
+        let req_a = &server_a.received_requests().await.unwrap()[0];
+        assert_eq!(
+            req_a
+                .headers
+                .get("authorization")
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "Bearer or-key"
+        );
+        let body: serde_json::Value = serde_json::from_slice(&req_a.body).unwrap();
+        assert_eq!(body["model"], "or/fallback");
+    }
+
+    #[tokio::test]
+    async fn unknown_provider_advances_the_chain() {
+        let server_a = MockServer::start().await;
+        Mock::given(path("/or/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ok_response()))
+            .expect(1)
+            .mount(&server_a)
+            .await;
+        let client = OpenRouterClient::with_base_url(
+            "or-key".into(),
+            AppAttribution::default(),
+            format!("{}/or/chat/completions", server_a.uri()),
+        );
+        let resp = client
+            .execute(ChatRequest {
+                model: "m@nope".into(),
+                fallback_model: vec!["good/m".into()],
+                messages: vec![ChatMessage {
+                    role: "user".into(),
+                    content: "hi".into(),
+                }],
+                temperature: 0.0,
+                max_tokens: 16,
+                ..Default::default()
+            })
+            .await
+            .expect("chain advances past the unresolvable candidate");
+        assert_eq!(resp.reply, "ok");
     }
 }

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -1379,9 +1379,6 @@ impl OpenRouterClient {
         use eventsource_stream::Eventsource;
         use futures_util::StreamExt;
 
-        if self.api_key.is_empty() {
-            return Err(LlmError::Config("openrouter: api key not set".into()));
-        }
         if model.is_empty() {
             return Err(LlmError::Config(
                 "openrouter: execute_stream requires a non-empty model".into(),
@@ -1392,8 +1389,9 @@ impl OpenRouterClient {
         // serialised unset audit fields as `user: null`, which OpenRouter
         // rejects (400 "expected string, received null"). Sharing WireRequest
         // keeps the skip-None behaviour and stops the two paths from drifting.
+        let (bare_model, ep) = self.resolve_endpoint(model)?;
         let wire = WireRequest {
-            model,
+            model: &bare_model,
             messages: &req.messages,
             temperature: req.temperature,
             top_p: req.top_p,
@@ -1407,13 +1405,14 @@ impl OpenRouterClient {
             reasoning: req.reasoning.as_ref(),
             provider: self.provider_prefs(),
             response_format: None,
-        };
+        }
+        .for_endpoint(&ep);
 
         let started = std::time::Instant::now();
-        let resp = self
+        let resp = ep
             .http
-            .post(&self.base_url)
-            .bearer_auth(&self.api_key)
+            .post(ep.url)
+            .bearer_auth(ep.api_key)
             .header(reqwest::header::ACCEPT, "text/event-stream")
             .json(&wire)
             .send()
@@ -2782,6 +2781,71 @@ data: [DONE]\n\n";
             .expect("stream opens");
         // Drain (single [DONE]).
         while stream.next().await.is_some() {}
+    }
+
+    #[tokio::test]
+    async fn stream_custom_provider_gets_bare_model_and_subset() {
+        let server_b = MockServer::start().await;
+        let sse = "data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\ndata: [DONE]\n\n";
+        Mock::given(path("/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(sse, "text/event-stream"),
+            )
+            .expect(1)
+            .mount(&server_b)
+            .await;
+        let client = OpenRouterClient::with_base_url(
+            "or-key".into(),
+            AppAttribution {
+                referer: Some("https://eros.example".into()),
+                title: Some("Eros".into()),
+                categories: None,
+            },
+            "https://unused.test/v1".into(),
+        )
+        .with_ignore_providers(vec!["bad".into()])
+        .with_providers(std::collections::HashMap::from([(
+            "venice".to_string(),
+            crate::provider::ProviderEndpoint {
+                base_url: format!("{}/v1/chat/completions", server_b.uri()),
+                api_key: "v-key".into(),
+            },
+        )]));
+        let req = ChatRequest {
+            model: String::new(), // placeholder; execute_stream_as takes the model separately
+            messages: vec![ChatMessage {
+                role: "user".into(),
+                content: "hi".into(),
+            }],
+            temperature: 0.0,
+            max_tokens: 16,
+            session_id: Some("sess".into()),
+            ..Default::default()
+        };
+        let mut s = client
+            .execute_stream_as(&req, "venice-model@venice")
+            .await
+            .expect("stream opens");
+        use futures_util::StreamExt as _;
+        while s.next().await.is_some() {}
+
+        let r = &server_b.received_requests().await.unwrap()[0];
+        assert_eq!(
+            r.headers.get("authorization").unwrap().to_str().unwrap(),
+            "Bearer v-key"
+        );
+        assert!(r.headers.get("HTTP-Referer").is_none());
+        let body: serde_json::Value = serde_json::from_slice(&r.body).unwrap();
+        assert_eq!(body["model"], "venice-model");
+        assert_eq!(body["stream"], true);
+        for k in ["session_id", "metadata", "reasoning", "provider"] {
+            assert!(
+                body.get(k).is_none(),
+                "body field {k} leaked into the stream wire"
+            );
+        }
     }
 
     // ─── B1: X-Generation-Id header capture ─────────────────────────────────

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -4,6 +4,9 @@
 //!
 //! Returns plain-text reply only; no JSON evaluation.
 
+use std::collections::HashMap;
+use std::sync::Arc;
+
 use serde::{Deserialize, Serialize};
 
 use crate::error::LlmError;
@@ -672,6 +675,16 @@ pub struct OpenRouterClient {
     /// [`OpenRouterClient::with_provider_sort`]. When `None` the field is
     /// omitted, preserving OpenRouter's default price-based load balancing.
     provider_sort: Option<String>,
+    /// Custom `[providers]` endpoints, name → endpoint. Empty by default;
+    /// installed at boot via [`OpenRouterClient::with_providers`]. Arc so the
+    /// client's Clone stays cheap.
+    providers: Arc<HashMap<String, crate::provider::ProviderEndpoint>>,
+    /// HTTP client WITHOUT the OpenRouter attribution default-headers, used
+    /// for every custom-provider post. The three attribution headers are
+    /// baked into `http` at construction and cannot be withdrawn per-request
+    /// (spec §3); same connect/pool bounds as `http`.
+    #[allow(dead_code)] // consumed by Task 4-6
+    plain_http: reqwest::Client,
 }
 
 impl OpenRouterClient {
@@ -734,10 +747,17 @@ impl OpenRouterClient {
             .pool_idle_timeout(POOL_IDLE_TIMEOUT)
             .build()
             .expect("reqwest client build never fails with empty config");
+        let plain_http = reqwest::Client::builder()
+            .connect_timeout(CONNECT_TIMEOUT)
+            .pool_idle_timeout(POOL_IDLE_TIMEOUT)
+            .build()
+            .expect("reqwest client build never fails with empty config");
         Self {
             http,
+            plain_http,
             api_key,
             base_url,
+            providers: Arc::new(HashMap::new()),
             ignore_providers: Vec::new(),
             provider_sort: None,
         }
@@ -759,6 +779,91 @@ impl OpenRouterClient {
     pub fn with_provider_sort(mut self, sort: Option<String>) -> Self {
         self.provider_sort = sort.filter(|s| !s.is_empty());
         self
+    }
+
+    /// Install the `[providers]` endpoint map (multi-provider spec §3).
+    /// Consuming builder, boot-chained like `with_ignore_providers`.
+    pub fn with_providers(
+        mut self,
+        providers: HashMap<String, crate::provider::ProviderEndpoint>,
+    ) -> Self {
+        self.providers = Arc::new(providers);
+        self
+    }
+
+    /// Override the built-in OpenRouter endpoint (the OPENROUTER_BASE_URL env
+    /// var). `None` keeps the pinned default. NOTE: distinct from the
+    /// `with_base_url` CONSTRUCTOR above, which tests use — this is a
+    /// consuming builder for boot.
+    pub fn with_openrouter_base_url(mut self, url: Option<String>) -> Self {
+        if let Some(u) = url {
+            self.base_url = u;
+        }
+        self
+    }
+}
+
+/// A resolved posting target: where one candidate's request goes.
+/// `name: None` ⇒ the built-in OpenRouter endpoint (attribution headers,
+/// full wire); `Some(name)` ⇒ a `[providers]` entry (plain client, strict
+/// OpenAI wire subset, audit model suffixed `@name`).
+#[allow(dead_code)] // consumed by Task 4-6
+struct Endpoint<'a> {
+    url: &'a str,
+    api_key: &'a str,
+    http: &'a reqwest::Client,
+    name: Option<&'a str>,
+}
+
+impl OpenRouterClient {
+    /// Split a candidate slug and resolve where it posts (spec §3). The
+    /// api-key emptiness guard lives HERE, per endpoint, rather than at the
+    /// head of each execute method — a mixed chain must check the key of the
+    /// endpoint each candidate actually uses. Unknown provider ⇒
+    /// `LlmError::Config`, which advances the caller's candidate chain
+    /// instead of panicking (unreachable for config slugs post-boot, but
+    /// `execute_stream_as` receives arbitrary server strings).
+    #[allow(dead_code)] // consumed by Task 4-6
+    fn resolve_endpoint<'s>(&'s self, slug: &str) -> Result<(String, Endpoint<'s>), LlmError> {
+        let (bare, provider) = crate::provider::split_model_slug(slug)
+            .map_err(|e| LlmError::Config(format!("openrouter: {e}")))?;
+        match provider {
+            None => {
+                if self.api_key.is_empty() {
+                    return Err(LlmError::Config("openrouter: api key not set".into()));
+                }
+                Ok((
+                    bare,
+                    Endpoint {
+                        url: &self.base_url,
+                        api_key: &self.api_key,
+                        http: &self.http,
+                        name: None,
+                    },
+                ))
+            }
+            Some(p) => {
+                let (name, ep) = self.providers.get_key_value(p).ok_or_else(|| {
+                    LlmError::Config(format!(
+                        "openrouter: model slug `{slug}` names undeclared provider `{p}`"
+                    ))
+                })?;
+                if ep.api_key.is_empty() {
+                    return Err(LlmError::Config(format!(
+                        "openrouter: provider `{p}`: api key not set"
+                    )));
+                }
+                Ok((
+                    bare,
+                    Endpoint {
+                        url: &ep.base_url,
+                        api_key: &ep.api_key,
+                        http: &self.plain_http,
+                        name: Some(name.as_str()),
+                    },
+                ))
+            }
+        }
     }
 
     /// Build the `ProviderPrefs` for a wire body, or `None` when neither the
@@ -2927,6 +3032,105 @@ data: [DONE]\n\n";
         let prefs = c.provider_prefs().expect("prefs present");
         assert_eq!(prefs.ignore, ["BadHost"]);
         assert_eq!(prefs.sort, Some("latency"));
+    }
+
+    // ---- multi-provider routing: resolve_endpoint (spec §3) ----
+
+    fn client_with_venice() -> OpenRouterClient {
+        OpenRouterClient::with_base_url(
+            "or-key".into(),
+            AppAttribution::default(),
+            "https://openrouter.test/v1".into(),
+        )
+        .with_providers(std::collections::HashMap::from([(
+            "venice".to_string(),
+            crate::provider::ProviderEndpoint {
+                base_url: "https://venice.test/v1/chat/completions".into(),
+                api_key: "v-key".into(),
+            },
+        )]))
+    }
+
+    #[test]
+    fn resolve_no_suffix_is_openrouter() {
+        let c = client_with_venice();
+        let (bare, ep) = c.resolve_endpoint("x-ai/grok-4.20").unwrap();
+        assert_eq!(bare, "x-ai/grok-4.20");
+        assert_eq!(ep.url, "https://openrouter.test/v1");
+        assert_eq!(ep.api_key, "or-key");
+        assert!(ep.name.is_none());
+    }
+
+    #[test]
+    fn resolve_suffix_hits_custom_endpoint() {
+        let c = client_with_venice();
+        let (bare, ep) = c.resolve_endpoint("some-slug@venice").unwrap();
+        assert_eq!(bare, "some-slug");
+        assert_eq!(ep.url, "https://venice.test/v1/chat/completions");
+        assert_eq!(ep.api_key, "v-key");
+        assert_eq!(ep.name, Some("venice"));
+    }
+
+    #[test]
+    fn resolve_escaped_at_stays_openrouter() {
+        let c = client_with_venice();
+        let (bare, ep) = c.resolve_endpoint("weird\\@vendor/m").unwrap();
+        assert_eq!(bare, "weird@vendor/m");
+        assert!(ep.name.is_none());
+    }
+
+    #[test]
+    fn resolve_unknown_provider_is_config_error() {
+        let c = client_with_venice();
+        assert!(matches!(
+            c.resolve_endpoint("m@nope"),
+            Err(LlmError::Config(_))
+        ));
+    }
+
+    #[test]
+    fn resolve_empty_openrouter_key_still_guards() {
+        // The old head-of-method guard moved here; same error, same wording.
+        let c = OpenRouterClient::with_base_url(
+            String::new(),
+            AppAttribution::default(),
+            "https://openrouter.test/v1".into(),
+        );
+        assert!(matches!(c.resolve_endpoint("m"), Err(LlmError::Config(_))));
+    }
+
+    #[test]
+    fn resolve_empty_custom_key_guards() {
+        let c = OpenRouterClient::with_base_url(
+            "or-key".into(),
+            AppAttribution::default(),
+            "https://openrouter.test/v1".into(),
+        )
+        .with_providers(std::collections::HashMap::from([(
+            "venice".to_string(),
+            crate::provider::ProviderEndpoint {
+                base_url: "https://venice.test/v1".into(),
+                api_key: String::new(),
+            },
+        )]));
+        assert!(matches!(
+            c.resolve_endpoint("m@venice"),
+            Err(LlmError::Config(_))
+        ));
+    }
+
+    #[test]
+    fn with_openrouter_base_url_overrides_and_none_keeps() {
+        let c = client_with_venice().with_openrouter_base_url(Some("https://proxy.test/v1".into()));
+        assert_eq!(
+            c.resolve_endpoint("m").unwrap().1.url,
+            "https://proxy.test/v1"
+        );
+        let c2 = client_with_venice().with_openrouter_base_url(None);
+        assert_eq!(
+            c2.resolve_endpoint("m").unwrap().1.url,
+            "https://openrouter.test/v1"
+        );
     }
 
     /// Garbled string used in garble-guard tests. `Ġ`/`Ċ` density is 2/12 ≈ 16.7 % >> 3 % threshold.

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -1019,26 +1019,32 @@ impl OpenRouterClient {
                 "openrouter: vision has no models configured".into(),
             ));
         }
-        if self.api_key.is_empty() {
-            return Err(LlmError::Config("openrouter: api key not set".into()));
-        }
-
         let mut last_err: Option<LlmError> = None;
         // Latest recoverable garble, kept separate so a later non-garble failure
         // can't discard a repairable earlier garble (mirrors `execute`). Tuple:
         // (model, raw, finish_reason).
         let mut last_garbled: Option<(String, String, Option<String>)> = None;
         for model in &candidates {
-            let mut body = build_vision_body(&req, model);
-            if let Some(prefs) = self.provider_prefs() {
-                if let Ok(v) = serde_json::to_value(&prefs) {
-                    body["provider"] = v;
+            let (bare_model, ep) = match self.resolve_endpoint(model) {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!(model = %model, error = %e, "openrouter: vision attempt failed (endpoint); next");
+                    last_err = Some(e);
+                    continue;
+                }
+            };
+            let mut body = build_vision_body(&req, &bare_model);
+            if ep.name.is_none() {
+                if let Some(prefs) = self.provider_prefs() {
+                    if let Ok(v) = serde_json::to_value(&prefs) {
+                        body["provider"] = v;
+                    }
                 }
             }
-            let resp = match self
+            let resp = match ep
                 .http
-                .post(&self.base_url)
-                .bearer_auth(&self.api_key)
+                .post(ep.url)
+                .bearer_auth(ep.api_key)
                 .json(&body)
                 .send()
                 .await
@@ -1096,10 +1102,20 @@ impl OpenRouterClient {
                 }
                 continue;
             }
+            // §6: a custom row self-identifies as <echo>@<provider> so a failed
+            // eros-audit join on generation_id explains itself from the model
+            // column. OpenRouter rows are byte-identical to before.
+            let model_out = match ep.name {
+                None => parsed.model,
+                Some(p) => Some(match parsed.model {
+                    Some(echo) => format!("{echo}@{p}"),
+                    None => format!("{bare_model}@{p}"),
+                }),
+            };
             return Ok(ChatResponse {
                 reply: clean_response(raw.trim()),
                 generation_id: parsed.id,
-                model: parsed.model,
+                model: model_out,
                 usage: parsed.usage,
                 finish_reason,
             });
@@ -3508,6 +3524,59 @@ data: [DONE]\n\n";
             "no generation_id when repaired"
         );
         assert_eq!(resp.model.as_deref(), Some("vp"));
+    }
+
+    #[tokio::test]
+    async fn vision_custom_provider_bare_model_no_prefs_suffixed_audit() {
+        let server_b = MockServer::start().await;
+        Mock::given(path("/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "v-gen-2",
+                "model": "venice-vision-echo",
+                "choices": [{ "message": { "content": "{\"desc\":\"a cat\"}" } }]
+            })))
+            .expect(1)
+            .mount(&server_b)
+            .await;
+        let client = OpenRouterClient::with_base_url(
+            "or-key".into(),
+            AppAttribution::default(),
+            "https://unused.test/v1".into(),
+        )
+        .with_ignore_providers(vec!["bad".into()]) // would inject body["provider"] on OpenRouter
+        .with_providers(std::collections::HashMap::from([(
+            "venice".to_string(),
+            crate::provider::ProviderEndpoint {
+                base_url: format!("{}/v1/chat/completions", server_b.uri()),
+                api_key: "v-key".into(),
+            },
+        )]));
+        let resp = client
+            .execute_vision(VisionRequest {
+                model: "vis@venice".into(),
+                fallback_model: vec![],
+                system_prompt: "describe".into(),
+                image_url: "data:image/png;base64,AAAA".into(),
+                caption: None,
+                temperature: 0.0,
+                max_tokens: 64,
+                reasoning: None,
+            })
+            .await
+            .expect("vision call succeeds");
+        assert_eq!(resp.model.as_deref(), Some("venice-vision-echo@venice"));
+
+        let r = &server_b.received_requests().await.unwrap()[0];
+        assert_eq!(
+            r.headers.get("authorization").unwrap().to_str().unwrap(),
+            "Bearer v-key"
+        );
+        let body: serde_json::Value = serde_json::from_slice(&r.body).unwrap();
+        assert_eq!(body["model"], "vis");
+        assert!(
+            body.get("provider").is_none(),
+            "provider prefs leaked to custom vision"
+        );
     }
 
     #[test]

--- a/crates/eros-engine-llm/src/provider.rs
+++ b/crates/eros-engine-llm/src/provider.rs
@@ -10,10 +10,22 @@ use std::fmt;
 /// One custom OpenAI-compatible endpoint from the `[providers]` block.
 /// `base_url` is the complete chat-completions URL, posted verbatim;
 /// `api_key` comes from the `<NAME>_API_KEY` env var at boot.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct ProviderEndpoint {
     pub base_url: String,
     pub api_key: String,
+}
+
+impl fmt::Debug for ProviderEndpoint {
+    /// Manual impl (not `derive`): `api_key` must never land in a log line or
+    /// a panic message via `{:?}`, so it's redacted here rather than relying
+    /// on every caller to remember not to print the field directly.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ProviderEndpoint")
+            .field("base_url", &self.base_url)
+            .field("api_key", &"<redacted>")
+            .finish()
+    }
 }
 
 /// Why a model slug failed to parse. Carries the offending slug so boot
@@ -38,12 +50,20 @@ impl fmt::Display for SlugError {
                  string, write `\"\\\\@\"`)"
             ),
             SlugError::EmptyModelId { slug } => {
-                write!(f, "model slug `{slug}` has an empty model id before `@`")
+                write!(
+                    f,
+                    "model slug `{slug}` has an empty model id before `@` — if the model id \
+                     itself is meant to start with a literal `@` (e.g. an OpenRouter preset \
+                     like `@preset/roleplay`), escape it as `\\@` (in a TOML double-quoted \
+                     string, write `\"\\\\@\"`)"
+                )
             }
             SlugError::EmptyProvider { slug } => {
                 write!(
                     f,
-                    "model slug `{slug}` has an empty provider name after `@`"
+                    "model slug `{slug}` has an empty provider name after `@` — if the trailing \
+                     `@` is meant to be a literal character in the model id, escape it as `\\@` \
+                     (in a TOML double-quoted string, write `\"\\\\@\"`)"
                 )
             }
         }
@@ -105,6 +125,19 @@ pub fn bare_model_id(slug: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn provider_endpoint_debug_redacts_api_key() {
+        let ep = ProviderEndpoint {
+            base_url: "https://api.venice.ai/chat/completions".to_string(),
+            api_key: "sk-live-SUPER-SECRET-KEY".to_string(),
+        };
+        let dbg = format!("{ep:?}");
+        assert!(
+            !dbg.contains("SUPER-SECRET-KEY"),
+            "Debug output must not leak api_key: {dbg}"
+        );
+    }
 
     #[test]
     fn no_at_is_openrouter_verbatim() {
@@ -198,6 +231,30 @@ mod tests {
     fn error_messages_name_the_slug_and_the_escape() {
         let msg = split_model_slug("a@b@venice").unwrap_err().to_string();
         assert!(msg.contains("a@b@venice"));
+        assert!(
+            msg.contains("\\@"),
+            "message should teach the escape: {msg}"
+        );
+    }
+
+    #[test]
+    fn empty_model_id_message_teaches_the_escape() {
+        // Finding 2: a preset-style slug like `@preset/roleplay` should point
+        // the operator at the `\@` escape, not just say "empty".
+        let msg = split_model_slug("@preset/roleplay")
+            .unwrap_err()
+            .to_string();
+        assert!(msg.contains("@preset/roleplay"));
+        assert!(
+            msg.contains("\\@"),
+            "message should teach the escape: {msg}"
+        );
+    }
+
+    #[test]
+    fn empty_provider_message_teaches_the_escape() {
+        let msg = split_model_slug("x@").unwrap_err().to_string();
+        assert!(msg.contains("x@"));
         assert!(
             msg.contains("\\@"),
             "message should teach the escape: {msg}"

--- a/crates/eros-engine-llm/src/provider.rs
+++ b/crates/eros-engine-llm/src/provider.rs
@@ -41,7 +41,10 @@ impl fmt::Display for SlugError {
                 write!(f, "model slug `{slug}` has an empty model id before `@`")
             }
             SlugError::EmptyProvider { slug } => {
-                write!(f, "model slug `{slug}` has an empty provider name after `@`")
+                write!(
+                    f,
+                    "model slug `{slug}` has an empty provider name after `@`"
+                )
             }
         }
     }
@@ -70,14 +73,20 @@ pub fn split_model_slug(slug: &str) -> Result<(String, Option<&str>), SlugError>
             let (id_raw, rest) = slug.split_at(*i);
             let provider = &rest[1..];
             if id_raw.is_empty() {
-                return Err(SlugError::EmptyModelId { slug: slug.to_string() });
+                return Err(SlugError::EmptyModelId {
+                    slug: slug.to_string(),
+                });
             }
             if provider.is_empty() {
-                return Err(SlugError::EmptyProvider { slug: slug.to_string() });
+                return Err(SlugError::EmptyProvider {
+                    slug: slug.to_string(),
+                });
             }
             Ok((unescape(id_raw), Some(provider)))
         }
-        _ => Err(SlugError::MultipleAt { slug: slug.to_string() }),
+        _ => Err(SlugError::MultipleAt {
+            slug: slug.to_string(),
+        }),
     }
 }
 
@@ -148,7 +157,10 @@ mod tests {
 
     #[test]
     fn empty_provider_errors() {
-        assert!(matches!(split_model_slug("x@"), Err(SlugError::EmptyProvider { .. })));
+        assert!(matches!(
+            split_model_slug("x@"),
+            Err(SlugError::EmptyProvider { .. })
+        ));
     }
 
     #[test]
@@ -186,6 +198,9 @@ mod tests {
     fn error_messages_name_the_slug_and_the_escape() {
         let msg = split_model_slug("a@b@venice").unwrap_err().to_string();
         assert!(msg.contains("a@b@venice"));
-        assert!(msg.contains("\\@"), "message should teach the escape: {msg}");
+        assert!(
+            msg.contains("\\@"),
+            "message should teach the escape: {msg}"
+        );
     }
 }

--- a/crates/eros-engine-llm/src/provider.rs
+++ b/crates/eros-engine-llm/src/provider.rs
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! Model-slug → provider routing primitives.
+//!
+//! Grammar (spec §2, applied AFTER TOML parsing): at most one unescaped `@`
+//! splits `<model id>@<provider name>`; the two-byte sequence `\@` escapes a
+//! literal `@` inside a model id. No `@` ⇒ built-in OpenRouter.
+
+use std::fmt;
+
+/// One custom OpenAI-compatible endpoint from the `[providers]` block.
+/// `base_url` is the complete chat-completions URL, posted verbatim;
+/// `api_key` comes from the `<NAME>_API_KEY` env var at boot.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderEndpoint {
+    pub base_url: String,
+    pub api_key: String,
+}
+
+/// Why a model slug failed to parse. Carries the offending slug so boot
+/// errors and `LlmError::Config` messages are self-locating.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SlugError {
+    /// More than one unescaped `@`.
+    MultipleAt { slug: String },
+    /// Nothing before the separator (`@venice`).
+    EmptyModelId { slug: String },
+    /// Nothing after the separator (`x@`).
+    EmptyProvider { slug: String },
+}
+
+impl fmt::Display for SlugError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SlugError::MultipleAt { slug } => write!(
+                f,
+                "model slug `{slug}` contains more than one unescaped `@` — a literal `@` \
+                 inside a model id must be escaped as `\\@` (in a TOML double-quoted \
+                 string, write `\"\\\\@\"`)"
+            ),
+            SlugError::EmptyModelId { slug } => {
+                write!(f, "model slug `{slug}` has an empty model id before `@`")
+            }
+            SlugError::EmptyProvider { slug } => {
+                write!(f, "model slug `{slug}` has an empty provider name after `@`")
+            }
+        }
+    }
+}
+
+impl std::error::Error for SlugError {}
+
+/// Split a config model slug into (unescaped model id, optional provider
+/// name). `None` provider ⇒ the built-in OpenRouter client. Only the two-byte
+/// sequence `\@` is an escape; every other backslash is an ordinary model-id
+/// byte, so a trailing lone `\` stays in the id.
+pub fn split_model_slug(slug: &str) -> Result<(String, Option<&str>), SlugError> {
+    // `@` and `\` are ASCII, so byte scanning is UTF-8-safe and the split
+    // index below is always a char boundary.
+    let bytes = slug.as_bytes();
+    let mut ats = Vec::new();
+    for (i, &b) in bytes.iter().enumerate() {
+        if b == b'@' && (i == 0 || bytes[i - 1] != b'\\') {
+            ats.push(i);
+        }
+    }
+    let unescape = |s: &str| s.replace("\\@", "@");
+    match ats.as_slice() {
+        [] => Ok((unescape(slug), None)),
+        [i] => {
+            let (id_raw, rest) = slug.split_at(*i);
+            let provider = &rest[1..];
+            if id_raw.is_empty() {
+                return Err(SlugError::EmptyModelId { slug: slug.to_string() });
+            }
+            if provider.is_empty() {
+                return Err(SlugError::EmptyProvider { slug: slug.to_string() });
+            }
+            Ok((unescape(id_raw), Some(provider)))
+        }
+        _ => Err(SlugError::MultipleAt { slug: slug.to_string() }),
+    }
+}
+
+/// The suffix-stripped, unescaped model id — what model-keyed config tables
+/// (`display` / `output_regex` / `output_filter.trigger`) and the wire `model`
+/// field use. Falls back to the raw string on invalid grammar: post-boot,
+/// config-supplied slugs are always valid, so this only fires on
+/// client-supplied strings, which were never routable anyway.
+pub fn bare_model_id(slug: &str) -> String {
+    match split_model_slug(slug) {
+        Ok((id, _)) => id,
+        Err(_) => slug.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_at_is_openrouter_verbatim() {
+        assert_eq!(
+            split_model_slug("x-ai/grok-4.20").unwrap(),
+            ("x-ai/grok-4.20".to_string(), None)
+        );
+    }
+
+    #[test]
+    fn one_at_splits_provider() {
+        assert_eq!(
+            split_model_slug("some-slug@venice").unwrap(),
+            ("some-slug".to_string(), Some("venice"))
+        );
+    }
+
+    #[test]
+    fn escaped_at_is_literal_and_openrouter() {
+        // Post-TOML string is weird\@vendor/m (single backslash).
+        assert_eq!(
+            split_model_slug("weird\\@vendor/m").unwrap(),
+            ("weird@vendor/m".to_string(), None)
+        );
+    }
+
+    #[test]
+    fn escape_and_suffix_compose() {
+        assert_eq!(
+            split_model_slug("weird\\@vendor/m@venice").unwrap(),
+            ("weird@vendor/m".to_string(), Some("venice"))
+        );
+    }
+
+    #[test]
+    fn two_unescaped_ats_error() {
+        assert!(matches!(
+            split_model_slug("a@b@venice"),
+            Err(SlugError::MultipleAt { .. })
+        ));
+    }
+
+    #[test]
+    fn empty_model_id_errors() {
+        assert!(matches!(
+            split_model_slug("@venice"),
+            Err(SlugError::EmptyModelId { .. })
+        ));
+    }
+
+    #[test]
+    fn empty_provider_errors() {
+        assert!(matches!(split_model_slug("x@"), Err(SlugError::EmptyProvider { .. })));
+    }
+
+    #[test]
+    fn trailing_lone_backslash_is_part_of_the_id() {
+        assert_eq!(
+            split_model_slug("weird\\").unwrap(),
+            ("weird\\".to_string(), None)
+        );
+    }
+
+    #[test]
+    fn escaped_then_unescaped_adjacent() {
+        // a\@@venice: first @ escaped, second is the separator.
+        assert_eq!(
+            split_model_slug("a\\@@venice").unwrap(),
+            ("a@".to_string(), Some("venice"))
+        );
+    }
+
+    #[test]
+    fn bare_model_id_strips_suffix_and_unescapes() {
+        assert_eq!(bare_model_id("some-slug@venice"), "some-slug");
+        assert_eq!(bare_model_id("weird\\@vendor/m"), "weird@vendor/m");
+        assert_eq!(bare_model_id("plain/model"), "plain/model");
+    }
+
+    #[test]
+    fn bare_model_id_falls_back_to_raw_on_invalid() {
+        // Invalid grammar can only reach this fn via non-config strings
+        // (post-boot everything from config is valid); fail open to the raw.
+        assert_eq!(bare_model_id("a@b@c"), "a@b@c");
+    }
+
+    #[test]
+    fn error_messages_name_the_slug_and_the_escape() {
+        let msg = split_model_slug("a@b@venice").unwrap_err().to_string();
+        assert!(msg.contains("a@b@venice"));
+        assert!(msg.contains("\\@"), "message should teach the escape: {msg}");
+    }
+}

--- a/crates/eros-engine-llm/src/provider.rs
+++ b/crates/eros-engine-llm/src/provider.rs
@@ -110,6 +110,13 @@ pub fn split_model_slug(slug: &str) -> Result<(String, Option<&str>), SlugError>
     }
 }
 
+/// Escape literal `@` bytes in a model id so the result round-trips through
+/// [`split_model_slug`] when a `@provider` suffix is appended. Inverse of the
+/// unescape performed by `split_model_slug`; identity for ids without `@`.
+pub fn escape_model_id(id: &str) -> String {
+    id.replace('@', "\\@")
+}
+
 /// The suffix-stripped, unescaped model id — what model-keyed config tables
 /// (`display` / `output_regex` / `output_filter.trigger`) and the wire `model`
 /// field use. Falls back to the raw string on invalid grammar: post-boot,
@@ -218,6 +225,26 @@ mod tests {
         assert_eq!(bare_model_id("some-slug@venice"), "some-slug");
         assert_eq!(bare_model_id("weird\\@vendor/m"), "weird@vendor/m");
         assert_eq!(bare_model_id("plain/model"), "plain/model");
+    }
+
+    #[test]
+    fn escape_model_id_escapes_literal_at() {
+        assert_eq!(escape_model_id("weird@vendor/m"), "weird\\@vendor/m");
+    }
+
+    #[test]
+    fn escape_model_id_is_identity_without_at() {
+        assert_eq!(escape_model_id("plain/model"), "plain/model");
+    }
+
+    #[test]
+    fn escape_model_id_round_trips_through_split_model_slug() {
+        let escaped = escape_model_id("weird@vendor/m");
+        let slug = format!("{escaped}@venice");
+        assert_eq!(
+            split_model_slug(&slug).unwrap(),
+            ("weird@vendor/m".to_string(), Some("venice"))
+        );
     }
 
     #[test]

--- a/crates/eros-engine-server/src/main.rs
+++ b/crates/eros-engine-server/src/main.rs
@@ -320,6 +320,13 @@ async fn run_server() -> Result<()> {
         anyhow::bail!(msg);
     }
 
+    // Multi-provider routing (spec 2026-07-31): [providers] table shape plus a
+    // literal full scan of every candidate slug — grammar, declaredness, and
+    // per-provider <NAME>_API_KEY presence. Refuses to boot on any miss.
+    if let Err(msg) = model_config.validate_providers() {
+        anyhow::bail!(msg);
+    }
+
     // Skip when the master switch is off — WORLD_DISABLED must be able to
     // isolate a staged/incomplete [tasks.world_director] section (the sweeper
     // won't spawn and injection is gated too, so a blank prompt is harmless).
@@ -352,10 +359,18 @@ async fn run_server() -> Result<()> {
     };
 
     // OpenRouter client is constructed after model_config so we can wire in the
-    // global provider routing prefs from [defaults]: the exclusion list and the
-    // optional sort preference (both off by default).
+    // global provider routing prefs from [defaults] (exclusion list + optional
+    // sort) and the [providers] endpoint map. OPENROUTER_BASE_URL (optional)
+    // overrides the built-in endpoint; empty counts as unset, matching the
+    // OPENROUTER_APP_* convention above.
     let openrouter = Arc::new(
         eros_engine_llm::openrouter::OpenRouterClient::new(openrouter_key, attribution)
+            .with_openrouter_base_url(
+                std::env::var("OPENROUTER_BASE_URL")
+                    .ok()
+                    .filter(|s| !s.is_empty()),
+            )
+            .with_providers(model_config.build_providers())
             .with_ignore_providers(model_config.defaults.ignore_providers.clone())
             .with_provider_sort(model_config.defaults.provider_sort.clone()),
     );

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -514,6 +514,10 @@ fn drive_chat_burst(
             // fallback failed differently (mirrors OpenRouterClient::execute).
             let mut last_complete_garble: Option<String> = None;
             for (idx, model_id) in chain.iter().enumerate() {
+                // Model-keyed config tables (display / output_regex / trigger)
+                // are written with bare ids; model_id here is the full config
+                // slug (may carry @provider — which audit KEEPS, spec §6).
+                let bare_model_id = eros_engine_llm::provider::bare_model_id(model_id);
                 let msg_ulid = Ulid::new();
                 let msg_uuid: Uuid = msg_ulid.into();
                 let mut acc = String::new();
@@ -526,13 +530,13 @@ fn drive_chat_burst(
                 // apply below. Empty rule set ⇒ pure passthrough.
                 let mut scrubber = eros_engine_llm::stream_scrub::StreamScrubber::new(
                     &state.output_regex,
-                    model_id,
+                    &bare_model_id,
                 );
 
                 yield ProtocolFrame::Meta {
                     message_id: ulid_string(msg_ulid),
                     action_type: frame_action,
-                    model: display_override.as_ref().and_then(|d| d.display(model_id)),
+                    model: display_override.as_ref().and_then(|d| d.display(&bare_model_id)),
                     continues_from: continues_from.map(ulid_string),
                 };
 
@@ -711,7 +715,7 @@ fn drive_chat_burst(
                 } else {
                     let strip = eros_engine_llm::model_config::apply_output_regex(
                         &state.output_regex,
-                        model_id,
+                        &bare_model_id,
                         &acc,
                     );
                     let audit = if strip.matched_rules.is_empty() {
@@ -908,6 +912,10 @@ fn drive_chat_burst(
         // `filter` is None when the turn buffers solely because of output_regex.
         let f_opt = filter.as_ref();
         for (idx, model_id) in chain.iter().enumerate() {
+            // Model-keyed config tables (display / output_regex / trigger)
+            // are written with bare ids; model_id here is the full config
+            // slug (may carry @provider — which audit KEEPS, spec §6).
+            let bare_model_id = eros_engine_llm::provider::bare_model_id(model_id);
             let msg_ulid = Ulid::new();
             let msg_uuid: Uuid = msg_ulid.into();
             let mut acc = String::new();
@@ -1068,7 +1076,7 @@ fn drive_chat_burst(
                     yield ProtocolFrame::Meta {
                         message_id: ulid_string(msg_ulid),
                         action_type: frame_action,
-                        model: display_override.as_ref().and_then(|d| d.display(model_id)),
+                        model: display_override.as_ref().and_then(|d| d.display(&bare_model_id)),
                         continues_from: None,
                     };
                     // Forward the served usage (a provider can emit a usage block
@@ -1145,7 +1153,7 @@ fn drive_chat_burst(
             yield ProtocolFrame::Meta {
                 message_id: ulid_string(msg_ulid),
                 action_type: frame_action,
-                model: display_override.as_ref().and_then(|d| d.display(model_id)),
+                model: display_override.as_ref().and_then(|d| d.display(&bare_model_id)),
                 continues_from: None,
             };
 
@@ -1161,7 +1169,7 @@ fn drive_chat_burst(
             // frame falsely reports `filtered = true`.
             let strip = eros_engine_llm::model_config::apply_output_regex(
                 &state.output_regex,
-                model_id,
+                &bare_model_id,
                 &acc,
             );
             let cleaned = strip.cleaned;
@@ -1207,7 +1215,7 @@ fn drive_chat_burst(
             } else {
                 match f_opt {
                     Some(f) => {
-                    let hits = f.trigger.should_filter(model_id, &tag_refs, random_draw);
+                    let hits = f.trigger.should_filter(&bare_model_id, &tag_refs, random_draw);
                     match hits {
                         Some(h) => match run_output_filter(&state, f, &cleaned).await {
                             Ok(out) => {
@@ -3923,7 +3931,9 @@ pub fn replay_stream(
                     // retries are wire-identical regardless of any
                     // display_override config.
                     model: row.model.as_deref().and_then(|m| {
-                        display_override.as_ref().and_then(|d| d.display(m))
+                        display_override
+                            .as_ref()
+                            .and_then(|d| d.display(&eros_engine_llm::provider::bare_model_id(m)))
                     }),
                     continues_from: prev_ulid.map(ulid_string),
                 };

--- a/docs/model-config.md
+++ b/docs/model-config.md
@@ -82,6 +82,56 @@ Field details:
 | `tasks.<name>.description` | `String` | no | Documentation field, ignored by code. |
 | `tasks.<name>.dimensions` | `u32` | no | Embedding-only. Ignored by chat / insight tasks. |
 
+### `[providers]` — custom OpenAI-compatible endpoints (opt-in)
+
+```toml
+[providers]
+venice = "https://api.venice.ai/api/v1/chat/completions"
+```
+
+Declares additional chat-completions endpoints alongside the built-in
+OpenRouter client. Reference one by suffixing a model slug anywhere a
+`model` / `fallback` accepts one (any shape — fixed, round-robin, weighted):
+
+```toml
+[tasks.chat_companion]
+model = "venice-uncensored@venice"   # served by [providers].venice
+fallback = ["x-ai/grok-4.20"]        # no suffix → built-in OpenRouter
+```
+
+Rules, all enforced at boot (the engine refuses to boot on any violation):
+
+- **Names** match `[a-z0-9_]+`; `openrouter` is reserved (override the
+  built-in endpoint with the `OPENROUTER_BASE_URL` env var instead).
+- **URL** is the complete chat-completions URL, posted verbatim — no path
+  joining.
+- **API key** comes from the environment as `<NAME_UPPERCASED>_API_KEY`
+  (`venice` → `$VENICE_API_KEY`), required only for providers actually
+  referenced by some model slug. Declared-but-unreferenced entries need no
+  key.
+- **Model ids are the provider's own slugs**, sent verbatim — the engine
+  never translates model names between providers.
+- A literal `@` inside a model id is escaped `\@`. In a TOML double-quoted
+  string that is written `"weird\\@vendor/m"`; at most one unescaped `@` per
+  slug.
+- **Model-keyed tables use bare ids**: `model_name_display_override`,
+  `output_regex` `models`, and `output_filter` trigger `models` match on the
+  id *without* `@provider`.
+- **Wire shape**: custom providers receive a strict OpenAI chat-completions
+  subset. `[defaults].ignore_providers`, `[defaults].provider_sort`, and
+  per-task `reasoning` are **inert** on custom providers, and the OpenRouter
+  attribution headers are not sent to them.
+- **Audit**: rows served by a custom provider record
+  `model = "<upstream echo>@<name>"` and the provider's own `generation_id`
+  verbatim — a `generation_id` join against OpenRouter's logs misses for
+  those rows, and the `model` column says why.
+- `[tasks.chat_image_generation]` does not accept `@provider` — the draw
+  endpoint speaks OpenRouter's `modalities` extension. The composer task
+  (`chat_image_prompt_compose`) is an ordinary chat task and routes like any
+  other.
+- Under `MODEL_CONFIG_DIR`, `[providers]` merges as one whole top-level key
+  (like `[defaults]`, unlike `[tasks]`): all providers live in one file.
+
 ### `model_name_display_override` (chat task only)
 
 Controls the `model` value sent to clients in chat SSE `meta` frames. Affects

--- a/docs/model-config.zh.md
+++ b/docs/model-config.zh.md
@@ -82,6 +82,51 @@ allow_traits = ["tag_a"]                    # optional, overrides task-level all
 | `tasks.<name>.description` | `String` | 否 | 文档字段，代码忽略。 |
 | `tasks.<name>.dimensions` | `u32` | 否 | 仅用于 embedding。chat / insight 任务会忽略。 |
 
+### `[providers]` — 自定义 OpenAI 兼容端点（opt-in）
+
+```toml
+[providers]
+venice = "https://api.venice.ai/api/v1/chat/completions"
+```
+
+在内置 OpenRouter client 之外声明额外的 chat-completions 端点。在任何接受
+`model` / `fallback` 的位置（三种形态：固定、轮询、加权）给模型 slug 加
+`@<name>` 后缀即可引用：
+
+```toml
+[tasks.chat_companion]
+model = "venice-uncensored@venice"   # 由 [providers].venice 提供服务
+fallback = ["x-ai/grok-4.20"]        # 无后缀 → 内置 OpenRouter
+```
+
+以下规则全部在启动时强制校验（任一违反即拒绝启动）：
+
+- **名称**匹配 `[a-z0-9_]+`；`openrouter` 为保留字（覆盖内置端点请用
+  `OPENROUTER_BASE_URL` 环境变量）。
+- **URL** 为完整的 chat-completions 地址，原样 POST，引擎不做任何路径拼接。
+- **API key** 来自环境变量 `<大写名称>_API_KEY`（`venice` →
+  `$VENICE_API_KEY`），仅对被模型 slug 实际引用的 provider 强制要求；
+  已声明但未引用的条目无需 key。
+- **模型 id 用该 provider 自己的 slug**，原样上线——引擎从不在 provider
+  之间转译模型名。
+- 模型 id 中的字面 `@` 用 `\@` 转义。TOML 双引号字符串写作
+  `"weird\\@vendor/m"`；每个 slug 至多一个未转义的 `@`。
+- **按模型匹配的表用裸 id**：`model_name_display_override`、`output_regex`
+  的 `models`、`output_filter` trigger 的 `models`，匹配时都不带
+  `@provider`。
+- **wire 形态**：自定义 provider 收到严格的 OpenAI chat-completions 子集。
+  `[defaults].ignore_providers`、`[defaults].provider_sort` 和任务级
+  `reasoning` 对自定义 provider **不生效**，OpenRouter 归因标头也不会发送。
+- **审计**：自定义 provider 服务的行记录
+  `model = "<上游回显>@<name>"`，`generation_id` 原样存 provider 返回的
+  id——用 `generation_id` 去 join OpenRouter 日志时这些行会 miss，
+  `model` 列会说明原因。
+- `[tasks.chat_image_generation]` 不接受 `@provider`——绘图端点使用
+  OpenRouter 的 `modalities` 扩展。改写器任务（`chat_image_prompt_compose`）
+  是普通 chat 任务，路由规则与其他任务相同。
+- 使用 `MODEL_CONFIG_DIR` 时，`[providers]` 作为单个顶层 key 整体合并
+  （同 `[defaults]`，不同于 `[tasks]`）：所有 provider 必须写在同一个文件里。
+
 ### `model_name_display_override`（仅限 chat 任务）
 
 控制 chat SSE `meta` frame 中发送给客户端的 `model` 值。它**只**影响客户端显示——绝不影响 OpenRouter 请求、持久化的 assistant 记录或用量日志。该字段位于 `[tasks.chat_companion]` 的任务级配置中；所有 tier 都会继承。为其他任务设置该字段可以通过解析，但不会产生效果。

--- a/docs/superpowers/specs/2026-07-31-multi-llm-providers-design.md
+++ b/docs/superpowers/specs/2026-07-31-multi-llm-providers-design.md
@@ -191,7 +191,7 @@ endpoint's* key. `execute_image_inner` keeps its existing guard on
 | `metadata` | sent | **dropped** |
 | `reasoning` | sent | **dropped** |
 | `provider` (ignore / sort) | sent | **dropped** |
-| `HTTP-Referer`, `X-Title`, `X-OpenRouter-Categories` | sent | **not sent** |
+| `HTTP-Referer`, `X-OpenRouter-Title`, `X-OpenRouter-Categories` | sent | **not sent** |
 
 Three body builders, so three edit sites:
 

--- a/docs/superpowers/specs/2026-07-31-multi-llm-providers-design.md
+++ b/docs/superpowers/specs/2026-07-31-multi-llm-providers-design.md
@@ -60,6 +60,11 @@ someprovider = "https://someprovider/api/v1/chat/completions"
 Parsed into `ModelConfig` as `#[serde(default)] pub providers: HashMap<String, String>`,
 sibling to `defaults` and `tasks`.
 
+Under `MODEL_CONFIG_DIR` (multi-file merge, `from_toml_dir`) the block needs no
+new merge code — but like `[defaults]` and unlike `[tasks]`, it merges as **one
+whole top-level key**: two files each declaring `[providers]` refuse to boot
+with the existing duplicate-definition error. All providers live in one file.
+
 **Name (the table key)**
 
 - Must match `^[a-z0-9_]+$`. Rejected at boot otherwise, with a message telling
@@ -159,17 +164,19 @@ the boot validation in §7 entirely. Left as-is, that input lands at OpenRouter
 as a nonsense model id and returns 400 — the same failure any other junk
 `req_model` already produces.
 
-**Why these four points.** Fallback chains are walked in two different places:
+**Why these three points.** Fallback chains are walked in two different places:
 `execute` / `execute_vision` iterate candidates internally, while the streaming
 path iterates in the **server** (`pipeline/stream.rs:549`, `voice.rs:179`),
-handing `execute_stream_as` one model id per attempt. These four `.post()` sites
-are the only place both shapes meet — the point where a model *string* becomes a
+handing `execute_stream_as` one model id per attempt. These `.post()` sites are
+the only place both shapes meet — the point where a model *string* becomes a
 *request*. Resolving there means mixed chains
 (`model = "a@venice"`, `fallback = ["b"]`) work with no coordination code, and
 `pipeline/stream.rs` needs no change to its call form.
 
-The `if self.api_key.is_empty()` guard currently at the head of each of the four
-methods moves into `resolve_endpoint`, where it checks *that endpoint's* key.
+The `if self.api_key.is_empty()` guard currently at the head of the three
+switching methods moves into `resolve_endpoint`, where it checks *that
+endpoint's* key. `execute_image_inner` keeps its existing guard on
+`self.api_key`, consistent with staying pinned to the built-in endpoint.
 
 ---
 
@@ -196,7 +203,10 @@ Three body builders, so three edit sites:
   the wire — no separate serialization path.
 - `execute_vision` builds a `serde_json::Value` and then injects
   `body["provider"]` (912-917). That injection becomes conditional.
-- `execute_image_inner` is untouched; §7 guarantees it never sees a suffix.
+- `execute_image_inner` is untouched. §7 keeps *config-supplied* draw slugs
+  suffix-free; a client-supplied `req_model` may still carry an `@`, which
+  passes through verbatim as a (nonsense) model id per §3 — never interpreted
+  as routing.
 
 **Known weakness, closed by test rather than by types.** Nothing in this design
 *forces* a future OpenRouter-specific field to be added to the drop list. The
@@ -230,8 +240,12 @@ All three receive the **unescaped, suffix-stripped** model id. Operators write
 so an unstripped slug would leak the deployment's provider topology to end
 users.
 
-Change site: the three `d.display(model_id)` calls in `stream.rs` each resolve
-the bare id first.
+Change sites — all in `stream.rs`, all the same one-line shape (resolve the
+bare id before passing `model_id`): the three `d.display(…)` calls
+(535/1071/1148), the two `apply_output_regex(…)` calls (712/1162), and the
+`should_filter(…)` call (1210). Since several of these cluster per attempt, the
+implementation should compute the bare id once per candidate iteration, not
+per call.
 
 ---
 

--- a/docs/superpowers/specs/2026-07-31-multi-llm-providers-design.md
+++ b/docs/superpowers/specs/2026-07-31-multi-llm-providers-design.md
@@ -242,10 +242,14 @@ users.
 
 Change sites — all in `stream.rs`, all the same one-line shape (resolve the
 bare id before passing `model_id`): the three `d.display(…)` calls
-(535/1071/1148), the two `apply_output_regex(…)` calls (712/1162), and the
-`should_filter(…)` call (1210). Since several of these cluster per attempt, the
-implementation should compute the bare id once per candidate iteration, not
-per call.
+(535/1071/1148), the two `apply_output_regex(…)` calls (712/1162), the
+`should_filter(…)` call (1210), and the streaming scrubber constructor
+`StreamScrubber::new(&state.output_regex, model_id)` (527) — the scrubber
+selects `output_regex` rules by model id, so it is the same model-keyed
+semantics as `apply_output_regex`. Since several of these cluster per attempt,
+the implementation should compute the bare id once per candidate iteration,
+not per call. (`voice.rs` and the product-QA loop consume none of these
+tables — audit only, which stays on the full slug.)
 
 ---
 

--- a/docs/superpowers/specs/2026-07-31-multi-llm-providers-design.md
+++ b/docs/superpowers/specs/2026-07-31-multi-llm-providers-design.md
@@ -145,9 +145,19 @@ struct Endpoint<'a> { url: &'a str, api_key: &'a str, http: &'a reqwest::Client,
 fn resolve_endpoint(&self, slug: &str) -> Result<(String, Endpoint<'_>), LlmError>;
 ```
 
-Four call sites switch from `self.base_url` / `self.api_key` / `self.http` to
-the resolved endpoint: `execute_vision` (920), `execute_image_inner` (1062),
-`call_once` (1175), `execute_stream_as` (1287).
+**Three** call sites switch from `self.base_url` / `self.api_key` / `self.http`
+to the resolved endpoint: `execute_vision` (920), `call_once` (1175),
+`execute_stream_as` (1287).
+
+`execute_image_inner` (1062) deliberately does **not**. It keeps posting to
+`self.base_url` with `self.api_key` and passes the whole slug through as the
+model id. The reason is `effective_image_chain` (`model_config.rs:1819`), whose
+first candidate is `req_model` — a **client-supplied, per-turn** string. Routing
+the draw endpoint through `resolve_endpoint` would let any client send
+`req_model = "x@venice"` and reach an arbitrary configured provider, bypassing
+the boot validation in §7 entirely. Left as-is, that input lands at OpenRouter
+as a nonsense model id and returns 400 — the same failure any other junk
+`req_model` already produces.
 
 **Why these four points.** Fallback chains are walked in two different places:
 `execute` / `execute_vision` iterate candidates internally, while the streaming
@@ -284,12 +294,18 @@ draws, it emits an `image_request` frame, and
 `[tasks.chat_image_prompt_compose]` is an ordinary chat-shaped task that
 supports `@provider` like any other.
 
-This is a *literal* check only. `[defaults].fallback_model` can still carry a
-suffix into the draw chain by inheritance; that hole is deliberately left open
-(§11) because the conditional rule needed to close it is a three-way
-conjunction that would become dead code the moment the draw endpoint is
-removed. The residual failure is an OpenRouter 400 model-not-found — loud and
-easy to diagnose, and bounded to one release cycle.
+**A literal check is complete here — no inheritance to chase.**
+`[defaults].fallback_model` is consumed only by `resolve()`
+(`model_config.rs:1277`, `1285`), the text-task resolver. The draw path never
+touches it: `resolve_image_gen` (1657) reads only `task_cfg.fallback`, and
+`effective_image_chain` (1819) composes only `req_model` + `r.model` +
+`r.fallback_model`. A global text fallback therefore cannot leak into a draw
+chain, so scanning `[tasks.chat_image_generation]`'s own two fields is
+exhaustive for config-supplied slugs.
+
+The one slug this check cannot cover is `req_model`, which arrives per-turn
+from the client rather than from config. That is handled structurally instead,
+by keeping the draw endpoint off `resolve_endpoint` entirely (§3).
 
 **Runtime.** After a full boot scan an unknown provider is unreachable in
 theory, but `execute_stream_as` receives a `&str` from the server, so
@@ -351,6 +367,10 @@ Two naming notes:
   so the draw-endpoint restriction can never widen to the compose task by
   accident.
 - **Wire allow-list lock** (§4): custom-endpoint body key set ⊆ allow-list.
+- **Draw endpoint stays on OpenRouter** (§3): a client-supplied
+  `req_model = "x@venice"` posts to the OpenRouter base URL with `x@venice` as
+  the model id — never to Venice. Locks the one path boot validation cannot
+  reach.
 - wiremock integration: two mock servers; assert the custom request reaches the
   right URL with the right bearer token, carries **none** of the three
   attribution headers, and omits **all four** OpenRouter-only body fields.
@@ -400,8 +420,7 @@ Scope of that PR:
 The chat stream already never draws — availability of the image PDE actions
 stopped depending on `[tasks.chat_image_generation]` some time ago
 (`docs/model-config.md:352`), so removing the block does not touch the PDE
-actions or the compose task. Closing the `[defaults].fallback_model`
-inheritance hole (§7) becomes moot once this lands.
+actions or the compose task.
 
 **Not addressed here:** per-provider timeouts or retry policy; non-chat
 endpoints (embeddings stay on Voyage); any provider-specific extension

--- a/docs/superpowers/specs/2026-07-31-multi-llm-providers-design.md
+++ b/docs/superpowers/specs/2026-07-31-multi-llm-providers-design.md
@@ -1,0 +1,384 @@
+# eros-engine — multiple LLM providers via `[providers]` + `model@provider`
+
+Lets a deployment route individual model slugs to its own OpenAI-compatible
+endpoints (Venice, a self-hosted proxy, anything speaking
+`POST /chat/completions`) alongside the built-in OpenRouter client, by declaring
+endpoints in a `[providers]` block and suffixing model slugs with `@name`.
+
+Today every LLM call in the engine goes to one pinned URL
+(`https://openrouter.ai/api/v1/chat/completions`, `openrouter.rs:12`) with one
+API key. A deployment that wants a second vendor has no seam at all. This design
+adds one without changing a single byte of the request the OpenRouter path
+already sends.
+
+---
+
+## 0. Decisions (settled during brainstorm)
+
+- **Per-provider API keys come from a naming convention, not from config.**
+  `venice` reads `$VENICE_API_KEY`. No secret ever appears in a TOML file, and
+  there is no `api_key_env` indirection field. The cost is that provider names
+  are constrained (§1) so the env-var name is derivable without mangling.
+- **Custom providers receive a strict OpenAI-compatible request.** The four
+  OpenRouter-specific body fields and the three attribution headers are dropped
+  (§4). Consequence, documented rather than papered over:
+  `[defaults].ignore_providers`, `[defaults].provider_sort`, and per-task
+  `reasoning` are **inert** on custom providers.
+- **The engine never translates model ids across providers.** Whatever precedes
+  the `@` goes on the wire verbatim, in that provider's own naming. There is no
+  mapping table and no attempt to make a Venice slug look like an OpenRouter
+  slug.
+- **`\@` escapes a literal `@`; written `"\\@"` in TOML.** `\@` is a *reserved*
+  escape in TOML basic strings, so the naive `model = "a\@b"` is a TOML parse
+  error at column 11 — before the engine sees the config and with no chance to
+  explain itself. The documented form is therefore a normal double-quoted
+  string with a doubled backslash. (Verified against `toml 0.8`, the version
+  this crate pins.)
+- **Exactly one unescaped `@` is permitted.** Two or more refuses to boot. This
+  makes `"aaa@bb"` fail with *unknown provider `bb`*, which points the operator
+  straight at the escape rather than silently guessing an interpretation.
+- **`OpenRouterClient` keeps its name.** It is public API of a published crate
+  (`eros-engine-llm`); a rename is a semver break with no functional payoff, and
+  is separable from this feature.
+- **Model-keyed config tables use bare ids** (§5). `@provider` appears only in
+  `model` and `fallback`.
+- **Image generation is out of scope and rejected at boot** (§7), pending its
+  removal in a follow-up (§11).
+
+---
+
+## 1. The `[providers]` block
+
+```toml
+[providers]
+venice = "https://api.venice.ai/api/v1/chat/completions"
+someprovider = "https://someprovider/api/v1/chat/completions"
+```
+
+Parsed into `ModelConfig` as `#[serde(default)] pub providers: HashMap<String, String>`,
+sibling to `defaults` and `tasks`.
+
+**Name (the table key)**
+
+- Must match `^[a-z0-9_]+$`. Rejected at boot otherwise, with a message telling
+  the operator to use underscores. The constraint exists because the name is
+  uppercased directly into an env-var name; permitting `-` or `.` would require
+  a mangling rule, and mangling rules are exactly the kind of implicit magic
+  this design is avoiding.
+- `openrouter` is **reserved**. Declaring it refuses to boot with a message
+  pointing at `OPENROUTER_BASE_URL` (§8). One knob, one way to turn it.
+
+**Value**
+
+The complete URL including path. Posted verbatim — the engine performs no path
+joining and never appends `/chat/completions`. What you write is what gets
+called.
+
+**API key**
+
+Derived as `<NAME_UPPERCASED>_API_KEY`: `venice` → `$VENICE_API_KEY`.
+
+The key is required to exist and be non-empty **only for providers actually
+referenced by some model slug**. A declared-but-unreferenced entry needs no key
+— that is what lets `examples/model_config.toml` ship a sample `[providers]`
+block without breaking boot for everyone who copies it. A referenced provider
+with a missing or empty key refuses to boot, matching the existing
+`VOYAGE_API_KEY` loud-fail precedent (`main.rs:228`).
+
+---
+
+## 2. Model slug grammar
+
+The grammar applies to the string **after** TOML parsing.
+
+| Slug (post-TOML) | Model id sent | Endpoint |
+|---|---|---|
+| `x-ai/grok-4.20` | `x-ai/grok-4.20` | built-in OpenRouter |
+| `some-slug@venice` | `some-slug` | `venice` |
+| `weird\@vendor/m` | `weird@vendor/m` | built-in OpenRouter |
+| `weird\@vendor/m@venice` | `weird@vendor/m` | `venice` |
+| `a@b@venice` | — | **boot error**: 2 unescaped `@` |
+| `@venice` | — | **boot error**: empty model id |
+| `x@` | — | **boot error**: empty provider name |
+
+In TOML these are written `"x-ai/grok-4.20"`, `"some-slug@venice"`,
+`"weird\\@vendor/m"`, `"weird\\@vendor/m@venice"`.
+
+Implemented as a free function so it is unit-testable without a client:
+
+```rust
+pub fn split_model_slug(slug: &str) -> Result<(String, Option<&str>), SlugError>;
+```
+
+Returns the unescaped model id and the provider name (`None` ⇒ built-in
+OpenRouter). Backslashes not preceding `@` are left alone — only the two-char
+sequence `\@` is meaningful, so a trailing lone `\` is part of the model id.
+
+`SlugError` carries the offending slug and the reason. Boot validation (§7)
+renders it into the `Result<(), String>` message; `resolve_endpoint` (§3) maps
+it to `LlmError::Config`.
+
+---
+
+## 3. Client routing
+
+`OpenRouterClient` gains two fields:
+
+```rust
+providers: Arc<HashMap<String, ProviderEndpoint>>,  // name -> { base_url, api_key }
+plain_http: reqwest::Client,                        // no attribution headers
+```
+
+`plain_http` is built at boot beside the existing `http`, with identical
+`connect_timeout` / `pool_idle_timeout` and *no* `default_headers`. It exists
+solely to honour "no attribution headers to custom providers": those three
+headers are baked into the shared client at construction (`openrouter.rs:690-737`)
+and cannot be withdrawn per-request.
+
+Resolution returns a borrowed view:
+
+```rust
+struct Endpoint<'a> { url: &'a str, api_key: &'a str, http: &'a reqwest::Client, openrouter: bool }
+
+fn resolve_endpoint(&self, slug: &str) -> Result<(String, Endpoint<'_>), LlmError>;
+```
+
+Four call sites switch from `self.base_url` / `self.api_key` / `self.http` to
+the resolved endpoint: `execute_vision` (920), `execute_image_inner` (1062),
+`call_once` (1175), `execute_stream_as` (1287).
+
+**Why these four points.** Fallback chains are walked in two different places:
+`execute` / `execute_vision` iterate candidates internally, while the streaming
+path iterates in the **server** (`pipeline/stream.rs:549`, `voice.rs:179`),
+handing `execute_stream_as` one model id per attempt. These four `.post()` sites
+are the only place both shapes meet — the point where a model *string* becomes a
+*request*. Resolving there means mixed chains
+(`model = "a@venice"`, `fallback = ["b"]`) work with no coordination code, and
+`pipeline/stream.rs` needs no change to its call form.
+
+The `if self.api_key.is_empty()` guard currently at the head of each of the four
+methods moves into `resolve_endpoint`, where it checks *that endpoint's* key.
+
+---
+
+## 4. Wire shape per endpoint
+
+| Field | OpenRouter | Custom provider |
+|---|---|---|
+| `model`, `messages`, `temperature` | sent | sent |
+| `top_p`, `frequency_penalty`, `presence_penalty` | sent | sent |
+| `max_tokens`, `stream`, `user`, `response_format` | sent | sent |
+| `session_id` | sent | **dropped** |
+| `metadata` | sent | **dropped** |
+| `reasoning` | sent | **dropped** |
+| `provider` (ignore / sort) | sent | **dropped** |
+| `HTTP-Referer`, `X-Title`, `X-OpenRouter-Categories` | sent | **not sent** |
+
+Three body builders, so three edit sites:
+
+- `call_once` and `execute_stream_as` **share `WireRequest`** (1157 and 1266;
+  the comment at 1262 exists precisely to stop those two from drifting). Add
+  `WireRequest::for_endpoint(self, ep) -> Self`, which sets the four fields to
+  `None` for a custom endpoint. All four already carry
+  `skip_serializing_if = "Option::is_none"`, so `None` alone removes them from
+  the wire — no separate serialization path.
+- `execute_vision` builds a `serde_json::Value` and then injects
+  `body["provider"]` (912-917). That injection becomes conditional.
+- `execute_image_inner` is untouched; §7 guarantees it never sees a suffix.
+
+**Known weakness, closed by test rather than by types.** Nothing in this design
+*forces* a future OpenRouter-specific field to be added to the drop list. The
+guard is a serialization test asserting that a custom-endpoint body's key set is
+a **subset** of the allow-list `{model, messages, temperature, top_p,
+frequency_penalty, presence_penalty, max_tokens, stream, user, response_format}`.
+Subset, not equality — `top_p`, `user`, `response_format` are `Option` and
+`stream` is skipped when false, so a strict equality assertion would fail on
+correct output. A newly added un-dropped field is not in the allow-list, so the
+subset assertion still catches it. This also covers the `json!`-built vision
+body, which a type-level scheme would not.
+
+---
+
+## 5. Model-keyed config tables use bare ids
+
+Three tables key off "which model is this", independent of routing:
+
+| Table | Consumer |
+|---|---|
+| `display` (`DisplayOverride`, `model_config.rs:270`) | `stream.rs:535/1071/1148` |
+| `output_regex.models` (`OutputRegexRule.models`) | `apply_output_regex` |
+| `output_filter.trigger` | `should_filter(model_id, …)`, `stream.rs:1210` |
+
+All three receive the **unescaped, suffix-stripped** model id. Operators write
+`display = { "grok" = "小灰" }`, never `"grok@venice"`. One rule to remember:
+`@` appears only in `model` and `fallback`.
+
+`display` is the load-bearing case rather than a consistency nicety:
+`DisplayOverride::Bool(true)` returns the real model id straight to the client,
+so an unstripped slug would leak the deployment's provider topology to end
+users.
+
+Change site: the three `d.display(model_id)` calls in `stream.rs` each resolve
+the bare id first.
+
+---
+
+## 6. Audit columns
+
+`OpenRouterCallMeta { generation_id, model, usage }` feeds
+`companion_insights_events` / `companion_affinity_events`, and `generation_id`
+is the join key into OpenRouter's own logs from `eros-audit`.
+
+- **Streaming: unchanged.** `stream.rs:744/1034/1289` already persist
+  `model_id.clone()` — the config slug verbatim, not the response echo. An
+  OpenRouter row stays byte-identical; a custom row is already
+  `<slug>@venice`. Zero conversion, zero ambiguity, zero regression risk.
+- **Non-streaming:** `call_once` returns `parsed.model` (the response echo). For
+  a custom endpoint it returns
+  `Some(format!("{}@{}", parsed.model.unwrap_or(bare_id), provider))`.
+  OpenRouter is untouched.
+- **`generation_id`:** stored verbatim, whatever the provider returned. No
+  NULLing and no schema change. The `model` column already says `@venice`, so a
+  failed `eros-audit` join explains itself from the row.
+- The garble-salvage path (`execute:868-880`) already fills the candidate string,
+  which carries the suffix. Unchanged.
+
+Model naming is *not* normalized across providers (§0), so a custom row's model
+segment is that vendor's own slug. That is intended.
+
+---
+
+## 7. Boot validation
+
+Follows the established `pub fn validate_*(&self) -> Result<(), String>` shape
+(cf. `validate_prompt_variants`, `model_config.rs:2040`), with `anyhow::bail!` at
+the call site in `main.rs`.
+
+**Literal full scan.** Walk `[defaults].fallback_model` plus every task's and
+every tier's `model` and `fallback`, visiting **each individual candidate
+string** — every element of a round-robin array and every key of a weighted
+table. For each: grammar is valid (§2), the named provider is declared in
+`[providers]`, and its `<NAME>_API_KEY` is present and non-empty.
+
+Scanning literally rather than via `resolve()` is required, not stylistic: a
+weighted table picks at random per call, so validating only what `resolve()`
+happens to return would let a provider with no key lie dormant until some
+unlucky draw at 3am.
+
+**Provider table checks.** Names match `^[a-z0-9_]+$`; `openrouter` is not
+declared; every URL is non-empty.
+
+**Image generation.** Any `@` in `[tasks.chat_image_gen]`'s own `model` or
+`fallback` refuses to boot, with a message explaining that image generation uses
+OpenRouter's `modalities` extension (`build_image_body`, `openrouter.rs:395`,
+sends `modalities: ["image"]` plus top-level `width`/`height` and reads back
+`choices[].message.images[].image_url.url` — not OpenAI-compatible in either
+direction).
+
+This is a *literal* check only. `[defaults].fallback_model` can still carry a
+suffix into an image-gen chain by inheritance; that hole is deliberately left
+open (§11) because the conditional rule needed to close it is a three-way
+conjunction that would become dead code the moment image generation is removed.
+The residual failure is an OpenRouter 400 model-not-found — loud and easy to
+diagnose, and bounded to one release cycle.
+
+**Runtime.** After a full boot scan an unknown provider is unreachable in
+theory, but `execute_stream_as` receives a `&str` from the server, so
+`resolve_endpoint` still returns `LlmError::Config` on a miss. That advances the
+candidate chain rather than panicking, which is also what makes a mixed chain
+degrade correctly when a whole vendor is down.
+
+---
+
+## 8. Environment
+
+| Variable | Required | Meaning |
+|---|---|---|
+| `OPENROUTER_BASE_URL` | no | Overrides the built-in OpenRouter endpoint. Empty string treated as unset, matching the existing `OPENROUTER_APP_*` handling (`main.rs:216-226`). |
+| `<NAME>_API_KEY` | per §1 | Key for the `[providers]` entry `name`. |
+
+Boot wiring goes in `main.rs` after `model_config` loads and before the client
+is built (~358), joining the existing chain:
+
+```rust
+// Validation and construction are separate calls, in this order.
+// validate_providers borrows only the config; build_providers reads the
+// environment and can therefore assume every referenced key exists.
+if let Err(msg) = model_config.validate_providers() { anyhow::bail!(msg); }
+let providers = model_config.build_providers();   // -> HashMap<String, ProviderEndpoint>
+
+let openrouter = Arc::new(
+    OpenRouterClient::new(openrouter_key, attribution)
+        .with_openrouter_base_url(std::env::var("OPENROUTER_BASE_URL").ok().filter(|s| !s.is_empty()))
+        .with_providers(providers)
+        .with_ignore_providers(model_config.defaults.ignore_providers.clone())
+        .with_provider_sort(model_config.defaults.provider_sort.clone()),
+);
+```
+
+Two naming notes:
+
+- `validate_providers` owns **every** rule in §7 — grammar, name constraints,
+  the reserved `openrouter` key, declared-ness, and the referenced-provider key
+  requirement (it needs `self.tasks` to know what "referenced" means, which is
+  why it lives on `ModelConfig` rather than in `main.rs`). `build_providers`
+  performs no checks; it runs only after validation passed.
+- The new builder is `with_openrouter_base_url`, *not* `with_base_url` — the
+  latter already exists as the associated constructor
+  `with_base_url(api_key, attribution, base_url)` used by tests
+  (`openrouter.rs:689`) and stays as-is. The new one is a consuming builder
+  taking `Option<String>`, where `None` keeps the pinned default.
+
+---
+
+## 9. Testing
+
+- `split_model_slug` unit tests: no `@`; one `@`; `\@` escape; escape and
+  suffix together; two unescaped `@`; empty model id (`@venice`); empty provider
+  (`x@`); trailing lone backslash.
+- Boot validation: a red and a green case per rule in §7, including the
+  image-gen literal check and the weighted-table full scan.
+- **Wire allow-list lock** (§4): custom-endpoint body key set ⊆ allow-list.
+- wiremock integration: two mock servers; assert the custom request reaches the
+  right URL with the right bearer token, carries **none** of the three
+  attribution headers, and omits **all four** OpenRouter-only body fields.
+- Mixed chain: primary `@venice` fails → fallback falls back to OpenRouter and
+  succeeds.
+- **Regression lock:** with no `[providers]` and no suffixes anywhere, the
+  OpenRouter request body and headers are byte-identical to today.
+
+---
+
+## 10. Documentation
+
+- `.env.example`: `OPENROUTER_BASE_URL` and a `VENICE_API_KEY` sample, both
+  commented out.
+- `examples/model_config.toml`: a `[providers]` section covering the `"\\@"`
+  spelling, the bare-id rule for `display` / `output_regex` / `trigger`, the
+  naming constraint, and the fields that go inert on custom providers.
+- `README.md` / `README.zh.md` / `README.ja.md`: synced per existing practice.
+
+---
+
+## 11. Out of scope / follow-up
+
+**Removing the image-generation endpoint** — a separate PR after this one lands.
+Rationale, as stated by the maintainer:
+
+1. Image generation was never a primary capability of the engine, and carrying
+   it costs more maintenance than it returns.
+2. Image API shapes differ per vendor and are actively churning — OpenRouter
+   itself has since shipped a new image API — so this is not a surface worth
+   generalizing behind the `[providers]` abstraction.
+
+Blast radius noted for that PR: `image_gen` / `ImageGen` / `reply_image` /
+`image_prompt_compose` appear across 8 files. `core/types.rs` and `core/pde.rs`
+carry the `reply_image` and `reply_text_image` PDE actions, and
+`chat_image_prompt_compose` — whose `filter_prompt` variants shipped in PR #201
+— loses its only consumer. Closing the `[defaults].fallback_model` inheritance
+hole (§7) becomes moot once this lands.
+
+**Not addressed here:** per-provider timeouts or retry policy; non-chat
+endpoints (embeddings stay on Voyage); any provider-specific extension
+parameters such as Venice's `venice_parameters`; and renaming `OpenRouterClient`
+(§0).

--- a/docs/superpowers/specs/2026-07-31-multi-llm-providers-design.md
+++ b/docs/superpowers/specs/2026-07-31-multi-llm-providers-design.md
@@ -42,8 +42,10 @@ already sends.
   is separable from this feature.
 - **Model-keyed config tables use bare ids** (§5). `@provider` appears only in
   `model` and `fallback`.
-- **Image generation is out of scope and rejected at boot** (§7), pending its
-  removal in a follow-up (§11).
+- **The draw endpoint is out of scope and rejected at boot** (§7), pending its
+  removal in a follow-up (§11). This is scoped to
+  `[tasks.chat_image_generation]` only — `chat_image_prompt_compose` is a
+  normal chat-shaped task and supports `@provider`.
 
 ---
 
@@ -268,19 +270,26 @@ unlucky draw at 3am.
 **Provider table checks.** Names match `^[a-z0-9_]+$`; `openrouter` is not
 declared; every URL is non-empty.
 
-**Image generation.** Any `@` in `[tasks.chat_image_gen]`'s own `model` or
-`fallback` refuses to boot, with a message explaining that image generation uses
-OpenRouter's `modalities` extension (`build_image_body`, `openrouter.rs:395`,
-sends `modalities: ["image"]` plus top-level `width`/`height` and reads back
-`choices[].message.images[].image_url.url` — not OpenAI-compatible in either
-direction).
+**The draw endpoint.** Any `@` in `[tasks.chat_image_generation]`'s own `model`
+or `fallback` refuses to boot, with a message explaining that the draw endpoint
+uses OpenRouter's `modalities` extension (`build_image_body`,
+`openrouter.rs:395`, sends `modalities: ["image"]` plus top-level
+`width`/`height` and reads back `choices[].message.images[].image_url.url` — not
+OpenAI-compatible in either direction).
+
+This restriction is scoped to the **draw endpoint**
+(`POST /comp/chat/{session_id}/image/stream`), which is the only consumer of
+that block. It does not touch the rest of the image path: the chat stream never
+draws, it emits an `image_request` frame, and
+`[tasks.chat_image_prompt_compose]` is an ordinary chat-shaped task that
+supports `@provider` like any other.
 
 This is a *literal* check only. `[defaults].fallback_model` can still carry a
-suffix into an image-gen chain by inheritance; that hole is deliberately left
-open (§11) because the conditional rule needed to close it is a three-way
-conjunction that would become dead code the moment image generation is removed.
-The residual failure is an OpenRouter 400 model-not-found — loud and easy to
-diagnose, and bounded to one release cycle.
+suffix into the draw chain by inheritance; that hole is deliberately left open
+(§11) because the conditional rule needed to close it is a three-way
+conjunction that would become dead code the moment the draw endpoint is
+removed. The residual failure is an OpenRouter 400 model-not-found — loud and
+easy to diagnose, and bounded to one release cycle.
 
 **Runtime.** After a full boot scan an unknown provider is unreachable in
 theory, but `execute_stream_as` receives a `&str` from the server, so
@@ -337,7 +346,10 @@ Two naming notes:
   suffix together; two unescaped `@`; empty model id (`@venice`); empty provider
   (`x@`); trailing lone backslash.
 - Boot validation: a red and a green case per rule in §7, including the
-  image-gen literal check and the weighted-table full scan.
+  `chat_image_generation` literal check and the weighted-table full scan. Also
+  a green case asserting `chat_image_prompt_compose` **accepts** `@provider`,
+  so the draw-endpoint restriction can never widen to the compose task by
+  accident.
 - **Wire allow-list lock** (§4): custom-endpoint body key set ⊆ allow-list.
 - wiremock integration: two mock servers; assert the custom request reaches the
   right URL with the right bearer token, carries **none** of the three
@@ -362,21 +374,34 @@ Two naming notes:
 
 ## 11. Out of scope / follow-up
 
-**Removing the image-generation endpoint** — a separate PR after this one lands.
+**Removing the draw endpoint** — a separate PR after this one lands. After it,
+the engine *composes image prompts but never calls a generation API*: the chat
+stream emits an `image_request` frame carrying the composed prompt, and the
+consumer calls whichever image vendor it likes.
+
 Rationale, as stated by the maintainer:
 
-1. Image generation was never a primary capability of the engine, and carrying
-   it costs more maintenance than it returns.
+1. Driving image generation was never a primary capability of the engine, and
+   carrying it costs more maintenance than it returns.
 2. Image API shapes differ per vendor and are actively churning — OpenRouter
    itself has since shipped a new image API — so this is not a surface worth
    generalizing behind the `[providers]` abstraction.
 
-Blast radius noted for that PR: `image_gen` / `ImageGen` / `reply_image` /
-`image_prompt_compose` appear across 8 files. `core/types.rs` and `core/pde.rs`
-carry the `reply_image` and `reply_text_image` PDE actions, and
-`chat_image_prompt_compose` — whose `filter_prompt` variants shipped in PR #201
-— loses its only consumer. Closing the `[defaults].fallback_model` inheritance
-hole (§7) becomes moot once this lands.
+Scope of that PR:
+
+| Removed | Kept |
+|---|---|
+| `[tasks.chat_image_generation]` | `[tasks.chat_image_prompt_compose]` — becomes the engine's only image output |
+| `POST /comp/chat/{session_id}/image/stream` | PDE actions `reply_image` / `reply_text_image` |
+| `execute_image`, `execute_image_inner`, `build_image_body`, `plan_attempts` | the `image_request` frame |
+| `ImageGenRequest` / `ImageGenResponse` / `ImageGenError`, `ResolvedImageGen`, `effective_image_chain` | `ImageReplyParams`, `image.prompt_variant` (PR #201) |
+| the draw-only `default_style` / `aspect_ratio` / `resolution` fields | |
+
+The chat stream already never draws — availability of the image PDE actions
+stopped depending on `[tasks.chat_image_generation]` some time ago
+(`docs/model-config.md:352`), so removing the block does not touch the PDE
+actions or the compose task. Closing the `[defaults].fallback_model`
+inheritance hole (§7) becomes moot once this lands.
 
 **Not addressed here:** per-provider timeouts or retry policy; non-chat
 endpoints (embeddings stay on Voyage); any provider-specific extension

--- a/docs/superpowers/specs/2026-07-31-multi-llm-providers-design.md
+++ b/docs/superpowers/specs/2026-07-31-multi-llm-providers-design.md
@@ -246,10 +246,13 @@ bare id before passing `model_id`): the three `d.display(…)` calls
 `should_filter(…)` call (1210), and the streaming scrubber constructor
 `StreamScrubber::new(&state.output_regex, model_id)` (527) — the scrubber
 selects `output_regex` rules by model id, so it is the same model-keyed
-semantics as `apply_output_regex`. Since several of these cluster per attempt,
-the implementation should compute the bare id once per candidate iteration,
-not per call. (`voice.rs` and the product-QA loop consume none of these
-tables — audit only, which stays on the full slug.)
+semantics as `apply_output_regex`. One more sits on the replay path: the
+idempotent-retry Meta frame feeds the **persisted** `row.model` — which §6
+stores as the full slug — into `d.display(…)` (stream.rs:3926), so it strips
+the same way. Since several of these cluster per attempt, the implementation
+should compute the bare id once per candidate iteration, not per call.
+(`voice.rs` and the product-QA loop consume none of these tables — audit
+only, which stays on the full slug.)
 
 ---
 

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -22,6 +22,37 @@
 #ignore_providers = ["some-bad-provider-slug"]
 #provider_sort = "latency"
 #
+# ── Custom providers (optional) ──────────────────────────────────────────────
+# Route individual model slugs to your own OpenAI-compatible endpoints.
+# Declare an endpoint here, then suffix a model id with "@<name>":
+#
+#   model = "venice-uncensored@venice"     # served by [providers].venice
+#   fallback = ["x-ai/grok-4.20"]          # no suffix → built-in OpenRouter
+#
+# Rules:
+# - Names match [a-z0-9_]+. "openrouter" is reserved — override the built-in
+#   endpoint with the OPENROUTER_BASE_URL env var instead.
+# - The value is the COMPLETE chat-completions URL, posted verbatim.
+# - The API key comes from env: [providers].venice → $VENICE_API_KEY.
+#   Required only when some model slug actually references the provider —
+#   this sample entry does not break boot.
+# - Model ids before "@" are the PROVIDER'S OWN slugs, sent verbatim; the
+#   engine never translates model names between providers.
+# - A literal "@" inside a model id is escaped "\@" — in a TOML double-quoted
+#   string write "weird\\@vendor/m".
+# - Model-keyed tables (`display`, `output_regex` models, `output_filter`
+#   trigger models) always use the BARE id, never "id@provider".
+# - Custom providers receive a strict OpenAI-compatible request:
+#   [defaults].ignore_providers / provider_sort and per-task `reasoning` are
+#   inert for them, and no attribution headers are sent.
+# - [tasks.chat_image_generation] does not accept "@provider" (the draw
+#   endpoint speaks OpenRouter's modalities extension).
+# - Under MODEL_CONFIG_DIR, [providers] merges as ONE top-level key (like
+#   [defaults]): all providers live in one file.
+#
+#[providers]
+#venice = "https://api.venice.ai/api/v1/chat/completions"
+#
 # One-off repair of rows already persisted with byte-BPE garble (run manually,
 # NOT a migration — the engine refuses to own downstream prod data). Repairs the
 # two unambiguous whitespace glyphs only (Ġ→space, Ċ→newline), idempotent,


### PR DESCRIPTION
Lets a deployment route individual model slugs to its own OpenAI-compatible endpoints (Venice, a self-hosted proxy, anything speaking `POST /chat/completions`) alongside the built-in OpenRouter client — declare endpoints in a `[providers]` block, suffix model slugs with `@name`.

Design spec: `docs/superpowers/specs/2026-07-31-multi-llm-providers-design.md` (first commits).

## What changed

```toml
[providers]
venice = "https://api.venice.ai/api/v1/chat/completions"

[tasks.chat_companion]
model = "venice-uncensored@venice"   # served by [providers].venice
fallback = ["x-ai/grok-4.20"]        # no suffix → built-in OpenRouter (mixed chains work)
```

- **Keys by convention, never in TOML**: `[providers].venice` reads `$VENICE_API_KEY` (names constrained to `[a-z0-9_]+`; `openrouter` reserved — the built-in endpoint is overridden by the new optional `OPENROUTER_BASE_URL` env var instead).
- **Routing resolves inside the client** at the three points where a model string becomes a request (`call_once`, `execute_stream_as`, `execute_vision`) — mixed fallback chains fall out for free, the server's chain-walk loops are untouched.
- **Custom providers get a strict OpenAI subset**: `session_id` / `metadata` / `reasoning` / `provider{ignore,sort}` dropped, no attribution headers (separate header-free reqwest client). Locked by subset tests on both the shared `WireRequest` and the `json!`-built vision body.
- **`\@` escapes a literal `@`** in a model id (TOML double quotes: `"weird\\@vendor/m"`). Exactly one unescaped `@` per slug; violations refuse boot.
- **Boot validation is a literal full scan** — every candidate in every task/tier `model`/`fallback`, including every round-robin element and weighted-table key (a weighted table picks at random; validating `resolve()` output would let a keyless provider hide until an unlucky draw). Referenced providers loud-fail on missing keys, declared-but-unreferenced entries need none.
- **Model-keyed tables use bare ids** (`display` / `output_regex` / `output_filter` trigger, 8 consumer sites incl. the replay path) — `display = true` must not leak provider topology to end users. Audit rows keep the full slug: custom rows self-identify as `<echo>@<name>`, `generation_id` stored verbatim, so an eros-audit join miss explains itself from the row.
- **The draw endpoint never routes**: `[tasks.chat_image_generation]` rejects any `@` at boot, and `execute_image_inner` deliberately bypasses `resolve_endpoint` — its first candidate is the client-supplied `req_model`, and routing it would let any client reach an arbitrary configured provider past boot validation. Pinned by a two-mock-server test (provider host must stay silent).

## Compatibility

**The no-suffix OpenRouter path is byte-identical** — same client, same headers, same body; `for_endpoint` is a no-op there and pre-existing wiremock tests pin it. `[providers]` absent ⇒ nothing changes. New env vars are all optional.

⚠️ **Release note:** additive but *technically* breaking for the published `eros-engine-llm` library under 0.x rules — `ModelConfig` gains a public field, `OpenRouterClient` gains fields/builders, new `provider` module. No existing signature changed; the version decision should still be deliberate.

## Verification

fmt · clippy `-D warnings` · **979 workspace tests** (llm 314 / server 480 / store 185; Postgres available, `#[sqlx::test]` ran) · openapi snapshot: no drift (no API surface change). All commits signed.

Key locks: wire-subset ⊆ allow-list (chat + vision), draw-endpoint isolation, mixed-chain fallback across providers, unknown-provider chain-advance, `chat_image_prompt_compose` *accepting* `@provider` (the draw restriction can never widen to it), redacted `Debug` for `ProviderEndpoint`.

Docs updated: `.env.example`, `examples/model_config.toml`, `docs/model-config{,.zh}.md`, README ×3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)