### PR TITLE
fix(llm): reserve `voyage` as a [providers] name

### DIFF
--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -2039,6 +2039,15 @@ impl ModelConfig {
                         .to_string(),
                 );
             }
+            if name == "voyage" {
+                return Err(
+                    "[providers]: `voyage` is reserved — $VOYAGE_API_KEY already \
+                     belongs to the built-in Voyage embeddings client, so a \
+                     [providers] entry named `voyage` would read the same key. \
+                     Pick another name."
+                        .to_string(),
+                );
+            }
             if name.is_empty()
                 || !name
                     .chars()
@@ -5449,6 +5458,14 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
         let msg = cfg.validate_providers_with(no_env).unwrap_err();
         assert!(msg.contains("reserved"));
         assert!(msg.contains("OPENROUTER_BASE_URL"));
+    }
+
+    #[test]
+    fn provider_name_voyage_is_reserved() {
+        let cfg = ModelConfig::from_toml_str("[providers]\nvoyage = \"https://x/v1\"\n").unwrap();
+        let msg = cfg.validate_providers_with(no_env).unwrap_err();
+        assert!(msg.contains("reserved"));
+        assert!(msg.contains("VOYAGE_API_KEY"));
     }
 
     #[test]

--- a/docs/model-config.md
+++ b/docs/model-config.md
@@ -102,7 +102,9 @@ fallback = ["x-ai/grok-4.20"]        # no suffix → built-in OpenRouter
 Rules, all enforced at boot (the engine refuses to boot on any violation):
 
 - **Names** match `[a-z0-9_]+`; `openrouter` is reserved (override the
-  built-in endpoint with the `OPENROUTER_BASE_URL` env var instead).
+  built-in endpoint with the `OPENROUTER_BASE_URL` env var instead), and so
+  is `voyage` (`$VOYAGE_API_KEY` already belongs to the built-in embeddings
+  client).
 - **URL** is the complete chat-completions URL, posted verbatim — no path
   joining.
 - **API key** comes from the environment as `<NAME_UPPERCASED>_API_KEY`

--- a/docs/model-config.zh.md
+++ b/docs/model-config.zh.md
@@ -102,7 +102,8 @@ fallback = ["x-ai/grok-4.20"]        # 无后缀 → 内置 OpenRouter
 以下规则全部在启动时强制校验（任一违反即拒绝启动）：
 
 - **名称**匹配 `[a-z0-9_]+`；`openrouter` 为保留字（覆盖内置端点请用
-  `OPENROUTER_BASE_URL` 环境变量）。
+  `OPENROUTER_BASE_URL` 环境变量），`voyage` 同为保留字（`$VOYAGE_API_KEY`
+  已属于内置 embeddings 客户端）。
 - **URL** 为完整的 chat-completions 地址，原样 POST，引擎不做任何路径拼接。
 - **API key** 来自环境变量 `<大写名称>_API_KEY`（`venice` →
   `$VENICE_API_KEY`），仅对被模型 slug 实际引用的 provider 强制要求；

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -31,7 +31,8 @@
 #
 # Rules:
 # - Names match [a-z0-9_]+. "openrouter" is reserved — override the built-in
-#   endpoint with the OPENROUTER_BASE_URL env var instead.
+#   endpoint with the OPENROUTER_BASE_URL env var instead. "voyage" is
+#   reserved too ($VOYAGE_API_KEY belongs to the built-in embeddings client).
 # - The value is the COMPLETE chat-completions URL, posted verbatim.
 # - The API key comes from env: [providers].venice → $VENICE_API_KEY.
 #   Required only when some model slug actually references the provider —


### PR DESCRIPTION
A `[providers] voyage = ...` entry would derive `VOYAGE_API_KEY` — the env var the built-in Voyage embeddings client already owns — silently coupling two unrelated credentials. Reserved-name boot error, same shape as `openrouter`; docs (en/zh) and the example TOML rules comment updated.

Pre-release fix folded in before v0.9.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)