### PR TITLE
chore(release): v0.9.3 — multi-provider routing + draw-endpoint removal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,7 +511,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "eros-engine-core"
-version = "0.9.3-dev"
+version = "0.9.3"
 dependencies = [
  "chrono",
  "serde",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-llm"
-version = "0.9.3-dev"
+version = "0.9.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-server"
-version = "0.9.3-dev"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-store"
-version = "0.9.3-dev"
+version = "0.9.3"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.9.3-dev"
+version = "0.9.3"
 edition = "2021"
 license = "AGPL-3.0-only"
 repository = "https://github.com/etherfunlab/eros-engine"

--- a/README.ja.md
+++ b/README.ja.md
@@ -78,7 +78,7 @@ eros-engine-llm   = "0.9"   # only if you want the OpenRouter + Voyage clients
 `eros-engine-server` のマルチアーキテクチャイメージ（`linux/amd64` + `linux/arm64`）は、`v*` タグごとに GitHub Container Registry へ公開されます。
 
 ```bash
-docker pull ghcr.io/etherfunlab/eros-engine:0.9.2
+docker pull ghcr.io/etherfunlab/eros-engine:0.9.3
 # or track the latest tagged release
 docker pull ghcr.io/etherfunlab/eros-engine:latest
 ```
@@ -87,7 +87,7 @@ docker pull ghcr.io/etherfunlab/eros-engine:latest
 
 ```bash
 docker run --rm -p 8080:8080 --env-file .env \
-  ghcr.io/etherfunlab/eros-engine:0.9.2 serve
+  ghcr.io/etherfunlab/eros-engine:0.9.3 serve
 ```
 
 このイメージのビルドには、同じ `docker/Dockerfile` が使われています。任意のコンテナホストにデプロイできます。詳細は [Deploying](docs/deploying.md) を参照してください。

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ eros-engine-llm   = "0.9"   # only if you want the OpenRouter + Voyage clients
 Multi-arch (`linux/amd64` + `linux/arm64`) images for `eros-engine-server` are published to GitHub Container Registry for every `v*` tag:
 
 ```bash
-docker pull ghcr.io/etherfunlab/eros-engine:0.9.2
+docker pull ghcr.io/etherfunlab/eros-engine:0.9.3
 # or track the latest tagged release
 docker pull ghcr.io/etherfunlab/eros-engine:latest
 ```
@@ -87,7 +87,7 @@ Minimal run (you bring Postgres + your own `.env`):
 
 ```bash
 docker run --rm -p 8080:8080 --env-file .env \
-  ghcr.io/etherfunlab/eros-engine:0.9.2 serve
+  ghcr.io/etherfunlab/eros-engine:0.9.3 serve
 ```
 
 The `docker/Dockerfile` is the same artifact used to build this image. Deploy it on any container host. See [Deploying](docs/deploying.md).

--- a/README.zh.md
+++ b/README.zh.md
@@ -78,7 +78,7 @@ eros-engine-llm   = "0.9"   # only if you want the OpenRouter + Voyage clients
 每个 `v*` tag 都会将 `eros-engine-server` 的多架构镜像（`linux/amd64` + `linux/arm64`）发布到 GitHub Container Registry：
 
 ```bash
-docker pull ghcr.io/etherfunlab/eros-engine:0.9.2
+docker pull ghcr.io/etherfunlab/eros-engine:0.9.3
 # or track the latest tagged release
 docker pull ghcr.io/etherfunlab/eros-engine:latest
 ```
@@ -87,7 +87,7 @@ docker pull ghcr.io/etherfunlab/eros-engine:latest
 
 ```bash
 docker run --rm -p 8080:8080 --env-file .env \
-  ghcr.io/etherfunlab/eros-engine:0.9.2 serve
+  ghcr.io/etherfunlab/eros-engine:0.9.3 serve
 ```
 
 构建此镜像使用的正是 `docker/Dockerfile`，可将其部署到任意容器托管平台。请参阅[部署](docs/deploying.zh.md)。

--- a/crates/eros-engine-llm/Cargo.toml
+++ b/crates/eros-engine-llm/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "openrouter", "voyage", "embeddings", "llm"]
 categories = ["api-bindings"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "0.9.3-dev" }
+eros-engine-core = { path = "../eros-engine-core", version = "0.9.3" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/eros-engine-server/Cargo.toml
+++ b/crates/eros-engine-server/Cargo.toml
@@ -13,9 +13,9 @@ name = "eros-engine"
 path = "src/main.rs"
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "0.9.3-dev" }
-eros-engine-llm  = { path = "../eros-engine-llm", version = "0.9.3-dev" }
-eros-engine-store = { path = "../eros-engine-store", version = "0.9.3-dev" }
+eros-engine-core = { path = "../eros-engine-core", version = "0.9.3" }
+eros-engine-llm  = { path = "../eros-engine-llm", version = "0.9.3" }
+eros-engine-store = { path = "../eros-engine-store", version = "0.9.3" }
 axum = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0-only",
       "identifier": "AGPL-3.0-only"
     },
-    "version": "0.9.3-dev"
+    "version": "0.9.3"
   },
   "servers": [
     {

--- a/crates/eros-engine-store/Cargo.toml
+++ b/crates/eros-engine-store/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "memory", "pgvector", "postgres", "sqlx"]
 categories = ["database"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "0.9.3-dev" }
+eros-engine-core = { path = "../eros-engine-core", version = "0.9.3" }
 sqlx = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
Version bump 0.9.3-dev → 0.9.3 (workspace + 5 path-dep pins), Cargo.lock, openapi.json info.version, README trio docker tags 0.9.2 → 0.9.3.

Release delta since v0.9.2: #200 #201 #202 #203 #204 #205 (notes on the GH release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)