### PR TITLE
feat: custom embedding providers + voyage read/write model split

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,12 +10,6 @@ DATABASE_URL=postgres://postgres:<password>@<host>:5432/postgres
 
 # ── OpenRouter ────────────────────────────────────────────────────────────────
 OPENROUTER_API_KEY=sk-or-...
-# Endpoint override — full URL including path; empty counts as unset.
-# OPENROUTER_BASE_URL=
-# App attribution headers (docs/deploying.md → Operational notes).
-# OPENROUTER_APP_REFERER=https://eros.example
-# OPENROUTER_APP_TITLE=Eros
-# OPENROUTER_APP_CATEGORIES=roleplay,general-chat
 # Usage keys hidden from API clients (docs/api-reference.md).
 # OPENROUTER_USAGE_HIDDEN_KEYS=cost,cost_details
 
@@ -30,7 +24,8 @@ SUPABASE_URL=https://<project-ref>.supabase.co
 SUPABASE_JWT_SECRET=
 
 # ── Voyage embeddings ─────────────────────────────────────────────────────────
-VOYAGE_API_KEY=pa-...
+# Required unless [tasks.embedding] routes BOTH read and write off Voyage.
+VOYAGE_API_KEY=
 
 # ── Server ────────────────────────────────────────────────────────────────────
 BIND_ADDR=0.0.0.0:8080

--- a/crates/eros-engine-llm/README.md
+++ b/crates/eros-engine-llm/README.md
@@ -9,7 +9,7 @@ External LLM + embedding HTTP clients for the [`eros-engine`](https://github.com
 ## What's in here
 
 - `openrouter` — chat-completion client for [OpenRouter](https://openrouter.ai).
-- `voyage` — embedding client for [Voyage AI](https://voyageai.com) (`voyage-3-lite`, 512-d).
+- `voyage` — embedding client for [Voyage AI](https://voyageai.com) (`voyage-4-lite` default, 512-d).
 - `model_config` — TOML schema mapping logical tasks (chat, summarize, classify, ...) to concrete model slugs. The on-disk schema is frozen for the OSS 0.x line.
 - `error` — `LlmError` for HTTP and parse failures.
 

--- a/crates/eros-engine-llm/src/embedding.rs
+++ b/crates/eros-engine-llm/src/embedding.rs
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! Embedding routing: the OpenRouter-compatible embeddings client and the
+//! read/write `EmbeddingRouter` facade (spec 2026-08-01-embedding-providers).
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::LlmError;
+use crate::voyage::EMBEDDING_DIM;
+
+/// Built-in OpenRouter embeddings endpoint. Overridable per deployment via
+/// `[providers].openrouter.embeddings`.
+pub const OPENROUTER_EMBEDDINGS_URL: &str = "https://openrouter.ai/api/v1/embeddings";
+
+/// OpenRouter-compatible embeddings client (also serves any `[providers]`
+/// entry's `embeddings` URL — the third-party contract is exactly this wire).
+/// No `input_type`: the query/document optimisation is Voyage-native.
+#[derive(Clone)]
+pub struct EmbedHttpClient {
+    http: reqwest::Client,
+    base_url: String,
+    api_key: String,
+    headers: reqwest::header::HeaderMap,
+    model: String,
+}
+
+#[derive(Debug, Serialize)]
+struct WireRequest<'a> {
+    model: &'a str,
+    input: Vec<&'a str>,
+    /// Always 512: the pgvector schema is VECTOR(512), and common models
+    /// default elsewhere (text-embedding-3-small → 1536), so the param is
+    /// mandatory, not optional.
+    dimensions: u32,
+}
+
+#[derive(Debug, Deserialize)]
+struct WireData {
+    embedding: Vec<f32>,
+    #[serde(default)]
+    index: Option<usize>,
+}
+
+#[derive(Debug, Deserialize)]
+struct WireResponse {
+    data: Vec<WireData>,
+}
+
+impl EmbedHttpClient {
+    pub fn new(
+        base_url: String,
+        api_key: String,
+        headers: reqwest::header::HeaderMap,
+        model: String,
+    ) -> Self {
+        Self {
+            http: reqwest::Client::new(),
+            base_url,
+            api_key,
+            headers,
+            model,
+        }
+    }
+
+    pub async fn embed_one(&self, text: &str) -> Result<Vec<f32>, LlmError> {
+        let mut out = self.post(&[text]).await?;
+        Ok(out.remove(0))
+    }
+
+    pub async fn embed_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, LlmError> {
+        if texts.is_empty() {
+            return Ok(vec![]);
+        }
+        self.post(texts).await
+    }
+
+    async fn post(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, LlmError> {
+        if self.api_key.is_empty() {
+            return Err(LlmError::Config("embeddings: api key not set".into()));
+        }
+        let body = WireRequest {
+            model: &self.model,
+            input: texts.to_vec(),
+            dimensions: EMBEDDING_DIM as u32,
+        };
+        let resp = self
+            .http
+            .post(&self.base_url)
+            .headers(self.headers.clone())
+            .bearer_auth(&self.api_key)
+            .json(&body)
+            .send()
+            .await?;
+        let status = resp.status();
+        let text = resp.text().await?;
+        if !status.is_success() {
+            let err = LlmError::Status(status, crate::openrouter::scrub_error_body(&text));
+            tracing::warn!("embeddings: {err}");
+            return Err(err);
+        }
+        parse_response(&text, texts.len(), &self.model)
+    }
+}
+
+/// Parse an OpenRouter-compatible embeddings response: exactly one embedding
+/// per input, re-ordered by `index` when present, every vector 512-dim.
+fn parse_response(body: &str, expected: usize, model: &str) -> Result<Vec<Vec<f32>>, LlmError> {
+    let parsed: WireResponse = serde_json::from_str(body)
+        .map_err(|e| LlmError::Provider(format!("embeddings: bad response: {e}")))?;
+    if parsed.data.len() != expected {
+        return Err(LlmError::Provider(format!(
+            "embeddings: expected {expected} embeddings, got {}",
+            parsed.data.len()
+        )));
+    }
+    let mut data = parsed.data;
+    // `index` is optional on the wire; when present on all rows, honour it.
+    if data.iter().all(|d| d.index.is_some()) {
+        data.sort_by_key(|d| d.index.unwrap_or(usize::MAX));
+    }
+    let out: Vec<Vec<f32>> = data.into_iter().map(|d| d.embedding).collect();
+    for v in &out {
+        if v.len() != EMBEDDING_DIM {
+            return Err(LlmError::Provider(format!(
+                "embeddings: model {model} returned a {}-dim embedding, expected \
+                 {EMBEDDING_DIM} (the pgvector schema is VECTOR({EMBEDDING_DIM}))",
+                v.len()
+            )));
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use wiremock::matchers::{body_partial_json, header, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn sends_openrouter_compatible_body_and_headers() {
+        let server = MockServer::start().await;
+        Mock::given(path("/v1/embeddings"))
+            .and(header("Authorization", "Bearer test-key"))
+            .and(header("X-Team", "companion"))
+            .and(body_partial_json(serde_json::json!({
+                "model": "openai/text-embedding-3-small",
+                "input": ["hello"],
+                "dimensions": 512
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                serde_json::json!({ "data": [ { "embedding": vec![0.0f32; 512], "index": 0 } ] }),
+            ))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert("X-Team", "companion".parse().unwrap());
+        let client = EmbedHttpClient::new(
+            format!("{}/v1/embeddings", server.uri()),
+            "test-key".into(),
+            headers,
+            "openai/text-embedding-3-small".into(),
+        );
+        let v = client.embed_one("hello").await.expect("embed succeeds");
+        assert_eq!(v.len(), 512);
+    }
+
+    #[tokio::test]
+    async fn batch_orders_by_index_and_checks_count() {
+        let server = MockServer::start().await;
+        let mut a = vec![0.0f32; 512];
+        a[0] = 1.0;
+        let mut b = vec![0.0f32; 512];
+        b[0] = 2.0;
+        // Deliberately index-swapped: the client must re-order.
+        Mock::given(path("/v1/embeddings"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": [
+                    { "embedding": b, "index": 1 },
+                    { "embedding": a, "index": 0 }
+                ]
+            })))
+            .mount(&server)
+            .await;
+        let client = EmbedHttpClient::new(
+            format!("{}/v1/embeddings", server.uri()),
+            "k".into(),
+            Default::default(),
+            "m".into(),
+        );
+        let out = client.embed_batch(&["x", "y"]).await.expect("succeeds");
+        assert_eq!(out[0][0], 1.0);
+        assert_eq!(out[1][0], 2.0);
+    }
+
+    #[tokio::test]
+    async fn count_mismatch_is_an_error() {
+        let server = MockServer::start().await;
+        Mock::given(path("/v1/embeddings"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": [ { "embedding": vec![0.0f32; 512], "index": 0 } ]
+            })))
+            .mount(&server)
+            .await;
+        let client = EmbedHttpClient::new(
+            format!("{}/v1/embeddings", server.uri()),
+            "k".into(),
+            Default::default(),
+            "m".into(),
+        );
+        assert!(client.embed_batch(&["x", "y"]).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn wrong_dim_is_a_clear_error() {
+        let server = MockServer::start().await;
+        Mock::given(path("/v1/embeddings"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": [ { "embedding": [0.0, 1.0], "index": 0 } ]
+            })))
+            .mount(&server)
+            .await;
+        let client = EmbedHttpClient::new(
+            format!("{}/v1/embeddings", server.uri()),
+            "k".into(),
+            Default::default(),
+            "m".into(),
+        );
+        let msg = client.embed_one("x").await.unwrap_err().to_string();
+        assert!(msg.contains("512"), "{msg}");
+    }
+
+    #[tokio::test]
+    async fn error_body_is_scrubbed_and_bounded() {
+        let server = MockServer::start().await;
+        let huge = format!(
+            r#"{{"error":{{"code":400,"message":"{}","metadata":{{"flagged_input":"SECRET"}}}}}}"#,
+            "x".repeat(5000)
+        );
+        Mock::given(path("/v1/embeddings"))
+            .respond_with(ResponseTemplate::new(400).set_body_string(huge))
+            .mount(&server)
+            .await;
+        let client = EmbedHttpClient::new(
+            format!("{}/v1/embeddings", server.uri()),
+            "k".into(),
+            Default::default(),
+            "m".into(),
+        );
+        let err = client.embed_one("x").await.unwrap_err();
+        let crate::error::LlmError::Status(_, msg) = err else {
+            panic!("expected Status, got {err:?}");
+        };
+        assert!(msg.chars().count() <= 220);
+        assert!(!msg.contains("SECRET"));
+    }
+
+    #[tokio::test]
+    async fn empty_batch_short_circuits() {
+        // No server: a network call would error, so Ok(vec![]) proves the
+        // short-circuit.
+        let client = EmbedHttpClient::new(
+            "http://127.0.0.1:9/v1/embeddings".into(),
+            "k".into(),
+            Default::default(),
+            "m".into(),
+        );
+        assert_eq!(
+            client.embed_batch(&[]).await.expect("ok"),
+            Vec::<Vec<f32>>::new()
+        );
+    }
+}

--- a/crates/eros-engine-llm/src/embedding.rs
+++ b/crates/eros-engine-llm/src/embedding.rs
@@ -130,6 +130,149 @@ fn parse_response(body: &str, expected: usize, model: &str) -> Result<Vec<Vec<f3
     Ok(out)
 }
 
+/// One embedding backend: native Voyage (keeps `input_type`) or the
+/// OpenRouter-compatible wire (no query/document distinction).
+pub(crate) enum EmbedBackend {
+    Voyage(crate::voyage::VoyageClient),
+    OpenAiCompat(EmbedHttpClient),
+}
+
+impl EmbedBackend {
+    async fn embed(&self, text: &str, input_type_query: bool) -> Result<Vec<f32>, LlmError> {
+        match self {
+            EmbedBackend::Voyage(v) if input_type_query => v.embed_query(text).await,
+            EmbedBackend::Voyage(v) => v.embed_document(text).await,
+            EmbedBackend::OpenAiCompat(c) => c.embed_one(text).await,
+        }
+    }
+
+    async fn embed_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, LlmError> {
+        match self {
+            EmbedBackend::Voyage(v) => v.embed_documents(texts).await,
+            EmbedBackend::OpenAiCompat(c) => c.embed_batch(texts).await,
+        }
+    }
+}
+
+/// Read/write embedding facade (spec §5.1). `read` serves `embed_query`
+/// (the per-turn recall path); `write` serves `embed_document(s)` (the
+/// storage paths). Both point at the same backend unless
+/// `model_read`/`model_write` split them.
+pub struct EmbeddingRouter {
+    pub(crate) read: EmbedBackend,
+    pub(crate) write: EmbedBackend,
+}
+
+impl EmbeddingRouter {
+    /// Production constructor: real env. Call after
+    /// `ModelConfig::validate_providers` passed.
+    pub fn from_config(cfg: &crate::model_config::ModelConfig) -> Result<Self, LlmError> {
+        Self::from_config_with(cfg, |k| std::env::var(k).ok())
+    }
+
+    /// Testable core: `env` abstracts `std::env::var`.
+    pub fn from_config_with(
+        cfg: &crate::model_config::ModelConfig,
+        env: impl Fn(&str) -> Option<String>,
+    ) -> Result<Self, LlmError> {
+        use crate::model_config::EmbedRoute;
+        let resolved = cfg.resolve_embedding();
+        let build = |target: &crate::model_config::EmbedTarget| -> Result<EmbedBackend, LlmError> {
+            match &target.route {
+                EmbedRoute::Voyage => {
+                    let key = env("VOYAGE_API_KEY").unwrap_or_default();
+                    if key.trim().is_empty() {
+                        return Err(LlmError::Config(
+                            "VOYAGE_API_KEY is unset or empty but the embedding config \
+                             resolves to the built-in Voyage client"
+                                .into(),
+                        ));
+                    }
+                    Ok(EmbedBackend::Voyage(
+                        crate::voyage::VoyageClient::new(key).with_model(target.model.clone()),
+                    ))
+                }
+                EmbedRoute::OpenRouter => {
+                    let key = env("OPENROUTER_API_KEY").unwrap_or_default();
+                    if key.is_empty() {
+                        return Err(LlmError::Config(
+                            "OPENROUTER_API_KEY is unset but [tasks.embedding] routes to \
+                             @openrouter"
+                                .into(),
+                        ));
+                    }
+                    let entry = cfg.providers.get("openrouter");
+                    let url = entry
+                        .and_then(|e| e.embeddings.clone())
+                        .unwrap_or_else(|| OPENROUTER_EMBEDDINGS_URL.to_string());
+                    let headers = entry.map(|e| e.header_map()).unwrap_or_default();
+                    Ok(EmbedBackend::OpenAiCompat(EmbedHttpClient::new(
+                        url,
+                        key,
+                        headers,
+                        target.model.clone(),
+                    )))
+                }
+                EmbedRoute::Custom(name) => {
+                    let entry = cfg.providers.get(name).ok_or_else(|| {
+                        LlmError::Config(format!("embedding provider `{name}` is not declared"))
+                    })?;
+                    let url = entry.embeddings.clone().ok_or_else(|| {
+                        LlmError::Config(format!("[providers].{name} declares no `embeddings` URL"))
+                    })?;
+                    let var = format!("{}_API_KEY", name.to_uppercase());
+                    let key = env(&var).unwrap_or_default();
+                    if key.is_empty() {
+                        return Err(LlmError::Config(format!("${var} is unset or empty")));
+                    }
+                    Ok(EmbedBackend::OpenAiCompat(EmbedHttpClient::new(
+                        url,
+                        key,
+                        entry.header_map(),
+                        target.model.clone(),
+                    )))
+                }
+            }
+        };
+        Ok(Self {
+            read: build(&resolved.read)?,
+            write: build(&resolved.write)?,
+        })
+    }
+
+    /// Embed a recall query (read backend; Voyage `input_type: "query"`).
+    pub async fn embed_query(&self, text: &str) -> Result<Vec<f32>, LlmError> {
+        self.read.embed(text, true).await
+    }
+
+    /// Embed one document for storage (write backend).
+    pub async fn embed_document(&self, text: &str) -> Result<Vec<f32>, LlmError> {
+        self.write.embed(text, false).await
+    }
+
+    /// Embed a batch of documents for storage (write backend,
+    /// order-preserving; empty input short-circuits).
+    pub async fn embed_documents(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, LlmError> {
+        self.write.embed_batch(texts).await
+    }
+}
+
+#[cfg(test)]
+impl EmbeddingRouter {
+    pub(crate) fn read_is_voyage(&self) -> bool {
+        matches!(self.read, EmbedBackend::Voyage(_))
+    }
+    pub(crate) fn write_is_voyage(&self) -> bool {
+        matches!(self.write, EmbedBackend::Voyage(_))
+    }
+    pub(crate) fn read_url(&self) -> Option<&str> {
+        match &self.read {
+            EmbedBackend::OpenAiCompat(c) => Some(c.base_url.as_str()),
+            EmbedBackend::Voyage(_) => None,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use wiremock::matchers::{body_partial_json, header, path};
@@ -270,5 +413,100 @@ mod tests {
             client.embed_batch(&[]).await.expect("ok"),
             Vec::<Vec<f32>>::new()
         );
+    }
+
+    fn env_with<'a>(pairs: &'a [(&'a str, &'a str)]) -> impl Fn(&str) -> Option<String> + 'a {
+        move |k| {
+            pairs
+                .iter()
+                .find(|(n, _)| *n == k)
+                .map(|(_, v)| v.to_string())
+        }
+    }
+
+    #[test]
+    fn from_config_defaults_to_voyage() {
+        let cfg = crate::model_config::ModelConfig::from_toml_str("").unwrap();
+        let router =
+            EmbeddingRouter::from_config_with(&cfg, env_with(&[("VOYAGE_API_KEY", "k")])).unwrap();
+        // Shape assertion via Debug-free matches: expose #[cfg(test)] accessors.
+        assert!(router.read_is_voyage() && router.write_is_voyage());
+    }
+
+    #[test]
+    fn from_config_missing_voyage_key_errors() {
+        let cfg = crate::model_config::ModelConfig::from_toml_str("").unwrap();
+        assert!(EmbeddingRouter::from_config_with(&cfg, |_| None).is_err());
+    }
+
+    #[test]
+    fn from_config_openrouter_route_uses_override_url_and_headers() {
+        let cfg = crate::model_config::ModelConfig::from_toml_str(
+            "[providers.openrouter]\n\
+             embeddings = \"http://proxy/v1/embeddings\"\n\
+             headers = { \"HTTP-Referer\" = \"https://eros.example\" }\n\
+             [tasks.embedding]\nmodel = \"openai/text-embedding-3-small@openrouter\"\n",
+        )
+        .unwrap();
+        let router =
+            EmbeddingRouter::from_config_with(&cfg, env_with(&[("OPENROUTER_API_KEY", "ok")]))
+                .unwrap();
+        assert_eq!(router.read_url(), Some("http://proxy/v1/embeddings"));
+    }
+
+    #[test]
+    fn from_config_custom_route_reads_name_key() {
+        let cfg = crate::model_config::ModelConfig::from_toml_str(
+            "[providers]\nlocal = { embeddings = \"http://e/v1/embeddings\" }\n\
+             [tasks.embedding]\nmodel = \"bge-m3@local\"\n",
+        )
+        .unwrap();
+        assert!(
+            EmbeddingRouter::from_config_with(&cfg, |_| None).is_err(),
+            "missing LOCAL_API_KEY must error"
+        );
+        assert!(
+            EmbeddingRouter::from_config_with(&cfg, env_with(&[("LOCAL_API_KEY", "k")])).is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn read_write_dispatch_hits_the_right_backend() {
+        // read → voyage-4-lite (query), write → voyage-4 (document), one mock
+        // server standing in for Voyage.
+        let server = MockServer::start().await;
+        Mock::given(path("/v1/embeddings"))
+            .and(body_partial_json(
+                serde_json::json!({ "model": "voyage-4-lite", "input_type": "query" }),
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                serde_json::json!({ "data": [ { "embedding": vec![0.0f32; 512] } ] }),
+            ))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(path("/v1/embeddings"))
+            .and(body_partial_json(
+                serde_json::json!({ "model": "voyage-4", "input_type": "document" }),
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                serde_json::json!({ "data": [ { "embedding": vec![0.0f32; 512] } ] }),
+            ))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let url = format!("{}/v1/embeddings", server.uri());
+        let router = EmbeddingRouter {
+            read: EmbedBackend::Voyage(
+                crate::voyage::VoyageClient::with_base_url("k".into(), url.clone())
+                    .with_model("voyage-4-lite".into()),
+            ),
+            write: EmbedBackend::Voyage(
+                crate::voyage::VoyageClient::with_base_url("k".into(), url)
+                    .with_model("voyage-4".into()),
+            ),
+        };
+        router.embed_query("q").await.expect("read ok");
+        router.embed_document("d").await.expect("write ok");
     }
 }

--- a/crates/eros-engine-llm/src/embedding.rs
+++ b/crates/eros-engine-llm/src/embedding.rs
@@ -113,9 +113,21 @@ fn parse_response(body: &str, expected: usize, model: &str) -> Result<Vec<Vec<f3
         )));
     }
     let mut data = parsed.data;
-    // `index` is optional on the wire; when present on all rows, honour it.
+    // `index` is optional on the wire; when present on all rows, honour it —
+    // but only as the exact permutation 0..expected. A duplicate or shifted
+    // index set ([0,0], [1,2]) would silently associate vectors with the
+    // wrong inputs and persist them; that must be a loud provider error.
     if data.iter().all(|d| d.index.is_some()) {
         data.sort_by_key(|d| d.index.unwrap_or(usize::MAX));
+        for (i, d) in data.iter().enumerate() {
+            if d.index != Some(i) {
+                return Err(LlmError::Provider(format!(
+                    "embeddings: model {model} returned indices that are not the \
+                     permutation 0..{expected} — refusing to associate vectors with \
+                     inputs"
+                )));
+            }
+        }
     }
     let out: Vec<Vec<f32>> = data.into_iter().map(|d| d.embedding).collect();
     for v in &out {
@@ -413,6 +425,24 @@ mod tests {
             client.embed_batch(&[]).await.expect("ok"),
             Vec::<Vec<f32>>::new()
         );
+    }
+
+    #[test]
+    fn malformed_indices_are_rejected() {
+        // Duplicate ([0,0]) or shifted ([1,2]) index sets pass the count and
+        // dim checks but would misassociate vectors with inputs — must error.
+        let v = vec![0.0f32; 512];
+        for indices in [[0usize, 0], [1, 2]] {
+            let body = serde_json::json!({
+                "data": [
+                    { "embedding": v, "index": indices[0] },
+                    { "embedding": v, "index": indices[1] }
+                ]
+            })
+            .to_string();
+            let msg = parse_response(&body, 2, "m").unwrap_err().to_string();
+            assert!(msg.contains("permutation"), "{indices:?}: {msg}");
+        }
     }
 
     fn env_with<'a>(pairs: &'a [(&'a str, &'a str)]) -> impl Fn(&str) -> Option<String> + 'a {

--- a/crates/eros-engine-llm/src/lib.rs
+++ b/crates/eros-engine-llm/src/lib.rs
@@ -2,6 +2,7 @@
 //! HTTP clients for external LLM + embedding providers, and the TOML task→model config.
 
 pub mod byte_bpe;
+pub mod embedding;
 pub mod error;
 pub mod model_config;
 pub mod openrouter;

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -533,15 +533,112 @@ pub struct DefaultConfig {
 /// on every request to this entry's endpoints (both `chat` and `embeddings`);
 /// `Authorization`/`Content-Type` are engine-owned and rejected at boot.
 /// `BTreeMap` so validation-error ordering is deterministic across restarts.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
-#[serde(deny_unknown_fields)]
+///
+/// `Deserialize` is hand-written (below) rather than derived: the 0.9.3
+/// shape was a plain string, and a config still written that way must not
+/// see a generic serde "invalid type: string ..., expected struct
+/// ProviderEntry" — it should see the table form it needs to switch to.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ProviderEntry {
-    #[serde(default)]
     pub chat: Option<String>,
-    #[serde(default)]
     pub embeddings: Option<String>,
-    #[serde(default)]
     pub headers: Option<BTreeMap<String, String>>,
+}
+
+/// Error taught to an operator whose `[providers]` entry is still the 0.9.3
+/// plain-string shape (dropped with no compatibility layer — spec §0/§1).
+const PROVIDER_ENTRY_TABLE_FORM_ERROR: &str = "[providers] values must be tables — write \
+     venice = { chat = \"https://…\" } (and/or embeddings = \"…\", headers = { … }); the \
+     0.9.3 string form was removed";
+
+impl<'de> Deserialize<'de> for ProviderEntry {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Table-only inner shape, `deny_unknown_fields` preserved exactly as
+        // before. Kept private and reached only via `visit_map` below, so a
+        // non-table value never reaches it and never gets its generic
+        // "expected struct" message.
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct Table {
+            #[serde(default)]
+            chat: Option<String>,
+            #[serde(default)]
+            embeddings: Option<String>,
+            #[serde(default)]
+            headers: Option<BTreeMap<String, String>>,
+        }
+
+        struct ProviderEntryVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for ProviderEntryVisitor {
+            type Value = ProviderEntry;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str(
+                    "a [providers] entry table (chat = \"…\", embeddings = \"…\", headers = { … })",
+                )
+            }
+
+            // Every scalar shape a 0.9.3-era config could still send —
+            // string is the one that actually shipped, the rest are
+            // defensive (an int/bool/etc is just as clearly not a table).
+            fn visit_str<E>(self, _v: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Err(E::custom(PROVIDER_ENTRY_TABLE_FORM_ERROR))
+            }
+
+            fn visit_bool<E>(self, _v: bool) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Err(E::custom(PROVIDER_ENTRY_TABLE_FORM_ERROR))
+            }
+
+            fn visit_i64<E>(self, _v: i64) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Err(E::custom(PROVIDER_ENTRY_TABLE_FORM_ERROR))
+            }
+
+            fn visit_f64<E>(self, _v: f64) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Err(E::custom(PROVIDER_ENTRY_TABLE_FORM_ERROR))
+            }
+
+            fn visit_seq<A>(self, _seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                use serde::de::Error as _;
+                Err(A::Error::custom(PROVIDER_ENTRY_TABLE_FORM_ERROR))
+            }
+
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                // Unknown-key / wrong-type errors from `Table`'s own
+                // `deny_unknown_fields` derive propagate unchanged — this
+                // adapter only changes how a NON-table value is reported.
+                let table = Table::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+                Ok(ProviderEntry {
+                    chat: table.chat,
+                    embeddings: table.embeddings,
+                    headers: table.headers,
+                })
+            }
+        }
+
+        deserializer.deserialize_any(ProviderEntryVisitor)
+    }
 }
 
 impl ProviderEntry {
@@ -711,9 +808,6 @@ pub struct TaskConfig {
     /// explicit opt-out and suppresses `defaults.fallback_model`.
     #[serde(default)]
     pub fallback: Option<FallbackSpec>,
-    /// Embedding-only: vector dimensions.
-    #[serde(default)]
-    pub dimensions: Option<u32>,
     /// Task-level (default-block) prompt-trait allow-list. Same three-state
     /// semantics as `TierConfig::allow_traits`.
     #[serde(default)]
@@ -757,7 +851,7 @@ pub struct TaskConfig {
     pub retry_depth: Option<u32>,
     /// PDE-only: ghost kill-switch. `false` disables ghosting across the whole
     /// PDE path; absent/`true` keeps it on. Read only on `[tasks.pde_decision]`
-    /// (other tasks ignore it), like `input_filter`/`dimensions`.
+    /// (other tasks ignore it), like `input_filter`.
     #[serde(default)]
     pub ghosting: Option<bool>,
     /// PDE-only: send `response_format = json_schema` on the judge request to
@@ -2606,10 +2700,15 @@ fn voyage_model_generation(bare_id: &str) -> Option<f64> {
         .split('-')
         .next()
         .expect("split always yields at least one element");
-    if segment.is_empty() {
+    // Reject anything but ASCII digits and dots BEFORE parsing. `f64::from_str`
+    // is far more permissive than a version number — it accepts `inf`, `nan`,
+    // and scientific notation like `4e2` (== 400.0), any of which would let a
+    // non-numeric or absurd segment sail through the `>= 4.0` gate below.
+    if segment.is_empty() || !segment.bytes().all(|b| b.is_ascii_digit() || b == b'.') {
         return None;
     }
-    segment.parse::<f64>().ok()
+    let n = segment.parse::<f64>().ok()?;
+    n.is_finite().then_some(n)
 }
 
 #[cfg(test)]
@@ -2920,7 +3019,7 @@ structured_output = true
 [tasks.embedding]
 model        = "voyage-3-lite"
 dimensions   = 512
-description  = "reserved — Voyage hard-codes its own model"
+description  = "active — routes embed_query/embed_document via EmbeddingRouter"
 
 [tasks.chat_input_filter]
 model        = "openai/gpt-5.4-nano"
@@ -3034,10 +3133,13 @@ filter_prompt = "Answer product questions from the docs."
             .expect("fixture product_qa resolves");
         assert_eq!(rpq.answer_prompt, "Answer product questions from the docs.");
 
-        // embedding — reserved, with `dimensions` set.
+        // embedding — active. `dimensions` was removed from `TaskConfig`
+        // (spec 2026-08-01-embedding-providers §0: dims are fixed at 512);
+        // the fixture keeps the `dimensions = 512` TOML line above to lock
+        // the compat contract that a leftover key from an old config still
+        // parses — it's just an ignored unknown key now, not a field.
         let emb = cfg.tasks.get("embedding").unwrap();
         assert_eq!(emb.model.as_fixed(), Some("voyage-3-lite"));
-        assert_eq!(emb.dimensions, Some(512));
 
         // Resolution behaviour on the live tasks.
         let r = cfg.resolve("chat_companion", None);
@@ -4678,6 +4780,18 @@ filter_prompt = "只根据产品资料作答。"
     }
 
     #[test]
+    fn voyage_generation_rejects_f64_leniency() {
+        // `f64::from_str` accepts far more than a version number does —
+        // segments must be ASCII digits/dots only, checked BEFORE parsing,
+        // so none of these ever reach `str::parse::<f64>`.
+        assert_eq!(voyage_model_generation("voyage-inf"), None);
+        assert_eq!(voyage_model_generation("voyage-nan"), None);
+        // "4e2" parses as 400.0 (scientific notation) — well past the N >= 4
+        // gate, but "e" isn't a version-number character.
+        assert_eq!(voyage_model_generation("voyage-4e2"), None);
+    }
+
+    #[test]
     fn ignore_providers_require_openrouter_suffix() {
         let cfg =
             ModelConfig::from_toml_str("[defaults]\nignore_providers = [\"bad-slug\"]\n").unwrap();
@@ -5891,14 +6005,28 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
     #[test]
     fn providers_string_value_is_rejected() {
         // 0.9.3's plain-string shape is dropped with no compat layer (spec §0).
+        // The error must teach the table form, not surface a generic serde
+        // "expected struct ProviderEntry" message.
         let err = ModelConfig::from_toml_str(
             "[providers]\nvenice = \"https://api.venice.ai/api/v1/chat/completions\"\n",
         )
         .unwrap_err();
         let msg = err.to_string();
         assert!(
-            msg.contains("venice"),
-            "error should locate the entry: {msg}"
+            msg.contains("[providers] values must be tables"),
+            "error should teach the table form: {msg}"
+        );
+        assert!(
+            msg.contains("chat = ") && msg.contains("embeddings = ") && msg.contains("headers ="),
+            "error should show the table shape (chat/embeddings/headers): {msg}"
+        );
+        assert!(
+            msg.contains("0.9.3 string form was removed"),
+            "error should explain why the old shape no longer works: {msg}"
+        );
+        assert!(
+            !msg.contains("expected struct ProviderEntry"),
+            "error should not leak the generic serde message: {msg}"
         );
     }
 
@@ -6253,7 +6381,13 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
 
     #[test]
     fn embedding_pair_below_voyage_4_is_rejected() {
-        for bad in ["voyage-3.5-lite", "voyage-code-3", "bge-m3"] {
+        for bad in [
+            "voyage-3.5-lite",
+            "voyage-code-3",
+            "bge-m3",
+            "voyage-inf",
+            "voyage-4e2",
+        ] {
             let cfg = ModelConfig::from_toml_str(&format!(
                 "[tasks.embedding]\nmodel_read = \"{bad}\"\nmodel_write = \"voyage-4\"\n"
             ))
@@ -6305,6 +6439,23 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
                 "must refuse: {toml}"
             );
         }
+    }
+
+    #[test]
+    fn stale_dimensions_key_is_an_ignored_unknown_field() {
+        // `dimensions` was removed from `TaskConfig` (spec
+        // 2026-08-01-embedding-providers §0: dims are hard-coded 512, no
+        // config knob). `TaskConfig` doesn't `deny_unknown_fields`, so a
+        // leftover `dimensions = 512` line from a pre-removal config must
+        // still parse — same compat contract as any other stale key.
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.embedding]\nmodel = \"voyage-3-lite\"\ndimensions = 512\n",
+        )
+        .expect("stale `dimensions` key must not break parsing");
+        assert_eq!(
+            cfg.tasks["embedding"].model.as_fixed(),
+            Some("voyage-3-lite")
+        );
     }
 
     #[test]

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -2148,6 +2148,25 @@ impl ModelConfig {
             self.providers[name].validate_headers(name)?;
         }
 
+        // 1.5. [defaults].ignore_providers must carry @openrouter (spec §4): the
+        // knob acts on OpenRouter routing only, and the mandatory suffix makes
+        // that scope part of the syntax.
+        for entry in &self.defaults.ignore_providers {
+            let (bare, provider) = crate::provider::split_model_slug(entry)
+                .map_err(|e| format!("[defaults].ignore_providers: {e}"))?;
+            match provider {
+                Some("openrouter") if !bare.is_empty() => {}
+                _ => {
+                    return Err(format!(
+                        "[defaults].ignore_providers: `{entry}` must be written \
+                         `<upstream-slug>@openrouter` — the exclusion list acts on \
+                         OpenRouter routing only (custom providers and Voyage never \
+                         receive provider.ignore)"
+                    ));
+                }
+            }
+        }
+
         // 2. Literal full scan of every candidate slug.
         let mut slugs: Vec<(String, &str)> = Vec::new();
         if let Some(fb) = self.defaults.fallback_model.as_deref() {
@@ -2242,6 +2261,22 @@ impl ModelConfig {
             .collect()
     }
 
+    /// `[defaults].ignore_providers` with the mandatory `@openrouter` suffix
+    /// stripped — what `provider.ignore` carries on the wire. Call only after
+    /// `validate_providers` passed; entries that fail the grammar are skipped
+    /// (unreachable post-boot).
+    pub fn ignore_provider_wire_slugs(&self) -> Vec<String> {
+        self.defaults
+            .ignore_providers
+            .iter()
+            .filter_map(|e| {
+                crate::provider::split_model_slug(e)
+                    .ok()
+                    .map(|(bare, _)| bare)
+            })
+            .collect()
+    }
+
     /// Reject config blocks for features that were removed, so an operator
     /// upgrading across the removal cannot silently keep a block that no
     /// longer does anything. Loud-fail, same shape as the other boot gates.
@@ -2320,6 +2355,24 @@ impl ModelConfig {
         }
         Ok(out)
     }
+}
+
+/// Parse the generation number out of a bare voyage model id: the numeric
+/// segment (digits and dots) immediately after `voyage-`, ending at the next
+/// `-` or end of string. `None` ⇒ no leading numeric segment (domain-named
+/// models like `voyage-code-3`) or not a single number. Used by the
+/// model_read/model_write boot gate: only the voyage-4 series and above
+/// guarantee one shared vector space across model sizes.
+fn voyage_model_generation(bare_id: &str) -> Option<f64> {
+    let rest = bare_id.strip_prefix("voyage-")?;
+    let segment: &str = rest
+        .split('-')
+        .next()
+        .expect("split always yields at least one element");
+    if segment.is_empty() {
+        return None;
+    }
+    segment.parse::<f64>().ok()
 }
 
 #[cfg(test)]
@@ -4349,14 +4402,14 @@ filter_prompt = "只根据产品资料作答。"
     fn defaults_ignore_providers_parses() {
         let toml = r#"
             [defaults]
-            ignore_providers = ["BadHost", "AnotherHost"]
+            ignore_providers = ["BadHost@openrouter", "AnotherHost@openrouter"]
             [tasks.chat_companion]
             model = "x/y"
         "#;
         let cfg = ModelConfig::from_toml_str(toml).expect("parse");
         assert_eq!(
             cfg.defaults.ignore_providers,
-            vec!["BadHost", "AnotherHost"]
+            vec!["BadHost@openrouter", "AnotherHost@openrouter"]
         );
     }
 
@@ -4368,6 +4421,54 @@ filter_prompt = "只根据产品资料作答。"
         "#;
         let cfg = ModelConfig::from_toml_str(toml).expect("parse");
         assert!(cfg.defaults.ignore_providers.is_empty());
+    }
+
+    #[test]
+    fn voyage_generation_parses_main_line() {
+        assert_eq!(voyage_model_generation("voyage-4"), Some(4.0));
+        assert_eq!(voyage_model_generation("voyage-4-lite"), Some(4.0));
+        assert_eq!(voyage_model_generation("voyage-4.5-large"), Some(4.5));
+        assert_eq!(voyage_model_generation("voyage-10"), Some(10.0));
+        assert_eq!(voyage_model_generation("voyage-3.5-lite"), Some(3.5));
+    }
+
+    #[test]
+    fn voyage_generation_rejects_unparseable() {
+        assert_eq!(voyage_model_generation("voyage-code-3"), None);
+        assert_eq!(voyage_model_generation("voyage-"), None);
+        assert_eq!(voyage_model_generation("bge-m3"), None);
+        assert_eq!(voyage_model_generation("voyage-4.5.1"), None); // not a single f64
+    }
+
+    #[test]
+    fn ignore_providers_require_openrouter_suffix() {
+        let cfg =
+            ModelConfig::from_toml_str("[defaults]\nignore_providers = [\"bad-slug\"]\n").unwrap();
+        let msg = cfg.validate_providers_with(|_| None).unwrap_err();
+        assert!(
+            msg.contains("@openrouter"),
+            "must teach the new form: {msg}"
+        );
+    }
+
+    #[test]
+    fn ignore_providers_reject_other_provider_suffix() {
+        let cfg = ModelConfig::from_toml_str(
+            "[providers]\nvenice = { chat = \"https://x/c\" }\n\
+             [defaults]\nignore_providers = [\"bad-slug@venice\"]\n",
+        )
+        .unwrap();
+        assert!(cfg.validate_providers_with(|_| None).is_err());
+    }
+
+    #[test]
+    fn ignore_providers_wire_slugs_are_stripped() {
+        let cfg = ModelConfig::from_toml_str(
+            "[defaults]\nignore_providers = [\"bad-a@openrouter\", \"bad-b@openrouter\"]\n",
+        )
+        .unwrap();
+        assert!(cfg.validate_providers_with(|_| None).is_ok());
+        assert_eq!(cfg.ignore_provider_wire_slugs(), vec!["bad-a", "bad-b"]);
     }
 
     #[test]

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -527,6 +527,83 @@ pub struct DefaultConfig {
     pub provider_sort: Option<String>,
 }
 
