### PR TITLE
feat(voice): bond/chemistry relationship line + per-turn relationship_scope

### DIFF
--- a/crates/eros-engine-core/src/scope.rs
+++ b/crates/eros-engine-core/src/scope.rs
@@ -43,6 +43,18 @@ impl MemoryScope {
     }
 }
 
+/// Caller-supplied voice relationship-line scope (voice turns only): which
+/// halves of the bond/chemistry relationship line to inject this turn.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum RelationshipScope {
+    None,
+    Bond,
+    Chemistry,
+    #[default]
+    Both,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AffinityAxis {
@@ -249,6 +261,24 @@ mod tests {
             "\"neutral_and_relationship\""
         );
         assert!(serde_json::from_str::<MemoryScope>("\"bogus\"").is_err());
+    }
+
+    #[test]
+    fn relationship_scope_default_is_both() {
+        assert_eq!(RelationshipScope::default(), RelationshipScope::Both);
+    }
+
+    #[test]
+    fn relationship_scope_serde_snake_case() {
+        for (v, s) in [
+            (RelationshipScope::None, "\"none\""),
+            (RelationshipScope::Bond, "\"bond\""),
+            (RelationshipScope::Chemistry, "\"chemistry\""),
+            (RelationshipScope::Both, "\"both\""),
+        ] {
+            assert_eq!(serde_json::to_string(&v).unwrap(), s);
+            assert_eq!(serde_json::from_str::<RelationshipScope>(s).unwrap(), v);
+        }
     }
 
     #[test]

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -1959,6 +1959,13 @@
           },
           "content": {
             "type": "string"
+          },
+          "relationship_scope": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Which halves of the relationship line to inject this turn:\n`none | bond | chemistry | both`. Omitted ⇒ `both`."
           }
         }
       }

--- a/crates/eros-engine-server/src/pipeline/voice.rs
+++ b/crates/eros-engine-server/src/pipeline/voice.rs
@@ -7,8 +7,9 @@ use std::sync::Arc;
 use ulid::Ulid;
 use uuid::Uuid;
 
-use eros_engine_core::affinity::{Affinity, RelationshipLabel};
+use eros_engine_core::affinity::{Affinity, BondLabel, ChemistryLabel};
 use eros_engine_core::persona::PersonaGenome;
+use eros_engine_core::scope::RelationshipScope;
 use eros_engine_llm::model_config::ResolvedVoice;
 use eros_engine_llm::openrouter::{ChatMessage as WireMessage, ChatRequest, UsageBlock};
 use eros_engine_store::affinity::AffinityRepo;