+/// One `[providers]` entry (spec 2026-08-01-embedding-providers §1). URLs are
+/// complete and posted verbatim — no path joining. `headers` are sent verbatim
+/// on every request to this entry's endpoints (both `chat` and `embeddings`);
+/// `Authorization`/`Content-Type` are engine-owned and rejected at boot.
+/// `BTreeMap` so validation-error ordering is deterministic across restarts.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProviderEntry {
+    #[serde(default)]
+    pub chat: Option<String>,
+    #[serde(default)]
+    pub embeddings: Option<String>,
+    #[serde(default)]
+    pub headers: Option<BTreeMap<String, String>>,
+}
+
+impl ProviderEntry {
+    /// True when nothing at all is declared (all-`None`).
+    pub fn is_empty(&self) -> bool {
+        self.chat.is_none() && self.embeddings.is_none() && self.headers.is_none()
+    }
+
+    /// Boot gate for the `headers` table: engine-owned names are rejected
+    /// (a silently overridden `Authorization` is the worst kind of footgun),
+    /// and every pair must be valid HTTP header material — loud-fail, not
+    /// the env era's warn-and-drop.
+    fn validate_headers(&self, entry: &str) -> Result<(), String> {
+        let Some(headers) = &self.headers else {
+            return Ok(());
+        };
+        if headers.is_empty() {
+            return Err(format!("[providers].{entry}.headers: table is empty"));
+        }
+        for (name, value) in headers {
+            let lower = name.to_ascii_lowercase();
+            if lower == "authorization" || lower == "content-type" {
+                return Err(format!(
+                    "[providers].{entry}.headers: `{name}` is engine-owned — the \
+                     engine sets Authorization from the provider's API key and \
+                     Content-Type from the request body; it cannot be overridden"
+                ));
+            }
+            if reqwest::header::HeaderName::from_bytes(name.as_bytes()).is_err() {
+                return Err(format!(
+                    "[providers].{entry}.headers: `{name}` is not a valid HTTP header name"
+                ));
+            }
+            if reqwest::header::HeaderValue::from_str(value).is_err() {
+                return Err(format!(
+                    "[providers].{entry}.headers: value for `{name}` is not a valid \
+                     HTTP header value"
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// The validated `headers` table as a reqwest `HeaderMap`. Invalid pairs
+    /// are skipped with a warning — unreachable after `validate_headers`, but
+    /// this method must not panic for library callers that skip validation.
+    pub fn header_map(&self) -> reqwest::header::HeaderMap {
+        let mut map = reqwest::header::HeaderMap::new();
+        for (name, value) in self.headers.iter().flatten() {
+            match (
+                reqwest::header::HeaderName::from_bytes(name.as_bytes()),
+                reqwest::header::HeaderValue::from_str(value),
+            ) {
+                (Ok(n), Ok(v)) => {
+                    map.insert(n, v);
+                }
+                _ => tracing::warn!(header = %name, "providers: skipping invalid header"),
+            }
+        }
+        map
+    }
+}
+
 fn default_model_spec() -> ModelSpec {
     ModelSpec::Fixed(String::new())
 }
@@ -736,13 +813,14 @@ pub struct ModelConfig {
     #[serde(default)]
     pub defaults: DefaultConfig,
     /// The `[providers]` block — custom OpenAI-compatible endpoints keyed by
-    /// name (spec 2026-07-31-multi-llm-providers). Value is the COMPLETE
-    /// chat-completions URL, posted verbatim (no path joining). The API key
-    /// comes from env as `<NAME_UPPERCASED>_API_KEY`. Under MODEL_CONFIG_DIR
-    /// this merges as one whole top-level key (like `[defaults]`, unlike
+    /// name (spec 2026-08-01-embedding-providers §1). Each entry is a table
+    /// with `chat` and/or `embeddings` URLs (COMPLETE, posted verbatim — no
+    /// path joining) plus an optional `headers` table. The API key comes
+    /// from env as `<NAME_UPPERCASED>_API_KEY`. Under MODEL_CONFIG_DIR this
+    /// merges as one whole top-level key (like `[defaults]`, unlike
     /// `[tasks]`): all providers live in one file.
     #[serde(default)]
-    pub providers: HashMap<String, String>,
+    pub providers: HashMap<String, ProviderEntry>,
     #[serde(default)]
     pub tasks: HashMap<String, TaskConfig>,
 }
@@ -2031,14 +2109,6 @@ impl ModelConfig {
         let mut names: Vec<&String> = self.providers.keys().collect();
         names.sort();
         for name in names {
-            if name == "openrouter" {
-                return Err(
-                    "[providers]: `openrouter` is reserved — override the built-in \
-                     endpoint with the OPENROUTER_BASE_URL env var, not a [providers] \
-                     entry"
-                        .to_string(),
-                );
-            }
             if name == "voyage" {
                 return Err(
                     "[providers]: `voyage` is reserved — $VOYAGE_API_KEY already \
@@ -2059,8 +2129,23 @@ impl ModelConfig {
                 ));
             }
             if self.providers[name].is_empty() {
-                return Err(format!("[providers].{name}: base URL is empty"));
+                return Err(format!(
+                    "[providers].{name}: entry is empty — declare at least one of \
+                     `chat = \"<url>\"` or `embeddings = \"<url>\"` (or `headers` on \
+                     the `openrouter` entry)"
+                ));
             }
+            if let Some(url) = self.providers[name].chat.as_deref() {
+                if url.is_empty() {
+                    return Err(format!("[providers].{name}.chat: URL is empty"));
+                }
+            }
+            if let Some(url) = self.providers[name].embeddings.as_deref() {
+                if url.is_empty() {
+                    return Err(format!("[providers].{name}.embeddings: URL is empty"));
+                }
+            }
+            self.providers[name].validate_headers(name)?;
         }
 
         // 2. Literal full scan of every candidate slug.
@@ -2127,8 +2212,9 @@ impl ModelConfig {
     }
 
     /// Build the name → endpoint map handed to `OpenRouterClient` at boot.
-    /// NO checks here — runs only after `validate_providers` passed. Every
-    /// declared entry is included; an unreferenced entry without a key gets an
+    /// NO checks here — runs only after `validate_providers` passed. Only
+    /// entries with a `chat` URL are included (chat routing is the only
+    /// consumer of this map); an unreferenced entry without a key gets an
     /// empty api_key (unreachable at runtime, and `resolve_endpoint` guards
     /// it anyway).
     pub fn build_providers(&self) -> HashMap<String, crate::provider::ProviderEndpoint> {
@@ -2141,15 +2227,17 @@ impl ModelConfig {
     ) -> HashMap<String, crate::provider::ProviderEndpoint> {
         self.providers
             .iter()
-            .map(|(name, url)| {
+            .filter_map(|(name, entry)| {
+                let chat = entry.chat.clone()?;
                 let key = env(&format!("{}_API_KEY", name.to_uppercase())).unwrap_or_default();
-                (
+                Some((
                     name.clone(),
                     crate::provider::ProviderEndpoint {
-                        base_url: url.clone(),
+                        base_url: chat,
                         api_key: key,
+                        headers: entry.header_map(),
                     },
-                )
+                ))
             })
             .collect()
     }
@@ -5433,15 +5521,51 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
     }
 
     #[test]
-    fn providers_block_parses() {
+    fn providers_table_value_parses() {
         let cfg = ModelConfig::from_toml_str(
-            "[providers]\nvenice = \"https://api.venice.ai/api/v1/chat/completions\"\n",
+            "[providers]\n\
+             venice = { chat = \"https://api.venice.ai/api/v1/chat/completions\" }\n\
+             local  = { embeddings = \"http://127.0.0.1:8080/v1/embeddings\" }\n\
+             [providers.proxy]\n\
+             chat    = \"https://proxy.internal/v1/chat/completions\"\n\
+             headers = { \"X-Team\" = \"companion\" }\n",
         )
         .unwrap();
         assert_eq!(
-            cfg.providers.get("venice").map(String::as_str),
+            cfg.providers["venice"].chat.as_deref(),
             Some("https://api.venice.ai/api/v1/chat/completions")
         );
+        assert!(cfg.providers["venice"].embeddings.is_none());
+        assert_eq!(
+            cfg.providers["local"].embeddings.as_deref(),
+            Some("http://127.0.0.1:8080/v1/embeddings")
+        );
+        assert_eq!(
+            cfg.providers["proxy"].headers.as_ref().unwrap()["X-Team"],
+            "companion"
+        );
+    }
+
+    #[test]
+    fn providers_string_value_is_rejected() {
+        // 0.9.3's plain-string shape is dropped with no compat layer (spec §0).
+        let err = ModelConfig::from_toml_str(
+            "[providers]\nvenice = \"https://api.venice.ai/api/v1/chat/completions\"\n",
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("venice"),
+            "error should locate the entry: {msg}"
+        );
+    }
+
+    #[test]
+    fn providers_unknown_key_is_rejected() {
+        assert!(ModelConfig::from_toml_str(
+            "[providers]\nvenice = { chat = \"https://x/v1/chat/completions\", api_key = \"nope\" }\n",
+        )
+        .is_err());
     }
 
     #[test]
@@ -5452,17 +5576,18 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
     }
 
     #[test]
-    fn provider_name_openrouter_is_reserved() {
-        let cfg =
-            ModelConfig::from_toml_str("[providers]\nopenrouter = \"https://x/v1\"\n").unwrap();
-        let msg = cfg.validate_providers_with(no_env).unwrap_err();
-        assert!(msg.contains("reserved"));
-        assert!(msg.contains("OPENROUTER_BASE_URL"));
+    fn providers_openrouter_entry_is_now_legal() {
+        let cfg = ModelConfig::from_toml_str(
+            "[providers]\nopenrouter = { embeddings = \"http://proxy/v1/embeddings\" }\n",
+        )
+        .unwrap();
+        assert!(cfg.validate_providers_with(|_| None).is_ok());
     }
 
     #[test]
     fn provider_name_voyage_is_reserved() {
-        let cfg = ModelConfig::from_toml_str("[providers]\nvoyage = \"https://x/v1\"\n").unwrap();
+        let cfg = ModelConfig::from_toml_str("[providers]\nvoyage = { chat = \"https://x/v1\" }\n")
+            .unwrap();
         let msg = cfg.validate_providers_with(no_env).unwrap_err();
         assert!(msg.contains("reserved"));
         assert!(msg.contains("VOYAGE_API_KEY"));
@@ -5471,15 +5596,17 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
     #[test]
     fn provider_name_charset_is_constrained() {
         // Dash is rejected: the name uppercases into an env var, no mangling.
-        let cfg =
-            ModelConfig::from_toml_str("[providers]\n\"venice-ai\" = \"https://x/v1\"\n").unwrap();
+        let cfg = ModelConfig::from_toml_str(
+            "[providers]\n\"venice-ai\" = { chat = \"https://x/v1\" }\n",
+        )
+        .unwrap();
         let msg = cfg.validate_providers_with(no_env).unwrap_err();
         assert!(msg.contains("a-z0-9_"), "should state the charset: {msg}");
     }
 
     #[test]
     fn provider_empty_url_refuses_boot() {
-        let cfg = ModelConfig::from_toml_str("[providers]\nvenice = \"\"\n").unwrap();
+        let cfg = ModelConfig::from_toml_str("[providers]\nvenice = { chat = \"\" }\n").unwrap();
         assert!(cfg
             .validate_providers_with(no_env)
             .unwrap_err()
@@ -5491,7 +5618,7 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
         // The examples/ config ships a sample [providers] entry; deployments
         // that copy it without using it must still boot.
         let cfg = ModelConfig::from_toml_str(
-            "[providers]\nvenice = \"https://x/v1\"\n[tasks.chat_companion]\nmodel=\"plain/m\"\n",
+            "[providers]\nvenice = { chat = \"https://x/v1\" }\n[tasks.chat_companion]\nmodel=\"plain/m\"\n",
         )
         .unwrap();
         assert!(cfg.validate_providers_with(no_env).is_ok());
@@ -5500,7 +5627,7 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
     #[test]
     fn referenced_provider_missing_key_refuses_boot() {
         let cfg = ModelConfig::from_toml_str(
-            "[providers]\nvenice = \"https://x/v1\"\n[tasks.chat_companion]\nmodel=\"m@venice\"\n",
+            "[providers]\nvenice = { chat = \"https://x/v1\" }\n[tasks.chat_companion]\nmodel=\"m@venice\"\n",
         )
         .unwrap();
         let msg = cfg.validate_providers_with(no_env).unwrap_err();
@@ -5513,7 +5640,7 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
     #[test]
     fn referenced_provider_empty_key_refuses_boot() {
         let cfg = ModelConfig::from_toml_str(
-            "[providers]\nvenice = \"https://x/v1\"\n[tasks.chat_companion]\nmodel=\"m@venice\"\n",
+            "[providers]\nvenice = { chat = \"https://x/v1\" }\n[tasks.chat_companion]\nmodel=\"m@venice\"\n",
         )
         .unwrap();
         let env = |k: &str| (k == "VENICE_API_KEY").then(String::new);
@@ -5523,7 +5650,7 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
     #[test]
     fn referenced_provider_with_key_is_green() {
         let cfg = ModelConfig::from_toml_str(
-            "[providers]\nvenice = \"https://x/v1\"\n[tasks.chat_companion]\nmodel=\"m@venice\"\nfallback=[\"other/m\"]\n",
+            "[providers]\nvenice = { chat = \"https://x/v1\" }\n[tasks.chat_companion]\nmodel=\"m@venice\"\nfallback=[\"other/m\"]\n",
         )
         .unwrap();
         let env = |k: &str| (k == "VENICE_API_KEY").then(|| "sk-v".to_string());
@@ -5585,7 +5712,7 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
         // Regression lock: the compose task must keep accepting `@provider` —
         // it is an ordinary chat-shaped task, not an OpenRouter-only executor.
         let cfg = ModelConfig::from_toml_str(
-            "[providers]\nvenice = \"https://x/v1\"\n[tasks.chat_image_prompt_compose]\nmodel=\"m@venice\"\nfilter_prompt=\"compose it\"\n",
+            "[providers]\nvenice = { chat = \"https://x/v1\" }\n[tasks.chat_image_prompt_compose]\nmodel=\"m@venice\"\nfilter_prompt=\"compose it\"\n",
         )
         .unwrap();
         let env = |k: &str| (k == "VENICE_API_KEY").then(|| "sk-v".to_string());
@@ -5616,7 +5743,7 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
     #[test]
     fn build_providers_maps_declared_entries() {
         let cfg = ModelConfig::from_toml_str(
-            "[providers]\nvenice = \"https://x/v1\"\nother = \"https://y/v1\"\n",
+            "[providers]\nvenice = { chat = \"https://x/v1\" }\nother = { chat = \"https://y/v1\" }\n",
         )
         .unwrap();
         let env = |k: &str| (k == "VENICE_API_KEY").then(|| "sk-v".to_string());
@@ -5626,5 +5753,47 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
         // Unreferenced/keyless entry still present, with an empty key —
         // resolve_endpoint's runtime guard covers the (unreachable) miss.
         assert_eq!(map["other"].api_key, "");
+    }
+
+    #[test]
+    fn providers_empty_entry_is_rejected() {
+        let cfg = ModelConfig::from_toml_str("[providers]\nvenice = {}\n").unwrap();
+        let msg = cfg.validate_providers_with(|_| None).unwrap_err();
+        assert!(msg.contains("[providers].venice"), "{msg}");
+    }
+
+    #[test]
+    fn providers_reserved_header_names_are_rejected() {
+        for header in ["Authorization", "authorization", "Content-Type"] {
+            let cfg = ModelConfig::from_toml_str(&format!(
+                "[providers]\nvenice = {{ chat = \"https://x/c\", headers = {{ \"{header}\" = \"boom\" }} }}\n",
+            ))
+            .unwrap();
+            let msg = cfg.validate_providers_with(|_| None).unwrap_err();
+            assert!(msg.contains("engine-owned"), "{header}: {msg}");
+        }
+    }
+
+    #[test]
+    fn providers_invalid_header_value_is_rejected() {
+        let cfg = ModelConfig::from_toml_str(
+            "[providers]\nvenice = { chat = \"https://x/c\", headers = { \"X-Bad\" = \"line\\nbreak\" } }\n",
+        )
+        .unwrap();
+        assert!(cfg.validate_providers_with(|_| None).is_err());
+    }
+
+    #[test]
+    fn build_providers_skips_embedding_only_entries_and_carries_headers() {
+        let cfg = ModelConfig::from_toml_str(
+            "[providers]\n\
+             venice = { chat = \"https://x/c\", headers = { \"X-Team\" = \"companion\" } }\n\
+             local  = { embeddings = \"http://e/v1/embeddings\" }\n",
+        )
+        .unwrap();
+        let map = cfg.build_providers_with(|_| Some("k".to_string()));
+        assert!(map.contains_key("venice"));
+        assert!(!map.contains_key("local"));
+        assert_eq!(map["venice"].headers.get("X-Team").unwrap(), "companion");
     }
 }

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -681,6 +681,14 @@ pub fn apply_output_regex(
 pub struct TaskConfig {
     #[serde(default = "default_model_spec")]
     pub model: ModelSpec,
+    /// Embedding-only: recall-path model (voyage-4 series and above; pair-only
+    /// with `model_write`; mutually exclusive with `model`). Plain string —
+    /// round-robin/weighted shapes are type errors by design.
+    #[serde(default)]
+    pub model_read: Option<String>,
+    /// Embedding-only: storage-path model. See `model_read`.
+    #[serde(default)]
+    pub model_write: Option<String>,
     #[serde(default)]
     pub temperature: Option<f64>,
     /// Nucleus-sampling probability mass. Chat task only; task-level (tiers
@@ -824,6 +832,36 @@ pub struct ModelConfig {
     #[serde(default)]
     pub tasks: HashMap<String, TaskConfig>,
 }
+
+/// Where one embedding call goes (spec 2026-08-01-embedding-providers §3).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EmbedRoute {
+    /// The built-in native Voyage client.
+    Voyage,
+    /// The built-in OpenRouter embeddings endpoint (URL overridable via
+    /// `[providers].openrouter.embeddings`).
+    OpenRouter,
+    /// A `[providers]` entry's `embeddings` URL.
+    Custom(String),
+}
+
+/// One resolved embedding target: bare model id + route.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmbedTarget {
+    pub model: String,
+    pub route: EmbedRoute,
+}
+
+/// Resolved `[tasks.embedding]`: the read (recall / embed_query) and write
+/// (storage / embed_document) targets. Identical targets when a single
+/// `model` is configured.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedEmbedding {
+    pub read: EmbedTarget,
+    pub write: EmbedTarget,
+}
+
+const DEFAULT_EMBED_MODEL: &str = "voyage-3-lite";
 
 /// Resolved model parameters for an LLM call.
 ///
@@ -1866,6 +1904,59 @@ impl ModelConfig {
             .unwrap_or(true)
     }
 
+    /// Pure resolution of `[tasks.embedding]` — call after `validate_providers`
+    /// passed. Absent block, or a block with no model fields, resolves to the
+    /// legacy default (native Voyage, voyage-3-lite) on both sides.
+    pub fn resolve_embedding(&self) -> ResolvedEmbedding {
+        let task = self.tasks.get("embedding");
+        let target = |slug: &str| -> EmbedTarget {
+            match crate::provider::split_model_slug(slug) {
+                Ok((bare, None)) | Ok((bare, Some("voyage"))) => EmbedTarget {
+                    model: bare,
+                    route: EmbedRoute::Voyage,
+                },
+                Ok((bare, Some("openrouter"))) => EmbedTarget {
+                    model: bare,
+                    route: EmbedRoute::OpenRouter,
+                },
+                Ok((bare, Some(p))) => EmbedTarget {
+                    model: bare,
+                    route: EmbedRoute::Custom(p.to_string()),
+                },
+                // Unreachable post-boot (validation walked every slug).
+                Err(_) => EmbedTarget {
+                    model: slug.to_string(),
+                    route: EmbedRoute::Voyage,
+                },
+            }
+        };
+        if let Some(t) = task {
+            if let (Some(r), Some(w)) = (t.model_read.as_deref(), t.model_write.as_deref()) {
+                return ResolvedEmbedding {
+                    read: target(r),
+                    write: target(w),
+                };
+            }
+            if let ModelSpec::Fixed(m) = &t.model {
+                if !m.is_empty() {
+                    let one = target(m);
+                    return ResolvedEmbedding {
+                        read: one.clone(),
+                        write: one,
+                    };
+                }
+            }
+        }
+        let default = EmbedTarget {
+            model: DEFAULT_EMBED_MODEL.to_string(),
+            route: EmbedRoute::Voyage,
+        };
+        ResolvedEmbedding {
+            read: default.clone(),
+            write: default,
+        }
+    }
+
     /// Resolve the insight-extraction (facts stage) prompt bundle. `None` when
     /// `[tasks.insight_extraction]` is absent OR its `filter_prompt` is blank.
     pub fn resolve_insight_extract(&self) -> Option<ResolvedExtract> {
@@ -2092,12 +2183,18 @@ impl ModelConfig {
     }
 
     /// Boot gate for the `[providers]` block and every `@provider` model slug
-    /// (multi-provider spec §7). Checks, in order: provider-table shape
-    /// (charset, reserved name, non-empty URL), then a LITERAL full scan of
-    /// every candidate slug — `[defaults].fallback_model`, every task's and
-    /// tier's `model`/`fallback`, including every round-robin element and
-    /// weighted-table key. Referenced providers must have a non-empty
-    /// `<NAME>_API_KEY` in the environment (loud-fail, like VOYAGE_API_KEY).
+    /// (spec 2026-08-01-embedding-providers §2/§4/§6/§7). Checks, in order:
+    /// provider-table shape (charset, reserved name, non-empty URL);
+    /// `[defaults].ignore_providers` grammar; a task-aware LITERAL full scan
+    /// of every candidate slug — `[defaults].fallback_model`, every task's and
+    /// tier's `model`/`fallback`, `[tasks.embedding]`'s `model`/`model_read`/
+    /// `model_write`, including every round-robin element and weighted-table
+    /// key — where `@voyage` is legal only on embedding-task slugs and every
+    /// other referenced provider must have a non-empty `<NAME>_API_KEY` in the
+    /// environment; `[tasks.embedding]`'s structural rules (model vs.
+    /// model_read/model_write exclusivity, no fallback/tiers, voyage-4+ gate
+    /// on the read/write pair); and finally VOYAGE_API_KEY, required iff the
+    /// resolved embedding config routes through the built-in Voyage client.
     pub fn validate_providers(&self) -> Result<(), String> {
         self.validate_providers_with(|k| std::env::var(k).ok())
     }
@@ -2167,23 +2264,40 @@ impl ModelConfig {
             }
         }
 
-        // 2. Literal full scan of every candidate slug.
-        let mut slugs: Vec<(String, &str)> = Vec::new();
+        // 2. Literal full scan of every candidate slug. The third element flags
+        // an embedding-task slug: `[tasks.embedding].model` (and, below,
+        // `.model_read`/`.model_write`) are the only entries where `@voyage`
+        // is legal and where routing demands an `embeddings` URL rather than
+        // a `chat` one.
+        let mut slugs: Vec<(String, &str, bool)> = Vec::new();
         if let Some(fb) = self.defaults.fallback_model.as_deref() {
             if !fb.is_empty() {
-                slugs.push(("[defaults].fallback_model".to_string(), fb));
+                slugs.push(("[defaults].fallback_model".to_string(), fb, false));
             }
         }
         let mut task_names: Vec<&String> = self.tasks.keys().collect();
         task_names.sort();
         for name in task_names {
             let task = &self.tasks[name];
+            let is_embedding = name == "embedding";
             for id in task.model.candidate_ids() {
-                slugs.push((format!("[tasks.{name}].model"), id));
+                slugs.push((format!("[tasks.{name}].model"), id, is_embedding));
             }
             if let Some(fb) = &task.fallback {
                 for id in fb.candidate_ids() {
-                    slugs.push((format!("[tasks.{name}].fallback"), id));
+                    slugs.push((format!("[tasks.{name}].fallback"), id, is_embedding));
+                }
+            }
+            if is_embedding {
+                if let Some(m) = task.model_read.as_deref() {
+                    if !m.is_empty() {
+                        slugs.push(("[tasks.embedding].model_read".to_string(), m, true));
+                    }
+                }
+                if let Some(m) = task.model_write.as_deref() {
+                    if !m.is_empty() {
+                        slugs.push(("[tasks.embedding].model_write".to_string(), m, true));
+                    }
                 }
             }
             let mut tier_names: Vec<&String> = task.tiers.keys().collect();
@@ -2192,40 +2306,143 @@ impl ModelConfig {
                 let t = &task.tiers[tier];
                 if let Some(m) = &t.model {
                     for id in m.candidate_ids() {
-                        slugs.push((format!("[tasks.{name}.tiers.{tier}].model"), id));
+                        slugs.push((format!("[tasks.{name}.tiers.{tier}].model"), id, false));
                     }
                 }
                 if let Some(fb) = &t.fallback {
                     for id in fb.candidate_ids() {
-                        slugs.push((format!("[tasks.{name}.tiers.{tier}].fallback"), id));
+                        slugs.push((format!("[tasks.{name}.tiers.{tier}].fallback"), id, false));
                     }
                 }
             }
         }
 
-        for (at, slug) in slugs {
+        for (at, slug, is_embedding) in slugs {
             let (_, provider) =
                 crate::provider::split_model_slug(slug).map_err(|e| format!("{at}: {e}"))?;
-            if let Some(p) = provider {
-                if !self.providers.contains_key(p) {
-                    let mut declared: Vec<&str> =
-                        self.providers.keys().map(String::as_str).collect();
-                    declared.sort();
+            match provider {
+                None => {}
+                // Built-in alias: valid everywhere a provider suffix is legal,
+                // no [providers] entry and no extra key check
+                // ($OPENROUTER_API_KEY is unconditionally required for chat).
+                Some("openrouter") => {}
+                Some("voyage") if is_embedding => {}
+                Some("voyage") => {
                     return Err(format!(
-                        "{at}: `{slug}` names provider `{p}`, which is not declared in \
-                         [providers] (declared: {declared:?}). If the `@` is part of the \
-                         model id, escape it as `\\@` (in TOML double quotes: `\"\\\\@\"`)."
+                        "{at}: `{slug}` routes to `voyage`, which serves embeddings only — \
+                         `@voyage` is valid on [tasks.embedding] model fields and nowhere else"
                     ));
                 }
-                let var = format!("{}_API_KEY", p.to_uppercase());
-                if env(&var).is_none_or(|v| v.is_empty()) {
-                    return Err(format!(
-                        "{at}: `{slug}` routes to provider `{p}` but ${var} is unset or \
-                         empty — eros-engine refuses to boot rather than fail at request \
-                         time"
-                    ));
+                Some(p) => {
+                    let Some(entry) = self.providers.get(p) else {
+                        let mut declared: Vec<&str> =
+                            self.providers.keys().map(String::as_str).collect();
+                        declared.sort();
+                        return Err(format!(
+                            "{at}: `{slug}` names provider `{p}`, which is not declared in \
+                             [providers] (declared: {declared:?}). If the `@` is part of the \
+                             model id, escape it as `\\@` (in TOML double quotes: `\"\\\\@\"`)."
+                        ));
+                    };
+                    if is_embedding && entry.embeddings.is_none() {
+                        return Err(format!(
+                            "{at}: `{slug}` routes embedding traffic to `{p}`, but \
+                             [providers].{p} declares no `embeddings` URL"
+                        ));
+                    }
+                    if !is_embedding && entry.chat.is_none() {
+                        return Err(format!(
+                            "{at}: `{slug}` routes chat traffic to `{p}`, but \
+                             [providers].{p} declares no `chat` URL"
+                        ));
+                    }
+                    let var = format!("{}_API_KEY", p.to_uppercase());
+                    if env(&var).is_none_or(|v| v.is_empty()) {
+                        return Err(format!(
+                            "{at}: `{slug}` routes to provider `{p}` but ${var} is unset or \
+                             empty — eros-engine refuses to boot rather than fail at request \
+                             time"
+                        ));
+                    }
                 }
             }
+        }
+
+        // 3. [tasks.embedding]-specific structure (spec §2/§6).
+        if let Some(t) = self.tasks.get("embedding") {
+            let model_set = !t.model.candidate_ids().is_empty();
+            let pair = (t.model_read.as_deref(), t.model_write.as_deref());
+            if model_set && (pair.0.is_some() || pair.1.is_some()) {
+                return Err(
+                    "[tasks.embedding]: `model` and `model_read`/`model_write` are mutually \
+                     exclusive — configure one or the other"
+                        .to_string(),
+                );
+            }
+            if pair.0.is_some() != pair.1.is_some() {
+                return Err(
+                    "[tasks.embedding]: `model_read` and `model_write` must appear together \
+                     (a lone half would leave the other path on an unspecified model)"
+                        .to_string(),
+                );
+            }
+            if model_set && !matches!(t.model, ModelSpec::Fixed(_)) {
+                return Err(
+                    "[tasks.embedding].model must be a single fixed id — round-robin and \
+                     weighted forms would interleave incompatible vector spaces"
+                        .to_string(),
+                );
+            }
+            if t.fallback.is_some() {
+                return Err(
+                    "[tasks.embedding]: `fallback` is not supported — a fallback model would \
+                     write vectors the primary cannot compare. Delete the key."
+                        .to_string(),
+                );
+            }
+            if !t.tiers.is_empty() {
+                return Err(
+                    "[tasks.embedding]: `tiers` are not supported on the embedding task. \
+                     Delete the block."
+                        .to_string(),
+                );
+            }
+            for (field, slug) in [("model_read", pair.0), ("model_write", pair.1)] {
+                let Some(slug) = slug else { continue };
+                let (bare, provider) = crate::provider::split_model_slug(slug)
+                    .map_err(|e| format!("[tasks.embedding].{field}: {e}"))?;
+                if !matches!(provider, None | Some("voyage")) {
+                    return Err(format!(
+                        "[tasks.embedding].{field}: `{slug}` — model_read/model_write are \
+                         Voyage-only (bare id or `@voyage`); other providers cannot \
+                         guarantee a shared vector space"
+                    ));
+                }
+                match voyage_model_generation(&bare) {
+                    Some(n) if n >= 4.0 => {}
+                    _ => {
+                        return Err(format!(
+                            "[tasks.embedding].{field}: `{bare}` — the read/write split \
+                             requires the voyage-4 series or above (a shared vector space \
+                             across model sizes); voyage-3.x and domain models refuse to \
+                             boot rather than silently write incomparable vectors"
+                        ));
+                    }
+                }
+            }
+        }
+
+        // 4. VOYAGE_API_KEY: required iff a Voyage backend is in play (spec §7).
+        let resolved = self.resolve_embedding();
+        let voyage_in_play =
+            resolved.read.route == EmbedRoute::Voyage || resolved.write.route == EmbedRoute::Voyage;
+        if voyage_in_play && env("VOYAGE_API_KEY").is_none_or(|v| v.trim().is_empty()) {
+            return Err(
+                "VOYAGE_API_KEY is unset or empty but the embedding config resolves to \
+                 the built-in Voyage client — eros-engine refuses to boot rather than \
+                 silently disable embeddings"
+                    .to_string(),
+            );
         }
         Ok(())
     }
@@ -4467,7 +4684,11 @@ filter_prompt = "只根据产品资料作答。"
             "[defaults]\nignore_providers = [\"bad-a@openrouter\", \"bad-b@openrouter\"]\n",
         )
         .unwrap();
-        assert!(cfg.validate_providers_with(|_| None).is_ok());
+        // No [tasks.embedding] ⇒ the default embedding route is the built-in
+        // Voyage client, so validation now also needs VOYAGE_API_KEY.
+        assert!(cfg
+            .validate_providers_with(|k| (k == "VOYAGE_API_KEY").then(|| "k".to_string()))
+            .is_ok());
         assert_eq!(cfg.ignore_provider_wire_slugs(), vec!["bad-a", "bad-b"]);
     }
 
@@ -5673,7 +5894,11 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
     fn providers_absent_is_empty_and_valid() {
         let cfg = ModelConfig::from_toml_str("[tasks.chat_companion]\nmodel=\"m\"\n").unwrap();
         assert!(cfg.providers.is_empty());
-        assert!(cfg.validate_providers_with(no_env).is_ok());
+        // No [tasks.embedding] ⇒ resolves to the default Voyage route, which
+        // now needs VOYAGE_API_KEY.
+        assert!(cfg
+            .validate_providers_with(|k| (k == "VOYAGE_API_KEY").then(|| "k".to_string()))
+            .is_ok());
     }
 
     #[test]
@@ -5682,7 +5907,9 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
             "[providers]\nopenrouter = { embeddings = \"http://proxy/v1/embeddings\" }\n",
         )
         .unwrap();
-        assert!(cfg.validate_providers_with(|_| None).is_ok());
+        assert!(cfg
+            .validate_providers_with(|k| (k == "VOYAGE_API_KEY").then(|| "k".to_string()))
+            .is_ok());
     }
 
     #[test]
@@ -5722,7 +5949,11 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
             "[providers]\nvenice = { chat = \"https://x/v1\" }\n[tasks.chat_companion]\nmodel=\"plain/m\"\n",
         )
         .unwrap();
-        assert!(cfg.validate_providers_with(no_env).is_ok());
+        // No [tasks.embedding] ⇒ resolves to the default Voyage route, which
+        // now needs VOYAGE_API_KEY.
+        assert!(cfg
+            .validate_providers_with(|k| (k == "VOYAGE_API_KEY").then(|| "k".to_string()))
+            .is_ok());
     }
 
     #[test]
@@ -5754,7 +5985,10 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
             "[providers]\nvenice = { chat = \"https://x/v1\" }\n[tasks.chat_companion]\nmodel=\"m@venice\"\nfallback=[\"other/m\"]\n",
         )
         .unwrap();
-        let env = |k: &str| (k == "VENICE_API_KEY").then(|| "sk-v".to_string());
+        // No [tasks.embedding] ⇒ resolves to the default Voyage route, which
+        // now needs VOYAGE_API_KEY alongside VENICE_API_KEY.
+        let env =
+            |k: &str| (k == "VENICE_API_KEY" || k == "VOYAGE_API_KEY").then(|| "sk-v".to_string());
         assert!(cfg.validate_providers_with(env).is_ok());
     }
 
@@ -5816,7 +6050,10 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
             "[providers]\nvenice = { chat = \"https://x/v1\" }\n[tasks.chat_image_prompt_compose]\nmodel=\"m@venice\"\nfilter_prompt=\"compose it\"\n",
         )
         .unwrap();
-        let env = |k: &str| (k == "VENICE_API_KEY").then(|| "sk-v".to_string());
+        // No [tasks.embedding] ⇒ resolves to the default Voyage route, which
+        // now needs VOYAGE_API_KEY alongside VENICE_API_KEY.
+        let env =
+            |k: &str| (k == "VENICE_API_KEY" || k == "VOYAGE_API_KEY").then(|| "sk-v".to_string());
         assert!(cfg.validate_providers_with(env).is_ok());
     }
 
@@ -5896,5 +6133,194 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
         assert!(map.contains_key("venice"));
         assert!(!map.contains_key("local"));
         assert_eq!(map["venice"].headers.get("X-Team").unwrap(), "companion");
+    }
+
+    // ---- [tasks.embedding] routing + resolve_embedding (spec 2026-08-01-embedding-providers §2/§3/§6) ----
+
+    /// env closure granting every key, for tests that target non-key rules.
+    fn env_all(k: &str) -> Option<String> {
+        let _ = k;
+        Some("key".to_string())
+    }
+
+    #[test]
+    fn at_openrouter_alias_passes_on_chat_tasks() {
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.chat_companion]\nmodel = \"x-ai/grok-4.20@openrouter\"\n\
+             fallback = [\"deepseek/deepseek-v4-flash@openrouter\"]\n",
+        )
+        .unwrap();
+        // No [tasks.embedding] ⇒ resolves to the default Voyage route, which
+        // needs VOYAGE_API_KEY — this test targets the @openrouter alias, not
+        // the key check.
+        assert!(cfg
+            .validate_providers_with(|k| (k == "VOYAGE_API_KEY").then(|| "k".to_string()))
+            .is_ok());
+    }
+
+    #[test]
+    fn at_voyage_on_chat_task_is_rejected() {
+        let cfg =
+            ModelConfig::from_toml_str("[tasks.chat_companion]\nmodel = \"voyage-4@voyage\"\n")
+                .unwrap();
+        let msg = cfg.validate_providers_with(env_all).unwrap_err();
+        assert!(
+            msg.contains("embedding"),
+            "should say voyage is embeddings-only: {msg}"
+        );
+    }
+
+    #[test]
+    fn chat_ref_to_embeddings_only_entry_is_rejected() {
+        let cfg = ModelConfig::from_toml_str(
+            "[providers]\nlocal = { embeddings = \"http://e/v1/embeddings\" }\n\
+             [tasks.chat_companion]\nmodel = \"m@local\"\n",
+        )
+        .unwrap();
+        let msg = cfg.validate_providers_with(env_all).unwrap_err();
+        assert!(msg.contains("chat"), "{msg}");
+    }
+
+    #[test]
+    fn embedding_ref_to_chat_only_entry_is_rejected() {
+        let cfg = ModelConfig::from_toml_str(
+            "[providers]\nvenice = { chat = \"https://x/c\" }\n\
+             [tasks.embedding]\nmodel = \"bge-m3@venice\"\n",
+        )
+        .unwrap();
+        let msg = cfg.validate_providers_with(env_all).unwrap_err();
+        assert!(msg.contains("embeddings"), "{msg}");
+    }
+
+    #[test]
+    fn embedding_bare_model_means_voyage_and_needs_voyage_key() {
+        let cfg =
+            ModelConfig::from_toml_str("[tasks.embedding]\nmodel = \"voyage-3-lite\"\n").unwrap();
+        // No VOYAGE_API_KEY in env ⇒ refuse.
+        let msg = cfg.validate_providers_with(|_| None).unwrap_err();
+        assert!(msg.contains("VOYAGE_API_KEY"), "{msg}");
+        // With the key ⇒ pass.
+        assert!(cfg
+            .validate_providers_with(|k| (k == "VOYAGE_API_KEY").then(|| "k".to_string()))
+            .is_ok());
+    }
+
+    #[test]
+    fn embedding_at_openrouter_does_not_need_voyage_key() {
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.embedding]\nmodel = \"openai/text-embedding-3-small@openrouter\"\n",
+        )
+        .unwrap();
+        assert!(cfg.validate_providers_with(|_| None).is_ok());
+    }
+
+    #[test]
+    fn embedding_model_and_pair_are_mutually_exclusive() {
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.embedding]\nmodel = \"voyage-3-lite\"\nmodel_read = \"voyage-4-lite\"\nmodel_write = \"voyage-4\"\n",
+        )
+        .unwrap();
+        assert!(cfg.validate_providers_with(env_all).is_err());
+    }
+
+    #[test]
+    fn embedding_half_pair_is_rejected() {
+        let cfg = ModelConfig::from_toml_str("[tasks.embedding]\nmodel_read = \"voyage-4-lite\"\n")
+            .unwrap();
+        let msg = cfg.validate_providers_with(env_all).unwrap_err();
+        assert!(msg.contains("model_write"), "{msg}");
+    }
+
+    #[test]
+    fn embedding_pair_below_voyage_4_is_rejected() {
+        for bad in ["voyage-3.5-lite", "voyage-code-3", "bge-m3"] {
+            let cfg = ModelConfig::from_toml_str(&format!(
+                "[tasks.embedding]\nmodel_read = \"{bad}\"\nmodel_write = \"voyage-4\"\n"
+            ))
+            .unwrap();
+            assert!(
+                cfg.validate_providers_with(env_all).is_err(),
+                "{bad} must refuse"
+            );
+        }
+    }
+
+    #[test]
+    fn embedding_pair_rejects_non_voyage_provider_suffix() {
+        for bad in ["voyage-4@openrouter", "voyage-4@local"] {
+            let cfg = ModelConfig::from_toml_str(&format!(
+                "[providers]\nlocal = {{ embeddings = \"http://e/v1/embeddings\" }}\n\
+                 [tasks.embedding]\nmodel_read = \"{bad}\"\nmodel_write = \"voyage-4\"\n"
+            ))
+            .unwrap();
+            assert!(
+                cfg.validate_providers_with(env_all).is_err(),
+                "{bad} must refuse"
+            );
+        }
+    }
+
+    #[test]
+    fn embedding_pair_accepts_explicit_at_voyage() {
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.embedding]\nmodel_read = \"voyage-4-lite@voyage\"\nmodel_write = \"voyage-4\"\n",
+        )
+        .unwrap();
+        assert!(cfg
+            .validate_providers_with(|k| (k == "VOYAGE_API_KEY").then(|| "k".to_string()))
+            .is_ok());
+    }
+
+    #[test]
+    fn embedding_model_rejects_round_robin_weighted_fallback_tiers() {
+        for toml in [
+            "[tasks.embedding]\nmodel = [\"voyage-3-lite\", \"voyage-4\"]\n",
+            "[tasks.embedding]\nmodel = { \"voyage-3-lite\" = 0.5, \"voyage-4\" = 0.5 }\n",
+            "[tasks.embedding]\nmodel = \"voyage-3-lite\"\nfallback = \"voyage-4\"\n",
+            "[tasks.embedding]\nmodel = \"voyage-3-lite\"\n[tasks.embedding.tiers.pro]\nmodel = \"voyage-4\"\n",
+        ] {
+            let cfg = ModelConfig::from_toml_str(toml).unwrap();
+            assert!(
+                cfg.validate_providers_with(env_all).is_err(),
+                "must refuse: {toml}"
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_embedding_defaults_to_voyage_3_lite() {
+        for toml in ["", "[tasks.embedding]\n"] {
+            let cfg = ModelConfig::from_toml_str(toml).unwrap();
+            let r = cfg.resolve_embedding();
+            assert_eq!(r.read.model, "voyage-3-lite");
+            assert_eq!(r.write.model, "voyage-3-lite");
+            assert!(matches!(r.read.route, EmbedRoute::Voyage));
+            assert!(matches!(r.write.route, EmbedRoute::Voyage));
+        }
+    }
+
+    #[test]
+    fn resolve_embedding_single_model_routes() {
+        let cfg = ModelConfig::from_toml_str(
+            "[providers]\nlocal = { embeddings = \"http://e/v1/embeddings\" }\n\
+             [tasks.embedding]\nmodel = \"bge-m3@local\"\n",
+        )
+        .unwrap();
+        let r = cfg.resolve_embedding();
+        assert_eq!(r.read.model, "bge-m3");
+        assert!(matches!(r.read.route, EmbedRoute::Custom(ref n) if n == "local"));
+        assert_eq!(r.write.model, "bge-m3");
+    }
+
+    #[test]
+    fn resolve_embedding_pair_splits_read_write() {
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.embedding]\nmodel_read = \"voyage-4-lite\"\nmodel_write = \"voyage-4\"\n",
+        )
+        .unwrap();
+        let r = cfg.resolve_embedding();
+        assert_eq!(r.read.model, "voyage-4-lite");
+        assert_eq!(r.write.model, "voyage-4");
+        assert!(matches!(r.read.route, EmbedRoute::Voyage));
     }
 }

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -515,8 +515,9 @@ pub struct DefaultConfig {
     #[serde(default)]
     pub fallback_max_tokens: Option<u32>,
     /// OpenRouter provider slugs to exclude from routing on EVERY task
-    /// (issue #84). Sent as `provider.ignore` on every outbound call; the
-    /// client reads this once at boot. Empty = no exclusion.
+    /// (issue #84). Each slug MUST carry the @openrouter suffix (the exclusion
+    /// list acts on OpenRouter routing only). Sent as `provider.ignore` on every
+    /// outbound call; the client reads this once at boot. Empty = no exclusion.
     #[serde(default)]
     pub ignore_providers: Vec<String>,
     /// OpenRouter `provider.sort` routing preference applied on EVERY task:
@@ -820,13 +821,15 @@ pub struct TaskConfig {
 pub struct ModelConfig {
     #[serde(default)]
     pub defaults: DefaultConfig,
-    /// The `[providers]` block — custom OpenAI-compatible endpoints keyed by
-    /// name (spec 2026-08-01-embedding-providers §1). Each entry is a table
-    /// with `chat` and/or `embeddings` URLs (COMPLETE, posted verbatim — no
-    /// path joining) plus an optional `headers` table. The API key comes
-    /// from env as `<NAME_UPPERCASED>_API_KEY`. Under MODEL_CONFIG_DIR this
-    /// merges as one whole top-level key (like `[defaults]`, unlike
-    /// `[tasks]`): all providers live in one file.
+    /// The `[providers]` block — custom endpoints keyed by name. Each entry is
+    /// a table with optional `chat` (OpenAI-compatible) and `embeddings`
+    /// (OpenRouter-compatible) URLs, plus an optional `headers` table sent
+    /// verbatim on every request. URLs are COMPLETE, posted verbatim — no
+    /// path joining. The API key comes from env as `<NAME_UPPERCASED>_API_KEY`.
+    /// "openrouter" is special: it overrides BUILT-IN OpenRouter endpoints per
+    /// key and homes the attribution headers (HTTP-Referer, X-OpenRouter-Title,
+    /// X-OpenRouter-Categories). Under MODEL_CONFIG_DIR this merges as one
+    /// whole top-level key (like `[defaults]`, unlike `[tasks]`).
     #[serde(default)]
     pub providers: HashMap<String, ProviderEntry>,
     #[serde(default)]

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -958,7 +958,7 @@ pub struct ResolvedEmbedding {
     pub write: EmbedTarget,
 }
 
-const DEFAULT_EMBED_MODEL: &str = "voyage-3-lite";
+const DEFAULT_EMBED_MODEL: &str = "voyage-4-lite";
 
 /// Resolved model parameters for an LLM call.
 ///
@@ -2003,7 +2003,10 @@ impl ModelConfig {
 
     /// Pure resolution of `[tasks.embedding]` — call after `validate_providers`
     /// passed. Absent block, or a block with no model fields, resolves to the
-    /// legacy default (native Voyage, voyage-3-lite) on both sides.
+    /// default (native Voyage, voyage-4-lite) on both sides. Deployments that
+    /// need the no-longer-recommended voyage-3-lite must pin it explicitly —
+    /// note the vector-space consequence: rows embedded by one model are not
+    /// comparable to queries embedded by another.
     pub fn resolve_embedding(&self) -> ResolvedEmbedding {
         let task = self.tasks.get("embedding");
         let target = |slug: &str| -> EmbedTarget {
@@ -6459,12 +6462,12 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
     }
 
     #[test]
-    fn resolve_embedding_defaults_to_voyage_3_lite() {
+    fn resolve_embedding_defaults_to_voyage_4_lite() {
         for toml in ["", "[tasks.embedding]\n"] {
             let cfg = ModelConfig::from_toml_str(toml).unwrap();
             let r = cfg.resolve_embedding();
-            assert_eq!(r.read.model, "voyage-3-lite");
-            assert_eq!(r.write.model, "voyage-3-lite");
+            assert_eq!(r.read.model, "voyage-4-lite");
+            assert_eq!(r.write.model, "voyage-4-lite");
             assert!(matches!(r.read.route, EmbedRoute::Voyage));
             assert!(matches!(r.write.route, EmbedRoute::Voyage));
         }

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -2494,6 +2494,23 @@ impl ModelConfig {
             .collect()
     }
 
+    /// `[providers].openrouter.chat`, if declared — the built-in chat URL
+    /// override (spec §4).
+    pub fn openrouter_chat_url(&self) -> Option<String> {
+        self.providers
+            .get("openrouter")
+            .and_then(|e| e.chat.clone())
+    }
+
+    /// `[providers].openrouter.headers` as a HeaderMap (empty when absent).
+    /// The one home for OpenRouter attribution headers.
+    pub fn openrouter_header_map(&self) -> reqwest::header::HeaderMap {
+        self.providers
+            .get("openrouter")
+            .map(|e| e.header_map())
+            .unwrap_or_default()
+    }
+
     /// Reject config blocks for features that were removed, so an operator
     /// upgrading across the removal cannot silently keep a block that no
     /// longer does anything. Loud-fail, same shape as the other boot gates.

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -2408,8 +2408,11 @@ data: [DONE]\n\n";
             .expect(1)
             .mount(&server_b)
             .await;
+        let mut openrouter_headers = reqwest::header::HeaderMap::new();
+        openrouter_headers.insert("HTTP-Referer", "https://eros.example".parse().unwrap());
         let client =
             OpenRouterClient::with_base_url("or-key".into(), "https://unused.test/v1".into())
+                .with_openrouter_headers(openrouter_headers)
                 .with_ignore_providers(vec!["bad".into()])
                 .with_providers(std::collections::HashMap::from([(
                     "venice".to_string(),
@@ -3387,11 +3390,19 @@ data: [DONE]\n\n";
             .expect(1)
             .mount(&server_b)
             .await;
-        // Prefs configured — none of it may reach the custom host.
+        // Headers + prefs configured — none of it may reach the custom host.
+        let mut openrouter_headers = reqwest::header::HeaderMap::new();
+        openrouter_headers.insert("HTTP-Referer", "https://eros.example".parse().unwrap());
+        openrouter_headers.insert("X-OpenRouter-Title", "Eros".parse().unwrap());
+        openrouter_headers.insert(
+            "X-OpenRouter-Categories",
+            "roleplay,general-chat".parse().unwrap(),
+        );
         let client = OpenRouterClient::with_base_url(
             "or-key".into(),
             "https://unused-openrouter.test/v1".into(),
         )
+        .with_openrouter_headers(openrouter_headers)
         .with_ignore_providers(vec!["bad".into()])
         .with_provider_sort(Some("latency".into()))
         .with_providers(std::collections::HashMap::from([(

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -585,11 +585,18 @@ impl OpenRouterClient {
     /// `LlmError::Config`, which advances the caller's candidate chain
     /// instead of panicking (unreachable for config slugs post-boot, but
     /// `execute_stream_as` receives arbitrary server strings).
+    ///
+    /// `openrouter` is a reserved alias for "no suffix" (spec §3/§4): a slug
+    /// suffixed `@openrouter` must be byte-for-byte equivalent to the same
+    /// slug with no suffix at all — built-in endpoint, attributed `http`
+    /// client, full OpenRouter wire, no `[providers]` lookup. It is handled
+    /// in THIS arm, not `Some(p)`, precisely so it never falls into the
+    /// custom-provider path (plain client, stripped wire, audit suffix).
     fn resolve_endpoint<'s>(&'s self, slug: &str) -> Result<(String, Endpoint<'s>), LlmError> {
         let (bare, provider) = crate::provider::split_model_slug(slug)
             .map_err(|e| LlmError::Config(format!("openrouter: {e}")))?;
         match provider {
-            None => {
+            None | Some("openrouter") => {
                 if self.api_key.is_empty() {
                     return Err(LlmError::Config("openrouter: api key not set".into()));
                 }
@@ -2752,6 +2759,114 @@ data: [DONE]\n\n";
         let (bare, ep) = c.resolve_endpoint("weird\\@vendor/m").unwrap();
         assert_eq!(bare, "weird@vendor/m");
         assert!(ep.name.is_none());
+    }
+
+    #[test]
+    fn resolve_at_openrouter_suffix_matches_no_suffix() {
+        // Critical-finding regression (spec §3/§4): `@openrouter` must be
+        // byte-for-byte equivalent to no suffix at all — built-in endpoint,
+        // no `[providers]` lookup. `client_with_venice` declares ONLY
+        // `venice`, no `openrouter` entry, so a resolution that (bugly)
+        // fell through to the `Some(p)` custom-provider arm would fail here
+        // with "names undeclared provider `openrouter`" — this test proves
+        // it does not.
+        let c = client_with_venice();
+        let (bare_plain, ep_plain) = c.resolve_endpoint("x-ai/grok-4.20").unwrap();
+        let (bare_alias, ep_alias) = c.resolve_endpoint("x-ai/grok-4.20@openrouter").unwrap();
+        assert_eq!(bare_alias, bare_plain);
+        assert_eq!(ep_alias.url, ep_plain.url);
+        assert_eq!(ep_alias.api_key, ep_plain.api_key);
+        assert!(ep_alias.name.is_none());
+        assert!(ep_alias.headers.is_none());
+    }
+
+    #[tokio::test]
+    async fn execute_at_openrouter_suffix_hits_built_in_endpoint_full_wire() {
+        // Critical-finding regression test: `@openrouter` on a chat slug must
+        // resolve through the SAME path as no suffix (spec §3/§4) — built-in
+        // endpoint, full OpenRouter wire (provider.ignore included), bare
+        // model on the wire — never the custom-provider subset. No
+        // `[providers]` map is installed at all, proving the alias needs no
+        // `[providers].openrouter` entry to work.
+        let server = MockServer::start().await;
+        Mock::given(path("/api/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ok_response()))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let client = OpenRouterClient::with_base_url(
+            "test-key".into(),
+            format!("{}/api/v1/chat/completions", server.uri()),
+        )
+        .with_ignore_providers(vec!["bad".into()]);
+        let _ = client
+            .execute(ChatRequest {
+                model: "test/model@openrouter".into(),
+                fallback_model: Vec::new(),
+                messages: vec![ChatMessage {
+                    role: "user".into(),
+                    content: "hi".into(),
+                }],
+                temperature: 0.0,
+                max_tokens: 16,
+                ..Default::default()
+            })
+            .await
+            .expect("call succeeds");
+
+        let reqs = server.received_requests().await.unwrap_or_default();
+        let body: serde_json::Value = serde_json::from_slice(&reqs[0].body).unwrap();
+        assert_eq!(
+            body["model"], "test/model",
+            "wire model must be the bare id — the @openrouter suffix must not reach the wire"
+        );
+        assert_eq!(
+            body["provider"]["ignore"][0], "bad",
+            "provider.ignore must be present — proves the full wire, not the custom subset"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_stream_as_openrouter_suffix_hits_built_in_endpoint() {
+        // Cheap parallel to the execute() alias-equivalence test above, on
+        // the streaming path — same resolve_endpoint fix, same assertions.
+        let server = MockServer::start().await;
+        let sse = "data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\ndata: [DONE]\n\n";
+        Mock::given(path("/api/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(sse, "text/event-stream"),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        let client = OpenRouterClient::with_base_url(
+            "test-key".into(),
+            format!("{}/api/v1/chat/completions", server.uri()),
+        )
+        .with_ignore_providers(vec!["bad".into()]);
+        let req = ChatRequest {
+            model: String::new(), // placeholder; execute_stream_as takes the model separately
+            messages: vec![ChatMessage {
+                role: "user".into(),
+                content: "hi".into(),
+            }],
+            temperature: 0.0,
+            max_tokens: 16,
+            ..Default::default()
+        };
+        let mut s = client
+            .execute_stream_as(&req, "test/model@openrouter")
+            .await
+            .expect("stream opens");
+        use futures_util::StreamExt as _;
+        while s.next().await.is_some() {}
+
+        let r = &server.received_requests().await.unwrap()[0];
+        let body: serde_json::Value = serde_json::from_slice(&r.body).unwrap();
+        assert_eq!(body["model"], "test/model");
+        assert_eq!(body["provider"]["ignore"][0], "bad");
     }
 
     #[test]

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -2499,6 +2499,7 @@ data: [DONE]\n\n";
             crate::provider::ProviderEndpoint {
                 base_url: format!("{}/v1/chat/completions", server_b.uri()),
                 api_key: "v-key".into(),
+                headers: reqwest::header::HeaderMap::new(),
             },
         )]));
         let req = ChatRequest {
@@ -2822,6 +2823,7 @@ data: [DONE]\n\n";
             crate::provider::ProviderEndpoint {
                 base_url: "https://venice.test/v1/chat/completions".into(),
                 api_key: "v-key".into(),
+                headers: reqwest::header::HeaderMap::new(),
             },
         )]))
     }
@@ -2886,6 +2888,7 @@ data: [DONE]\n\n";
             crate::provider::ProviderEndpoint {
                 base_url: "https://venice.test/v1".into(),
                 api_key: String::new(),
+                headers: reqwest::header::HeaderMap::new(),
             },
         )]));
         assert!(matches!(
@@ -3221,6 +3224,7 @@ data: [DONE]\n\n";
             crate::provider::ProviderEndpoint {
                 base_url: format!("{}/v1/chat/completions", server_b.uri()),
                 api_key: "v-key".into(),
+                headers: reqwest::header::HeaderMap::new(),
             },
         )]));
         let resp = client
@@ -3519,6 +3523,7 @@ data: [DONE]\n\n";
             crate::provider::ProviderEndpoint {
                 base_url: format!("{}/v1/chat/completions", server_b.uri()),
                 api_key: "v-key".into(),
+                headers: reqwest::header::HeaderMap::new(),
             },
         )]));
         let mut meta = serde_json::Map::new();
@@ -3591,6 +3596,7 @@ data: [DONE]\n\n";
             crate::provider::ProviderEndpoint {
                 base_url: format!("{}/v1/chat/completions", server_b.uri()),
                 api_key: "v-key".into(),
+                headers: reqwest::header::HeaderMap::new(),
             },
         )]));
         let resp = client