@@ -21,38 +22,68 @@ use crate::pipeline::stream::{
 use crate::state::AppState;
 
 /// Assemble the thin voice system prompt: persona + voice directive + one
-/// optional relationship line. Deliberately excludes recall, memories, traits,
+/// optional relationship line (bond/chemistry-derived, gated by
+/// `relationship_scope`). Deliberately excludes recall, memories, traits,
 /// scopes, and every heavy block the text path's `build_prompt` composes.
 pub fn build_voice_prompt(
     genome: &PersonaGenome,
     directive: &str,
     affinity: Option<&Affinity>,
+    relationship_scope: RelationshipScope,
 ) -> String {
-    let mut s = String::with_capacity(genome.system_prompt.len() + directive.len() + 96);
+    let mut s = String::with_capacity(genome.system_prompt.len() + directive.len() + 384);
     s.push_str(&genome.system_prompt);
     s.push_str("\n\n");
     s.push_str(directive);
-    if let Some(line) = affinity.and_then(relationship_line) {
+    if let Some(line) = affinity.and_then(|a| relationship_line(a, relationship_scope)) {
         s.push_str("\n\n");
         s.push_str(&line);
     }
     s
 }
 
-/// One short relationship-tone line from the cached `relationship_label`.
-/// `None` (fresh affinity, no label yet) ⇒ no line.
-fn relationship_line(affinity: &Affinity) -> Option<String> {
-    let phrase = match &affinity.relationship_label {
-        Some(RelationshipLabel::Stranger) => {
-            "You two are still getting to know each other; keep it light."
+/// One relationship-tone line, derived at read time from the affinity row's
+/// bond/chemistry tiers — never from the cached `relationship_label`, which
+/// the voice path (no per-turn affinity eval) would leave stale forever.
+/// `scope` gates which halves are injected.
+fn relationship_line(affinity: &Affinity, scope: RelationshipScope) -> Option<String> {
+    let base = || {
+        match affinity.bond_label() {
+        BondLabel::Acquaintance => {
+            "You two are still getting to know each other; keep it light and natural."
         }
-        Some(RelationshipLabel::Friend) => "You two are close friends; be warm and familiar.",
-        Some(RelationshipLabel::Romantic) => "You share a romantic bond; be affectionate.",
-        Some(RelationshipLabel::Frenemy) => "Your dynamic is playful and a little combative.",
-        Some(RelationshipLabel::SlowBurn) => "There's a slow-building closeness between you.",
-        None => return None,
+        BondLabel::Friend => "You two are friends; be warm, easy, and natural.",
+        BondLabel::CloseFriend => "You two are close friends; be warm, familiar, and comfortable.",
+        BondLabel::Confidant => {
+            "You two trust each other deeply; speak openly, at ease, and with quiet closeness."
+        }
+        BondLabel::Soulmate => {
+            "You two know each other inside out; total comfort, familiarity, and unspoken understanding."
+        }
+    }
     };
-    Some(phrase.to_string())
+    let clause = || {
+        match affinity.chemistry_label() {
+        ChemistryLabel::Spark | ChemistryLabel::Flirtation => {
+            "A faint, unspoken spark exists between you. Keep it subtle — light teasing is allowed, but do not lean into romance or seduction yet."
+        }
+        ChemistryLabel::Crush => {
+            "There's a clear and growing attraction between you. Let soft flirtation and quiet allure color your words. Be teasing, a little magnetic, but still restrained."
+        }
+        ChemistryLabel::Lover => {
+            "You share a romantic and physical bond. Be affectionate, intimate, and gently alluring. Your voice and manner should feel warm, close, and quietly seductive."
+        }
+        ChemistryLabel::Beloved => {
+            "You two are deeply in love and highly attuned to each other. Be openly affectionate, sensual, and alluring. Speak with natural intimacy, quiet desire, and magnetic ease — as if the other person is already yours."
+        }
+    }
+    };
+    match scope {
+        RelationshipScope::None => None,
+        RelationshipScope::Bond => Some(base().to_string()),
+        RelationshipScope::Chemistry => Some(clause().to_string()),
+        RelationshipScope::Both => Some(format!("{} {}", base(), clause())),
+    }
 }
 
 /// Inputs for one voice turn. The user utterance is already persisted (by the
@@ -62,6 +93,7 @@ pub struct VoiceTurn {
     pub session_id: Uuid,
     pub instance_id: Uuid,
     pub user_message_id: Uuid,
+    pub relationship_scope: RelationshipScope,
 }
 
 /// Recent turns fed to the model on a voice turn. Shorter than the text path to
@@ -117,8 +149,12 @@ pub fn run_voice_turn(
             }
         };
 
-        let system_prompt =
-            build_voice_prompt(&persona.genome, &resolved.directive, affinity.as_ref());
+        let system_prompt = build_voice_prompt(
+            &persona.genome,
+            &resolved.directive,
+            affinity.as_ref(),
+            turn.relationship_scope,
+        );
 
         let mut messages = Vec::with_capacity(history.len() + 1);
         messages.push(WireMessage { role: "system".into(), content: system_prompt });
@@ -275,6 +311,7 @@ pub fn run_voice_turn(
         // gets the FULL unfiltered usage; the wire `Done` frame below gets a
         // separate, hidden-keys-filtered copy (mirrors the text/replay paths).
         let usage_full = last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok());
+        let scope_metadata = serde_json::json!({ "relationship_scope": turn.relationship_scope });
         if !acc.is_empty() {
             if let Err(e) = chat_repo
                 .insert_voice_assistant_message(
@@ -286,7 +323,7 @@ pub fn run_voice_turn(
                     usage_full.as_ref(),
                     last_gen_id.as_deref(),
                     truncated,
-                    None,
+                    Some(&scope_metadata),
                 )
                 .await
             {
@@ -326,49 +363,129 @@ mod tests {
         }
     }
 
-    fn affinity_with(label: Option<RelationshipLabel>) -> Affinity {
+    /// Affinity row landing on chosen tiers via raw axis values; cached
+    /// relationship_label deliberately None — the line must not read it.
+    fn affinity_at(
+        warmth: f64,
+        trust: f64,
+        intrigue: f64,
+        intimacy: f64,
+        tension: f64,
+    ) -> Affinity {
         let now = Utc::now();
         Affinity {
             id: Uuid::new_v4(),
             session_id: Uuid::new_v4(),
             user_id: Uuid::new_v4(),
             instance_id: Uuid::new_v4(),
-            warmth: 0.0,
-            trust: 0.0,
-            intrigue: 0.0,
-            intimacy: 0.0,
-            patience: 0.0,
-            tension: 0.0,
+            warmth,
+            trust,
+            intrigue,
+            intimacy,
+            patience: 0.5,
+            tension,
             ghost_streak: 0,
             last_ghost_at: None,
             total_ghosts: 0,
-            relationship_label: label,
+            relationship_label: None,
             created_at: now,
             updated_at: now,
         }
     }
 
     #[test]
-    fn includes_persona_and_directive() {
-        let p = build_voice_prompt(&genome(), "DIRECTIVE", None);
-        assert!(p.contains("You are Mia."));
-        assert!(p.contains("DIRECTIVE"));
-        // No affinity ⇒ no relationship line.
-        assert!(!p.contains("romantic"));
-    }
-
-    #[test]
-    fn appends_relationship_line_when_labelled() {
-        let a = affinity_with(Some(RelationshipLabel::Romantic));
-        let p = build_voice_prompt(&genome(), "DIRECTIVE", Some(&a));
-        assert!(p.contains("romantic bond"));
-    }
-
-    #[test]
-    fn no_relationship_line_when_label_none() {
-        let a = affinity_with(None);
-        let p = build_voice_prompt(&genome(), "DIRECTIVE", Some(&a));
+    fn includes_persona_and_directive_without_affinity() {
+        let p = build_voice_prompt(&genome(), "DIRECTIVE", None, RelationshipScope::default());
         assert_eq!(p, "You are Mia.\n\nDIRECTIVE");
+    }
+
+    #[test]
+    fn fresh_affinity_gets_acquaintance_and_spark_line() {
+        // bond 0 ⇒ tier 1 Acquaintance; chemistry 0 ⇒ tier 1 Spark.
+        let a = affinity_at(0.0, 0.0, 0.0, 0.0, 0.0);
+        let p = build_voice_prompt(
+            &genome(),
+            "DIRECTIVE",
+            Some(&a),
+            RelationshipScope::default(),
+        );
+        assert!(p.contains("still getting to know each other"));
+        assert!(p.contains("faint, unspoken spark"));
+    }
+
+    #[test]
+    fn high_bond_low_chemistry_keeps_romance_restrained() {
+        // bond (0.9+0.9+0.9)/3 = 0.9 ⇒ tier 5 Soulmate;
+        // chemistry (0.9+0+0)/3 = 0.3 ⇒ tier 2 Flirtation.
+        let a = affinity_at(0.9, 0.9, 0.9, 0.0, 0.0);
+        let p = build_voice_prompt(
+            &genome(),
+            "DIRECTIVE",
+            Some(&a),
+            RelationshipScope::default(),
+        );
+        assert!(p.contains("know each other inside out"));
+        assert!(p.contains("do not lean into romance or seduction yet"));
+        assert!(!p.contains("growing attraction"));
+        assert!(!p.contains("quietly seductive"));
+        assert!(!p.contains("deeply in love"));
+    }
+
+    #[test]
+    fn high_chemistry_appends_affectionate_clause() {
+        // bond (0.9+0.2+0.2)/3 ≈ 0.433 ⇒ tier 3 CloseFriend;
+        // chemistry (0.9+0.9+0.9)/3 = 0.9 ⇒ tier 5 Beloved.
+        let a = affinity_at(0.9, 0.2, 0.2, 0.9, 0.9);
+        let p = build_voice_prompt(
+            &genome(),
+            "DIRECTIVE",
+            Some(&a),
+            RelationshipScope::default(),
+        );
+        assert!(p.contains("close friends"));
+        assert!(p.contains("deeply in love"));
+    }
+
+    #[test]
+    fn chemistry_boundary_switches_clause_at_crush() {
+        // (0+0.52+0.50)/3 ≈ 0.34 ⇒ tier 2: still the subtle clause.
+        let low = affinity_at(0.0, 0.0, 0.0, 0.52, 0.50);
+        let p_low = build_voice_prompt(&genome(), "D", Some(&low), RelationshipScope::default());
+        assert!(p_low.contains("faint, unspoken spark"));
+        assert!(!p_low.contains("growing attraction"));
+        // (0+0.54+0.54)/3 = 0.36 ⇒ tier 3: switches to the Crush clause.
+        let high = affinity_at(0.0, 0.0, 0.0, 0.54, 0.54);
+        let p_high = build_voice_prompt(&genome(), "D", Some(&high), RelationshipScope::default());
+        assert!(p_high.contains("growing attraction"));
+        assert!(!p_high.contains("faint, unspoken spark"));
+    }
+
+    #[test]
+    fn scope_none_suppresses_line() {
+        let a = affinity_at(0.9, 0.2, 0.2, 0.9, 0.9);
+        let p = build_voice_prompt(&genome(), "DIRECTIVE", Some(&a), RelationshipScope::None);
+        assert_eq!(p, "You are Mia.\n\nDIRECTIVE");
+    }
+
+    #[test]
+    fn scope_bond_emits_base_only() {
+        let a = affinity_at(0.9, 0.2, 0.2, 0.9, 0.9); // CloseFriend / Beloved
+        let p = build_voice_prompt(&genome(), "DIRECTIVE", Some(&a), RelationshipScope::Bond);
+        assert!(p.contains("close friends"));
+        assert!(!p.contains("deeply in love"));
+    }
+
+    #[test]
+    fn scope_chemistry_emits_clause_only() {
+        let a = affinity_at(0.9, 0.2, 0.2, 0.9, 0.9);
+        let p = build_voice_prompt(
+            &genome(),
+            "DIRECTIVE",
+            Some(&a),
+            RelationshipScope::Chemistry,
+        );
+        assert!(!p.contains("close friends"));
+        assert!(p.contains("deeply in love"));
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
@@ -447,6 +564,7 @@ data: [DONE]\n\n";
                 session_id,
                 instance_id,
                 user_message_id: umid,
+                relationship_scope: RelationshipScope::default(),
             },
             resolved,
         )
@@ -478,6 +596,17 @@ data: [DONE]\n\n";
         .unwrap();
         assert_eq!(content, "hi there");
         assert_eq!(channel.as_deref(), Some("voice"));
+
+        // Resolved scope audited on the assistant row.
+        let scope_meta: Option<String> = sqlx::query_scalar(
+            "SELECT metadata->>'relationship_scope' FROM engine.chat_messages \
+             WHERE session_id = $1 AND role = 'assistant'",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(scope_meta.as_deref(), Some("both"));
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
@@ -557,6 +686,7 @@ data: [DONE]\n\n";
                 session_id,
                 instance_id,
                 user_message_id: umid,
+                relationship_scope: RelationshipScope::default(),
             },
             resolved,
         )
@@ -687,6 +817,7 @@ data: [DONE]\n\n";
                 session_id,
                 instance_id,
                 user_message_id: umid,
+                relationship_scope: RelationshipScope::default(),
             },
             resolved,
         )
@@ -817,6 +948,7 @@ data: [DONE]\n\n";
                 session_id,
                 instance_id,
                 user_message_id: umid,
+                relationship_scope: RelationshipScope::default(),
             },
             resolved,
         )
@@ -940,6 +1072,7 @@ data: [DONE]\n\n";
                 session_id,
                 instance_id,
                 user_message_id: umid,
+                relationship_scope: RelationshipScope::default(),
             },
             resolved,
         )