@@ -3634,6 +3640,7 @@ data: [DONE]\n\n";
             crate::provider::ProviderEndpoint {
                 base_url: format!("{}/v1/chat/completions", server_b.uri()),
                 api_key: "v-key".into(),
+                headers: reqwest::header::HeaderMap::new(),
             },
         )]));
         let resp = client
@@ -3677,6 +3684,7 @@ data: [DONE]\n\n";
             crate::provider::ProviderEndpoint {
                 base_url: format!("{}/v1/chat/completions", server_b.uri()),
                 api_key: "v-key".into(),
+                headers: reqwest::header::HeaderMap::new(),
             },
         )]));
         let resp = client

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -55,15 +55,6 @@ where
     })
 }
 
-/// OpenRouter app-attribution header names. Pinned to the current
-/// `https://openrouter.ai/docs/app-attribution` spec. If OpenRouter
-/// renames either header in the future, update the value here; today's
-/// names become legacy and (if a transition window applies) get added as
-/// a parallel alias below.
-const HEADER_REFERER: &str = "HTTP-Referer";
-const HEADER_TITLE: &str = "X-OpenRouter-Title";
-const HEADER_CATEGORIES: &str = "X-OpenRouter-Categories";
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChatMessage {
     pub role: String,
@@ -450,25 +441,6 @@ struct WireStreamFrame {
     error: Option<WireStreamError>,
 }
 
-/// App-Attribution headers sent on every outbound OpenRouter call.
-/// Skipping `None` fields avoids emitting blank-but-set headers, which
-/// OpenRouter would record as a real attribution. Both `None` reverts
-/// to today's no-header behaviour.
-#[derive(Debug, Clone, Default)]
-pub struct AppAttribution {
-    /// Sent as `HTTP-Referer`. Identifies the deploying app to OpenRouter.
-    pub referer: Option<String>,
-    /// Sent as `X-OpenRouter-Title`. Display name in OpenRouter's app
-    /// analytics. (OpenRouter also accepts the legacy `X-Title` alias; we
-    /// send the current canonical name.)
-    pub title: Option<String>,
-    /// Sent as `X-OpenRouter-Categories`. Comma-separated marketplace
-    /// categories for OpenRouter's app directory. Passed through verbatim;
-    /// OpenRouter silently ignores unrecognised values, so the engine does
-    /// no validation. Only takes effect when paired with `referer`.
-    pub categories: Option<String>,
-}
-
 #[derive(Clone)]
 pub struct OpenRouterClient {
     http: reqwest::Client,
@@ -486,18 +458,19 @@ pub struct OpenRouterClient {
     /// installed at boot via [`OpenRouterClient::with_providers`]. Arc so the
     /// client's Clone stays cheap.
     providers: Arc<HashMap<String, crate::provider::ProviderEndpoint>>,
-    /// HTTP client WITHOUT the OpenRouter attribution default-headers, used
-    /// for every custom-provider post. The three attribution headers are
-    /// baked into `http` at construction and cannot be withdrawn per-request
-    /// (spec §3); same connect/pool bounds as `http`.
+    /// HTTP client WITHOUT the `[providers].openrouter.headers` default
+    /// headers, used for every custom-provider post. Those default headers
+    /// are baked into `http` at boot via [`OpenRouterClient::with_openrouter_headers`]
+    /// and cannot be withdrawn per-request; custom `[providers]` endpoints
+    /// instead carry their own declared headers per-request (spec §3). Same
+    /// connect/pool bounds as `http`.
     plain_http: reqwest::Client,
 }
 
 impl OpenRouterClient {
-    /// Production constructor. Pins to OpenRouter's canonical URL and
-    /// bakes attribution headers into the shared reqwest client at boot.
-    pub fn new(api_key: String, attribution: AppAttribution) -> Self {
-        Self::with_base_url(api_key, attribution, BASE_URL.to_string())
+    /// Production constructor. Pins to OpenRouter's canonical URL.
+    pub fn new(api_key: String) -> Self {
+        Self::with_base_url(api_key, BASE_URL.to_string())
     }
 
     /// Low-level constructor that lets callers override the OpenRouter
@@ -505,50 +478,15 @@ impl OpenRouterClient {
     /// downstream) that wire a wiremock or fake server in front of the
     /// client. Production code should use `new`, which pins to OpenRouter's
     /// canonical URL.
-    pub fn with_base_url(api_key: String, attribution: AppAttribution, base_url: String) -> Self {
-        let mut headers = reqwest::header::HeaderMap::new();
-        if let Some(ref referer) = attribution.referer {
-            match reqwest::header::HeaderValue::from_str(referer) {
-                Ok(v) => {
-                    headers.insert(HEADER_REFERER, v);
-                }
-                Err(e) => tracing::warn!(
-                    error = %e,
-                    header = HEADER_REFERER,
-                    "openrouter: dropping invalid attribution value"
-                ),
-            }
-        }
-        if let Some(ref title) = attribution.title {
-            match reqwest::header::HeaderValue::from_str(title) {
-                Ok(v) => {
-                    headers.insert(HEADER_TITLE, v);
-                }
-                Err(e) => tracing::warn!(
-                    error = %e,
-                    header = HEADER_TITLE,
-                    "openrouter: dropping invalid attribution value"
-                ),
-            }
-        }
-        if let Some(ref categories) = attribution.categories {
-            match reqwest::header::HeaderValue::from_str(categories) {
-                Ok(v) => {
-                    headers.insert(HEADER_CATEGORIES, v);
-                }
-                Err(e) => tracing::warn!(
-                    error = %e,
-                    header = HEADER_CATEGORIES,
-                    "openrouter: dropping invalid attribution value"
-                ),
-            }
-        }
+    pub fn with_base_url(api_key: String, base_url: String) -> Self {
+        // http and plain_http start identical; with_openrouter_headers
+        // rebuilds `http` with default headers when the config declares any.
+        //
         // connect/pool bounds only — deliberately NO global `.timeout()` or
         // client-level read timeout: both would also bound non-streaming calls
         // (image generation legitimately spends its whole wall-time before the
         // first body byte). Stream liveness is `idle_bounded`'s job.
         let http = reqwest::Client::builder()
-            .default_headers(headers)
             .connect_timeout(CONNECT_TIMEOUT)
             .pool_idle_timeout(POOL_IDLE_TIMEOUT)
             .build()
@@ -569,8 +507,33 @@ impl OpenRouterClient {
         }
     }
 
+    /// Install `[providers].openrouter.headers` as default headers on the
+    /// built-in-endpoint client. Consuming builder, boot-chained. `plain_http`
+    /// (custom providers) is untouched — their headers ride per-request.
+    pub fn with_openrouter_headers(mut self, headers: reqwest::header::HeaderMap) -> Self {
+        if !headers.is_empty() {
+            self.http = reqwest::Client::builder()
+                .default_headers(headers)
+                .connect_timeout(CONNECT_TIMEOUT)
+                .pool_idle_timeout(POOL_IDLE_TIMEOUT)
+                .build()
+                .expect("reqwest client build never fails with static config");
+        }
+        self
+    }
+
+    /// Override the built-in chat URL from `[providers].openrouter.chat`.
+    /// `None` keeps the pinned default. Replaces the removed
+    /// OPENROUTER_BASE_URL env var.
+    pub fn with_openrouter_chat_url(mut self, url: Option<String>) -> Self {
+        if let Some(u) = url {
+            self.base_url = u;
+        }
+        self
+    }
+
     /// Set the global provider-exclusion list (issue #84). Consuming builder so
-    /// boot can chain it: `OpenRouterClient::new(key, attr).with_ignore_providers(list)`.
+    /// boot can chain it: `OpenRouterClient::new(key).with_ignore_providers(list)`.
     /// Sent as `provider.ignore` on every outbound call.
     pub fn with_ignore_providers(mut self, providers: Vec<String>) -> Self {
         self.ignore_providers = providers;
@@ -596,28 +559,22 @@ impl OpenRouterClient {
         self.providers = Arc::new(providers);
         self
     }
-
-    /// Override the built-in OpenRouter endpoint (the OPENROUTER_BASE_URL env
-    /// var). `None` keeps the pinned default. NOTE: distinct from the
-    /// `with_base_url` CONSTRUCTOR above, which tests use — this is a
-    /// consuming builder for boot.
-    pub fn with_openrouter_base_url(mut self, url: Option<String>) -> Self {
-        if let Some(u) = url {
-            self.base_url = u;
-        }
-        self
-    }
 }
 
 /// A resolved posting target: where one candidate's request goes.
-/// `name: None` ⇒ the built-in OpenRouter endpoint (attribution headers,
-/// full wire); `Some(name)` ⇒ a `[providers]` entry (plain client, strict
+/// `name: None` ⇒ the built-in OpenRouter endpoint (config-driven default
+/// headers ride on `http`, full wire); `Some(name)` ⇒ a `[providers]` entry
+/// (plain client, its own declared headers threaded per-request, strict
 /// OpenAI wire subset, audit model suffixed `@name`).
 struct Endpoint<'a> {
     url: &'a str,
     api_key: &'a str,
     http: &'a reqwest::Client,
     name: Option<&'a str>,
+    /// `None` for the built-in endpoint (default headers already ride on
+    /// `http`); `Some(&ep.headers)` for a custom `[providers]` endpoint,
+    /// applied per-request since `plain_http` carries no default headers.
+    headers: Option<&'a reqwest::header::HeaderMap>,
 }
 
 impl OpenRouterClient {
@@ -643,6 +600,7 @@ impl OpenRouterClient {
                         api_key: &self.api_key,
                         http: &self.http,
                         name: None,
+                        headers: None,
                     },
                 ))
             }
@@ -664,6 +622,7 @@ impl OpenRouterClient {
                         api_key: &ep.api_key,
                         http: &self.plain_http,
                         name: Some(name.as_str()),
+                        headers: Some(&ep.headers),
                     },
                 ))
             }
@@ -836,14 +795,11 @@ impl OpenRouterClient {
                 // it back out here, mirroring `WireRequest::for_endpoint`.
                 strip_openrouter_vision_fields(&mut body);
             }
-            let resp = match ep
-                .http
-                .post(ep.url)
-                .bearer_auth(ep.api_key)
-                .json(&body)
-                .send()
-                .await
-            {
+            let mut builder = ep.http.post(ep.url).bearer_auth(ep.api_key);
+            if let Some(h) = ep.headers {
+                builder = builder.headers(h.clone());
+            }
+            let resp = match builder.json(&body).send().await {
                 Ok(r) => r,
                 Err(e) => {
                     tracing::warn!(model = %model, error = %e, "openrouter: vision attempt failed (transport); next");
@@ -974,13 +930,11 @@ impl OpenRouterClient {
         }
         .for_endpoint(&ep);
 
-        let resp = ep
-            .http
-            .post(ep.url)
-            .bearer_auth(ep.api_key)
-            .json(&wire)
-            .send()
-            .await?;
+        let mut builder = ep.http.post(ep.url).bearer_auth(ep.api_key);
+        if let Some(h) = ep.headers {
+            builder = builder.headers(h.clone());
+        }
+        let resp = builder.json(&wire).send().await?;
 
         let status = resp.status();
         if !status.is_success() {
@@ -1097,14 +1051,15 @@ impl OpenRouterClient {
         .for_endpoint(&ep);
 
         let started = std::time::Instant::now();
-        let resp = ep
+        let mut builder = ep
             .http
             .post(ep.url)
             .bearer_auth(ep.api_key)
-            .header(reqwest::header::ACCEPT, "text/event-stream")
-            .json(&wire)
-            .send()
-            .await?;
+            .header(reqwest::header::ACCEPT, "text/event-stream");
+        if let Some(h) = ep.headers {
+            builder = builder.headers(h.clone());
+        }
+        let resp = builder.json(&wire).send().await?;
 
         let status = resp.status();
         if !status.is_success() {
@@ -1232,7 +1187,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn client_sends_app_attribution_headers_when_set() {
+    async fn client_sends_configured_openrouter_headers() {
         let server = MockServer::start().await;
         Mock::given(path("/api/v1/chat/completions"))
             .and(header("HTTP-Referer", "https://eros.example"))
@@ -1241,16 +1196,18 @@ mod tests {
             .expect(1)
             .mount(&server)
             .await;
-
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert("HTTP-Referer", "https://eros.example".parse().unwrap());
+        headers.insert("X-OpenRouter-Title", "Eros".parse().unwrap());
+        headers.insert(
+            "X-OpenRouter-Categories",
+            "roleplay,general-chat".parse().unwrap(),
+        );
         let client = OpenRouterClient::with_base_url(
             "test-key".into(),
-            AppAttribution {
-                referer: Some("https://eros.example".into()),
-                title: Some("Eros".into()),
-                categories: Some("roleplay,general-chat".into()),
-            },
             format!("{}/api/v1/chat/completions", server.uri()),
-        );
+        )
+        .with_openrouter_headers(headers);
         let _ = client
             .execute(ChatRequest {
                 model: "test/model".into(),
@@ -1265,7 +1222,6 @@ mod tests {
             })
             .await
             .expect("call succeeds");
-
         // Categories is checked on the raw received value rather than via
         // wiremock's `header` matcher: that matcher splits the received value
         // on commas, so a comma-joined string would never compare equal. We
@@ -1275,14 +1231,11 @@ mod tests {
             .iter()
             .find_map(|r| r.headers.get("x-openrouter-categories"))
             .expect("X-OpenRouter-Categories header present");
-        assert_eq!(
-            categories.to_str().expect("header is valid utf-8"),
-            "roleplay,general-chat"
-        );
+        assert_eq!(categories.to_str().unwrap(), "roleplay,general-chat");
     }
 
     #[tokio::test]
-    async fn client_omits_app_attribution_headers_when_default() {
+    async fn client_omits_headers_when_none_configured() {
         let server = MockServer::start().await;
         Mock::given(path("/api/v1/chat/completions"))
             .respond_with(ResponseTemplate::new(200).set_body_json(ok_response()))
@@ -1292,7 +1245,6 @@ mod tests {
 
         let client = OpenRouterClient::with_base_url(
             "test-key".into(),
-            AppAttribution::default(),
             format!("{}/api/v1/chat/completions", server.uri()),
         );
         let _ = client
@@ -1327,26 +1279,30 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn client_drops_invalid_attribution_value() {
+    async fn custom_provider_receives_declared_headers_only() {
         let server = MockServer::start().await;
-        Mock::given(path("/api/v1/chat/completions"))
+        Mock::given(path("/v1/chat/completions"))
+            .and(header("X-Team", "companion"))
             .respond_with(ResponseTemplate::new(200).set_body_json(ok_response()))
             .expect(1)
             .mount(&server)
             .await;
-
-        let client = OpenRouterClient::with_base_url(
-            "test-key".into(),
-            AppAttribution {
-                referer: Some("bad\nvalue".into()),
-                title: Some("also\rbad".into()),
-                categories: Some("still\nbad".into()),
+        let mut ep_headers = reqwest::header::HeaderMap::new();
+        ep_headers.insert("X-Team", "companion".parse().unwrap());
+        let mut providers = HashMap::new();
+        providers.insert(
+            "venice".to_string(),
+            crate::provider::ProviderEndpoint {
+                base_url: format!("{}/v1/chat/completions", server.uri()),
+                api_key: "vk".into(),
+                headers: ep_headers,
             },
-            format!("{}/api/v1/chat/completions", server.uri()),
         );
+        let client = OpenRouterClient::with_base_url("test-key".into(), "http://unused/".into())
+            .with_providers(providers);
         let _ = client
             .execute(ChatRequest {
-                model: "test/model".into(),
+                model: "some-model@venice".into(),
                 fallback_model: Vec::new(),
                 messages: vec![ChatMessage {
                     role: "user".into(),
@@ -1357,22 +1313,7 @@ mod tests {
                 ..Default::default()
             })
             .await
-            .expect("call succeeds despite dropped header");
-
-        for req in server.received_requests().await.unwrap_or_default() {
-            assert!(
-                req.headers.get("http-referer").is_none(),
-                "HTTP-Referer must be dropped"
-            );
-            assert!(
-                req.headers.get("x-openrouter-title").is_none(),
-                "X-OpenRouter-Title must be dropped"
-            );
-            assert!(
-                req.headers.get("x-openrouter-categories").is_none(),
-                "X-OpenRouter-Categories must be dropped"
-            );
-        }
+            .expect("call succeeds");
     }
 
     #[test]
@@ -1497,7 +1438,6 @@ mod tests {
 
         let client = OpenRouterClient::with_base_url(
             "test-key".into(),
-            AppAttribution::default(),
             format!("{}/api/v1/chat/completions", server.uri()),
         );
         let resp = client
@@ -1537,7 +1477,6 @@ mod tests {
 
         let client = OpenRouterClient::with_base_url(
             "test-key".into(),
-            AppAttribution::default(),
             format!("{}/api/v1/chat/completions", server.uri()),
         );
         let resp = client
@@ -1583,7 +1522,6 @@ mod tests {
 
         let client = OpenRouterClient::with_base_url(
             "test-key".into(),
-            AppAttribution::default(),
             format!("{}/api/v1/chat/completions", server.uri()),
         );
         let resp = client
@@ -1633,7 +1571,6 @@ mod tests {
 
         let client = OpenRouterClient::with_base_url(
             "test-key".into(),
-            AppAttribution::default(),
             format!("{}/api/v1/chat/completions", server.uri()),
         );
         let resp = client
@@ -1664,7 +1601,6 @@ mod tests {
 
         let client = OpenRouterClient::with_base_url(
             "test-key".into(),
-            AppAttribution::default(),
             format!("{}/api/v1/chat/completions", server.uri()),
         );
         let err = client
@@ -1811,7 +1747,6 @@ mod tests {
             .await;
         let client = OpenRouterClient::with_base_url(
             "test-key".into(),
-            AppAttribution::default(),
             format!("{}/api/v1/chat/completions", server.uri()),
         );
         let err = client
@@ -1860,7 +1795,6 @@ mod tests {
             .await;
         let client = OpenRouterClient::with_base_url(
             "test-key".into(),
-            AppAttribution::default(),
             format!("{}/api/v1/chat/completions", server.uri()),
         );
         let resp = client
@@ -1896,7 +1830,6 @@ mod tests {
             .await;
         let client = OpenRouterClient::with_base_url(
             "test-key".into(),
-            AppAttribution::default(),
             format!("{}/api/v1/chat/completions", server.uri()),
         );
         let err = client
@@ -1925,7 +1858,6 @@ mod tests {
         let server = MockServer::start().await;
         let client = OpenRouterClient::with_base_url(
             "test-key".into(),
-            AppAttribution::default(),
             format!("{}/api/v1/chat/completions", server.uri()),
         );
         let err = client
@@ -1972,7 +1904,6 @@ mod tests {
 
         let client = OpenRouterClient::with_base_url(
             "test-key".into(),
-            AppAttribution::default(),
             format!("{}/api/v1/chat/completions", server.uri()),
         );
         let resp = client
@@ -2023,7 +1954,6 @@ data: [DONE]\n\n";
 
         let client = OpenRouterClient::with_base_url(
             "test-key".into(),
-            AppAttribution::default(),
             format!("{}/api/v1/chat/completions", server.uri()),
         );
 
@@ -2092,7 +2022,6 @@ data: [DONE]\n\n";
 
         let client = OpenRouterClient::with_base_url(
             "test-key".into(),
-            AppAttribution::default(),
             format!("{}/api/v1/chat/completions", server.uri()),
         );
 
@@ -2141,7 +2070,6 @@ data: [DONE]\n\n";
 
         let client = OpenRouterClient::with_base_url(
             "test-key".into(),
-            AppAttribution::default(),
             format!("{}/api/v1/chat/completions", server.uri()),
         );
         let err = client
@@ -2275,7 +2203,6 @@ data: [DONE]\n\n";
 
         let client = OpenRouterClient::with_base_url(
             "test-key".into(),
-            AppAttribution::default(),
             format!("{}/api/v1/chat/completions", server.uri()),
         );
         let mut stream = client
@@ -2352,7 +2279,6 @@ data: [DONE]\n\n";
 
         let client = OpenRouterClient::with_base_url(
             "test-key".into(),
-            AppAttribution::default(),
             format!("{}/api/v1/chat/completions", server.uri()),
         );
         let mut stream = client
@@ -2406,7 +2332,6 @@ data: [DONE]\n\n";
 
         let client = OpenRouterClient::with_base_url(
             "test-key".into(),
-            AppAttribution::default(),
             format!("{}/api/v1/chat/completions", server.uri()),
         );
         let mut stream = client
@@ -2449,7 +2374,6 @@ data: [DONE]\n\n";
             .await;
         let client = OpenRouterClient::with_base_url(
             "test-key".into(),
-            AppAttribution::default(),
             format!("{}/api/v1/chat/completions", server.uri()),
         );
         let req = ChatRequest {
@@ -2484,24 +2408,17 @@ data: [DONE]\n\n";
             .expect(1)
             .mount(&server_b)
             .await;
-        let client = OpenRouterClient::with_base_url(
-            "or-key".into(),
-            AppAttribution {
-                referer: Some("https://eros.example".into()),
-                title: Some("Eros".into()),
-                categories: None,
-            },
-            "https://unused.test/v1".into(),
-        )
-        .with_ignore_providers(vec!["bad".into()])
-        .with_providers(std::collections::HashMap::from([(
-            "venice".to_string(),
-            crate::provider::ProviderEndpoint {
-                base_url: format!("{}/v1/chat/completions", server_b.uri()),
-                api_key: "v-key".into(),
-                headers: reqwest::header::HeaderMap::new(),
-            },
-        )]));
+        let client =
+            OpenRouterClient::with_base_url("or-key".into(), "https://unused.test/v1".into())
+                .with_ignore_providers(vec!["bad".into()])
+                .with_providers(std::collections::HashMap::from([(
+                    "venice".to_string(),
+                    crate::provider::ProviderEndpoint {
+                        base_url: format!("{}/v1/chat/completions", server_b.uri()),
+                        api_key: "v-key".into(),
+                        headers: reqwest::header::HeaderMap::new(),
+                    },
+                )]));
         let req = ChatRequest {
             model: String::new(), // placeholder; execute_stream_as takes the model separately
             messages: vec![ChatMessage {
@@ -2558,7 +2475,6 @@ data: [DONE]\n\n";
             .await;
         let client = OpenRouterClient::with_base_url(
             "test-key".into(),
-            AppAttribution::default(),
             format!("{}/api/v1/chat/completions", server.uri()),
         );
         let mut stream = client
@@ -2603,7 +2519,6 @@ data: [DONE]\n\n";
             .await;
         let client = OpenRouterClient::with_base_url(
             "test-key".into(),
-            AppAttribution::default(),
             format!("{}/api/v1/chat/completions", server.uri()),
         );
         let mut stream = client
@@ -2764,12 +2679,8 @@ data: [DONE]\n\n";
 
     #[test]
     fn with_ignore_providers_sets_prefs() {
-        let c = OpenRouterClient::with_base_url(
-            "k".into(),
-            AppAttribution::default(),
-            "http://localhost".into(),
-        )
-        .with_ignore_providers(vec!["BadHost".into()]);
+        let c = OpenRouterClient::with_base_url("k".into(), "http://localhost".into())
+            .with_ignore_providers(vec!["BadHost".into()]);
         let prefs = c.provider_prefs().expect("prefs present");
         assert_eq!(prefs.ignore, ["BadHost"]);
         assert!(prefs.sort.is_none());
@@ -2778,33 +2689,21 @@ data: [DONE]\n\n";
     #[test]
     fn with_provider_sort_sets_prefs_and_composes_with_ignore() {
         // sort alone → prefs present.
-        let c = OpenRouterClient::with_base_url(
-            "k".into(),
-            AppAttribution::default(),
-            "http://localhost".into(),
-        )
-        .with_provider_sort(Some("throughput".into()));
+        let c = OpenRouterClient::with_base_url("k".into(), "http://localhost".into())
+            .with_provider_sort(Some("throughput".into()));
         let prefs = c.provider_prefs().expect("prefs present for sort-only");
         assert_eq!(prefs.sort, Some("throughput"));
         assert!(prefs.ignore.is_empty());
 
         // empty string sort → treated as unset (no prefs when nothing else set).
-        let c = OpenRouterClient::with_base_url(
-            "k".into(),
-            AppAttribution::default(),
-            "http://localhost".into(),
-        )
-        .with_provider_sort(Some(String::new()));
+        let c = OpenRouterClient::with_base_url("k".into(), "http://localhost".into())
+            .with_provider_sort(Some(String::new()));
         assert!(c.provider_prefs().is_none(), "empty sort is unset");
 
         // ignore + sort compose into one prefs object.
-        let c = OpenRouterClient::with_base_url(
-            "k".into(),
-            AppAttribution::default(),
-            "http://localhost".into(),
-        )
-        .with_ignore_providers(vec!["BadHost".into()])
-        .with_provider_sort(Some("latency".into()));
+        let c = OpenRouterClient::with_base_url("k".into(), "http://localhost".into())
+            .with_ignore_providers(vec!["BadHost".into()])
+            .with_provider_sort(Some("latency".into()));
         let prefs = c.provider_prefs().expect("prefs present");
         assert_eq!(prefs.ignore, ["BadHost"]);
         assert_eq!(prefs.sort, Some("latency"));
@@ -2813,19 +2712,15 @@ data: [DONE]\n\n";
     // ---- multi-provider routing: resolve_endpoint (spec §3) ----
 
     fn client_with_venice() -> OpenRouterClient {
-        OpenRouterClient::with_base_url(
-            "or-key".into(),
-            AppAttribution::default(),
-            "https://openrouter.test/v1".into(),
-        )
-        .with_providers(std::collections::HashMap::from([(
-            "venice".to_string(),
-            crate::provider::ProviderEndpoint {
-                base_url: "https://venice.test/v1/chat/completions".into(),
-                api_key: "v-key".into(),
-                headers: reqwest::header::HeaderMap::new(),
-            },
-        )]))
+        OpenRouterClient::with_base_url("or-key".into(), "https://openrouter.test/v1".into())
+            .with_providers(std::collections::HashMap::from([(
+                "venice".to_string(),
+                crate::provider::ProviderEndpoint {
+                    base_url: "https://venice.test/v1/chat/completions".into(),
+                    api_key: "v-key".into(),
+                    headers: reqwest::header::HeaderMap::new(),
+                },
+            )]))
     }
 
     #[test]
@@ -2868,29 +2763,22 @@ data: [DONE]\n\n";
     #[test]
     fn resolve_empty_openrouter_key_still_guards() {
         // The old head-of-method guard moved here; same error, same wording.
-        let c = OpenRouterClient::with_base_url(
-            String::new(),
-            AppAttribution::default(),
-            "https://openrouter.test/v1".into(),
-        );
+        let c = OpenRouterClient::with_base_url(String::new(), "https://openrouter.test/v1".into());
         assert!(matches!(c.resolve_endpoint("m"), Err(LlmError::Config(_))));
     }
 
     #[test]
     fn resolve_empty_custom_key_guards() {
-        let c = OpenRouterClient::with_base_url(
-            "or-key".into(),
-            AppAttribution::default(),
-            "https://openrouter.test/v1".into(),
-        )
-        .with_providers(std::collections::HashMap::from([(
-            "venice".to_string(),
-            crate::provider::ProviderEndpoint {
-                base_url: "https://venice.test/v1".into(),
-                api_key: String::new(),
-                headers: reqwest::header::HeaderMap::new(),
-            },
-        )]));
+        let c =
+            OpenRouterClient::with_base_url("or-key".into(), "https://openrouter.test/v1".into())
+                .with_providers(std::collections::HashMap::from([(
+                    "venice".to_string(),
+                    crate::provider::ProviderEndpoint {
+                        base_url: "https://venice.test/v1".into(),
+                        api_key: String::new(),
+                        headers: reqwest::header::HeaderMap::new(),
+                    },
+                )]));
         assert!(matches!(
             c.resolve_endpoint("m@venice"),
             Err(LlmError::Config(_))
@@ -2898,13 +2786,13 @@ data: [DONE]\n\n";
     }
 
     #[test]
-    fn with_openrouter_base_url_overrides_and_none_keeps() {
-        let c = client_with_venice().with_openrouter_base_url(Some("https://proxy.test/v1".into()));
+    fn with_openrouter_chat_url_overrides_and_none_keeps() {
+        let c = client_with_venice().with_openrouter_chat_url(Some("https://proxy.test/v1".into()));
         assert_eq!(
             c.resolve_endpoint("m").unwrap().1.url,
             "https://proxy.test/v1"
         );
-        let c2 = client_with_venice().with_openrouter_base_url(None);
+        let c2 = client_with_venice().with_openrouter_chat_url(None);
         assert_eq!(
             c2.resolve_endpoint("m").unwrap().1.url,
             "https://openrouter.test/v1"
@@ -2944,7 +2832,6 @@ data: [DONE]\n\n";
 
         let client = OpenRouterClient::with_base_url(
             "test-key".into(),
-            AppAttribution::default(),
             format!("{}/api/v1/chat/completions", server.uri()),
         );
         let resp = client
@@ -2989,7 +2876,6 @@ data: [DONE]\n\n";
 
         let client = OpenRouterClient::with_base_url(
             "test-key".into(),
-            AppAttribution::default(),
             format!("{}/api/v1/chat/completions", server.uri()),
         );
         let resp = client
@@ -3043,7 +2929,6 @@ data: [DONE]\n\n";
 
         let client = OpenRouterClient::with_base_url(
             "test-key".into(),
-            AppAttribution::default(),
             format!("{}/api/v1/chat/completions", server.uri()),
         );
         let resp = client
@@ -3084,7 +2969,6 @@ data: [DONE]\n\n";
 
         let client = OpenRouterClient::with_base_url(
             "test-key".into(),
-            AppAttribution::default(),
             format!("{}/api/v1/chat/completions", server.uri()),
         );
         let resp = client
@@ -3128,7 +3012,6 @@ data: [DONE]\n\n";
 
         let client = OpenRouterClient::with_base_url(
             "test-key".into(),
-            AppAttribution::default(),
             format!("{}/api/v1/chat/completions", server.uri()),
         );
         let err = client
@@ -3173,7 +3056,6 @@ data: [DONE]\n\n";
 
         let client = OpenRouterClient::with_base_url(
             "test-key".into(),
-            AppAttribution::default(),
             format!("{}/api/v1/chat/completions", server.uri()),
         );
         let resp = client
@@ -3213,20 +3095,17 @@ data: [DONE]\n\n";
             .expect(1)
             .mount(&server_b)
             .await;
-        let client = OpenRouterClient::with_base_url(
-            "or-key".into(),
-            AppAttribution::default(),
-            "https://unused.test/v1".into(),
-        )
-        .with_ignore_providers(vec!["bad".into()]) // would inject body["provider"] on OpenRouter
-        .with_providers(std::collections::HashMap::from([(
-            "venice".to_string(),
-            crate::provider::ProviderEndpoint {
-                base_url: format!("{}/v1/chat/completions", server_b.uri()),
-                api_key: "v-key".into(),
-                headers: reqwest::header::HeaderMap::new(),
-            },
-        )]));
+        let client =
+            OpenRouterClient::with_base_url("or-key".into(), "https://unused.test/v1".into())
+                .with_ignore_providers(vec!["bad".into()]) // would inject body["provider"] on OpenRouter
+                .with_providers(std::collections::HashMap::from([(
+                    "venice".to_string(),
+                    crate::provider::ProviderEndpoint {
+                        base_url: format!("{}/v1/chat/completions", server_b.uri()),
+                        api_key: "v-key".into(),
+                        headers: reqwest::header::HeaderMap::new(),
+                    },
+                )]));
         let resp = client
             .execute_vision(VisionRequest {
                 model: "vis@venice".into(),
@@ -3365,6 +3244,7 @@ data: [DONE]\n\n";
             api_key: "k",
             http: &http,
             name: Some("venice"),
+            headers: None,
         };
         let wire = WireRequest {
             model: "m",
@@ -3463,6 +3343,7 @@ data: [DONE]\n\n";
             api_key: "k",
             http: &http,
             name: None,
+            headers: None,
         };
         let wire = WireRequest {
             model: "m",
@@ -3506,14 +3387,9 @@ data: [DONE]\n\n";
             .expect(1)
             .mount(&server_b)
             .await;
-        // Attribution + prefs configured — none of it may reach the custom host.
+        // Prefs configured — none of it may reach the custom host.
         let client = OpenRouterClient::with_base_url(
             "or-key".into(),
-            AppAttribution {
-                referer: Some("https://eros.example".into()),
-                title: Some("Eros".into()),
-                categories: Some("roleplay".into()),
-            },
             "https://unused-openrouter.test/v1".into(),
         )
         .with_ignore_providers(vec!["bad".into()])
@@ -3586,19 +3462,16 @@ data: [DONE]\n\n";
             .expect(1)
             .mount(&server_b)
             .await;
-        let client = OpenRouterClient::with_base_url(
-            "or-key".into(),
-            AppAttribution::default(),
-            "https://unused.test/v1".into(),
-        )
-        .with_providers(std::collections::HashMap::from([(
-            "venice".to_string(),
-            crate::provider::ProviderEndpoint {
-                base_url: format!("{}/v1/chat/completions", server_b.uri()),
-                api_key: "v-key".into(),
-                headers: reqwest::header::HeaderMap::new(),
-            },
-        )]));
+        let client =
+            OpenRouterClient::with_base_url("or-key".into(), "https://unused.test/v1".into())
+                .with_providers(std::collections::HashMap::from([(
+                    "venice".to_string(),
+                    crate::provider::ProviderEndpoint {
+                        base_url: format!("{}/v1/chat/completions", server_b.uri()),
+                        api_key: "v-key".into(),
+                        headers: reqwest::header::HeaderMap::new(),
+                    },
+                )]));
         let resp = client
             .execute(ChatRequest {
                 model: "weird\\@vendor/m@venice".into(),
@@ -3630,19 +3503,16 @@ data: [DONE]\n\n";
             .expect(1)
             .mount(&server_b)
             .await;
-        let client = OpenRouterClient::with_base_url(
-            "or-key".into(),
-            AppAttribution::default(),
-            "https://unused.test/v1".into(),
-        )
-        .with_providers(std::collections::HashMap::from([(
-            "venice".to_string(),
-            crate::provider::ProviderEndpoint {
-                base_url: format!("{}/v1/chat/completions", server_b.uri()),
-                api_key: "v-key".into(),
-                headers: reqwest::header::HeaderMap::new(),
-            },
-        )]));
+        let client =
+            OpenRouterClient::with_base_url("or-key".into(), "https://unused.test/v1".into())
+                .with_providers(std::collections::HashMap::from([(
+                    "venice".to_string(),
+                    crate::provider::ProviderEndpoint {
+                        base_url: format!("{}/v1/chat/completions", server_b.uri()),
+                        api_key: "v-key".into(),
+                        headers: reqwest::header::HeaderMap::new(),
+                    },
+                )]));
         let resp = client
             .execute(ChatRequest {
                 model: "vm@venice".into(),
@@ -3676,7 +3546,6 @@ data: [DONE]\n\n";
             .await;
         let client = OpenRouterClient::with_base_url(
             "or-key".into(),
-            AppAttribution::default(),
             format!("{}/or/chat/completions", server_a.uri()),
         )
         .with_providers(std::collections::HashMap::from([(
@@ -3727,7 +3596,6 @@ data: [DONE]\n\n";
             .await;
         let client = OpenRouterClient::with_base_url(
             "or-key".into(),
-            AppAttribution::default(),
             format!("{}/or/chat/completions", server_a.uri()),
         );
         let resp = client

--- a/crates/eros-engine-llm/src/provider.rs
+++ b/crates/eros-engine-llm/src/provider.rs
@@ -9,21 +9,30 @@ use std::fmt;
 
 /// One custom OpenAI-compatible endpoint from the `[providers]` block.
 /// `base_url` is the complete chat-completions URL, posted verbatim;
-/// `api_key` comes from the `<NAME>_API_KEY` env var at boot.
-#[derive(Clone, PartialEq, Eq)]
+/// `api_key` comes from the `<NAME>_API_KEY` env var at boot. `headers` is
+/// the entry's config-declared `headers` table, applied per-request.
+///
+/// `Eq` is dropped (not derived) because `HeaderMap` doesn't implement it —
+/// `PartialEq` is enough for the existing equality-based tests.
+#[derive(Clone, PartialEq)]
 pub struct ProviderEndpoint {
     pub base_url: String,
     pub api_key: String,
+    /// Config-declared custom headers, applied per-request. Empty by default.
+    pub headers: reqwest::header::HeaderMap,
 }
 
 impl fmt::Debug for ProviderEndpoint {
     /// Manual impl (not `derive`): `api_key` must never land in a log line or
     /// a panic message via `{:?}`, so it's redacted here rather than relying
-    /// on every caller to remember not to print the field directly.
+    /// on every caller to remember not to print the field directly. Header
+    /// VALUES may be sensitive too (e.g. a proxy auth token), so the whole
+    /// `headers` map is redacted rather than printed key-by-key.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ProviderEndpoint")
             .field("base_url", &self.base_url)
             .field("api_key", &"<redacted>")
+            .field("headers", &"<redacted>")
             .finish()
     }
 }
@@ -138,11 +147,31 @@ mod tests {
         let ep = ProviderEndpoint {
             base_url: "https://api.venice.ai/chat/completions".to_string(),
             api_key: "sk-live-SUPER-SECRET-KEY".to_string(),
+            headers: reqwest::header::HeaderMap::new(),
         };
         let dbg = format!("{ep:?}");
         assert!(
             !dbg.contains("SUPER-SECRET-KEY"),
             "Debug output must not leak api_key: {dbg}"
+        );
+    }
+
+    #[test]
+    fn provider_endpoint_debug_redacts_headers() {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(
+            "x-proxy-secret",
+            reqwest::header::HeaderValue::from_static("SUPER-SECRET-HEADER-VALUE"),
+        );
+        let ep = ProviderEndpoint {
+            base_url: "https://api.venice.ai/chat/completions".to_string(),
+            api_key: "sk-live-key".to_string(),
+            headers,
+        };
+        let dbg = format!("{ep:?}");
+        assert!(
+            !dbg.contains("SUPER-SECRET-HEADER-VALUE"),
+            "Debug output must not leak header values: {dbg}"
         );
     }
 

--- a/crates/eros-engine-llm/src/voyage.rs
+++ b/crates/eros-engine-llm/src/voyage.rs
@@ -11,10 +11,17 @@ const BASE_URL: &str = "https://api.voyageai.com/v1/embeddings";
 const DEFAULT_MODEL: &str = "voyage-3-lite";
 pub const EMBEDDING_DIM: usize = 512;
 
+/// Voyage models with a FIXED output dimension, where the API's
+/// `output_dimension` parameter must not be sent. voyage-3-lite is the
+/// pre-config-era default (512-dim); keeping the param off its wire keeps
+/// previously shipped configs byte-identical on the wire.
+const FIXED_DIM_MODELS: &[&str] = &["voyage-3-lite"];
+
 #[derive(Clone)]
 pub struct VoyageClient {
     http: reqwest::Client,
     api_key: String,
+    base_url: String,
     model: String,
 }
 
@@ -23,6 +30,8 @@ struct EmbedRequest<'a> {
     input: Vec<&'a str>,
     model: &'a str,
     input_type: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    output_dimension: Option<u32>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -37,10 +46,34 @@ struct EmbedResponse {
 
 impl VoyageClient {
     pub fn new(api_key: String) -> Self {
+        Self::with_base_url(api_key, BASE_URL.to_string())
+    }
+
+    /// Test constructor: point the client at a mock server. Production code
+    /// uses `new`, which pins Voyage's canonical URL.
+    pub fn with_base_url(api_key: String, base_url: String) -> Self {
         Self {
             http: reqwest::Client::new(),
             api_key,
+            base_url,
             model: DEFAULT_MODEL.to_string(),
+        }
+    }
+
+    /// Set the model from `[tasks.embedding]` (spec 2026-08-01). Consuming
+    /// builder, boot-chained.
+    pub fn with_model(mut self, model: String) -> Self {
+        self.model = model;
+        self
+    }
+
+    /// `output_dimension` for the wire: always 512 (the pgvector schema is
+    /// VECTOR(512)) — omitted for fixed-dim legacy models.
+    fn wire_output_dimension(&self) -> Option<u32> {
+        if FIXED_DIM_MODELS.contains(&self.model.as_str()) {
+            None
+        } else {
+            Some(EMBEDDING_DIM as u32)
         }
     }
 
@@ -66,11 +99,12 @@ impl VoyageClient {
             input: vec![text],
             model: &self.model,
             input_type,
+            output_dimension: self.wire_output_dimension(),
         };
 
         let resp = self
             .http
-            .post(BASE_URL)
+            .post(&self.base_url)
             .bearer_auth(&self.api_key)
             .json(&body)
             .send()
@@ -85,12 +119,14 @@ impl VoyageClient {
         }
 
         let parsed: EmbedResponse = resp.json().await?;
-        parsed
+        let embedding = parsed
             .data
             .into_iter()
             .next()
             .map(|d| d.embedding)
-            .ok_or_else(|| LlmError::Provider("voyage: empty data array".into()))
+            .ok_or_else(|| LlmError::Provider("voyage: empty data array".into()))?;
+        check_dim(&embedding, &self.model)?;
+        Ok(embedding)
     }
 
     /// Embed a batch of documents in one HTTP call (order-preserving).
@@ -106,10 +142,11 @@ impl VoyageClient {
             input: texts.to_vec(),
             model: &self.model,
             input_type: "document",
+            output_dimension: self.wire_output_dimension(),
         };
         let resp = self
             .http
-            .post(BASE_URL)
+            .post(&self.base_url)
             .bearer_auth(&self.api_key)
             .json(&body)
             .send()
@@ -121,8 +158,20 @@ impl VoyageClient {
             tracing::warn!("voyage: {err}");
             return Err(err);
         }
-        parse_embed_batch(&text, texts.len())
+        parse_embed_batch(&text, texts.len(), &self.model)
     }
+}
+
+/// Check that an embedding has the expected dimension.
+fn check_dim(embedding: &[f32], model: &str) -> Result<(), LlmError> {
+    if embedding.len() != EMBEDDING_DIM {
+        return Err(LlmError::Provider(format!(
+            "voyage: model {model} returned a {}-dim embedding, expected {EMBEDDING_DIM} \
+             (the pgvector schema is VECTOR({EMBEDDING_DIM}))",
+            embedding.len()
+        )));
+    }
+    Ok(())
 }
 
 /// Build the bounded `LlmError::Status` for a non-success Voyage response.
@@ -135,8 +184,9 @@ fn status_error(status: reqwest::StatusCode, body: &str) -> LlmError {
 }
 
 /// Parse a Voyage batch response body into ordered vectors, enforcing that
-/// the provider returned exactly one embedding per input.
-fn parse_embed_batch(body: &str, expected: usize) -> Result<Vec<Vec<f32>>, LlmError> {
+/// the provider returned exactly one embedding per input. Checks that each
+/// embedding has the expected dimension.
+fn parse_embed_batch(body: &str, expected: usize, model: &str) -> Result<Vec<Vec<f32>>, LlmError> {
     let parsed: EmbedResponse = serde_json::from_str(body)
         .map_err(|e| LlmError::Provider(format!("voyage: bad response: {e}")))?;
     if parsed.data.len() != expected {
@@ -145,7 +195,15 @@ fn parse_embed_batch(body: &str, expected: usize) -> Result<Vec<Vec<f32>>, LlmEr
             parsed.data.len()
         )));
     }
-    Ok(parsed.data.into_iter().map(|d| d.embedding).collect())
+    let embeddings: Result<Vec<_>, _> = parsed
+        .data
+        .into_iter()
+        .map(|d| {
+            check_dim(&d.embedding, model)?;
+            Ok(d.embedding)
+        })
+        .collect();
+    embeddings
 }
 
 /// Format an f32 vector into the PostgreSQL pgvector textual form: `[0.1,0.2,...]`.
@@ -172,25 +230,113 @@ mod tests {
 
     #[test]
     fn parse_embed_batch_preserves_order_and_count() {
-        let body = r#"{"data":[{"embedding":[1.0,0.0]},{"embedding":[0.0,1.0]}]}"#;
-        let out = parse_embed_batch(body, 2).unwrap();
+        let mut v1 = vec![0.0; 512];
+        let mut v2 = vec![0.0; 512];
+        v1[0] = 1.0;
+        v2[0] = 0.0;
+        let v1_vec = serde_json::json!(v1);
+        let v2_vec = serde_json::json!(v2);
+        let body =
+            serde_json::json!({ "data": [{ "embedding": v1_vec }, { "embedding": v2_vec }] });
+        let out = parse_embed_batch(&body.to_string(), 2, "voyage-3-lite").unwrap();
         assert_eq!(out.len(), 2);
-        assert_eq!(out[0], vec![1.0, 0.0]);
-        assert_eq!(out[1], vec![0.0, 1.0]);
+        assert_eq!(out[0], v1);
+        assert_eq!(out[1], v2);
     }
 
     #[test]
     fn parse_embed_batch_rejects_count_mismatch() {
         let body = r#"{"data":[{"embedding":[1.0]}]}"#;
         assert!(
-            parse_embed_batch(body, 2).is_err(),
+            parse_embed_batch(body, 2, "voyage-3-lite").is_err(),
             "1 vector for 2 inputs must error"
         );
     }
 
     #[test]
     fn parse_embed_batch_rejects_garbage() {
-        assert!(parse_embed_batch("not json", 1).is_err());
+        assert!(parse_embed_batch("not json", 1, "voyage-3-lite").is_err());
+    }
+
+    fn vec512() -> Vec<f32> {
+        vec![0.0; 512]
+    }
+
+    #[tokio::test]
+    async fn voyage_4_sends_output_dimension_512() {
+        use wiremock::matchers::{body_partial_json, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(path("/v1/embeddings"))
+            .and(body_partial_json(serde_json::json!({
+                "model": "voyage-4-lite",
+                "output_dimension": 512
+            })))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "data": [ { "embedding": vec512() } ] })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        let client =
+            VoyageClient::with_base_url("k".into(), format!("{}/v1/embeddings", server.uri()))
+                .with_model("voyage-4-lite".into());
+        let v = client.embed_query("hello").await.expect("embed succeeds");
+        assert_eq!(v.len(), 512);
+    }
+
+    #[tokio::test]
+    async fn voyage_3_lite_omits_output_dimension() {
+        use wiremock::matchers::path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(path("/v1/embeddings"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "data": [ { "embedding": vec512() } ] })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        let client =
+            VoyageClient::with_base_url("k".into(), format!("{}/v1/embeddings", server.uri()));
+        let _ = client
+            .embed_document("hello")
+            .await
+            .expect("embed succeeds");
+        let reqs = server.received_requests().await.unwrap_or_default();
+        let body: serde_json::Value = serde_json::from_slice(&reqs[0].body).unwrap();
+        assert!(
+            body.get("output_dimension").is_none(),
+            "voyage-3-lite is fixed-dim; the param must be absent: {body}"
+        );
+        assert_eq!(body["input_type"], "document");
+    }
+
+    #[tokio::test]
+    async fn wrong_dimension_response_is_a_clear_error() {
+        use wiremock::matchers::path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(path("/v1/embeddings"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "data": [ { "embedding": [0.0, 1.0] } ] })),
+            )
+            .mount(&server)
+            .await;
+        let client =
+            VoyageClient::with_base_url("k".into(), format!("{}/v1/embeddings", server.uri()));
+        let err = client.embed_query("hello").await.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("512"),
+            "error must name the expected dim: {msg}"
+        );
     }
 
     #[test]

--- a/crates/eros-engine-llm/src/voyage.rs
+++ b/crates/eros-engine-llm/src/voyage.rs
@@ -8,13 +8,13 @@ use serde::{Deserialize, Serialize};
 use crate::error::LlmError;
 
 const BASE_URL: &str = "https://api.voyageai.com/v1/embeddings";
-const DEFAULT_MODEL: &str = "voyage-3-lite";
+const DEFAULT_MODEL: &str = "voyage-4-lite";
 pub const EMBEDDING_DIM: usize = 512;
 
 /// Voyage models with a FIXED output dimension, where the API's
-/// `output_dimension` parameter must not be sent. voyage-3-lite is the
-/// pre-config-era default (512-dim); keeping the param off its wire keeps
-/// previously shipped configs byte-identical on the wire.
+/// `output_dimension` parameter must not be sent. voyage-3-lite (the
+/// pre-voyage-4-era default, 512-dim, no longer recommended by Voyage) stays
+/// listed so a deployment that pins it keeps its pre-config wire unchanged.
 const FIXED_DIM_MODELS: &[&str] = &["voyage-3-lite"];
 
 #[derive(Clone)]
@@ -302,7 +302,8 @@ mod tests {
             .mount(&server)
             .await;
         let client =
-            VoyageClient::with_base_url("k".into(), format!("{}/v1/embeddings", server.uri()));
+            VoyageClient::with_base_url("k".into(), format!("{}/v1/embeddings", server.uri()))
+                .with_model("voyage-3-lite".into());
         let _ = client
             .embed_document("hello")
             .await

--- a/crates/eros-engine-server/src/main.rs
+++ b/crates/eros-engine-server/src/main.rs
@@ -213,17 +213,6 @@ async fn run_server() -> Result<()> {
 
     let openrouter_key =
         std::env::var("OPENROUTER_API_KEY").context("OPENROUTER_API_KEY is required")?;
-    let attribution = eros_engine_llm::openrouter::AppAttribution {
-        referer: std::env::var("OPENROUTER_APP_REFERER")
-            .ok()
-            .filter(|s| !s.is_empty()),
-        title: std::env::var("OPENROUTER_APP_TITLE")
-            .ok()
-            .filter(|s| !s.is_empty()),
-        categories: std::env::var("OPENROUTER_APP_CATEGORIES")
-            .ok()
-            .filter(|s| !s.is_empty()),
-    };
     let voyage_key = std::env::var("VOYAGE_API_KEY").context("VOYAGE_API_KEY is required")?;
     if voyage_key.trim().is_empty() {
         // Loud-fail vs gateway's silent-skip. The gateway has a known
@@ -364,18 +353,15 @@ async fn run_server() -> Result<()> {
 
     // OpenRouter client is constructed after model_config so we can wire in the
     // global provider routing prefs from [defaults] (exclusion list + optional
-    // sort) and the [providers] endpoint map. OPENROUTER_BASE_URL (optional)
-    // overrides the built-in endpoint; empty counts as unset, matching the
-    // OPENROUTER_APP_* convention above.
+    // sort), the [providers] endpoint map, and the [providers].openrouter
+    // entry (chat URL override + default headers, replacing the old
+    // OPENROUTER_BASE_URL / OPENROUTER_APP_* env vars).
     let openrouter = Arc::new(
-        eros_engine_llm::openrouter::OpenRouterClient::new(openrouter_key, attribution)
-            .with_openrouter_base_url(
-                std::env::var("OPENROUTER_BASE_URL")
-                    .ok()
-                    .filter(|s| !s.is_empty()),
-            )
+        eros_engine_llm::openrouter::OpenRouterClient::new(openrouter_key)
+            .with_openrouter_chat_url(model_config.openrouter_chat_url())
+            .with_openrouter_headers(model_config.openrouter_header_map())
             .with_providers(model_config.build_providers())
-            .with_ignore_providers(model_config.defaults.ignore_providers.clone())
+            .with_ignore_providers(model_config.ignore_provider_wire_slugs())
             .with_provider_sort(model_config.defaults.provider_sort.clone()),
     );
 

--- a/crates/eros-engine-server/src/main.rs
+++ b/crates/eros-engine-server/src/main.rs
@@ -213,16 +213,6 @@ async fn run_server() -> Result<()> {
 
     let openrouter_key =
         std::env::var("OPENROUTER_API_KEY").context("OPENROUTER_API_KEY is required")?;
-    let voyage_key = std::env::var("VOYAGE_API_KEY").context("VOYAGE_API_KEY is required")?;
-    if voyage_key.trim().is_empty() {
-        // Loud-fail vs gateway's silent-skip. The gateway has a known
-        // regression where an empty VOYAGE_API_KEY silently disables
-        // embeddings; we refuse to boot rather than carry that footgun.
-        anyhow::bail!(
-            "VOYAGE_API_KEY is empty — eros-engine refuses to boot rather than silently disable embeddings"
-        );
-    }
-    let voyage = Arc::new(eros_engine_llm::voyage::VoyageClient::new(voyage_key));
 
     // Auth: prefer JWKS (asymmetric, the post-2025 Supabase default) and
     // fall back to a legacy HS256 shared secret if one is configured. At
@@ -316,6 +306,14 @@ async fn run_server() -> Result<()> {
         anyhow::bail!(msg);
     }
 
+    // Embedding routing (spec 2026-08-01): read/write backends resolved from
+    // [tasks.embedding] + [providers]. validate_providers has already gated
+    // every failure mode; from_config re-checks keys defensively.
+    let embed = Arc::new(
+        eros_engine_llm::embedding::EmbeddingRouter::from_config(&model_config)
+            .map_err(|e| anyhow::anyhow!("embedding router construction failed: {e}"))?,
+    );
+
     if let Err(msg) = model_config.validate_removed_tasks() {
         anyhow::bail!(msg);
     }
@@ -376,7 +374,7 @@ async fn run_server() -> Result<()> {
         auth,
         config: cfg.clone(),
         openrouter,
-        voyage,
+        embed,
         model_config,
         output_regex,
         stream_slots: Arc::new(crate::state::StreamSlots::default()),

--- a/crates/eros-engine-server/src/pipeline/dreaming.rs
+++ b/crates/eros-engine-server/src/pipeline/dreaming.rs
@@ -239,7 +239,7 @@ async fn classify_session(
         }
         let category = normalise_category(&cand.category);
         let metadata = candidate_metadata(cand);
-        match state.voyage.embed_document(trimmed).await {
+        match state.embed.embed_document(trimmed).await {
             Ok(embedding) => {
                 if let Err(e) = repo
                     .upsert(
@@ -260,7 +260,7 @@ async fn classify_session(
                 }
             }
             Err(e) => {
-                tracing::warn!(%session_id, "dreaming: voyage embed failed: {e}");
+                tracing::warn!(%session_id, "dreaming: embed failed: {e}");
             }
         }
     }

--- a/crates/eros-engine-server/src/pipeline/dreaming.rs
+++ b/crates/eros-engine-server/src/pipeline/dreaming.rs
@@ -448,7 +448,6 @@ mod tests {
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "k".into(),
-                Default::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -527,7 +526,6 @@ mod tests {
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "test-key".into(),
-                eros_engine_llm::openrouter::AppAttribution::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -313,10 +313,10 @@ async fn recall_memory(
     if (!x_on && !y_on) || query_text.trim().is_empty() {
         return (vec![], vec![], None);
     }
-    let embedding = match state.voyage.embed_query(query_text).await {
+    let embedding = match state.embed.embed_query(query_text).await {
         Ok(e) => e,
         Err(e) => {
-            tracing::warn!("voyage embed_query failed: {e}");
+            tracing::warn!("embed_query failed: {e}");
             return (vec![], vec![], None);
         }
     };

--- a/crates/eros-engine-server/src/pipeline/post_process.rs
+++ b/crates/eros-engine-server/src/pipeline/post_process.rs
@@ -1459,7 +1459,6 @@ mod tests {
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "k".into(),
-                Default::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -1545,7 +1544,6 @@ mod tests {
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "k".into(),
-                Default::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -1626,7 +1624,6 @@ mod tests {
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "k".into(),
-                Default::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -1702,7 +1699,6 @@ mod tests {
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "k".into(),
-                Default::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );

--- a/crates/eros-engine-server/src/pipeline/post_process.rs
+++ b/crates/eros-engine-server/src/pipeline/post_process.rs
@@ -17,9 +17,9 @@
 use uuid::Uuid;
 
 use eros_engine_core::types::{ActionPlan, ActionType, Event};
+use eros_engine_llm::embedding::EmbeddingRouter;
 use eros_engine_llm::model_config::ModelConfig;
 use eros_engine_llm::openrouter::{ChatMessage, ChatRequest, OpenRouterClient};
-use eros_engine_llm::voyage::VoyageClient;
 use eros_engine_store::affinity::AffinityRepo;
 use eros_engine_store::chat::ChatRepo;
 use eros_engine_store::human_insight::HumanInsightRepo;
@@ -318,7 +318,7 @@ async fn write_turn(
     let rel_content = relationship_memory_content(user_msg);
     if let Err(e) = embed_and_upsert(
         &repo,
-        &state.voyage,
+        &state.embed,
         MemoryLayer::Relationship,
         session_id,
         user_id,
@@ -334,7 +334,7 @@ async fn write_turn(
     if !user_msg.trim().is_empty() {
         if let Err(e) = embed_and_upsert(
             &repo,
-            &state.voyage,
+            &state.embed,
             MemoryLayer::Profile,
             session_id,
             user_id,
@@ -350,7 +350,7 @@ async fn write_turn(
 
 async fn embed_and_upsert(
     repo: &MemoryRepo<'_>,
-    voyage: &VoyageClient,
+    embed: &EmbeddingRouter,
     layer: MemoryLayer,
     session_id: Uuid,
     user_id: Uuid,
@@ -360,10 +360,10 @@ async fn embed_and_upsert(
     if content.trim().is_empty() {
         return Ok(());
     }
-    let embedding = voyage
+    let embedding = embed
         .embed_document(content)
         .await
-        .map_err(|e| format!("voyage embed failed: {e}"))?;
+        .map_err(|e| format!("embed failed: {e}"))?;
     // category=None: this writer dumps raw turns. The classifier extraction
     // step (future) will write its own rows with category populated.
     repo.upsert(

--- a/crates/eros-engine-server/src/pipeline/story.rs
+++ b/crates/eros-engine-server/src/pipeline/story.rs
@@ -595,7 +595,6 @@ mod tests {
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "k".into(),
-                Default::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -714,7 +713,6 @@ mod tests {
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "k".into(),
-                Default::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );

--- a/crates/eros-engine-server/src/pipeline/story.rs
+++ b/crates/eros-engine-server/src/pipeline/story.rs
@@ -343,10 +343,10 @@ async fn direct_story(
         Vec::new()
     } else {
         state
-            .voyage
+            .embed
             .embed_documents(&texts)
             .await
-            .map_err(|e| format!("voyage embed_documents failed: {e}"))?
+            .map_err(|e| format!("embed_documents failed: {e}"))?
     };
     let inserts: Vec<StoryEventInsert> = events
         .into_iter()
@@ -510,12 +510,13 @@ mod tests {
 
     // NOTE: both integration tests below mock `world_stories_director` with an
     // EMPTY `events: []` array. The runner's `texts.is_empty()` guard in
-    // `direct_story` then skips the Voyage call entirely (mirrors world.rs's
+    // `direct_story` then skips the embedding call entirely (mirrors world.rs's
     // `direct_world_persists_seed_and_digests_without_fragments`, which dodges
-    // Voyage the same way via empty script_fragments). `test_state`'s default
-    // `VoyageClient::new("stub")` is kept and never invoked — `VoyageClient`
-    // has no `with_base_url` constructor to mock against (only `new`), unlike
-    // `OpenRouterClient`, which does and is wiremocked normally below.
+    // the embedding router the same way via empty script_fragments). `test_state`'s
+    // default embedding router resolves to the built-in Voyage backend and is
+    // kept but never invoked — `VoyageClient` has no `with_base_url` constructor
+    // to mock against (only `new`), unlike `OpenRouterClient`, which does and is
+    // wiremocked normally below.
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
     async fn direct_story_persists_full_round(pool: sqlx::PgPool) {
         use wiremock::matchers::{method, path as wm_path};

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -4852,7 +4852,6 @@ data: [DONE]\n\n";
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "test-key".into(),
-                eros_engine_llm::openrouter::AppAttribution::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -4951,7 +4950,6 @@ data: [DONE]\n\n";
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "test-key".into(),
-                eros_engine_llm::openrouter::AppAttribution::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -5063,7 +5061,6 @@ data: [DONE]\n\n";
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "test-key".into(),
-                eros_engine_llm::openrouter::AppAttribution::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -5213,7 +5210,6 @@ data: [DONE]\n\n";
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "test-key".into(),
-                eros_engine_llm::openrouter::AppAttribution::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -5347,7 +5343,6 @@ data: [DONE]\n\n";
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "test-key".into(),
-                eros_engine_llm::openrouter::AppAttribution::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -5451,7 +5446,6 @@ data: [DONE]\n\n";
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "test-key".into(),
-                eros_engine_llm::openrouter::AppAttribution::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -5561,7 +5555,6 @@ data: [DONE]\n\n";
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "test-key".into(),
-                eros_engine_llm::openrouter::AppAttribution::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -5743,7 +5736,6 @@ data: [DONE]\n\n";
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "test-key".into(),
-                eros_engine_llm::openrouter::AppAttribution::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -5892,7 +5884,6 @@ data: [DONE]\n\n";
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "test-key".into(),
-                eros_engine_llm::openrouter::AppAttribution::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -6046,7 +6037,6 @@ data: [DONE]\n\n";
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "test-key".into(),
-                eros_engine_llm::openrouter::AppAttribution::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -6365,7 +6355,6 @@ data: [DONE]\n\n";
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "k".into(),
-                Default::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -6491,7 +6480,6 @@ data: [DONE]\n\n";
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "k".into(),
-                Default::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -6630,7 +6618,6 @@ data: [DONE]\n\n";
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "k".into(),
-                Default::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -6784,7 +6771,6 @@ data: [DONE]\n\n";
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "k".into(),
-                Default::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -6900,7 +6886,6 @@ data: [DONE]\n\n";
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "k".into(),
-                Default::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -6997,7 +6982,6 @@ data: [DONE]\n\n";
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "test-key".into(),
-                eros_engine_llm::openrouter::AppAttribution::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -7106,7 +7090,6 @@ data: [DONE]\n\n";
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "k".into(),
-                Default::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -7217,7 +7200,6 @@ data: [DONE]\n\n";
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "k".into(),
-                Default::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -7347,7 +7329,6 @@ data: [DONE]\n\n";
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "k".into(),
-                Default::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -7550,7 +7531,6 @@ data: [DONE]\n\n";
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "k".into(),
-                Default::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -7696,7 +7676,6 @@ data: [DONE]\n\n";
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "k".into(),
-                Default::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -7804,7 +7783,6 @@ data: [DONE]\n\n";
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "k".into(),
-                Default::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -7983,7 +7961,6 @@ data: [DONE]\n\n";
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "k".into(),
-                Default::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -8146,7 +8123,6 @@ data: [DONE]\n\n";
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "k".into(),
-                Default::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -8290,7 +8266,6 @@ data: [DONE]\n\n";
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "k".into(),
-                Default::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -8436,7 +8411,6 @@ data: [DONE]\n\n";
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "k".into(),
-                Default::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -8684,7 +8658,6 @@ data: [DONE]\n\n";
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "k".into(),
-                Default::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -8875,7 +8848,6 @@ data: [DONE]\n\n";
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "k".into(),
-                Default::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -9001,7 +8973,6 @@ data: [DONE]\n\n";
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "k".into(),
-                Default::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -9137,7 +9108,6 @@ data: [DONE]\n\n";
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "test-key".into(),
-                eros_engine_llm::openrouter::AppAttribution::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -9291,7 +9261,6 @@ data: [DONE]\n\n";
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "test-key".into(),
-                eros_engine_llm::openrouter::AppAttribution::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -9418,7 +9387,6 @@ data: [DONE]\n\n";
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "test-key".into(),
-                eros_engine_llm::openrouter::AppAttribution::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -9528,7 +9496,6 @@ data: [DONE]\n\n";
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "test-key".into(),
-                eros_engine_llm::openrouter::AppAttribution::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -9682,7 +9649,6 @@ data: [DONE]\n\n";
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "test-key".into(),
-                eros_engine_llm::openrouter::AppAttribution::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -9797,7 +9763,6 @@ data: [DONE]\n\n";
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "test-key".into(),
-                eros_engine_llm::openrouter::AppAttribution::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -9925,7 +9890,6 @@ data: [DONE]\n\n";
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "test-key".into(),
-                eros_engine_llm::openrouter::AppAttribution::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -10234,7 +10198,6 @@ data: [DONE]\n\n";
 
         let client = eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
             "k".into(),
-            eros_engine_llm::openrouter::AppAttribution::default(),
             format!("{}/api/v1/chat/completions", mock.uri()),
         );
         let p = test_resolved_pde(vec!["model-a".into(), "model-b".into()]);
@@ -10259,7 +10222,6 @@ data: [DONE]\n\n";
 
         let client = eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
             "k".into(),
-            eros_engine_llm::openrouter::AppAttribution::default(),
             format!("{}/api/v1/chat/completions", mock.uri()),
         );
         let p = test_resolved_pde(vec!["model-a".into(), "model-b".into()]);
@@ -10348,7 +10310,6 @@ data: [DONE]\n\n";
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "test-key".into(),
-                eros_engine_llm::openrouter::AppAttribution::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -10512,7 +10473,6 @@ data: [DONE]\n\n";
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "test-key".into(),
-                eros_engine_llm::openrouter::AppAttribution::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -10703,7 +10663,6 @@ data: [DONE]\n\n"
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "test-key".into(),
-                eros_engine_llm::openrouter::AppAttribution::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -10905,7 +10864,6 @@ data: [DONE]\n\n";
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "test-key".into(),
-                eros_engine_llm::openrouter::AppAttribution::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -11091,7 +11049,6 @@ data: [DONE]\n\n";
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "test-key".into(),
-                eros_engine_llm::openrouter::AppAttribution::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -11291,7 +11248,6 @@ data: [DONE]\n\n"
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "test-key".into(),
-                eros_engine_llm::openrouter::AppAttribution::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -11537,7 +11493,6 @@ data: [DONE]\n\n"
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "test-key".into(),
-                eros_engine_llm::openrouter::AppAttribution::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );

--- a/crates/eros-engine-server/src/pipeline/voice.rs
+++ b/crates/eros-engine-server/src/pipeline/voice.rs
@@ -435,7 +435,6 @@ data: [DONE]\n\n";
         state.openrouter = Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "test-key".into(),
-                eros_engine_llm::openrouter::AppAttribution::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -546,7 +545,6 @@ data: [DONE]\n\n";
         state.openrouter = Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "test-key".into(),
-                eros_engine_llm::openrouter::AppAttribution::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -676,7 +674,6 @@ data: [DONE]\n\n";
         state.openrouter = Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "test-key".into(),
-                eros_engine_llm::openrouter::AppAttribution::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -808,7 +805,6 @@ data: [DONE]\n\n";
         state.openrouter = Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "test-key".into(),
-                eros_engine_llm::openrouter::AppAttribution::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -930,7 +926,6 @@ data: [DONE]\n\n";
         state.openrouter = Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "test-key".into(),
-                eros_engine_llm::openrouter::AppAttribution::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -1047,7 +1042,6 @@ data: [DONE]\n\n";
         state.openrouter = Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "test-key".into(),
-                eros_engine_llm::openrouter::AppAttribution::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -1167,7 +1161,6 @@ data: [DONE]\n\n";
         state.openrouter = Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "test-key".into(),
-                eros_engine_llm::openrouter::AppAttribution::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );

--- a/crates/eros-engine-server/src/pipeline/world.rs
+++ b/crates/eros-engine-server/src/pipeline/world.rs
@@ -883,7 +883,6 @@ mod tests {
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "k".into(),
-                Default::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -991,7 +990,6 @@ mod tests {
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "k".into(),
-                Default::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -1137,7 +1135,6 @@ mod tests {
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "k".into(),
-                Default::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -1252,7 +1249,6 @@ mod tests {
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "k".into(),
-                Default::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -1379,7 +1375,6 @@ mod tests {
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "k".into(),
-                Default::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );
@@ -1528,7 +1523,6 @@ mod tests {
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "k".into(),
-                Default::default(),
                 format!("{}/api/v1/chat/completions", mock.uri()),
             ),
         );

--- a/crates/eros-engine-server/src/pipeline/world.rs
+++ b/crates/eros-engine-server/src/pipeline/world.rs
@@ -351,10 +351,10 @@ async fn direct_world(
     // Batch-embed all fragments in one Voyage call (order-preserving).
     let texts: Vec<&str> = fragments.iter().map(|(_, f)| f.as_str()).collect();
     let embeddings = state
-        .voyage
+        .embed
         .embed_documents(&texts)
         .await
-        .map_err(|e| format!("voyage embed_documents failed: {e}"))?;
+        .map_err(|e| format!("embed_documents failed: {e}"))?;
     let inserts: Vec<FragmentInsert> = fragments
         .into_iter()
         .zip(embeddings)

--- a/crates/eros-engine-server/src/pipeline/world_town.rs
+++ b/crates/eros-engine-server/src/pipeline/world_town.rs
@@ -483,7 +483,6 @@ mod tests {
         state.openrouter = std::sync::Arc::new(
             eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
                 "k".into(),
-                Default::default(),
                 format!("{mock_uri}/api/v1/chat/completions"),
             ),
         );

--- a/crates/eros-engine-server/src/prompt.rs
+++ b/crates/eros-engine-server/src/prompt.rs
@@ -19,7 +19,7 @@
 //!    `companion_insights` pipeline. The schema description constant
 //!    `COMPANION_INSIGHTS_SCHEMA` is shared by the second of these.
 //!
-//! Memory-layer "prompts" are not LLM-driven (Voyage embedding only) and
+//! Memory-layer "prompts" are not LLM-driven (the embedding router only) and
 //! so don't live here. Future port targets (dream / proactive) should be
 //! added as new families in this file.
 

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -720,7 +720,6 @@ pub(crate) fn test_state(pool: sqlx::PgPool) -> AppState {
         },
         openrouter: Arc::new(eros_engine_llm::openrouter::OpenRouterClient::new(
             "stub".into(),
-            eros_engine_llm::openrouter::AppAttribution::default(),
         )),
         voyage: Arc::new(eros_engine_llm::voyage::VoyageClient::new("stub".into())),
         model_config: Arc::new(eros_engine_llm::model_config::ModelConfig::default()),

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -721,7 +721,13 @@ pub(crate) fn test_state(pool: sqlx::PgPool) -> AppState {
         openrouter: Arc::new(eros_engine_llm::openrouter::OpenRouterClient::new(
             "stub".into(),
         )),
-        voyage: Arc::new(eros_engine_llm::voyage::VoyageClient::new("stub".into())),
+        embed: Arc::new(
+            eros_engine_llm::embedding::EmbeddingRouter::from_config_with(
+                &eros_engine_llm::model_config::ModelConfig::default(),
+                |k| (k == "VOYAGE_API_KEY").then(|| "test-key".to_string()),
+            )
+            .expect("test embedding router: default config resolves to Voyage with a test key"),
+        ),
         model_config: Arc::new(eros_engine_llm::model_config::ModelConfig::default()),
         output_regex: std::sync::Arc::new(Vec::new()),
         stream_slots: std::sync::Arc::new(crate::state::StreamSlots::default()),

--- a/crates/eros-engine-server/src/state.rs
+++ b/crates/eros-engine-server/src/state.rs
@@ -12,7 +12,7 @@ pub struct AppState {
     pub auth: Arc<dyn crate::auth::AuthValidator>,
     pub config: ServerConfig,
     pub openrouter: Arc<eros_engine_llm::openrouter::OpenRouterClient>,
-    pub voyage: Arc<eros_engine_llm::voyage::VoyageClient>,
+    pub embed: Arc<eros_engine_llm::embedding::EmbeddingRouter>,
     pub model_config: Arc<eros_engine_llm::model_config::ModelConfig>,
     /// Compiled `[tasks.chat_companion].output_regex` rules, built once at boot
     /// (fail-fast). Empty when none configured. Read by `drive_chat_burst`.
@@ -196,7 +196,7 @@ pub struct ServerConfig {
     /// How long a `classification_claimed_at` claim is considered fresh.
     /// Older than this and the picker treats it as a crashed worker and
     /// re-claims the row. Should comfortably exceed the worst-case
-    /// processing time (one LLM call + N voyage embeddings).
+    /// processing time (one LLM call + N calls to the embedding router).
     pub dreaming_claim_stale_threshold: Duration,
     /// Top-level keys removed from the `usage` object before it leaves the
     /// engine — both `CompanionReplyResponse.usage` (sync) and the SSE

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -11,7 +11,7 @@ Two supported paths, in order of effort:
 
 - Postgres 16+ with the `pgvector` extension (≥ 0.7).
 - An OpenRouter account (`OPENROUTER_API_KEY`).
-- A Voyage AI account (`VOYAGE_API_KEY`).
+- A Voyage AI account (`VOYAGE_API_KEY`) — required unless `[tasks.embedding]` routes both read and write off Voyage (see [Model config](model-config.md)); the default (no `[tasks.embedding]` block) still needs it.
 - Either a Supabase project (for default JWT auth) or your own JWT issuer (implement `AuthValidator`).
 
 ## Subcommands
@@ -101,10 +101,7 @@ Then construct a pool, repos, LLM clients, and write your own dispatch layer:
 
 ```rust
 let pool = eros_engine_store::pool::build(&database_url).await?;
-let openrouter = eros_engine_llm::openrouter::OpenRouterClient::new(
-    or_key,
-    eros_engine_llm::openrouter::AppAttribution::default(),
-);
+let openrouter = eros_engine_llm::openrouter::OpenRouterClient::new(or_key);
 let voyage = eros_engine_llm::voyage::VoyageClient::new(voyage_key);
 
 let affinity_repo = eros_engine_store::affinity::AffinityRepo { pool: &pool };
@@ -264,7 +261,7 @@ call. Details, data model, and the boot-validation rules are in
 
 - **Env vars:** the complete variable list lives in [`.env.example`](../.env.example); it is deliberately terse — details live in this guide and in [model-config.md](model-config.md).
 - **Background sweepers:** `serve` also runs the dreaming-lite (session-end memory classifier) and insight-snapshot sweepers. Both are optional: `DREAMING_DISABLED=1` / `SNAPSHOT_DISABLED=1` turn them off without affecting the chat path. Dreaming wakes every `DREAMING_TICK_SECS` (default 300) and classifies sessions idle for at least `DREAMING_IDLE_SECS` (default 1800); a classification claim older than `DREAMING_CLAIM_STALE_SECS` (default 600) is treated as a crashed worker and re-claimed. The snapshot sweeper runs on a 6-field cron `SNAPSHOT_CRON` (default `0 0 23 * * *`) in `SNAPSHOT_TZ` (default `Asia/Singapore`); an unparseable cron means the sweeper never starts (chat path unaffected), and an unparseable zone falls back to the default.
-- **OpenRouter attribution (optional):** `OPENROUTER_APP_REFERER` / `OPENROUTER_APP_TITLE` add attribution headers to every outbound OpenRouter call so the deployment shows up on OpenRouter's app dashboard; leave unset to stay anonymous. `OPENROUTER_APP_CATEGORIES` (comma-separated) only takes effect alongside the referer; unrecognised values are silently ignored.
+- **OpenRouter attribution (optional):** declare a `headers` table under `[providers.openrouter]` in the model config — `HTTP-Referer` / `X-OpenRouter-Title` / `X-OpenRouter-Categories` — to add attribution headers to every outbound OpenRouter call so the deployment shows up on OpenRouter's app dashboard; leave the entry (or its `headers` key) absent to stay anonymous. See [Model config → Built-in endpoint overrides](model-config.md#built-in-endpoint-overrides-via-providersopenrouter). The old `OPENROUTER_APP_REFERER` / `OPENROUTER_APP_TITLE` / `OPENROUTER_APP_CATEGORIES` env vars are soft-deprecated: still-set values are silently ignored, never a boot error, and `OPENROUTER_BASE_URL` has been removed outright — override the endpoint URL via `[providers].openrouter.chat` / `.embeddings` instead.
 - **Health probe:** `GET /healthz` returns 200 with `{ status: "ok", service, version, timestamp }`. Wire this into your platform's health check.
 - **OpenAPI / Scalar:** `GET /docs` serves a live Scalar reference. The raw OpenAPI JSON is not served over HTTP — dump it with the `print-openapi` subcommand.
 - **Affinity debug:** `GET /comp/affinity/{session_id}` is gated by `EXPOSE_AFFINITY_DEBUG=true`. Production deploys typically leave it off; turn it on if your frontend renders a live radar of the affinity vector.

--- a/docs/deploying.zh.md
+++ b/docs/deploying.zh.md
@@ -11,7 +11,7 @@
 
 - Postgres 16+，裝了 `pgvector` extension（≥ 0.7）。
 - 一個 OpenRouter 賬號（`OPENROUTER_API_KEY`）。
-- 一個 Voyage AI 賬號（`VOYAGE_API_KEY`）。
+- 一個 Voyage AI 賬號（`VOYAGE_API_KEY`）——除非 `[tasks.embedding]` 把 read 和 write 都路由离开 Voyage，否则必需（见 [model-config.zh.md](model-config.zh.md)）；默认配置（没有 `[tasks.embedding]` 块）仍然需要它。
 - 要麼 Supabase 項目（默認 JWT auth 用），要麼你自己的 JWT 簽發者（實現 `AuthValidator`）。
 
 ## 子命令
@@ -101,10 +101,7 @@ eros-engine-store = "0.9"
 
 ```rust
 let pool = eros_engine_store::pool::build(&database_url).await?;
-let openrouter = eros_engine_llm::openrouter::OpenRouterClient::new(
-    or_key,
-    eros_engine_llm::openrouter::AppAttribution::default(),
-);
+let openrouter = eros_engine_llm::openrouter::OpenRouterClient::new(or_key);
 let voyage = eros_engine_llm::voyage::VoyageClient::new(voyage_key);
 
 let affinity_repo = eros_engine_store::affinity::AffinityRepo { pool: &pool };
@@ -257,7 +254,7 @@ World Stories 按实例生活模拟）默认完全关闭：模型配置里没有
 
 - **环境变量：**完整的变量清单在 [`.env.example`](../.env.example)；该文件刻意精简——细节以本指南和 [model-config.zh.md](model-config.zh.md) 为准。
 - **后台 sweeper：**`serve` 还会跑 dreaming-lite（会话结束记忆分类器）和 insight 快照两个 sweeper。都可选：`DREAMING_DISABLED=1` / `SNAPSHOT_DISABLED=1` 关掉，不影响聊天路径。dreaming 每 `DREAMING_TICK_SECS`（默认 300）秒醒一次，分类空闲至少 `DREAMING_IDLE_SECS`（默认 1800）秒的会话；分类认领超过 `DREAMING_CLAIM_STALE_SECS`（默认 600）秒视为 worker 崩溃、可被重新认领。快照 sweeper 按 6 段 cron `SNAPSHOT_CRON`（默认 `0 0 23 * * *`）在 `SNAPSHOT_TZ`（默认 `Asia/Singapore`）时区运行；cron 解析失败则 sweeper 不启动（聊天路径不受影响），时区解析失败回退默认值。
-- **OpenRouter 归因（可选）：**`OPENROUTER_APP_REFERER` / `OPENROUTER_APP_TITLE` 会给每个出站 OpenRouter 调用加归因头，让部署出现在 OpenRouter 的应用面板上；不设则保持匿名。`OPENROUTER_APP_CATEGORIES`（逗号分隔）仅在设置了 referer 时生效；无法识别的值会被静默忽略。
+- **OpenRouter 归因（可选）：**在模型配置的 `[providers.openrouter]` 下声明一个 `headers` 表——`HTTP-Referer` / `X-OpenRouter-Title` / `X-OpenRouter-Categories`——给每个出站 OpenRouter 调用加归因头，让部署出现在 OpenRouter 的应用面板上；不写这个条目（或不写它的 `headers` key）就保持匿名。见 [model-config.zh.md → 通过 `[providers].openrouter` 覆盖内置端点](model-config.zh.md#通过-providersopenrouter-覆盖内置端点)。旧的 `OPENROUTER_APP_REFERER` / `OPENROUTER_APP_TITLE` / `OPENROUTER_APP_CATEGORIES` 环境变量已软废弃：仍然设置也只会被静默忽略，不是启动报错；`OPENROUTER_BASE_URL` 则彻底移除——改用 `[providers].openrouter.chat` / `.embeddings` 覆盖端点 URL。
 - **健康探針：** `GET /healthz` 返 200，響應 `{ status: "ok", service, version, timestamp }`。把這個接到平台的健康檢查上。
 - **OpenAPI / Scalar：** `GET /docs` 提供實時的 Scalar 參考。原始 OpenAPI JSON 不走 HTTP——用 `print-openapi` 子命令导出。
 - **Affinity debug：** `GET /comp/affinity/{session_id}` 受 `EXPOSE_AFFINITY_DEBUG=true` 控制。生產部署一般關掉；如果你的前端要實時畫好感度雷達圖，再打開。

--- a/docs/llm-audit.md
+++ b/docs/llm-audit.md
@@ -3,8 +3,8 @@
 eros-engine exposes an opaque OpenRouter passthrough on the streaming
 chat endpoint. Three caller-supplied fields ride to
 `openrouter.ai/api/v1/chat/completions` unchanged, three OpenRouter wire
-echoes come back on the SSE `done` frame, and two deployer-set env vars
-add app-attribution headers to every outbound call.
+echoes come back on the SSE `done` frame, and a deployer-declared
+`headers` table adds app-attribution headers to every outbound call.
 
 The engine never inspects content. PII scrubbing, hashing, and
 metadata semantics are the caller's responsibility.
@@ -114,25 +114,45 @@ prompt_tokens=… completion_tokens=… total_tokens=… cost=…
 
 ## App-attribution headers
 
-Three optional env vars add headers to every outbound OpenRouter call:
+Declare a `headers` table on `[providers.openrouter]` in the model config
+(`docs/model-config.md` → "Built-in endpoint overrides via
+`[providers].openrouter`") to add headers to every outbound OpenRouter
+call:
 
-| Env                         | Header                    | Purpose                                          |
-|-----------------------------|---------------------------|--------------------------------------------------|
-| `OPENROUTER_APP_REFERER`    | `HTTP-Referer`            | App identifier on OpenRouter dashboards          |
-| `OPENROUTER_APP_TITLE`      | `X-OpenRouter-Title`      | Display name in OpenRouter app analytics         |
-| `OPENROUTER_APP_CATEGORIES` | `X-OpenRouter-Categories` | Comma-separated marketplace categories           |
+```toml
+[providers.openrouter]
+headers = {
+  "HTTP-Referer" = "https://eros.example",
+  "X-OpenRouter-Title" = "Eros",
+  "X-OpenRouter-Categories" = "companion,roleplay",
+}
+```
 
-All unset → today's behaviour (no attribution headers). They are set
-per deployment, not per request — App-Attribution is intended for
-app-level aggregation. Per-user attribution belongs in `audit.user`.
+| Purpose-built header      | Meaning                                          |
+|----------------------------|--------------------------------------------------|
+| `HTTP-Referer`             | App identifier on OpenRouter dashboards          |
+| `X-OpenRouter-Title`       | Display name in OpenRouter app analytics         |
+| `X-OpenRouter-Categories`  | Comma-separated marketplace categories           |
 
-`OPENROUTER_APP_CATEGORIES` is passed through verbatim; OpenRouter
-silently ignores unrecognised values and only honours it when
-`OPENROUTER_APP_REFERER` is also set.
+No `[providers.openrouter]` entry, or one without `headers` → today's
+behaviour (no attribution headers). They are set per deployment, not per
+request — App-Attribution is intended for app-level aggregation. Per-user
+attribution belongs in `audit.user`.
 
-Invalid values (control characters, non-ASCII outside header rules)
-are dropped at construction time with a `tracing::warn!`; the client
-still works.
+`X-OpenRouter-Categories` is passed through verbatim; OpenRouter silently
+ignores unrecognised values and only honours it when `HTTP-Referer` is
+also set.
+
+Header names/values are validated at boot — engine-owned names
+(`Authorization`, `Content-Type`, case-insensitive) or anything that isn't
+valid HTTP header material refuses the load, rather than the older
+construction-time warn-and-drop.
+
+**Migration note:** the `OPENROUTER_APP_REFERER` / `OPENROUTER_APP_TITLE` /
+`OPENROUTER_APP_CATEGORIES` env vars are soft-deprecated — a still-set
+value is silently ignored, never a boot error, but it no longer does
+anything. Re-declare the same headers under `[providers.openrouter].headers`
+as shown above.
 
 ## What the engine does NOT do
 

--- a/docs/llm-audit.zh.md
+++ b/docs/llm-audit.zh.md
@@ -3,8 +3,8 @@
 eros-engine 在流式 chat 路由上暴露一个不透明的 OpenRouter 透传层。
 三个 caller 提供的字段原样发给
 `openrouter.ai/api/v1/chat/completions`，三个 OpenRouter 的 wire 回显
-在 SSE `done` 帧里带回来，两个 deployer 设的环境变量会给每次出站调用都
-带上 app-attribution headers。
+在 SSE `done` 帧里带回来，一个 deployer 声明的 `headers` 表会给每次出站
+调用都带上 app-attribution headers。
 
 引擎不解读内容。PII 脱敏、hash、metadata 语义都是 caller 的责任。
 
@@ -99,23 +99,41 @@ prompt_tokens=… completion_tokens=… total_tokens=… cost=…
 
 ## App-attribution headers
 
-三个可选环境变量给每次出站 OpenRouter 调用加 header：
+在模型配置的 `[providers.openrouter]` 下声明一个 `headers` 表（见
+`docs/model-config.zh.md` → “通过 `[providers].openrouter` 覆盖内置
+端点”），就能给每次出站 OpenRouter 调用加 header：
 
-| Env                         | Header                    | 用途                                          |
-|-----------------------------|---------------------------|-----------------------------------------------|
-| `OPENROUTER_APP_REFERER`    | `HTTP-Referer`            | OpenRouter 仪表盘上的 app 标识                |
-| `OPENROUTER_APP_TITLE`      | `X-OpenRouter-Title`      | OpenRouter app analytics 里显示的名字         |
-| `OPENROUTER_APP_CATEGORIES` | `X-OpenRouter-Categories` | 逗号分隔的 marketplace 分类                   |
+```toml
+[providers.openrouter]
+headers = {
+  "HTTP-Referer" = "https://eros.example",
+  "X-OpenRouter-Title" = "Eros",
+  "X-OpenRouter-Categories" = "companion,roleplay",
+}
+```
 
-都不设 → 维持现状（不发任何 attribution header）。它们是
-deployment 级别的设置，不是 per-request —— App-Attribution 的目的是
-app-level 聚合。Per-user 维度走 `audit.user`。
+| 常用 header                | 用途                                          |
+|-----------------------------|-----------------------------------------------|
+| `HTTP-Referer`              | OpenRouter 仪表盘上的 app 标识                |
+| `X-OpenRouter-Title`        | OpenRouter app analytics 里显示的名字         |
+| `X-OpenRouter-Categories`   | 逗号分隔的 marketplace 分类                   |
 
-`OPENROUTER_APP_CATEGORIES` 原样透传；OpenRouter 对无法识别的值静默
-忽略，且只有在同时设了 `OPENROUTER_APP_REFERER` 时才生效。
+没有 `[providers.openrouter]` 条目，或者有条目但没写 `headers` → 维持
+现状（不发任何 attribution header）。这是 deployment 级别的设置，不是
+per-request —— App-Attribution 的目的是 app-level 聚合。Per-user 维度走
+`audit.user`。
 
-非法值（控制字符、非 ASCII 之类）在构造时被丢弃并打一条
-`tracing::warn!`，client 仍然可用。
+`X-OpenRouter-Categories` 原样透传；OpenRouter 对无法识别的值静默忽略，
+且只有在同时设了 `HTTP-Referer` 时才生效。
+
+header 的 name/value 在启动时就会校验：引擎自有的 name
+（`Authorization`、`Content-Type`，不分大小写）或者不合法的 HTTP header
+material 会直接拒绝加载，而不是像以前那样在构造时 warn-and-drop。
+
+**迁移提示：**`OPENROUTER_APP_REFERER` / `OPENROUTER_APP_TITLE` /
+`OPENROUTER_APP_CATEGORIES` 环境变量已软废弃——仍然设置也会被静默忽略，
+不是启动报错，但也不再起任何作用。请把同样的 header 按上面的写法迁到
+`[providers.openrouter].headers` 下。
 
 ## 引擎不做的事
 

--- a/docs/memory-layers.md
+++ b/docs/memory-layers.md
@@ -43,7 +43,7 @@ CREATE INDEX idx_memories_session
 
 ## Embedding
 
-`voyage-3-lite` via Voyage's API. 512 dimensions, multilingual, ~$0.02 per 1M input tokens.
+`voyage-4-lite` via Voyage's API by default (configurable in `[tasks.embedding]`). 512 dimensions, multilingual.
 
 ```rust
 // crates/eros-engine-llm/src/voyage.rs

--- a/docs/memory-layers.zh.md
+++ b/docs/memory-layers.zh.md
@@ -43,7 +43,7 @@ CREATE INDEX idx_memories_session
 
 ## Embedding
 
-`voyage-3-lite` 走 Voyage API。512 維、多語言、約每百萬輸入 token $0.02 美元。
+默认 `voyage-4-lite` 走 Voyage API（可在 `[tasks.embedding]` 配置）。512 维、多语言。
 
 ```rust
 // crates/eros-engine-llm/src/voyage.rs

--- a/docs/model-config.md
+++ b/docs/model-config.md
@@ -56,7 +56,6 @@ temperature  = 0.85                         # optional, falls back to defaults.f
 max_tokens   = 600                          # optional, falls back to defaults.fallback_max_tokens
 allow_traits = ["tag_a", "tag_b"]           # optional, prompt-trait allow-list (three-state)
 description  = "free-form note"             # optional, documentation only — not consumed by code
-dimensions   = 512                          # optional, embedding-only field
 
 [tasks.<name>.tiers.<tier>]
 model        = "<provider>/<model-id>"      # optional, overrides task-level model for this tier
@@ -71,7 +70,7 @@ Field details:
 | `defaults.fallback_model` | `String` | no | Hard fallback if the task config provides no model. If still missing, code uses the compiled-in default `x-ai/grok-4-mini`. |
 | `defaults.fallback_temperature` | `f64` | no | Same precedence; compiled-in default `0.5`. |
 | `defaults.fallback_max_tokens` | `u32` | no | Same precedence; compiled-in default `200`. |
-| `defaults.ignore_providers` | `Array<String>` | no | OpenRouter provider slugs to exclude from routing on **every** task. Sent as `provider.ignore` on each outbound call; `allow_fallbacks` remains `true` so the model is still served by any healthy provider. Use this when a specific provider returns garbled output for a model (e.g. undecoded byte-BPE text — issue #84). Find the offending slug via the OpenRouter generation API. Empty or absent means no exclusion. |
+| `defaults.ignore_providers` | `Array<String>` | no | OpenRouter provider slugs to exclude from routing on **every** task. Each entry must carry the `@openrouter` suffix (`"some-bad-provider-slug@openrouter"`) — a bare slug, any other `@<provider>` suffix, or malformed `@` grammar refuses to boot. The suffix is stripped before the wire: sent as `provider.ignore` (bare slug) on each outbound OpenRouter call only; custom providers and Voyage never receive it. `allow_fallbacks` remains `true` so the model is still served by any healthy provider. Use this when a specific provider returns garbled output for a model (e.g. undecoded byte-BPE text — issue #84). Find the offending slug via the OpenRouter generation API. Empty or absent means no exclusion. |
 | `tasks.<name>.model` | `String` \| `Array<String>` \| `Table<String,f64>` | yes | Primary model. String = fixed; array = round-robin; table = weighted random. See "Primary model selection". |
 | `tasks.<name>.fallback` | `String` | no | Secondary model used by `OpenRouterClient` if the primary call fails. |
 | `tasks.<name>.temperature` | `f64` | no | Per-task sampling temperature. No per-tier override. |
@@ -80,37 +79,67 @@ Field details:
 | `tasks.<name>.tiers.<tier>` | sub-table | no | Per-tier overrides. May set `model`, `fallback`, and/or `allow_traits`. Does not override `temperature` or `max_tokens`. |
 | `tasks.chat_companion.input_filter` | `bool` \| `f64` | no | Global trigger for the user-input rewrite filter. Task-level only on `chat_companion` (no per-tier override). `false`/absent = off, `true` = every turn, `0.8` = ~80% of turns (a number outside `[0.0, 1.0]` is rejected). See "`input_filter`". |
 | `tasks.<name>.description` | `String` | no | Documentation field, ignored by code. |
-| `tasks.<name>.dimensions` | `u32` | no | Embedding-only. Ignored by chat / insight tasks. |
 
-### `[providers]` — custom OpenAI-compatible endpoints (opt-in)
+### `[providers]` — custom chat/embeddings endpoints (opt-in)
 
 ```toml
 [providers]
-venice = "https://api.venice.ai/api/v1/chat/completions"
+venice = { chat = "https://api.venice.ai/api/v1/chat/completions" }
+mixed  = { chat = "https://x/v1/chat/completions", embeddings = "https://x/v1/embeddings" }
+local  = { embeddings = "http://127.0.0.1:8080/v1/embeddings" }
+
+[providers.proxy]           # TOML section form works too
+chat    = "https://proxy.internal/v1/chat/completions"
+headers = { "X-Team" = "companion", "X-Env" = "prod" }
 ```
 
-Declares additional chat-completions endpoints alongside the built-in
-OpenRouter client. Reference one by suffixing a model slug anywhere a
-`model` / `fallback` accepts one (any shape — fixed, round-robin, weighted):
+Each entry is a table with up to three keys — `chat` (an OpenAI-compatible
+chat-completions URL), `embeddings` (an OpenRouter-compatible embeddings
+URL — see [`https://openrouter.ai/docs/api_reference/embeddings`](https://openrouter.ai/docs/api_reference/embeddings)
+for the wire shape), and `headers` (sent verbatim on every request to this
+entry's endpoints). **A plain-string value is rejected**: the pre-0.9.4
+shape (`venice = "https://…"`) was dropped with no compatibility layer, and
+the boot error names the table form. `deny_unknown_fields` applies — an
+unknown key, an empty table, or an empty URL string also refuses the load.
+
+Declares additional endpoints alongside the built-in OpenRouter client.
+Reference one by suffixing a model slug anywhere a `model` / `fallback`
+accepts one (any shape — fixed, round-robin, weighted) on a chat-shaped
+task, or on `[tasks.embedding]`'s model fields for embeddings:
 
 ```toml
 [tasks.chat_companion]
-model = "venice-uncensored@venice"   # served by [providers].venice
+model = "venice-uncensored@venice"   # served by [providers].venice.chat
 fallback = ["x-ai/grok-4.20"]        # no suffix → built-in OpenRouter
+
+[tasks.embedding]
+model = "bge-m3@local"               # served by [providers].local.embeddings
 ```
 
 Rules, all enforced at boot (the engine refuses to boot on any violation):
 
-- **Names** match `[a-z0-9_]+`; `openrouter` is reserved (override the
-  built-in endpoint with the `OPENROUTER_BASE_URL` env var instead), and so
-  is `voyage` (`$VOYAGE_API_KEY` already belongs to the built-in embeddings
-  client).
-- **URL** is the complete chat-completions URL, posted verbatim — no path
-  joining.
+- **Names** match `[a-z0-9_]+`. `voyage` stays reserved — its native API is
+  not the OpenRouter-compatible embeddings format this mechanism speaks, and
+  `$VOYAGE_API_KEY` already belongs to the built-in native Voyage client.
+  `openrouter` is a valid, declarable name: it doesn't add a separate
+  provider, it **overrides the built-in OpenRouter endpoint URLs** per key
+  (see below).
+- **URLs** are complete and posted verbatim — no path joining. A provider
+  referenced from a chat-shaped task must declare `chat`; one referenced
+  from `[tasks.embedding]` must declare `embeddings`. A miss on either
+  refuses to boot, naming the slug, the entry, and the missing key.
+- **`headers`** (optional) is a table sent verbatim on every request to this
+  entry's endpoints (both `chat` and `embeddings`). `Authorization` and
+  `Content-Type` are engine-owned and refuse the load if declared
+  (case-insensitive) — a silently overridden `Authorization` is the worst
+  kind of footgun. Every other name/value must be valid HTTP header material
+  or the load refuses.
 - **API key** comes from the environment as `<NAME_UPPERCASED>_API_KEY`
-  (`venice` → `$VENICE_API_KEY`), required only for providers actually
+  (`venice` → `$VENICE_API_KEY`), one key covering both the `chat` and
+  `embeddings` endpoints of that entry, required only for providers actually
   referenced by some model slug. Declared-but-unreferenced entries need no
-  key.
+  key. `openrouter` keeps using the existing `$OPENROUTER_API_KEY` — the
+  naming convention degenerates to the var that already exists.
 - **Model ids are the provider's own slugs**, sent verbatim — the engine
   never translates model names between providers.
 - A literal `@` inside a model id is escaped `\@`. In a TOML double-quoted
@@ -119,16 +148,69 @@ Rules, all enforced at boot (the engine refuses to boot on any violation):
 - **Model-keyed tables use bare ids**: `model_name_display_override`,
   `output_regex` `models`, and `output_filter` trigger `models` match on the
   id *without* `@provider`.
-- **Wire shape**: custom providers receive a strict OpenAI chat-completions
+- **Wire shape**: custom providers receive a strict OpenAI-compatible
   subset. `[defaults].ignore_providers`, `[defaults].provider_sort`, and
-  per-task `reasoning` are **inert** on custom providers, and the OpenRouter
-  attribution headers are not sent to them.
+  per-task `reasoning` are **inert** on custom providers; they receive
+  exactly this entry's own declared `headers`, never the OpenRouter
+  attribution headers.
 - **Audit**: rows served by a custom provider record
   `model = "<upstream echo>@<name>"` and the provider's own `generation_id`
   verbatim — a `generation_id` join against OpenRouter's logs misses for
   those rows, and the `model` column says why.
 - Under `MODEL_CONFIG_DIR`, `[providers]` merges as one whole top-level key
   (like `[defaults]`, unlike `[tasks]`): all providers live in one file.
+
+#### Built-in endpoint overrides via `[providers].openrouter`
+
+```toml
+[providers.openrouter]
+embeddings = "http://my-proxy/v1/embeddings"
+headers    = { "HTTP-Referer" = "https://eros.example", "X-OpenRouter-Title" = "Eros" }
+```
+
+- Each present key (`chat` and/or `embeddings`) overrides that built-in URL;
+  each absent key keeps the built-in default
+  (`https://openrouter.ai/api/v1/chat/completions` /
+  `https://openrouter.ai/api/v1/embeddings`). This partial-override rule is
+  unique to `openrouter` — for ordinary entries a missing key is a boot
+  error when referenced, because there is no built-in default to fall back
+  to.
+- The override changes the URL **only**. Traffic through it remains the
+  full OpenRouter wire: `provider.ignore`, `provider_sort`, and per-task
+  `reasoning` are all still sent — unlike custom providers, which keep
+  receiving the strict OpenAI subset.
+- **Attribution headers now live here, and nowhere else.** No
+  `[providers.openrouter]` entry, or one without `headers`, means no
+  attribution headers are sent. The `OPENROUTER_APP_REFERER` /
+  `OPENROUTER_APP_TITLE` / `OPENROUTER_APP_CATEGORIES` env vars are
+  **soft-deprecated**: a still-set value is silently ignored, never a boot
+  error — re-declare the same headers under `[providers].openrouter.headers`
+  instead (see [`llm-audit.md`](llm-audit.md) for the header/purpose
+  mapping).
+- The API key stays `$OPENROUTER_API_KEY`.
+- **`OPENROUTER_BASE_URL` no longer exists as an env var.** The only
+  override mechanism is `[providers].openrouter.chat` /
+  `[providers].openrouter.embeddings`. A still-set `OPENROUTER_BASE_URL` is
+  not read and causes no boot error — it's just an unrelated env var now.
+- `voyage` remains undeclarable in `[providers]` (see above).
+
+#### `[defaults].ignore_providers` — `@openrouter` required
+
+```toml
+[defaults]
+ignore_providers = ["some-bad-provider-slug@openrouter"]
+```
+
+Every entry must parse (the same `@`-suffix grammar as a model slug) to a
+non-empty upstream slug plus provider `openrouter`; a bare entry, any other
+`@<provider>` suffix, or malformed `@` grammar refuses to boot naming the
+entry and the required form. The wire is unchanged: `provider.ignore`
+carries the bare upstream slug, on OpenRouter traffic only — the mandatory
+suffix makes that scope part of the syntax; custom providers and Voyage
+never receive `provider.ignore`. `[defaults].provider_sort` is untouched (it
+has no per-entry syntax to scope). Breaking change for configs written
+before this suffix existed — the fix is appending `@openrouter` to each
+entry.
 
 ### `model_name_display_override` (chat task only)
 
@@ -381,7 +463,7 @@ input filter has no triggers, timing, or tiers).
 | `affinity_evaluation` | `pipeline::post_process` (per-turn 6-axis affinity delta; runs after each Reply turn, fire-and-forget) | live |
 | `memory_extraction` | dreaming sweeper (session-end memory consolidation; off when task block absent) | live (opt-in) |
 | `chat_input_filter` | `pipeline::stream` (user-input rewrite filter; activated by `input_filter` on `[tasks.chat_companion]` and this task block; off by default) | live (opt-in) |
-| `embedding` | reserved — `VoyageClient` reads its own `VOYAGE_API_KEY` and hard-codes `voyage-3-lite` | reserved |
+| `embedding` | `EmbeddingRouter::from_config()` at boot (`main.rs`), via `ModelConfig::resolve_embedding()` — routes `embed_query`/`embed_document`/`embed_documents` to native Voyage, the built-in OpenRouter embeddings endpoint, or a custom `[providers]` entry; absent block = native Voyage `voyage-3-lite` (unchanged pre-config behaviour) | live |
 
 A `[tasks.<name>]` entry is only meaningful if the engine actually calls `model_config.resolve("<name>", ...)` somewhere. The current call sites are:
 
@@ -389,7 +471,10 @@ A `[tasks.<name>]` entry is only meaningful if the engine actually calls `model_
 - `crates/eros-engine-server/src/pipeline/post_process.rs` → `insight_extraction`, `affinity_evaluation`
 - `crates/eros-engine-server/src/pipeline/stream.rs` → `pde_decision` via `run_pde_decision` inside `run_stream` (only when `filter_prompt` is set); `chat_image_prompt_compose` via `resolve_image_prompt_compose()` (image-prompt composer, opt-in, resolved lazily only on image turns); `chat_vision` via `resolve_vision()` (vision pre-stage, opt-in); `chat_product_qa` via `resolve_product_qa()` (product-QA executor, opt-in); `chat_input_filter` via `resolve_input_filter()` (input rewrite, opt-in); `memory_extraction` via the dreaming sweeper
 
-`embedding` is vestigial — Voyage doesn't go through this path.
+`embedding` doesn't go through the generic `resolve()` path above — it has
+its own resolver, `ModelConfig::resolve_embedding()`, called once at boot
+from `main.rs` to build the `EmbeddingRouter`. See "`[tasks.embedding]` —
+active" below.
 
 ### `[tasks.pde_decision]` — opt-in LLM PDE judge
 
@@ -599,6 +684,84 @@ an `Error` frame instead.
 Call site: `crates/eros-engine-server/src/pipeline/stream.rs` via
 `resolve_product_qa()` in `model_config.rs`.
 
+### `[tasks.embedding]` — active
+
+`VoyageClient` used to hard-code `voyage-3-lite`; `[tasks.embedding]` is now
+consumed, and the embedding model, and which backend it routes to, are
+config-driven.
+
+```toml
+# Single model — read and write use the same backend.
+[tasks.embedding]
+model = "voyage-3-lite"                       # ≡ "voyage-3-lite@voyage"
+# model = "openai/text-embedding-3-small@openrouter"
+# model = "bge-m3@local"                      # third-party, OpenRouter-compatible wire
+
+# OR: split read/write — voyage-4 series and above ONLY.
+#[tasks.embedding]
+#model_read  = "voyage-4-lite"   # recall path: embed_query, input_type "query"
+#model_write = "voyage-4"        # storage path: embed_document(s), input_type "document"
+```
+
+**Dimensions are fixed at 512, with no config knob.** The three pgvector
+columns are `VECTOR(512) NOT NULL`, the clients request 512 on the wire, and
+every response is length-checked. There used to be a `dimensions` field on
+`[tasks.<name>]` — it was never consumed and has been removed; a leftover
+`dimensions = 512` line in an existing config is now an inert unknown key
+(serde ignores it, exactly like any other stale key).
+
+| field | type | rules |
+|---|---|---|
+| `model` | single fixed string | bare ⇒ `@voyage`; `@openrouter` / `@<custom>` route to the OpenRouter-compatible wire; mutually exclusive with the pair |
+| `model_read` | `Option<String>` | pair-only, voyage-only, N ≥ 4 (see the gate below); serves `embed_query` |
+| `model_write` | `Option<String>` | pair-only, voyage-only, N ≥ 4; serves `embed_document` / `embed_documents` |
+
+Routing per suffix, resolved by `ModelConfig::resolve_embedding()`:
+
+| bare (no suffix) | `@openrouter` | `@voyage` | `@<custom>` |
+|---|---|---|---|
+| native Voyage | built-in OpenRouter embeddings endpoint (overridable, see `[providers].openrouter` above) | same as bare | `[providers].<name>.embeddings` (OpenRouter-compatible wire) |
+
+- `model_read` / `model_write` are plain `Option<String>` — array/table
+  shapes are type errors at parse time. `model_read = model_write` is legal
+  (redundant but harmless — equivalent to `model`). `@openrouter` and
+  `@<custom>` refuse to boot on `model_read`/`model_write` (only Voyage
+  guarantees a shared vector space across model sizes).
+- `[tasks.embedding]` **absent** ⇒ exactly the pre-config behaviour: native
+  Voyage, `voyage-3-lite`, no dimension parameter on the wire.
+- `model` must be a single fixed string; round-robin, weighted, `fallback`,
+  and `tiers` all refuse to boot (mixed/incompatible vector spaces would be
+  the result — the `chat_voice` fixed-only precedent).
+- The wire has no `input_type`: the query/document optimisation is a
+  Voyage-native nuance. Routing embedding off Voyage forfeits it.
+
+**The voyage-4 gate.** Applied to the bare id after stripping an optional
+`@voyage` suffix. The id must begin `voyage-` followed by a numeric segment
+(ASCII digits and dots only, ending at the next `-` or end of string) that
+parses as a finite number ≥ 4:
+
+- ✓ `voyage-4`, `voyage-4-lite`, `voyage-4.5-large`, `voyage-10`
+- ✗ `voyage-3.5-lite` (N = 3.5), `voyage-code-3` (no leading numeric segment
+  after `voyage-`), `voyage-inf`/`voyage-nan` (non-digit characters, and
+  non-finite even if they parsed), `bge-m3@local` (not voyage), any
+  `@openrouter` or custom-provider slug
+
+Only the voyage-4 series and above guarantee a shared vector space across
+model sizes — mixing a lower or non-numeric model into the pair would
+silently write vectors the read model cannot compare, so the gate is a boot
+refusal, not a docs footnote.
+
+**`VOYAGE_API_KEY`** is required iff the resolved read or write backend is
+Voyage (block absent ⇒ Voyage default ⇒ still required, so existing
+deployments see no change). A deployment that routes both read and write
+entirely off Voyage no longer needs the var.
+
+Call site: `crates/eros-engine-server/src/main.rs` builds
+`eros_engine_llm::embedding::EmbeddingRouter::from_config(&model_config)`
+once at boot; `AppState.embed: Arc<EmbeddingRouter>` serves `embed_query` /
+`embed_document` / `embed_documents` from `handlers.rs` / `post_process.rs`
+/ `dreaming.rs` / `world.rs` / `story.rs`, unchanged call shapes.
+
 ### Enabling / disabling extraction
 
 `insight_extraction` (per-turn fact mining) and `memory_extraction` (session-end
@@ -678,7 +841,7 @@ For the duration of `0.x`, the OSS engine commits to:
 1. **No removed fields.** Existing field names in `[defaults]` and `[tasks.<name>]` will not disappear.
 2. **No renamed fields.** `fallback` will not become `fallback_model`. `model` will not become `primary_model`. Etc.
 3. **No newly required fields.** Anything added is optional with a sensible default.
-4. **No removed task names from this list:** `chat_companion`, `insight_extraction`, `pde_decision`. Reserved task names (`embedding`) may shift if a real implementation lands and supersedes their current placeholder semantics; that change will be called out in the changelog.
+4. **No removed task names from this list:** `chat_companion`, `insight_extraction`, `pde_decision`, `embedding`.
 5. **Resolution precedence is fixed.** `matched tier > task default block > [defaults] > compiled-in fallback` for `model`/`fallback`/`allow_traits`. `temperature`/`max_tokens` are task-level only.
 6. **`model` accepts a string, array (round-robin), or table (weighted).** A plain string remains valid forever; the array/table forms are an additive widening.
 
@@ -708,10 +871,21 @@ What may still change without notice:
   extract. The `filtered` flag is `true` when either the regex strip or the LLM
   filter (or both) produced non-raw output. See "`output_regex` — deterministic
   per-model regex strip" above.
+- **`[tasks.embedding]` is now active** (previously reserved and unconsumed).
+  Breaking changes bundled with the activation: `[providers]` values are now
+  tables, not plain strings (the string shape is rejected with no compat
+  layer); `[defaults].ignore_providers` entries now require the
+  `@openrouter` suffix; the `OPENROUTER_BASE_URL` env var is gone (use
+  `[providers].openrouter.chat`/`.embeddings`); the `OPENROUTER_APP_*` env
+  vars are soft-deprecated (silently ignored, use
+  `[providers].openrouter.headers`); the `dimensions` field on
+  `[tasks.<name>]` was removed (dims are hard-coded 512; a leftover
+  `dimensions = 512` line is now an inert unknown key). See "`[providers]`"
+  and "`[tasks.embedding]` — active" above.
 
 ## What this config does NOT control
 
-- **Voyage embedding** — `VoyageClient` hard-codes `voyage-3-lite` and reads `VOYAGE_API_KEY` directly. The `[tasks.embedding]` block is reserved for a future generalisation.
+- **Voyage's own base URL** — the native Voyage wire always posts to Voyage's canonical endpoint; only the model id is configurable, via `[tasks.embedding]`. Route around Voyage entirely with an `@openrouter` or custom `[providers]` suffix instead.
 - **PDE decisions (default path)** — the rule engine in `eros-engine-core/src/pde.rs` runs unconditionally when no `filter_prompt` is set. Set `[tasks.pde_decision].filter_prompt` to activate the opt-in LLM judge; the rule engine then serves as fallback + hard-safety guardrails.
 - **OpenRouter API key** — read directly from `OPENROUTER_API_KEY`, not the config file.
 - **Per-call streaming / response format flags** — fixed in `OpenRouterClient`.

--- a/docs/model-config.md
+++ b/docs/model-config.md
@@ -463,7 +463,7 @@ input filter has no triggers, timing, or tiers).
 | `affinity_evaluation` | `pipeline::post_process` (per-turn 6-axis affinity delta; runs after each Reply turn, fire-and-forget) | live |
 | `memory_extraction` | dreaming sweeper (session-end memory consolidation; off when task block absent) | live (opt-in) |
 | `chat_input_filter` | `pipeline::stream` (user-input rewrite filter; activated by `input_filter` on `[tasks.chat_companion]` and this task block; off by default) | live (opt-in) |
-| `embedding` | `EmbeddingRouter::from_config()` at boot (`main.rs`), via `ModelConfig::resolve_embedding()` — routes `embed_query`/`embed_document`/`embed_documents` to native Voyage, the built-in OpenRouter embeddings endpoint, or a custom `[providers]` entry; absent block = native Voyage `voyage-3-lite` (unchanged pre-config behaviour) | live |
+| `embedding` | `EmbeddingRouter::from_config()` at boot (`main.rs`), via `ModelConfig::resolve_embedding()` — routes `embed_query`/`embed_document`/`embed_documents` to native Voyage, the built-in OpenRouter embeddings endpoint, or a custom `[providers]` entry; absent block = native Voyage `voyage-4-lite` | live |
 
 A `[tasks.<name>]` entry is only meaningful if the engine actually calls `model_config.resolve("<name>", ...)` somewhere. The current call sites are:
 
@@ -693,7 +693,8 @@ config-driven.
 ```toml
 # Single model — read and write use the same backend.
 [tasks.embedding]
-model = "voyage-3-lite"                       # ≡ "voyage-3-lite@voyage"
+model = "voyage-4-lite"                       # ≡ "voyage-4-lite@voyage"
+# model = "voyage-3-lite"                     # legacy pin (no longer recommended by Voyage)
 # model = "openai/text-embedding-3-small@openrouter"
 # model = "bge-m3@local"                      # third-party, OpenRouter-compatible wire
 
@@ -727,8 +728,12 @@ Routing per suffix, resolved by `ModelConfig::resolve_embedding()`:
   (redundant but harmless — equivalent to `model`). `@openrouter` and
   `@<custom>` refuse to boot on `model_read`/`model_write` (only Voyage
   guarantees a shared vector space across model sizes).
-- `[tasks.embedding]` **absent** ⇒ exactly the pre-config behaviour: native
-  Voyage, `voyage-3-lite`, no dimension parameter on the wire.
+- `[tasks.embedding]` **absent** ⇒ native Voyage with `voyage-4-lite`
+  (`output_dimension: 512` on the wire). Voyage no longer recommends
+  `voyage-3-lite`; a deployment that still needs it must pin it explicitly.
+  Switching models over existing data changes the vector space — old rows
+  are not comparable to new queries — so either pin the old model or
+  re-embed.
 - `model` must be a single fixed string; round-robin, weighted, `fallback`,
   and `tiers` all refuse to boot (mixed/incompatible vector spaces would be
   the result — the `chat_voice` fixed-only precedent).

--- a/docs/model-config.zh.md
+++ b/docs/model-config.zh.md
@@ -56,7 +56,6 @@ temperature  = 0.85                         # optional, falls back to defaults.f
 max_tokens   = 600                          # optional, falls back to defaults.fallback_max_tokens
 allow_traits = ["tag_a", "tag_b"]           # optional, prompt-trait allow-list (three-state)
 description  = "free-form note"             # optional, documentation only — not consumed by code
-dimensions   = 512                          # optional, embedding-only field
 
 [tasks.<name>.tiers.<tier>]
 model        = "<provider>/<model-id>"      # optional, overrides task-level model for this tier
@@ -71,7 +70,7 @@ allow_traits = ["tag_a"]                    # optional, overrides task-level all
 | `defaults.fallback_model` | `String` | 否 | 任务配置未提供 model 时使用的最终 fallback。若仍然缺失，代码使用编译时内置默认值 `x-ai/grok-4-mini`。 |
 | `defaults.fallback_temperature` | `f64` | 否 | 优先级相同；编译时内置默认值为 `0.5`。 |
 | `defaults.fallback_max_tokens` | `u32` | 否 | 优先级相同；编译时内置默认值为 `200`。 |
-| `defaults.ignore_providers` | `Array<String>` | 否 | 要从**每个**任务的路由中排除的 OpenRouter provider slug。每次对外调用时作为 `provider.ignore` 发送；`allow_fallbacks` 仍为 `true`，因此模型仍可由任意健康的 provider 提供。某个 provider 为模型返回乱码时（例如未解码的 byte-BPE 文本——issue #84），可使用此字段。通过 OpenRouter generation API 查找有问题的 slug。为空或缺失表示不排除任何 provider。 |
+| `defaults.ignore_providers` | `Array<String>` | 否 | 要从**每个**任务的路由中排除的 OpenRouter provider slug。每个条目必须带 `@openrouter` 后缀（`"some-bad-provider-slug@openrouter"`）——裸 slug、其他 `@<provider>` 后缀、或格式错误的 `@` 语法都会拒绝启动。发到 wire 前会剥掉后缀：只作为 `provider.ignore`（裸 slug）发给 OpenRouter 调用；自定义 provider 和 Voyage 永远不会收到它。`allow_fallbacks` 仍为 `true`，因此模型仍可由任意健康的 provider 提供。某个 provider 为模型返回乱码时（例如未解码的 byte-BPE 文本——issue #84），可使用此字段。通过 OpenRouter generation API 查找有问题的 slug。为空或缺失表示不排除任何 provider。 |
 | `tasks.<name>.model` | `String` \| `Array<String>` \| `Table<String,f64>` | 是 | 主模型。字符串 = 固定；数组 = round-robin；表 = weighted 随机。参见“主模型选择”。 |
 | `tasks.<name>.fallback` | `String` | 否 | 主调用失败时由 `OpenRouterClient` 使用的次要模型。 |
 | `tasks.<name>.temperature` | `f64` | 否 | 每任务的采样 temperature。无 per-tier 覆盖。 |
@@ -80,34 +79,62 @@ allow_traits = ["tag_a"]                    # optional, overrides task-level all
 | `tasks.<name>.tiers.<tier>` | 子表 | 否 | Per-tier 覆盖。可设置 `model`、`fallback` 和/或 `allow_traits`。不覆盖 `temperature` 或 `max_tokens`。 |
 | `tasks.chat_companion.input_filter` | `bool` \| `f64` | 否 | 用户输入改写 filter 的全局 trigger。仅可在 `chat_companion` 的任务级配置中设置（无 per-tier 覆盖）。`false`/缺失 = 关闭，`true` = 每轮执行，`0.8` = 约 80% 的轮次执行（超出 `[0.0, 1.0]` 的数字会被拒绝）。参见“`input_filter`”。 |
 | `tasks.<name>.description` | `String` | 否 | 文档字段，代码忽略。 |
-| `tasks.<name>.dimensions` | `u32` | 否 | 仅用于 embedding。chat / insight 任务会忽略。 |
 
-### `[providers]` — 自定义 OpenAI 兼容端点（opt-in）
+### `[providers]` — 自定义 chat/embeddings 端点（opt-in）
 
 ```toml
 [providers]
-venice = "https://api.venice.ai/api/v1/chat/completions"
+venice = { chat = "https://api.venice.ai/api/v1/chat/completions" }
+mixed  = { chat = "https://x/v1/chat/completions", embeddings = "https://x/v1/embeddings" }
+local  = { embeddings = "http://127.0.0.1:8080/v1/embeddings" }
+
+[providers.proxy]           # TOML section 写法也可以
+chat    = "https://proxy.internal/v1/chat/completions"
+headers = { "X-Team" = "companion", "X-Env" = "prod" }
 ```
 
-在内置 OpenRouter client 之外声明额外的 chat-completions 端点。在任何接受
+每个条目都是一张表，最多三个 key——`chat`（OpenAI 兼容的
+chat-completions URL）、`embeddings`（OpenRouter 兼容的 embeddings
+URL，wire 形态见
+[`https://openrouter.ai/docs/api_reference/embeddings`](https://openrouter.ai/docs/api_reference/embeddings)）、
+以及 `headers`（原样发到该条目所有端点的每个请求上）。**字符串值会被拒绝**：
+0.9.4 之前的写法（`venice = "https://…"`）已彻底移除、无兼容层，启动报错
+会指出正确的表写法。适用 `deny_unknown_fields`——未知 key、空表、空
+URL 字符串同样拒绝加载。
+
+在内置 OpenRouter client 之外声明额外的端点。在任何接受
 `model` / `fallback` 的位置（三种形态：固定、轮询、加权）给模型 slug 加
-`@<name>` 后缀即可引用：
+`@<name>` 后缀即可引用（chat 类任务）；embedding 则在
+`[tasks.embedding]` 的模型字段上加后缀：
 
 ```toml
 [tasks.chat_companion]
-model = "venice-uncensored@venice"   # 由 [providers].venice 提供服务
+model = "venice-uncensored@venice"   # 由 [providers].venice.chat 提供服务
 fallback = ["x-ai/grok-4.20"]        # 无后缀 → 内置 OpenRouter
+
+[tasks.embedding]
+model = "bge-m3@local"               # 由 [providers].local.embeddings 提供服务
 ```
 
 以下规则全部在启动时强制校验（任一违反即拒绝启动）：
 
-- **名称**匹配 `[a-z0-9_]+`；`openrouter` 为保留字（覆盖内置端点请用
-  `OPENROUTER_BASE_URL` 环境变量），`voyage` 同为保留字（`$VOYAGE_API_KEY`
-  已属于内置 embeddings 客户端）。
-- **URL** 为完整的 chat-completions 地址，原样 POST，引擎不做任何路径拼接。
+- **名称**匹配 `[a-z0-9_]+`。`voyage` 仍为保留字——它的原生 API 不是本
+  机制所讲的 OpenRouter 兼容 embeddings 格式，且 `$VOYAGE_API_KEY` 已属于
+  内置的原生 Voyage 客户端。`openrouter` 是可以声明的合法名字：它不新增
+  一个独立 provider，而是**按 key 覆盖内置的 OpenRouter 端点 URL**（见下）。
+- **URL** 完整、原样 POST——引擎不做任何路径拼接。被 chat 类任务引用的
+  provider 必须声明 `chat`；被 `[tasks.embedding]` 引用的必须声明
+  `embeddings`。缺失其一即拒绝启动，并点名 slug、条目和缺失的 key。
+- **`headers`**（可选）是原样发到该条目所有端点（`chat` 和
+  `embeddings` 都算）每个请求上的表。`Authorization` 和 `Content-Type`
+  是引擎自有的，声明它们（不区分大小写）即拒绝加载——静默覆盖
+  `Authorization` 是最糟糕的那种坑。其余每个 name/value 都必须是合法的
+  HTTP header，否则拒绝加载。
 - **API key** 来自环境变量 `<大写名称>_API_KEY`（`venice` →
-  `$VENICE_API_KEY`），仅对被模型 slug 实际引用的 provider 强制要求；
-  已声明但未引用的条目无需 key。
+  `$VENICE_API_KEY`），一个 key 同时覆盖该条目的 `chat` 和 `embeddings`
+  端点，仅对被某个模型 slug 实际引用的 provider 强制要求；已声明但未引用
+  的条目无需 key。`openrouter` 继续用现有的 `$OPENROUTER_API_KEY`——命名
+  约定退化为那个本来就存在的变量。
 - **模型 id 用该 provider 自己的 slug**，原样上线——引擎从不在 provider
   之间转译模型名。
 - 模型 id 中的字面 `@` 用 `\@` 转义。TOML 双引号字符串写作
@@ -115,15 +142,62 @@ fallback = ["x-ai/grok-4.20"]        # 无后缀 → 内置 OpenRouter
 - **按模型匹配的表用裸 id**：`model_name_display_override`、`output_regex`
   的 `models`、`output_filter` trigger 的 `models`，匹配时都不带
   `@provider`。
-- **wire 形态**：自定义 provider 收到严格的 OpenAI chat-completions 子集。
+- **wire 形态**：自定义 provider 收到严格的 OpenAI 兼容子集。
   `[defaults].ignore_providers`、`[defaults].provider_sort` 和任务级
-  `reasoning` 对自定义 provider **不生效**，OpenRouter 归因标头也不会发送。
+  `reasoning` 对自定义 provider **不生效**；它们只收到该条目自己声明的
+  `headers`，绝不会收到 OpenRouter 归因标头。
 - **审计**：自定义 provider 服务的行记录
   `model = "<上游回显>@<name>"`，`generation_id` 原样存 provider 返回的
   id——用 `generation_id` 去 join OpenRouter 日志时这些行会 miss，
   `model` 列会说明原因。
 - 使用 `MODEL_CONFIG_DIR` 时，`[providers]` 作为单个顶层 key 整体合并
   （同 `[defaults]`，不同于 `[tasks]`）：所有 provider 必须写在同一个文件里。
+
+#### 通过 `[providers].openrouter` 覆盖内置端点
+
+```toml
+[providers.openrouter]
+embeddings = "http://my-proxy/v1/embeddings"
+headers    = { "HTTP-Referer" = "https://eros.example", "X-OpenRouter-Title" = "Eros" }
+```
+
+- 声明的每个 key（`chat` 和/或 `embeddings`）覆盖对应的内置 URL；缺失的
+  key 保留内置默认值（`https://openrouter.ai/api/v1/chat/completions` /
+  `https://openrouter.ai/api/v1/embeddings`）。这条“部分覆盖”规则只对
+  `openrouter` 生效——普通条目缺 key 且被引用时是启动报错，因为它没有内置
+  默认值可以兜底。
+- 覆盖**只**改变 URL。流量走的仍然是完整的 OpenRouter wire：
+  `provider.ignore`、`provider_sort`、任务级 `reasoning` 全部照常发送——
+  和只收到严格 OpenAI 子集的自定义 provider 不同。
+- **归因 header 现在只从这里来。** 没有 `[providers.openrouter]` 条目，
+  或有条目但没写 `headers`，就不发任何归因 header。
+  `OPENROUTER_APP_REFERER` / `OPENROUTER_APP_TITLE` /
+  `OPENROUTER_APP_CATEGORIES` 环境变量**软废弃**：仍然设置也会被静默
+  忽略，不是启动报错——请把同样的 header 改到
+  `[providers.openrouter].headers` 下（对应关系见
+  [`llm-audit.zh.md`](llm-audit.zh.md)）。
+- API key 仍然是 `$OPENROUTER_API_KEY`。
+- **`OPENROUTER_BASE_URL` 环境变量已不存在。** 唯一的覆盖方式是
+  `[providers].openrouter.chat` / `[providers].openrouter.embeddings`。仍然
+  设置 `OPENROUTER_BASE_URL` 不会被读取，也不会导致启动报错——它现在只是
+  一个无关的环境变量。
+- `voyage` 仍不能在 `[providers]` 中声明（见上文）。
+
+#### `[defaults].ignore_providers` — 必须带 `@openrouter`
+
+```toml
+[defaults]
+ignore_providers = ["some-bad-provider-slug@openrouter"]
+```
+
+每个条目都必须能解析出（与模型 slug 相同的 `@` 后缀语法）一个非空的上游
+slug 加 provider `openrouter`；裸条目、其他 `@<provider>` 后缀、或格式
+错误的 `@` 语法都会拒绝启动，并点名该条目和正确写法。wire 行为不变：
+`provider.ignore` 只带裸上游 slug，只发给 OpenRouter 流量——强制后缀把这个
+作用范围写进了语法本身；自定义 provider 和 Voyage 永远不会收到
+`provider.ignore`。`[defaults].provider_sort` 不受影响（它没有 per-entry
+语法可限定范围）。对在这个后缀出现之前写好的配置是破坏性变更——修复方式
+是给每个条目加上 `@openrouter`。
 
 ### `model_name_display_override`（仅限 chat 任务）
 
@@ -331,7 +405,7 @@ SSE `final` frame 的 `filtered` 字段在客户端收到的是非原始输出�
 | `affinity_evaluation` | `pipeline::post_process`（每轮六轴 affinity delta；每个 Reply 轮次后以 fire-and-forget 方式运行） | live |
 | `memory_extraction` | dreaming sweeper（会话结束时进行 memory 整合；任务块缺失时关闭） | live（opt-in） |
 | `chat_input_filter` | `pipeline::stream`（用户输入改写 filter；由 `[tasks.chat_companion]` 上的 `input_filter` 和此任务块共同激活；默认关闭） | live（opt-in） |
-| `embedding` | 保留——`VoyageClient` 读取自己的 `VOYAGE_API_KEY` 并 hard-code `voyage-3-lite` | reserved |
+| `embedding` | 启动时的 `EmbeddingRouter::from_config()`（`main.rs`），经由 `ModelConfig::resolve_embedding()`——把 `embed_query`/`embed_document`/`embed_documents` 路由到原生 Voyage、内置 OpenRouter embeddings 端点、或某个 `[providers]` 条目；块缺失 = 原生 Voyage `voyage-3-lite`（与引入配置前的行为一致） | live |
 
 只有当引擎确实在某处调用 `model_config.resolve("<name>", ...)` 时，`[tasks.<name>]` 条目才有意义。当前调用点如下：
 
@@ -339,7 +413,9 @@ SSE `final` frame 的 `filtered` 字段在客户端收到的是非原始输出�
 - `crates/eros-engine-server/src/pipeline/post_process.rs` → `insight_extraction`、`affinity_evaluation`
 - `crates/eros-engine-server/src/pipeline/stream.rs` → `pde_decision`，通过 `run_stream` 内的 `run_pde_decision`（仅当设置了 `filter_prompt`）；`chat_image_prompt_compose`，通过 `resolve_image_prompt_compose()`（图片提示词改写器，opt-in，仅在图片轮次按需解析）；`chat_vision`，通过 `resolve_vision()`（视觉预处理阶段，opt-in）；`chat_product_qa`，通过 `resolve_product_qa()`（产品问答执行器，opt-in）；`chat_input_filter`，通过 `resolve_input_filter()`（输入改写，opt-in）；`memory_extraction`，通过 dreaming sweeper
 
-`embedding` 已无实际作用——Voyage 不经过此路径。
+`embedding` 不走上面这条通用 `resolve()` 路径——它有自己的解析器
+`ModelConfig::resolve_embedding()`，在 `main.rs` 启动时调用一次来构建
+`EmbeddingRouter`。见下文“`[tasks.embedding]` — 已激活”。
 
 ### `[tasks.pde_decision]` — opt-in LLM PDE 判断器
 
@@ -497,6 +573,79 @@ filter_prompt = """
 调用点：`crates/eros-engine-server/src/pipeline/stream.rs`，通过
 `model_config.rs` 中的 `resolve_product_qa()`。
 
+### `[tasks.embedding]` — 已激活
+
+`VoyageClient` 以前 hard-code `voyage-3-lite`；现在 `[tasks.embedding]`
+真正被消费，embedding 模型本身、以及它路由到哪个后端，都由配置驱动。
+
+```toml
+# 单模型——read 和 write 用同一个后端。
+[tasks.embedding]
+model = "voyage-3-lite"                       # ≡ "voyage-3-lite@voyage"
+# model = "openai/text-embedding-3-small@openrouter"
+# model = "bge-m3@local"                      # 第三方，OpenRouter 兼容 wire
+
+# 或者：拆分 read/write——仅限 voyage-4 系列及以上。
+#[tasks.embedding]
+#model_read  = "voyage-4-lite"   # 召回路径：embed_query，input_type "query"
+#model_write = "voyage-4"        # 存储路径：embed_document(s)，input_type "document"
+```
+
+**维度固定为 512，没有配置开关。** pgvector 的三个列都是
+`VECTOR(512) NOT NULL`，client 在 wire 上请求的也是 512，且每次响应都会
+做长度校验。以前 `[tasks.<name>]` 上有一个 `dimensions` 字段——它从未被
+消费，现已移除；已有配置里残留的 `dimensions = 512` 行，现在只是一个被
+静默忽略的未知 key（和其他过期 key 一样，serde 直接忽略）。
+
+| 字段 | 类型 | 规则 |
+|---|---|---|
+| `model` | 单个固定字符串 | 裸 id ⇒ `@voyage`；`@openrouter` / `@<custom>` 路由到 OpenRouter 兼容 wire；与 read/write 对互斥 |
+| `model_read` | `Option<String>` | 仅限 read/write 对使用，仅限 Voyage，N ≥ 4（见下方的 gate）；服务 `embed_query` |
+| `model_write` | `Option<String>` | 仅限 read/write 对使用，仅限 Voyage，N ≥ 4；服务 `embed_document` / `embed_documents` |
+
+按后缀路由，由 `ModelConfig::resolve_embedding()` 解析：
+
+| 裸 id（无后缀） | `@openrouter` | `@voyage` | `@<custom>` |
+|---|---|---|---|
+| 原生 Voyage | 内置 OpenRouter embeddings 端点（可覆盖，见上文 `[providers].openrouter`） | 同裸 id | `[providers].<name>.embeddings`（OpenRouter 兼容 wire） |
+
+- `model_read` / `model_write` 是普通的 `Option<String>`——数组/表形态在
+  解析时就是类型错误。`model_read = model_write` 合法（虽然多余但无害——
+  等价于 `model`）。`@openrouter` 和 `@<custom>` 在 `model_read`/
+  `model_write` 上会拒绝启动（只有 Voyage 能保证跨模型体量共享一个向量
+  空间）。
+- `[tasks.embedding]` **缺失** ⇒ 与引入配置前完全一致的行为：原生
+  Voyage、`voyage-3-lite`、wire 上不带 dimension 参数。
+- `model` 必须是单个固定字符串；round-robin、weighted、`fallback`、
+  `tiers` 全部拒绝启动（否则会产生混合/不兼容的向量空间——沿用
+  `chat_voice` 仅固定字符串的先例）。
+- wire 上没有 `input_type`：query/document 的优化是 Voyage 原生的特性。
+  把 embedding 路由离开 Voyage 就放弃了这个优化。
+
+**voyage-4 gate。** 应用于剥掉可选 `@voyage` 后缀之后的裸 id。该 id 必须
+以 `voyage-` 开头，后接一个数字段（只能是 ASCII 数字和点号，到下一个 `-`
+或字符串末尾为止），且该数字段能解析为一个 ≥ 4 的有限数：
+
+- ✓ `voyage-4`、`voyage-4-lite`、`voyage-4.5-large`、`voyage-10`
+- ✗ `voyage-3.5-lite`（N = 3.5）、`voyage-code-3`（`voyage-` 后面没有
+  紧跟数字段）、`voyage-inf`/`voyage-nan`（含非数字字符，且即便解析出来
+  也不是有限数）、`bge-m3@local`（不是 voyage）、任何 `@openrouter` 或
+  自定义 provider 的 slug
+
+只有 voyage-4 系列及以上才能保证跨模型体量共享同一个向量空间——把一个
+更低版本或非数字的模型混进 read/write 对，会静默写入 read 模型无法比较
+的向量，所以这里是启动拒绝，不只是文档脚注。
+
+**`VOYAGE_API_KEY`** 仅当解析出的 read 或 write 后端是 Voyage 时才要求
+（块缺失 ⇒ 默认走 Voyage ⇒ 依然要求，现有部署行为不变）。把 read 和
+write 全部路由离开 Voyage 的部署不再需要这个变量。
+
+调用点：`crates/eros-engine-server/src/main.rs` 在启动时构建一次
+`eros_engine_llm::embedding::EmbeddingRouter::from_config(&model_config)`；
+`AppState.embed: Arc<EmbeddingRouter>` 为 `handlers.rs` / `post_process.rs`
+/ `dreaming.rs` / `world.rs` / `story.rs` 里的 `embed_query` /
+`embed_document` / `embed_documents` 提供服务，调用形态不变。
+
 ### 启用/禁用 extraction
 
 `insight_extraction`（每轮事实挖掘）和 `memory_extraction`（会话结束时的 dreaming sweeper）由其 `[tasks.*_extraction]` **章节是否存在**控制：
@@ -567,7 +716,7 @@ model = { "x-ai/grok-4.20" = 0.8, "z-ai/glm-4.7-flash" = 0.2 }  # weighted rando
 1. **不删除字段。** `[defaults]` 和 `[tasks.<name>]` 中现有的字段名不会消失。
 2. **不重命名字段。** `fallback` 不会变为 `fallback_model`，`model` 不会变为 `primary_model`，以此类推。
 3. **不新增必填字段。** 任何新增字段都是可选的，并具有合理默认值。
-4. **不从此列表中删除任务名：**`chat_companion`、`insight_extraction`、`pde_decision`。若真实实现落地并取代 reserved 任务名（`embedding`）当前的占位语义，reserved 任务名可能发生变化；该变更会在 changelog 中说明。
+4. **不从此列表中删除任务名：**`chat_companion`、`insight_extraction`、`pde_decision`、`embedding`。
 5. **解析优先级固定。** 对于 `model`/`fallback`/`allow_traits`，优先级为 `matched tier > task default block > [defaults] > compiled-in fallback`。`temperature`/`max_tokens` 仅限任务级。
 6. **`model` 接受字符串、数组（round-robin）或表（weighted）。** 普通字符串将始终有效；数组/表形式属于扩展能力。
 
@@ -586,10 +735,19 @@ model = { "x-ai/grok-4.20" = 0.8, "z-ai/glm-4.7-flash" = 0.2 }  # weighted rando
 - `[tasks.chat_output_filter]`（新任务）：在 0.x 中新增。默认缺失（filter 不生效）。参见上文“`output_filter` — 二次回复改写”。
 - SSE `final` frame 字段 `filtered`、`retries_chat`、`retries_filter`、`prompt_injected`、`tier`：在 0.x 中新增。
 - `output_regex`（可选数组，位于 `[tasks.chat_companion]`）：在 0.x 中新增。仅限任务级（无 per-tier 覆盖）。在客户端看到回复之前、LLM `output_filter` 之前、提取之前应用的确定性 regex 过滤。regex 过滤或 LLM filter（或两者）产生非原始输出时，`filtered` 标志均为 `true`。参见上文"`output_regex` — 确定性 per-model 正则过滤"。
+- **`[tasks.embedding]` 现已激活**（此前是保留、未被消费的占位）。随激活
+  一起打包的破坏性变更：`[providers]` 的值现在是表，不再是纯字符串（字符串
+  写法会被拒绝、无兼容层）；`[defaults].ignore_providers` 的条目现在必须带
+  `@openrouter` 后缀；`OPENROUTER_BASE_URL` 环境变量已移除（改用
+  `[providers].openrouter.chat`/`.embeddings`）；`OPENROUTER_APP_*` 环境变量
+  软废弃（静默忽略，改用 `[providers].openrouter.headers`）；
+  `[tasks.<name>]` 上的 `dimensions` 字段已移除（维度固定为 512；已有配置
+  里残留的 `dimensions = 512` 行现在是被忽略的未知 key）。详见上文
+  “`[providers]`”和“`[tasks.embedding]` — 已激活”。
 
 ## 此配置不控制的内容
 
-- **Voyage embedding**——`VoyageClient` hard-code `voyage-3-lite` 并直接读取 `VOYAGE_API_KEY`。`[tasks.embedding]` 块为将来的通用化保留。
+- **Voyage 自己的 base URL**——原生 Voyage wire 始终打到 Voyage 的官方端点；只有模型 id 可以配置，通过 `[tasks.embedding]`。要完全绕开 Voyage，改用 `@openrouter` 或自定义 `[providers]` 后缀。
 - **PDE 决策（默认路径）**——未设置 `filter_prompt` 时，`eros-engine-core/src/pde.rs` 中的规则引擎无条件运行。设置 `[tasks.pde_decision].filter_prompt` 可激活 opt-in LLM 判断器；此时规则引擎充当 fallback + 硬安全 guardrail。
 - **OpenRouter API key**——直接从 `OPENROUTER_API_KEY` 读取，而非从配置文件读取。
 - **每次调用的 streaming / response format 标志**——在 `OpenRouterClient` 中固定。

--- a/docs/model-config.zh.md
+++ b/docs/model-config.zh.md
@@ -405,7 +405,7 @@ SSE `final` frame 的 `filtered` 字段在客户端收到的是非原始输出�
 | `affinity_evaluation` | `pipeline::post_process`（每轮六轴 affinity delta；每个 Reply 轮次后以 fire-and-forget 方式运行） | live |
 | `memory_extraction` | dreaming sweeper（会话结束时进行 memory 整合；任务块缺失时关闭） | live（opt-in） |
 | `chat_input_filter` | `pipeline::stream`（用户输入改写 filter；由 `[tasks.chat_companion]` 上的 `input_filter` 和此任务块共同激活；默认关闭） | live（opt-in） |
-| `embedding` | 启动时的 `EmbeddingRouter::from_config()`（`main.rs`），经由 `ModelConfig::resolve_embedding()`——把 `embed_query`/`embed_document`/`embed_documents` 路由到原生 Voyage、内置 OpenRouter embeddings 端点、或某个 `[providers]` 条目；块缺失 = 原生 Voyage `voyage-3-lite`（与引入配置前的行为一致） | live |
+| `embedding` | 启动时的 `EmbeddingRouter::from_config()`（`main.rs`），经由 `ModelConfig::resolve_embedding()`——把 `embed_query`/`embed_document`/`embed_documents` 路由到原生 Voyage、内置 OpenRouter embeddings 端点、或某个 `[providers]` 条目；块缺失 = 原生 Voyage `voyage-4-lite` | live |
 
 只有当引擎确实在某处调用 `model_config.resolve("<name>", ...)` 时，`[tasks.<name>]` 条目才有意义。当前调用点如下：
 
@@ -581,7 +581,8 @@ filter_prompt = """
 ```toml
 # 单模型——read 和 write 用同一个后端。
 [tasks.embedding]
-model = "voyage-3-lite"                       # ≡ "voyage-3-lite@voyage"
+model = "voyage-4-lite"                       # ≡ "voyage-4-lite@voyage"
+# model = "voyage-3-lite"                     # 遗留写法显式钉住（Voyage 官方已不再推荐）
 # model = "openai/text-embedding-3-small@openrouter"
 # model = "bge-m3@local"                      # 第三方，OpenRouter 兼容 wire
 
@@ -614,8 +615,10 @@ model = "voyage-3-lite"                       # ≡ "voyage-3-lite@voyage"
   等价于 `model`）。`@openrouter` 和 `@<custom>` 在 `model_read`/
   `model_write` 上会拒绝启动（只有 Voyage 能保证跨模型体量共享一个向量
   空间）。
-- `[tasks.embedding]` **缺失** ⇒ 与引入配置前完全一致的行为：原生
-  Voyage、`voyage-3-lite`、wire 上不带 dimension 参数。
+- `[tasks.embedding]` **缺失** ⇒ 原生 Voyage + `voyage-4-lite`（wire 上带
+  `output_dimension: 512`）。Voyage 官方已不再推荐 `voyage-3-lite`，仍要
+  用它的部署必须在配置里显式钉住。在已有数据上换模型会切换向量空间——
+  旧行与新查询不可比——所以要么钉住旧模型，要么整体重嵌入。
 - `model` 必须是单个固定字符串；round-robin、weighted、`fallback`、
   `tiers` 全部拒绝启动（否则会产生混合/不兼容的向量空间——沿用
   `chat_voice` 仅固定字符串的先例）。

--- a/docs/superpowers/specs/2026-08-01-embedding-providers-design.md
+++ b/docs/superpowers/specs/2026-08-01-embedding-providers-design.md
@@ -1,0 +1,427 @@
+# eros-engine — custom embedding providers + voyage read/write model split
+
+Activates the long-reserved `[tasks.embedding]` block for real: the embedding
+model becomes configurable, embedding calls can route to the built-in Voyage
+client, the built-in OpenRouter embeddings endpoint, or any third-party
+endpoint speaking the OpenRouter-compatible embeddings format — and, on the
+voyage-4 series and above, the recall (read) and storage (write) paths can use
+two different models that share one vector space.
+
+Today `VoyageClient` hard-codes `voyage-3-lite`, 512 dims, and
+`$VOYAGE_API_KEY` (`voyage.rs:10-12`); `[tasks.embedding]` is documented as
+"Reserved — not consumed by current code". This design makes the config real
+and clears that tech debt in the same move.
+
+Builds directly on the multi-provider design
+(`2026-07-31-multi-llm-providers-design.md`); everything not amended here —
+slug grammar, `\@` escaping, name charset, key naming, bare-id rules for
+model-keyed tables — carries over unchanged.
+
+---
+
+## 0. Decisions (settled during brainstorm)
+
+- **`[providers]` values become tables** — `{ chat = "…" }`,
+  `{ embeddings = "…" }`, or both. The 0.9.3 plain-string shape is **dropped
+  with no compatibility layer**: that shape shipped in an unpublished
+  release-in-progress and has no consumers. A string value now fails the load
+  with a message showing the table form.
+- **`dimensions` is removed from `[tasks.embedding]`.** It was a mistaken
+  reservation, never consumed. The engine hard-codes **512** end to end: the
+  three pgvector columns are `VECTOR(512) NOT NULL`
+  (`0003_memory.sql`, `0035_world_memories.sql`, `0038_world_stories.sql`),
+  the clients request 512 on the wire (one legacy fixed-dim exception,
+  §5.2), and every response is length-checked.
+  A leftover `dimensions = 512` line in an operator's config is inert
+  (serde ignores unknown keys, exactly like any stale key today).
+- **The `openrouter` reservation in `[providers]` is relaxed, and the
+  `OPENROUTER_BASE_URL` env var is removed.** Declaring
+  `[providers].openrouter` overrides the built-in endpoint URLs, per key
+  (§4), and is now the only override mechanism. No boot guard for a
+  still-set `OPENROUTER_BASE_URL`: the var never shipped in a release and
+  has no consumers, so it is simply deleted and any set value is ignored
+  like any unrelated env var.
+- **`[providers]` entries carry custom headers; the env attribution vars
+  are soft-deprecated.** Each entry accepts an optional `headers` table
+  sent verbatim on every request to that provider's endpoints — for
+  `openrouter`, this is where `HTTP-Referer` / `X-OpenRouter-Title` /
+  `X-OpenRouter-Categories` now live. The three `OPENROUTER_APP_*` env
+  vars become **inert: still-set values are silently ignored, not a boot
+  error** — these vars did ship, but losing an attribution header costs
+  analytics, not correctness, so a boot refusal would punish upgrades out
+  of proportion. Deployments re-declare their headers under
+  `[providers].openrouter`.
+- **`[defaults].ignore_providers` entries must carry `@openrouter`.**
+  Each entry is now written `<upstream-slug>@openrouter` (e.g.
+  `"some-bad-provider-slug@openrouter"`); a bare entry, any other
+  `@<provider>` suffix, or malformed `@` grammar refuses to boot with a
+  message showing the new form. The suffix is stripped before the wire —
+  `provider.ignore` still sends bare upstream slugs. This makes the
+  knob's scope part of its syntax: it acts on OpenRouter routing only
+  (custom providers and Voyage never receive `provider.ignore`), and the
+  notation leaves room for per-provider ignore lists later. Breaking for
+  existing configs (the field shipped pre-v0.6.1), loud not silent: the
+  migration is appending `@openrouter` to each entry.
+- **Bare chat slugs still mean OpenRouter** — the chat wire format is defined
+  against OpenRouter, so no suffix ⇒ the built-in (or overridden) OpenRouter
+  chat endpoint, exactly as in 0.9.3. `@openrouter` becomes a globally valid
+  explicit spelling of the same thing.
+- **Bare embedding slugs mean Voyage.** In `[tasks.embedding]`,
+  `"voyage-3-lite"` ≡ `"voyage-3-lite@voyage"`. The default provider flips
+  per task family because the incumbent embedding backend is Voyage, not
+  OpenRouter.
+- **`@voyage` is embeddings-only.** A `@voyage` suffix on any non-embedding
+  task slug refuses to boot. `voyage` stays undeclarable in `[providers]`
+  (its native API is not the OpenRouter-compatible format this mechanism
+  speaks).
+- **`model_read` / `model_write` are a voyage-4-gated pair.** Mutually
+  exclusive with `model`, must appear together, voyage-only, and the model id
+  must parse as `voyage-<N>…` with N ≥ 4 — enforced at boot, because mixing
+  vector spaces fails silently at query time, the worst possible failure
+  mode.
+- **Client structure: an `EmbeddingRouter` facade** holding a read backend
+  and a write backend (the same object when a single `model` is configured),
+  each backend either the native `VoyageClient` or a new OpenAI/OpenRouter-
+  compatible `EmbedHttpClient`. The server-facing API
+  (`embed_query` / `embed_document` / `embed_documents`) is unchanged.
+- **Third-party embedding providers must speak the OpenRouter-compatible
+  embeddings format** (`POST` body `{model, input, dimensions}` → response
+  `data[].embedding`), per
+  <https://openrouter.ai/docs/api_reference/embeddings>. The engine never
+  translates model ids; whatever precedes `@` goes on the wire verbatim.
+- **Embedding model specs are single fixed strings.** Round-robin and
+  weighted forms would interleave incompatible vector spaces; `fallback` and
+  `tiers` on `[tasks.embedding]` are rejected for the same reason. All
+  refuse to boot (the `chat_voice` fixed-only precedent).
+
+---
+
+## 1. The `[providers]` block — table values
+
+```toml
+[providers]
+venice = { chat = "https://api.venice.ai/api/v1/chat/completions" }
+mixed  = { chat = "https://x/v1/chat/completions", embeddings = "https://x/v1/embeddings" }
+local  = { embeddings = "http://127.0.0.1:8080/v1/embeddings" }
+
+[providers.proxy]           # TOML section form works too
+chat    = "https://proxy.internal/v1/chat/completions"
+headers = { "X-Team" = "companion", "X-Env" = "prod" }
+```
+
+- Parsed as `HashMap<String, ProviderEntry>` where `ProviderEntry
+  { chat: Option<String>, embeddings: Option<String>, headers:
+  Option<HashMap<String, String>> }` with `deny_unknown_fields`. A
+  plain-string value, an empty table, an unknown key, or an empty URL
+  string refuses the load.
+- `headers` are sent verbatim on every request to that entry's endpoints
+  (both `chat` and `embeddings`). Header names and values must be valid
+  HTTP header material at boot (refuse, don't warn-and-drop);
+  `Authorization` and `Content-Type` are engine-owned and refuse the load
+  if declared (case-insensitive) — a silently overridden `Authorization`
+  is the worst kind of footgun.
+- Both URLs are complete and posted verbatim — no path joining, unchanged
+  from the multi-provider design.
+- One name, one key: `<NAME_UPPERCASED>_API_KEY` covers both the `chat` and
+  `embeddings` endpoints of that entry. Required only when the entry is
+  actually referenced by some slug (unchanged).
+- A provider referenced from a chat-shaped task must declare `chat`; one
+  referenced from `[tasks.embedding]` must declare `embeddings`. A miss on
+  either refuses to boot naming the slug, the entry, and the missing key.
+- Merge behaviour under `MODEL_CONFIG_DIR` is unchanged: `[providers]` is
+  one whole top-level key.
+
+---
+
+## 2. `[tasks.embedding]` — activated
+
+```toml
+# Single model — read and write use the same backend.
+[tasks.embedding]
+model = "voyage-3-lite"                       # ≡ "voyage-3-lite@voyage"
+# model = "openai/text-embedding-3-small@openrouter"
+# model = "bge-m3@local"                      # third-party, OpenRouter-compatible wire
+
+# OR: split read/write — voyage-4 series and above ONLY.
+#[tasks.embedding]
+#model_read  = "voyage-4-lite"   # recall path: embed_query, input_type "query"
+#model_write = "voyage-4"        # storage path: embed_document(s), input_type "document"
+```
+
+Field semantics:
+
+| field | type | rules |
+|---|---|---|
+| `model` | single fixed string | bare ⇒ `@voyage`; `@openrouter` / `@<custom>` route to the OpenRouter-compatible wire; mutually exclusive with the pair |
+| `model_read` | `Option<String>` | pair-only, voyage-only, N ≥ 4; serves `embed_query` |
+| `model_write` | `Option<String>` | pair-only, voyage-only, N ≥ 4; serves `embed_document` / `embed_documents` |
+
+- `model_read` / `model_write` are plain `Option<String>` in `TaskConfig`,
+  so array/table shapes are type errors at parse time; `model` stays the
+  shared `ModelSpec` and boot validation enforces the `Fixed` shape.
+- `model_read = model_write` is legal (redundant but harmless — equivalent
+  to `model`).
+- The read/write split exists because documents are embedded once but
+  queries are embedded every turn: a deployment can write with a large
+  voyage-4 model and read with a cheap one (or vice versa) inside the one
+  shared voyage-4 vector space.
+- `[tasks.embedding]` **absent** ⇒ exactly today's behaviour: native Voyage,
+  `voyage-3-lite`, no dimension parameter on the wire, `$VOYAGE_API_KEY`
+  required.
+- On other `[tasks.embedding]` fields: `temperature`, `max_tokens`, etc.
+  remain ignored as today; `fallback` and `tiers` refuse to boot (§6).
+
+### The voyage-4 gate
+
+Applied to the bare id after stripping an optional `@voyage` suffix. The id
+must begin `voyage-` followed by a numeric segment (digits and dots, ending
+at the next `-` or end of string) that parses as a number ≥ 4:
+
+- ✓ `voyage-4`, `voyage-4-lite`, `voyage-4.5-large`, `voyage-10`
+- ✗ `voyage-3.5-lite` (N = 3.5), `voyage-code-3` (no leading numeric
+  segment after `voyage-`), `bge-m3@local` (not voyage), any `@openrouter`
+  or custom-provider slug
+
+Rationale: only the voyage-4 series and above guarantee a shared vector
+space across model sizes. A lower or non-numeric model in the pair would
+silently write vectors the read model cannot compare — so the gate is a
+boot refusal, not a docs footnote. Cost, accepted: if Voyage changes its
+naming scheme, the gate needs a code change to admit the new names.
+
+---
+
+## 3. Slug semantics per context
+
+| context | bare (no suffix) | `@openrouter` | `@voyage` | `@<custom>` |
+|---|---|---|---|---|
+| chat-shaped task `model`/`fallback` | built-in OpenRouter chat (unchanged) | same as bare | **boot error** | `[providers].<name>.chat` |
+| `[tasks.embedding].model` | native Voyage | OpenRouter embeddings endpoint | same as bare | `[providers].<name>.embeddings` |
+| `model_read` / `model_write` | native Voyage | **boot error** | same as bare | **boot error** |
+
+`@openrouter` needs no `[providers]` entry and no extra key check
+(`$OPENROUTER_API_KEY` is already unconditionally required for chat). The
+slug grammar in `provider.rs` is untouched — `openrouter` and `voyage` are
+resolution-level semantics applied after `split_model_slug`, not new syntax.
+
+---
+
+## 4. Built-in endpoint overrides via `[providers].openrouter`
+
+```toml
+[providers.openrouter]
+embeddings = "http://my-proxy/v1/embeddings"
+headers    = { "HTTP-Referer" = "https://eros.example", "X-OpenRouter-Title" = "Eros" }
+```
+
+- Each present key overrides that built-in URL; each absent key keeps the
+  built-in default (`https://openrouter.ai/api/v1/chat/completions` /
+  `https://openrouter.ai/api/v1/embeddings`). This partial-override rule is
+  unique to `openrouter` — for ordinary entries a missing key is a boot
+  error when referenced, because there is no built-in default to fall back
+  to.
+- The override changes the URL **only**. Traffic through it remains the
+  full OpenRouter wire: `provider.ignore`, `provider_sort`, and per-task
+  `reasoning` are all still sent — unlike custom providers, which keep
+  receiving the strict OpenAI subset.
+- Attribution headers now come from this entry's `headers` table and
+  nowhere else. No entry, or an entry without `headers` ⇒ no attribution
+  headers are sent. `AppAttribution` and its warn-and-drop env plumbing
+  are removed with the env vars (§7) — the same tech-debt sweep as
+  `voyage.rs`.
+- The API key stays `$OPENROUTER_API_KEY` — the `<NAME>_API_KEY` naming
+  convention degenerates to exactly the env var that already exists.
+- `OPENROUTER_BASE_URL` is removed as an env var (§0) — the
+  `with_openrouter_base_url` builder and the `main.rs` env read go with
+  it; no boot guard (never shipped, no consumers).
+- `voyage` remains undeclarable in `[providers]`.
+
+### `[defaults].ignore_providers` — `@openrouter` required
+
+```toml
+[defaults]
+ignore_providers = ["some-bad-provider-slug@openrouter"]
+```
+
+- Every entry must parse (same `split_model_slug` grammar) to a non-empty
+  upstream slug plus provider `openrouter`; anything else refuses to boot.
+- The wire is unchanged: `provider.ignore` carries the bare upstream
+  slugs, on OpenRouter traffic only. The knob stays inert for custom
+  providers and Voyage — which is exactly what the mandatory suffix now
+  says out loud. `[defaults].provider_sort` is untouched (it has no
+  per-entry syntax to scope).
+
+---
+
+## 5. Clients
+
+### 5.1 `EmbeddingRouter` (new module `eros-engine-llm/src/embedding.rs`)
+
+```rust
+pub struct EmbeddingRouter {
+    read:  EmbedBackend,   // embed_query
+    write: EmbedBackend,   // embed_document, embed_documents
+}
+
+enum EmbedBackend {
+    Voyage(VoyageClient),          // native Voyage wire, keeps input_type
+    OpenAiCompat(EmbedHttpClient), // OpenRouter-compatible wire
+}
+```
+
+- Public API mirrors today's `VoyageClient` surface: `embed_query`,
+  `embed_document`, `embed_documents`. Call sites keep their shape.
+- Built once at boot from `ModelConfig` + env; a single `model` yields the
+  same backend on both sides.
+
+### 5.2 `VoyageClient` — consumes the config (tech-debt cleanup)
+
+- Model comes from `[tasks.embedding]` instead of the hard-coded
+  `voyage-3-lite`; the hard-coded default remains only for the
+  block-absent path.
+- Sends `output_dimension: 512` on the wire **except** for `voyage-3-lite`,
+  which is a fixed-512-dim legacy model (the parameter is unnecessary
+  there, and the exception keeps the previously shipped example config
+  byte-identical on the wire). The exception is a named constant with a
+  comment; implementation verifies the exact parameter-support boundary
+  against the Voyage API docs.
+- `input_type` (`"query"` / `"document"`) behaviour is unchanged.
+- Response embeddings are length-checked to 512 before returning
+  (a clear `LlmError` instead of a downstream SQL error).
+
+### 5.3 `EmbedHttpClient` (new) — OpenRouter-compatible wire
+
+- `POST <declared embeddings URL>` verbatim;
+  `Authorization: Bearer <key>`; plus the entry's declared `headers`, if
+  any — nothing else (consistent with custom chat providers).
+- Request body: `{ "model": "<bare id>", "input": ["…", …],
+  "dimensions": 512 }`. `dimensions` is always sent — without it,
+  common models default to other widths (e.g. `text-embedding-3-small` →
+  1536) and would be unusable against the `VECTOR(512)` schema.
+- Response: `data[].embedding`, ordered by `index` when present; count must
+  equal the input count; every vector length-checked to 512.
+- Error bodies pass through the existing `scrub_error_body` bounding
+  (issue #188 precedent). Non-2xx maps to `LlmError::Status`.
+- The wire has no `input_type` — the query/document optimisation is a
+  Voyage-native nuance. Documented in the example config: routing embedding
+  off Voyage forfeits it.
+
+---
+
+## 6. Boot validation
+
+Extends `validate_providers`; the slug scan becomes task-aware (it already
+walks every task's `model`/`fallback` including tier blocks — it now also
+walks `model_read`/`model_write` and carries the task name).
+
+| condition | outcome |
+|---|---|
+| `[providers]` value is a string, empty table, unknown key, or empty URL | refuse |
+| entry named `voyage` | refuse (unchanged message) |
+| `headers` declares `Authorization` or `Content-Type` (case-insensitive) | refuse |
+| `headers` name/value is not valid HTTP header material | refuse |
+| `ignore_providers` entry lacks `@openrouter`, names another provider, or has malformed `@` grammar | refuse |
+| chat-shaped slug references an entry with no `chat` URL | refuse |
+| `[tasks.embedding]` slug references an entry with no `embeddings` URL | refuse |
+| referenced entry's `<NAME>_API_KEY` unset/empty | refuse (unchanged) |
+| `@voyage` on any non-embedding task | refuse |
+| `@openrouter` on chat-shaped slugs or `[tasks.embedding].model` | pass (built-in alias; no `[providers]` lookup) |
+| `model` present together with `model_read`/`model_write` | refuse |
+| exactly one of `model_read`/`model_write` present | refuse |
+| `model_read`/`model_write` slug is non-voyage, or fails the N ≥ 4 gate | refuse |
+| `[tasks.embedding].model` is round-robin or weighted | refuse |
+| `[tasks.embedding]` has `fallback` or `tiers` | refuse |
+
+All refusals are boot-time `Err(String)` in the existing loud-fail style:
+name the config location, the offending value, and the fix.
+
+---
+
+## 7. Server wiring & environment
+
+- `AppState.voyage: Arc<VoyageClient>` → `AppState.embed:
+  Arc<EmbeddingRouter>`. Five call sites rename the field, nothing else:
+  `handlers.rs` (`embed_query`), `post_process.rs` / `dreaming.rs`
+  (`embed_document`), `world.rs` / `story.rs` (`embed_documents`).
+- `VOYAGE_API_KEY` goes from unconditionally required to **required iff the
+  resolved read or write backend is Voyage**. Block absent ⇒ Voyage default
+  ⇒ still required, so existing deployments see no change; a deployment
+  routing embedding entirely off Voyage no longer needs the var.
+- `OPENROUTER_API_KEY`: unchanged (unconditionally required, chat needs it).
+- `OPENROUTER_BASE_URL`: removed, no boot guard (never shipped, no
+  consumers). Endpoint overrides live in `[providers].openrouter` only.
+- `OPENROUTER_APP_REFERER` / `OPENROUTER_APP_TITLE` /
+  `OPENROUTER_APP_CATEGORIES`: soft-deprecated — still-set values are
+  silently ignored, never a boot error. Attribution headers are declared
+  under `[providers].openrouter.headers` instead.
+- Custom provider keys: `<NAME>_API_KEY`, required iff referenced —
+  unchanged rule, now also triggered by embedding references.
+- No new env vars. No DB migration. No OpenAPI change (embedding is
+  internal). No audit-column change.
+
+---
+
+## 8. Testing
+
+- **Validation matrix**: one unit test per row of §6, via
+  `validate_providers_with` (injected env closure, no process-global
+  mutation).
+- **voyage-4 gate parser**: `voyage-4`, `voyage-4-lite`, `voyage-4.5-large`,
+  `voyage-10` pass; `voyage-3.5-lite`, `voyage-code-3`, `voyage-`,
+  non-voyage slugs fail.
+- **`ProviderUrls` parsing**: table forms, string rejection, unknown-key
+  rejection, empty-URL rejection, `MODEL_CONFIG_DIR` single-key merge
+  unchanged.
+- **`EmbedHttpClient`**: mock-server wire tests in the `openrouter.rs`
+  `with_base_url` pattern — request body shape (`dimensions: 512`),
+  declared `headers` present and nothing extra, index-ordered response
+  parsing, count mismatch, dim mismatch, error-body scrubbing.
+- **Headers**: declared headers reach both chat and embeddings requests;
+  reserved-name refusal; invalid header-value refusal; `OPENROUTER_APP_*`
+  env vars have no effect on the wire.
+- **`ignore_providers`**: suffixed entries parse and strip to bare slugs
+  on the wire; bare / wrong-provider / malformed entries refuse.
+- **`VoyageClient`**: model-from-config, `output_dimension` present for
+  voyage-4-class models, absent for `voyage-3-lite`, response length check.
+- **`EmbeddingRouter`**: read/write dispatch (query → read backend,
+  document(s) → write backend), single-model construction.
+- Server sqlx tests: unaffected beyond the state field rename.
+- Full local gate before PR: `cargo fmt` / `clippy` / `test` / openapi
+  check (openapi is expected byte-identical).
+
+---
+
+## 9. Documentation
+
+- `examples/model_config.toml`: rewrite the `[providers]` comment block to
+  the table form (including the `openrouter` partial-override rule and the
+  chat/embeddings key rules); replace the "Reserved — not consumed" note on
+  `[tasks.embedding]` with the real contract — bare-means-voyage, the
+  `@openrouter`/custom routes, `model_read`/`model_write` with the voyage-4
+  rationale, the hard-coded 512, the removed `dimensions` line, and the
+  input_type forfeiture note for non-Voyage routing.
+- `.env.example`: `VOYAGE_API_KEY` comment becomes "required unless
+  `[tasks.embedding]` routes read and write off Voyage"; the
+  `OPENROUTER_BASE_URL` and `OPENROUTER_APP_*` lines are deleted.
+- `examples/model_config.toml`: the `[providers]` block documents the
+  `headers` key, including the `[providers].openrouter.headers` home for
+  attribution headers.
+- The `[defaults]` comment block: `ignore_providers` examples gain the
+  `@openrouter` suffix and a line stating the knob acts on OpenRouter
+  routing only.
+- Migration note for the multi-provider spec's readers: `[providers]`
+  string values are gone, `OPENROUTER_BASE_URL` moved into
+  `[providers].openrouter`, `OPENROUTER_APP_*` attribution moved into its
+  `headers` table, and `ignore_providers` entries need the `@openrouter`
+  suffix (§0); a one-line fix per item.
+
+---
+
+## 10. Out of scope
+
+- Non-512 dimensions (would require a pgvector migration and a full
+  re-embed; nothing in this design moves toward it).
+- Fallback chains, tiers, round-robin/weighted specs for embedding.
+- Model-id translation between providers.
+- Auditing embedding calls to the DB.
+- Overriding the native Voyage base URL.
+- Any hosted-service or deployment concern (OSS boundary).

--- a/docs/superpowers/specs/2026-08-01-embedding-providers-design.md
+++ b/docs/superpowers/specs/2026-08-01-embedding-providers-design.md
@@ -67,9 +67,13 @@ model-keyed tables — carries over unchanged.
   chat endpoint, exactly as in 0.9.3. `@openrouter` becomes a globally valid
   explicit spelling of the same thing.
 - **Bare embedding slugs mean Voyage.** In `[tasks.embedding]`,
-  `"voyage-3-lite"` ≡ `"voyage-3-lite@voyage"`. The default provider flips
+  `"voyage-4-lite"` ≡ `"voyage-4-lite@voyage"`. The default provider flips
   per task family because the incumbent embedding backend is Voyage, not
   OpenRouter.
+- **The default model is `voyage-4-lite`** (post-review amendment,
+  2026-08-01: Voyage no longer recommends `voyage-3-lite`). A deployment
+  that still wants `voyage-3-lite` must pin it explicitly — and switching
+  models over existing data changes the vector space, so pin or re-embed.
 - **`@voyage` is embeddings-only.** A `@voyage` suffix on any non-embedding
   task slug refuses to boot. `voyage` stays undeclarable in `[providers]`
   (its native API is not the OpenRouter-compatible format this mechanism
@@ -138,7 +142,8 @@ headers = { "X-Team" = "companion", "X-Env" = "prod" }
 ```toml
 # Single model — read and write use the same backend.
 [tasks.embedding]
-model = "voyage-3-lite"                       # ≡ "voyage-3-lite@voyage"
+model = "voyage-4-lite"                       # ≡ "voyage-4-lite@voyage"
+# model = "voyage-3-lite"                     # legacy pin (no longer recommended by Voyage)
 # model = "openai/text-embedding-3-small@openrouter"
 # model = "bge-m3@local"                      # third-party, OpenRouter-compatible wire
 
@@ -165,9 +170,8 @@ Field semantics:
   queries are embedded every turn: a deployment can write with a large
   voyage-4 model and read with a cheap one (or vice versa) inside the one
   shared voyage-4 vector space.
-- `[tasks.embedding]` **absent** ⇒ exactly today's behaviour: native Voyage,
-  `voyage-3-lite`, no dimension parameter on the wire, `$VOYAGE_API_KEY`
-  required.
+- `[tasks.embedding]` **absent** ⇒ native Voyage, `voyage-4-lite`
+  (`output_dimension: 512` on the wire), `$VOYAGE_API_KEY` required.
 - On other `[tasks.embedding]` fields: `temperature`, `max_tokens`, etc.
   remain ignored as today; `fallback` and `tiers` refuse to boot (§6).
 
@@ -275,15 +279,15 @@ enum EmbedBackend {
 
 ### 5.2 `VoyageClient` — consumes the config (tech-debt cleanup)
 
-- Model comes from `[tasks.embedding]` instead of the hard-coded
-  `voyage-3-lite`; the hard-coded default remains only for the
-  block-absent path.
+- Model comes from `[tasks.embedding]` instead of the old hard-coded
+  `voyage-3-lite`; the hard-coded default (`voyage-4-lite` after the §0
+  amendment) remains only for the block-absent path.
 - Sends `output_dimension: 512` on the wire **except** for `voyage-3-lite`,
   which is a fixed-512-dim legacy model (the parameter is unnecessary
-  there, and the exception keeps the previously shipped example config
-  byte-identical on the wire). The exception is a named constant with a
-  comment; implementation verifies the exact parameter-support boundary
-  against the Voyage API docs.
+  there, and the exception keeps a pinned legacy config byte-identical to
+  its pre-config wire). The exception is a named constant with a comment;
+  implementation verifies the exact parameter-support boundary against the
+  Voyage API docs.
 - `input_type` (`"query"` / `"document"`) behaviour is unchanged.
 - Response embeddings are length-checked to 512 before returning
   (a clear `LlmError` instead of a downstream SQL error).

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -19,38 +19,52 @@
 # "latency" favours TTFT for chat; note it disables price load-balancing, so
 # watch cost and success rate separately.
 #[defaults]
-#ignore_providers = ["some-bad-provider-slug"]
+#ignore_providers = ["some-bad-provider-slug@openrouter"]
+# Entries MUST carry the @openrouter suffix — the exclusion list acts on OpenRouter routing only.
 #provider_sort = "latency"
 #
 # ── Custom providers (optional) ──────────────────────────────────────────────
-# Route individual model slugs to your own OpenAI-compatible endpoints.
-# Declare an endpoint here, then suffix a model id with "@<name>":
+# Route model slugs to your own endpoints. Each entry is a table with up to
+# three keys — `chat` (an OpenAI-compatible chat-completions URL), `embeddings`
+# (an OpenRouter-compatible embeddings URL), and `headers` (sent verbatim on
+# every request to this entry's endpoints):
 #
-#   model = "venice-uncensored@venice"     # served by [providers].venice
-#   fallback = ["x-ai/grok-4.20"]          # no suffix → built-in OpenRouter
+#   [providers.venice]
+#   chat    = "https://api.venice.ai/api/v1/chat/completions"
+#   headers = { "X-Team" = "companion" }
+#
+#   [providers.local]
+#   embeddings = "http://127.0.0.1:8080/v1/embeddings"
 #
 # Rules:
-# - Names match [a-z0-9_]+. "openrouter" is reserved — override the built-in
-#   endpoint with the OPENROUTER_BASE_URL env var instead. "voyage" is
-#   reserved too ($VOYAGE_API_KEY belongs to the built-in embeddings client).
-# - The value is the COMPLETE chat-completions URL, posted verbatim.
-# - The API key comes from env: [providers].venice → $VENICE_API_KEY.
-#   Required only when some model slug actually references the provider —
-#   this sample entry does not break boot.
-# - Model ids before "@" are the PROVIDER'S OWN slugs, sent verbatim; the
-#   engine never translates model names between providers.
-# - A literal "@" inside a model id is escaped "\@" — in a TOML double-quoted
-#   string write "weird\\@vendor/m".
+# - Names match [a-z0-9_]+. "voyage" is reserved ($VOYAGE_API_KEY belongs to
+#   the built-in native Voyage embeddings client).
+# - "openrouter" is special: declaring it overrides the BUILT-IN endpoints
+#   per key (an absent key keeps the official URL), and its `headers` table
+#   is the one home for the attribution headers (HTTP-Referer,
+#   X-OpenRouter-Title, X-OpenRouter-Categories). The old OPENROUTER_APP_*
+#   env vars are ignored; OPENROUTER_BASE_URL is gone.
+#
+#   [providers.openrouter]
+#   headers = { "HTTP-Referer" = "https://eros.example", "X-OpenRouter-Title" = "Eros" }
+#
+# - URLs are COMPLETE and posted verbatim — no path joining.
+# - The API key comes from env: [providers].venice → $VENICE_API_KEY
+#   (one key per entry, shared by both endpoints). Required only when some
+#   slug actually references the entry. `openrouter` uses the existing
+#   $OPENROUTER_API_KEY.
+# - `headers` cannot declare Authorization or Content-Type (engine-owned).
+# - Suffix a model slug with "@<name>" to route it. "@openrouter" is always
+#   valid and means the built-in endpoint — on chat tasks it is equivalent
+#   to writing no suffix at all.
+# - Model ids before "@" are the PROVIDER'S OWN slugs, sent verbatim; a
+#   literal "@" inside a model id is escaped "\@" (in TOML: "weird\\@vendor/m").
 # - Model-keyed tables (`display`, `output_regex` models, `output_filter`
 #   trigger models) always use the BARE id, never "id@provider".
 # - Custom providers receive a strict OpenAI-compatible request:
 #   [defaults].ignore_providers / provider_sort and per-task `reasoning` are
-#   inert for them, and no attribution headers are sent.
-# - Under MODEL_CONFIG_DIR, [providers] merges as ONE top-level key (like
-#   [defaults]): all providers live in one file.
-#
-#[providers]
-#venice = "https://api.venice.ai/api/v1/chat/completions"
+#   inert for them; they receive exactly the headers you declare.
+# - Under MODEL_CONFIG_DIR, [providers] merges as ONE top-level key.
 #
 # One-off repair of rows already persisted with byte-BPE garble (run manually,
 # NOT a migration — the engine refuses to own downstream prod data). Repairs the
@@ -583,13 +597,28 @@ filter_prompt = """
 保持角色口吻，简短口语化，只输出评论正文。
 """
 
-# Reserved — not consumed by current code. `VoyageClient` reads
-# `VOYAGE_API_KEY` directly and hard-codes `voyage-3-lite` (512 dims).
-# This entry exists for future generalisation if we ever support a
-# pluggable embedding provider.
+# ── Embeddings ───────────────────────────────────────────────────────────────
+# Dimensions are FIXED at 512 (the pgvector schema is VECTOR(512)); there is
+# no dimensions knob. Absent block = built-in Voyage with voyage-3-lite.
+#
+# `model` is a SINGLE fixed id (no round-robin/weighted, no fallback, no
+# tiers — mixed vector spaces are incomparable). A bare id means the native
+# Voyage client ("voyage-3-lite" ≡ "voyage-3-lite@voyage"). Route elsewhere
+# with "@openrouter" (built-in OpenRouter embeddings endpoint) or a custom
+# "[providers]" entry that declares an `embeddings` URL — both speak the
+# OpenRouter-compatible embeddings wire. NOTE: only the native Voyage client
+# distinguishes query vs document embeddings (input_type); routing off
+# Voyage forfeits that optimisation.
 [tasks.embedding]
 model = "voyage-3-lite"
-dimensions = 512
+
+# OR split read/write across two models in ONE shared vector space —
+# voyage-4 series and above ONLY (lower series refuse to boot: mixing their
+# spaces corrupts recall silently). `model_read` serves the per-turn recall
+# query; `model_write` embeds documents at storage time. Mutually exclusive
+# with `model`; both halves required.
+#model_read  = "voyage-4-lite"
+#model_write = "voyage-4"
 
 # ── Voice channel (chat_voice) ───────────────────────────────────────────────
 # OPT-IN. Feature is OFF unless this block exists. Powers the lean voice-call

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -599,18 +599,24 @@ filter_prompt = """
 
 # ── Embeddings ───────────────────────────────────────────────────────────────
 # Dimensions are FIXED at 512 (the pgvector schema is VECTOR(512)); there is
-# no dimensions knob. Absent block = built-in Voyage with voyage-3-lite.
+# no dimensions knob. Absent block = built-in Voyage with voyage-4-lite.
 #
 # `model` is a SINGLE fixed id (no round-robin/weighted, no fallback, no
 # tiers — mixed vector spaces are incomparable). A bare id means the native
-# Voyage client ("voyage-3-lite" ≡ "voyage-3-lite@voyage"). Route elsewhere
+# Voyage client ("voyage-4-lite" ≡ "voyage-4-lite@voyage"). Route elsewhere
 # with "@openrouter" (built-in OpenRouter embeddings endpoint) or a custom
 # "[providers]" entry that declares an `embeddings` URL — both speak the
 # OpenRouter-compatible embeddings wire. NOTE: only the native Voyage client
 # distinguishes query vs document embeddings (input_type); routing off
 # Voyage forfeits that optimisation.
+#
+# The legacy voyage-3-lite (no longer recommended by Voyage) is still usable
+# by pinning it here explicitly: model = "voyage-3-lite". Careful when
+# switching models on an existing deployment: rows embedded by the old model
+# are NOT comparable to queries embedded by the new one — pin the old model
+# or re-embed.
 [tasks.embedding]
-model = "voyage-3-lite"
+model = "voyage-4-lite"
 
 # OR split read/write across two models in ONE shared vector space —
 # voyage-4 series and above ONLY (lower series refuse to boot: mixing their


### PR DESCRIPTION
## Summary

Activates `[tasks.embedding]` for real: embedding calls can now route to the native Voyage client, the built-in OpenRouter embeddings endpoint, or any `[providers]` entry speaking the OpenRouter-compatible embeddings wire — and on the voyage-4 series, recall (`model_read`) and storage (`model_write`) can use different models sharing one vector space. Spec: `docs/superpowers/specs/2026-08-01-embedding-providers-design.md`.

Key changes:
- `[providers]` values become tables `{ chat, embeddings, headers }`; per-provider custom headers; `[providers].openrouter` partially overrides the built-in endpoints and homes the attribution headers.
- `@openrouter` is a globally valid alias (≡ bare on chat slugs, full OpenRouter wire); `@voyage` is embeddings-only; `model_read`/`model_write` are a voyage-4+-gated pair, boot-validated.
- New `EmbeddingRouter` read/write facade + `EmbedHttpClient` in `eros-engine-llm`; `VoyageClient` consumes the config model, sends `output_dimension: 512` (except fixed-dim `voyage-3-lite`), and length-checks every response; server routes through `state.embed` with `VOYAGE_API_KEY` required only when a Voyage backend is resolved.

Breaking config changes (pre-release surface, per spec §0): the default embedding model is now `voyage-4-lite` (Voyage no longer recommends `voyage-3-lite`; pin it explicitly to keep it, or re-embed — switching models changes the vector space); `[providers]` string values refuse to load; `[defaults].ignore_providers` entries require the `@openrouter` suffix; `OPENROUTER_BASE_URL` is removed; `OPENROUTER_APP_*` are inert (attribution moves to `[providers].openrouter.headers`); the never-consumed `dimensions` key is gone (dims fixed at 512). Reference docs + zh mirrors updated.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (1063 passed, incl. DB-backed server suite)
- [x] OpenAPI snapshot byte-identical

## Checklist

- [ ] CLA signed via cla-assistant.io (maintainer PR)
- [x] Conventional Commits format on commits
- [ ] DCO sign-off (`git commit -s`) (maintainer PR; commits GPG-signed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