@@ -1054,6 +1187,7 @@ data: [DONE]\n\n";
                 session_id,
                 instance_id,
                 user_message_id: umid,
+                relationship_scope: RelationshipScope::default(),
             },
             resolved,
         )
@@ -1174,6 +1308,7 @@ data: [DONE]\n\n";
                 session_id,
                 instance_id,
                 user_message_id: umid,
+                relationship_scope: RelationshipScope::default(),
             },
             resolved,
         )

--- a/crates/eros-engine-server/src/pipeline/voice.rs
+++ b/crates/eros-engine-server/src/pipeline/voice.rs
@@ -286,6 +286,7 @@ pub fn run_voice_turn(
                     usage_full.as_ref(),
                     last_gen_id.as_deref(),
                     truncated,
+                    None,
                 )
                 .await
             {

--- a/crates/eros-engine-server/src/routes/voice.rs
+++ b/crates/eros-engine-server/src/routes/voice.rs
@@ -15,6 +15,7 @@ use std::time::Duration;
 use utoipa_axum::{router::OpenApiRouter, routes};
 use uuid::Uuid;
 
+use eros_engine_core::scope::RelationshipScope;
 use eros_engine_store::chat::{ChatRepo, VoiceUserInsert};
 use eros_engine_store::persona::PersonaRepo;
 
@@ -200,6 +201,7 @@ pub async fn voice_turn_stream(
         session_id,
         instance_id,
         user_message_id,
+        relationship_scope: RelationshipScope::default(),
     };
     let proto = run_voice_turn(Arc::new(state.clone()), turn, resolved);
 

--- a/crates/eros-engine-server/src/routes/voice.rs
+++ b/crates/eros-engine-server/src/routes/voice.rs
@@ -35,6 +35,11 @@ const SSE_KEEPALIVE_SECS: u64 = 15;
 pub struct VoiceTurnRequest {
     pub content: String,
     pub client_msg_id: String,
+    /// Which halves of the relationship line to inject this turn:
+    /// `none | bond | chemistry | both`. Omitted ⇒ `both`.
+    #[serde(default)]
+    #[schema(value_type = Option<String>)]
+    pub relationship_scope: Option<RelationshipScope>,
 }
 
 fn pre(status: StatusCode, code: &'static str, message: &str, user_message: &str) -> AppError {
@@ -201,7 +206,7 @@ pub async fn voice_turn_stream(
         session_id,
         instance_id,
         user_message_id,
-        relationship_scope: RelationshipScope::default(),
+        relationship_scope: req.relationship_scope.unwrap_or_default(),
     };
     let proto = run_voice_turn(Arc::new(state.clone()), turn, resolved);
 
@@ -321,6 +326,26 @@ mod tests {
             session_id,
             &jwt,
             json!({"content":"","client_msg_id":"01J2222222222222222222222A"}),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn voice_422_when_relationship_scope_invalid(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let session_id = seed(&pool, user_id).await;
+        let mut app = build_router(with_voice(crate::routes::companion::test_state(pool)));
+        let jwt = mint_jwt(user_id);
+        let resp = post_voice(
+            &mut app,
+            session_id,
+            &jwt,
+            json!({
+                "content": "hi",
+                "client_msg_id": "01J2222222222222222222222A",
+                "relationship_scope": "romance"
+            }),
         )
         .await;
         assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -989,12 +989,13 @@ impl<'a> ChatRepo<'a> {
         usage: Option<&serde_json::Value>,
         generation_id: Option<&str>,
         truncated: bool,
+        metadata: Option<&serde_json::Value>,
     ) -> Result<(), sqlx::Error> {
         sqlx::query(
             "INSERT INTO engine.chat_messages \
              (id, session_id, role, content, user_message_id, truncated, model, usage, \
-              generation_id, assistant_action_type, channel) \
-             VALUES ($1, $2, 'assistant', $3, $4, $5, $6, $7, $8, 'reply', 'voice')",
+              generation_id, assistant_action_type, channel, metadata) \
+             VALUES ($1, $2, 'assistant', $3, $4, $5, $6, $7, $8, 'reply', 'voice', $9)",
         )
         .bind(id)
         .bind(session_id)
@@ -1004,6 +1005,7 @@ impl<'a> ChatRepo<'a> {
         .bind(model)
         .bind(usage)
         .bind(generation_id)
+        .bind(metadata)
         .execute(self.pool)
         .await?;
         Ok(())
@@ -2991,19 +2993,23 @@ mod tests {
             None,
             Some("gen-1"),
             false,
+            Some(&serde_json::json!({"relationship_scope": "both"})),
         )
         .await
         .unwrap();
-        let (role, aat, channel): (String, Option<String>, Option<String>) = sqlx::query_as(
-            "SELECT role, assistant_action_type, channel FROM engine.chat_messages WHERE id = $1",
-        )
-        .bind(aid)
-        .fetch_one(&pool)
-        .await
-        .unwrap();
+        let (role, aat, channel, scope): (String, Option<String>, Option<String>, Option<String>) =
+            sqlx::query_as(
+                "SELECT role, assistant_action_type, channel, metadata->>'relationship_scope' \
+                 FROM engine.chat_messages WHERE id = $1",
+            )
+            .bind(aid)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
         assert_eq!(role, "assistant");
         assert_eq!(aat.as_deref(), Some("reply"));
         assert_eq!(channel.as_deref(), Some("voice"));
+        assert_eq!(scope.as_deref(), Some("both"));
 
         // history() returns both, chronologically, and content survives.
         let h = repo.history(session_id, 10, 0).await.unwrap();

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -55,6 +55,11 @@ curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json"
 
 `is_new=false` if you call `/start` again with the same `genome_id` for the same user — the engine resumes the existing session rather than creating a duplicate.
 
+Optional `channel` field: `"text"` (default) or `"voice"`. Start/resume is
+channel-scoped — a voice-channel start never resumes a text session (and
+vice versa). Voice clients must obtain their session here with
+`"channel": "voice"` before calling the voice turn endpoint.
+
 ### `POST /comp/chat/{session_id}/message/stream`
 
 Streaming chat turn. Returns `text/event-stream` with the
@@ -348,6 +353,46 @@ carries an optional `channel` field — `"product_qa"` marks an
 out-of-character product answer (excluded from companion context/memory,
 same as its live-stream `action_type`); the field is omitted for normal
 turns.
+
+## Voice
+
+### `POST /comp/voice/{session_id}/turn/stream`
+
+Lean voice-channel turn: one transcribed user utterance in, one streamed
+text reply out. STT and TTS are entirely the caller's job — the engine
+never touches audio (see the
+[voice-call parts design spec](superpowers/specs/2026-07-07-voice-call-parts-design.md)).
+
+Returns `text/event-stream` with a reduced frame set: `delta`* then a
+terminal `done`, or a single `error` — the same frame shapes as the chat
+message stream above, but with **no** `meta` frame and no `action_type`.
+
+The session must be a **voice-channel** session (`409 wrong_channel`
+otherwise) — obtain one via `POST /comp/chat/start` with
+`"channel": "voice"`. Voice is opt-in per deployment: without a
+`[tasks.chat_voice]` block in the model config the endpoint returns
+`501 voice_disabled`.
+
+The prompt is deliberately thin: persona + voice directive + one
+relationship line derived from the session's affinity (bond/chemistry
+tiers). No vector recall, no memories, no traits/scopes/heavy blocks.
+
+Body fields:
+
+- `content` — the user utterance. Max 4096 chars.
+- `client_msg_id` — 26..36 ASCII-printable chars (any UUID or ULID).
+  Replaying the same `(session_id, client_msg_id)` returns `409 duplicate`
+  rather than generating a second reply.
+- `relationship_scope` (optional) — which halves of the relationship line
+  to inject this turn: `"none"`, `"bond"`, `"chemistry"`, `"both"`
+  (default `"both"`). The resolved value is recorded on the assistant
+  row's `metadata.relationship_scope`.
+
+```bash
+curl -N -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json" \
+  -d '{"content":"你今天在干嘛？","client_msg_id":"01JABCDEFGHJKMNPQRSTVWXYZ0","relationship_scope":"both"}' \
+  http://localhost:8080/comp/voice/{session_id}/turn/stream
+```
 
 ## Profile
 

--- a/docs/superpowers/specs/2026-08-02-voice-relationship-line-bond-chemistry-design.md
+++ b/docs/superpowers/specs/2026-08-02-voice-relationship-line-bond-chemistry-design.md
@@ -77,9 +77,14 @@ gating which halves of the relationship line the voice prompt injects.
   - `bond` — base phrase only.
   - `chemistry` — the chemistry clause alone as the line.
   - `both` (default) — base + clause, i.e. the behaviour above.
-- Deliberately **no** voice-side scope audit metadata: the voice persist
-  path is thin fixed-arg (no metadata channel); chat's raw-scope audit
-  recording is not ported.
+- Audit: the voice **assistant row's** `metadata` always records the
+  post-resolve scope — `{"relationship_scope": "both"}` etc. — mirroring
+  how chat writes post-resolve `memory_scope` / `affinity_scope` on its
+  assistant rows. `insert_voice_assistant_message` gains a
+  `metadata: Option<&serde_json::Value>` parameter (the column already
+  exists on `chat_messages`). Chat's *raw*-value user-row audit
+  (`memory_scope_raw`) is still not ported — one post-resolve key on the
+  assistant row is enough for the thin path.
 
 ### Behaviour changes (accepted)
 
@@ -103,12 +108,15 @@ gating which halves of the relationship line the voice prompt injects.
   still say "cached `relationship_label`".
 - `crates/eros-engine-server/src/routes/voice.rs` — request field +
   resolve.
+- `crates/eros-engine-store/src/chat.rs` —
+  `insert_voice_assistant_message` gains a `metadata` parameter, bound
+  into the INSERT's column list.
 - `crates/eros-engine-server/openapi.json` — regenerated snapshot (new
   request field + schema).
 - `docs/api-reference.md` — currently has **no voice coverage at all**;
   catch it up (see below).
 
-`store` / `dto` are untouched.
+`dto` is untouched.
 
 ## Docs: `api-reference.md` voice section
 
@@ -141,6 +149,9 @@ the rest of the file) covering:
   `bond` ⇒ base only, no chemistry wording; `chemistry` ⇒ clause only, no
   bond wording; omitted field ⇒ behaves as `both`; invalid string ⇒ 422
   (route test).
+- Metadata audit: the voice-turn integration test asserts the persisted
+  assistant row has `metadata->>'relationship_scope'` = the resolved
+  value (`both` when the field is omitted).
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-08-02-voice-relationship-line-bond-chemistry-design.md
+++ b/docs/superpowers/specs/2026-08-02-voice-relationship-line-bond-chemistry-design.md
@@ -1,0 +1,89 @@
+# Voice relationship line → Bond/Chemistry — design
+
+- Date: 2026-08-02
+- Status: design agreed, implementation plan pending
+- Repo: `eros-engine`
+- Amends: the "one relationship line" section of
+  `2026-07-07-voice-call-parts-design.md` (which predates this change and
+  still describes the cached-label read)
+
+## Background & problem
+
+`voice.rs::relationship_line` still reflects the pre-#132 relationship model:
+
+- It reads the **cached** `affinity.relationship_label` DB field. Since
+  PR #132 (Bond/Chemistry lines) the label is a *derived* value —
+  `legacy_relationship_label()` folds the two line scores — and read paths
+  (`dto.rs`) compute it on the fly instead of trusting the cache.
+- The cache is only refreshed when the text path's affinity eval writes the
+  row. The voice path runs no affinity eval **by design**, so a voice-heavy
+  session's cached label never updates; rows untouched since #132 may still
+  carry old-heuristic labels, including `frenemy`, which is retired from
+  emission.
+- Core guidance (`eros-engine-core/src/affinity.rs`) says new consumers
+  should read `bond_label()` / `chemistry_label()`; the legacy 5-name
+  vocabulary is kept only for API back-compat.
+
+## Decision
+
+Rewrite `relationship_line` in terms of the Bond/Chemistry tier labels,
+derived from the affinity row at read time. Drop the `RelationshipLabel`
+import from `voice.rs` entirely.
+
+## Behaviour
+
+- No affinity row ⇒ no line (unchanged).
+- With a row: always emit **one** line (thin-prompt intent unchanged) —
+  a base phrase from `bond_label()`, plus a romance clause appended in the
+  same line when `chemistry_label()` is **Crush or higher** (tier ≥ 3).
+
+| bond tier | base phrase |
+| --- | --- |
+| Acquaintance | "You two are still getting to know each other; keep it light." |
+| Friend | "You two are friends; be warm and natural." |
+| CloseFriend | "You two are close friends; be warm and familiar." |
+| Confidant | "You two trust each other deeply; speak openly and at ease." |
+| Soulmate | "You two know each other inside out; total comfort and familiarity." |
+
+| chemistry tier | appended clause |
+| --- | --- |
+| Spark / Flirtation | (none — deliberately more conservative than the legacy `SlowBurn` fold: early chemistry must not push the voice tone toward romance) |
+| Crush | "There's a growing attraction between you; let a little flirtation through." |
+| Lover | "You share a romantic bond; be affectionate." |
+| Beloved | "You two are deeply in love; be openly affectionate." |
+
+### Behaviour changes (accepted)
+
+1. Old rows cached with `frenemy` / stale heuristic labels no longer affect
+   voice tone.
+2. Rows whose cached label is NULL now get a line (previously silently
+   none); a fresh all-zero row derives Acquaintance, matching what the old
+   `Stranger` phrase conveyed.
+3. The `relationship_label` field is no longer consumed anywhere on the
+   voice path. The core enum itself is untouched (dto back-compat still
+   uses it).
+
+## Code changes
+
+Only `crates/eros-engine-server/src/pipeline/voice.rs`:
+
+- Import `BondLabel, ChemistryLabel` instead of `RelationshipLabel`.
+- `relationship_line(a: &Affinity) -> String`; call site becomes
+  `affinity.map(relationship_line)`.
+- Update the doc comments that still say "cached `relationship_label`".
+
+`core` / `store` / `dto` are untouched.
+
+## Testing
+
+- Replace the `affinity_with(label)` test helper with an axis-value
+  constructor that lands on target tiers.
+- Cases: no affinity ⇒ no line; fresh (all-zero) row ⇒ Acquaintance line;
+  high bond + low chemistry ⇒ no romance wording; high chemistry ⇒
+  affectionate clause present; boundary: chemistry tier 2 appends nothing.
+
+## Out of scope
+
+`story.rs` feeds the cached `relationship_label` string into the story
+context JSON (`StoryAffinity` selects the raw column) — the same class of
+staleness. Not touched here; fix under its own issue if wanted.

--- a/docs/superpowers/specs/2026-08-02-voice-relationship-line-bond-chemistry-design.md
+++ b/docs/superpowers/specs/2026-08-02-voice-relationship-line-bond-chemistry-design.md
@@ -34,23 +34,24 @@ import from `voice.rs` entirely.
 
 - No affinity row ⇒ no line (unchanged).
 - With a row: always emit **one** line (thin-prompt intent unchanged) —
-  a base phrase from `bond_label()`, plus a romance clause appended in the
-  same line when `chemistry_label()` is **Crush or higher** (tier ≥ 3).
+  a base phrase from `bond_label()`, plus the `chemistry_label()` tier's
+  clause appended in the same line (every tier appends; the low tiers'
+  clause explicitly holds romance back).
 
-| bond tier | base phrase |
-| --- | --- |
-| Acquaintance | "You two are still getting to know each other; keep it light." |
-| Friend | "You two are friends; be warm and natural." |
-| CloseFriend | "You two are close friends; be warm and familiar." |
-| Confidant | "You two trust each other deeply; speak openly and at ease." |
-| Soulmate | "You two know each other inside out; total comfort and familiarity." |
+| bond tier     | base phrase |
+|---------------|-------------|
+| Acquaintance  | "You two are still getting to know each other; keep it light and natural." |
+| Friend        | "You two are friends; be warm, easy, and natural." |
+| CloseFriend   | "You two are close friends; be warm, familiar, and comfortable." |
+| Confidant     | "You two trust each other deeply; speak openly, at ease, and with quiet closeness." |
+| Soulmate      | "You two know each other inside out; total comfort, familiarity, and unspoken understanding." |
 
-| chemistry tier | appended clause |
-| --- | --- |
-| Spark / Flirtation | (none — deliberately more conservative than the legacy `SlowBurn` fold: early chemistry must not push the voice tone toward romance) |
-| Crush | "There's a growing attraction between you; let a little flirtation through." |
-| Lover | "You share a romantic bond; be affectionate." |
-| Beloved | "You two are deeply in love; be openly affectionate." |
+| chemistry tier     | appended clause |
+|--------------------|-----------------|
+| Spark / Flirtation | "A faint, unspoken spark exists between you. Keep it subtle — light teasing is allowed, but do not lean into romance or seduction yet." |
+| Crush              | "There's a clear and growing attraction between you. Let soft flirtation and quiet allure color your words. Be teasing, a little magnetic, but still restrained." |
+| Lover              | "You share a romantic and physical bond. Be affectionate, intimate, and gently alluring. Your voice and manner should feel warm, close, and quietly seductive." |
+| Beloved            | "You two are deeply in love and highly attuned to each other. Be openly affectionate, sensual, and alluring. Speak with natural intimacy, quiet desire, and magnetic ease — as if the other person is already yours." |
 
 ### Behaviour changes (accepted)
 
@@ -78,9 +79,11 @@ Only `crates/eros-engine-server/src/pipeline/voice.rs`:
 
 - Replace the `affinity_with(label)` test helper with an axis-value
   constructor that lands on target tiers.
-- Cases: no affinity ⇒ no line; fresh (all-zero) row ⇒ Acquaintance line;
-  high bond + low chemistry ⇒ no romance wording; high chemistry ⇒
-  affectionate clause present; boundary: chemistry tier 2 appends nothing.
+- Cases: no affinity ⇒ no line; fresh (all-zero) row ⇒ Acquaintance base +
+  the subtle Spark/Flirtation clause; high bond + low chemistry ⇒ the
+  restrained clause, no Crush-and-up wording; high chemistry ⇒ affectionate
+  clause present; boundary: tier 2 (Flirtation) still uses the subtle
+  clause, tier 3 (Crush) switches to the attraction clause.
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-08-02-voice-relationship-line-bond-chemistry-design.md
+++ b/docs/superpowers/specs/2026-08-02-voice-relationship-line-bond-chemistry-design.md
@@ -53,6 +53,34 @@ import from `voice.rs` entirely.
 | Lover              | "You share a romantic and physical bond. Be affectionate, intimate, and gently alluring. Your voice and manner should feel warm, close, and quietly seductive." |
 | Beloved            | "You two are deeply in love and highly attuned to each other. Be openly affectionate, sensual, and alluring. Speak with natural intimacy, quiet desire, and magnetic ease — as if the other person is already yours." |
 
+### Per-turn `relationship_scope` (voice request switch)
+
+Mirror of the chat turn's `memory_scope`: a caller-supplied per-turn switch
+gating which halves of the relationship line the voice prompt injects.
+
+- New enum in `eros-engine-core/src/scope.rs` (the per-request injection
+  scope home), derives matching `MemoryScope` (`snake_case` serde,
+  `Default`):
+
+  ```rust
+  pub enum RelationshipScope { None, Bond, Chemistry, #[default] Both }
+  ```
+
+- `VoiceTurnRequest` gains
+  `#[serde(default)] #[schema(value_type = Option<String>)]
+  pub relationship_scope: Option<RelationshipScope>`; the route resolves
+  `unwrap_or_default()` and threads it through `VoiceTurn` into
+  `build_voice_prompt`. An invalid string ⇒ 422 (same behaviour as chat's
+  `memory_scope`).
+- Semantics (`relationship_line(a, scope) -> Option<String>`):
+  - `none` — no line, even with an affinity row.
+  - `bond` — base phrase only.
+  - `chemistry` — the chemistry clause alone as the line.
+  - `both` (default) — base + clause, i.e. the behaviour above.
+- Deliberately **no** voice-side scope audit metadata: the voice persist
+  path is thin fixed-arg (no metadata channel); chat's raw-scope audit
+  recording is not ported.
+
 ### Behaviour changes (accepted)
 
 1. Old rows cached with `frenemy` / stale heuristic labels no longer affect
@@ -66,14 +94,39 @@ import from `voice.rs` entirely.
 
 ## Code changes
 
-Only `crates/eros-engine-server/src/pipeline/voice.rs`:
+- `crates/eros-engine-core/src/scope.rs` — add `RelationshipScope`.
+- `crates/eros-engine-server/src/pipeline/voice.rs` — import
+  `BondLabel, ChemistryLabel` instead of `RelationshipLabel`;
+  `relationship_line(a: &Affinity, scope: RelationshipScope) ->
+  Option<String>`; `build_voice_prompt` gains the `scope` parameter;
+  `VoiceTurn` carries `relationship_scope`; update the doc comments that
+  still say "cached `relationship_label`".
+- `crates/eros-engine-server/src/routes/voice.rs` — request field +
+  resolve.
+- `crates/eros-engine-server/openapi.json` — regenerated snapshot (new
+  request field + schema).
+- `docs/api-reference.md` — currently has **no voice coverage at all**;
+  catch it up (see below).
 
-- Import `BondLabel, ChemistryLabel` instead of `RelationshipLabel`.
-- `relationship_line(a: &Affinity) -> String`; call site becomes
-  `affinity.map(relationship_line)`.
-- Update the doc comments that still say "cached `relationship_label`".
+`store` / `dto` are untouched.
 
-`core` / `store` / `dto` are untouched.
+## Docs: `api-reference.md` voice section
+
+Add a `## Voice` section (after "Chat lifecycle", same curl + JSON style as
+the rest of the file) covering:
+
+- `POST /comp/voice/{session_id}/turn/stream` — request body (`content`,
+  `client_msg_id` 26..36 ASCII, optional `relationship_scope`:
+  `none | bond | chemistry | both`, default `both`), SSE frame set
+  (`delta`* then terminal `done`, or a single `error`; **no** `meta`, no
+  `action_type`), and the thin-prompt behaviour (persona + voice directive
+  + one relationship line; no recall/memories/heavy blocks).
+- The channel-scoped session rule: the endpoint only accepts
+  voice-channel sessions; voice clients obtain one via `chat/start` with
+  `channel: "voice"`.
+- Also document the `channel` field (`"text"` default / `"voice"`) in the
+  existing `POST /comp/chat/start` section — it is missing today and is
+  the voice on-ramp.
 
 ## Testing
 
@@ -84,6 +137,10 @@ Only `crates/eros-engine-server/src/pipeline/voice.rs`:
   restrained clause, no Crush-and-up wording; high chemistry ⇒ affectionate
   clause present; boundary: tier 2 (Flirtation) still uses the subtle
   clause, tier 3 (Crush) switches to the attraction clause.
+- Scope cases (all with an affinity row present): `none` ⇒ no line;
+  `bond` ⇒ base only, no chemistry wording; `chemistry` ⇒ clause only, no
+  bond wording; omitted field ⇒ behaves as `both`; invalid string ⇒ 422
+  (route test).
 
 ## Out of scope
 


### PR DESCRIPTION
## Summary

Migrates the voice prompt's relationship line off the stale cached `relationship_label` (pre-#132 model) onto phrases derived at read time from the affinity row's bond/chemistry tiers, adds a per-turn `relationship_scope` request switch, audits the resolved scope on the voice assistant row, and catches `docs/api-reference.md` up on the voice endpoint.

Spec (on this branch): `docs/superpowers/specs/2026-08-02-voice-relationship-line-bond-chemistry-design.md`

## Changes

- **core**: new `RelationshipScope` enum in `scope.rs` — `none | bond | chemistry | both`, default `both`, serde snake_case (mirrors `MemoryScope` conventions)
- **pipeline/voice**: `relationship_line` now derives from `bond_label()` / `chemistry_label()` (never the cached field, which the voice path never refreshes); one line = bond base phrase + the chemistry tier's clause (low tiers explicitly hold romance back); gated by scope
- **route**: optional `relationship_scope` on `VoiceTurnRequest` (`#[serde(default)]`, invalid value ⇒ 422, same pattern as chat's `memory_scope`)
- **store**: `insert_voice_assistant_message` gains a `metadata` param; assistant row always records post-resolve `{"relationship_scope": …}` (mirrors chat's post-resolve scope audit)
- **openapi**: snapshot regenerated (drift = the new field only)
- **docs**: `api-reference.md` gains the previously-undocumented `## Voice` section + `channel` field on `chat/start`

Behaviour changes (spec'd): old rows cached with `frenemy`/stale labels no longer affect voice tone; NULL-cached rows now get a line; `relationship_label` is no longer consumed on the voice path (enum kept for dto back-compat; store `label_from_str` still parses `frenemy`).

Out of scope (noted in spec): `story.rs` still passes the cached label into story context — same staleness class, separate issue.

## Testing

- TDD throughout; per-task reviews + whole-branch review clean
- Full local CI parity: `fmt` / `clippy -D warnings` / `cargo test --workspace --all-features` (1072 passed, 0 failed) / openapi snapshot diff empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)