### PR TITLE
feat(image): compose-call audit trio on metadata.image

### DIFF
--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -1156,6 +1156,11 @@ pub struct ResolvedImagePromptCompose {
     pub compose_prompt: String,
     pub retry_depth: u32,
     pub reasoning: Option<ReasoningConfig>,
+    /// The Keyed key / Indexed index that selected `compose_prompt`, for the
+    /// `metadata.image.compose_variant` audit key. `None` when there was no
+    /// variant selection to speak of: `Plain`, no `filter_prompt`, or a miss
+    /// (built-in prompt fallback).
+    pub variant_key: Option<String>,
 }
 
 /// Resolved PDE decision task (`pde_decision`). Mirrors `ResolvedVision`: the
@@ -1893,6 +1898,13 @@ impl ModelConfig {
             .filter_prompt
             .as_ref()
             .and_then(|s| s.select(variant));
+        // Audit value, NOT derivable from `selected` alone: `Plain` returns
+        // `Some` from `select()` regardless of the supplied variant, but has
+        // no variant selection to audit.
+        let variant_key = match task_cfg.filter_prompt.as_ref() {
+            None | Some(PromptSpec::Plain(_)) => None,
+            Some(_) => selected.and(variant).map(str::to_string),
+        };
         // The warn/debug decision is a pure function of (selected, variant,
         // has a filter_prompt at all) — pulled out of the tracing call so it
         // can be unit-tested directly, without a tracing subscriber, and so a
@@ -1939,6 +1951,7 @@ impl ModelConfig {
             compose_prompt,
             retry_depth,
             reasoning: task_cfg.reasoning.clone(),
+            variant_key,
         })
     }
 }
@@ -5919,6 +5932,72 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
         let c =
             cfg("[tasks.chat_image_prompt_compose]\nmodel = \"m\"\nfilter_prompt = \"custom\"\n");
         assert!(c.resolve_image_prompt_compose(Some(" raw \n")).is_none());
+    }
+
+    /// `variant_key` surfaces WHICH variant selected the prompt — the audit
+    /// value persisted to `metadata.image.compose_variant`. `Some` iff a
+    /// Keyed/Indexed entry was actually hit; `Plain` and the built-in
+    /// fallback have a single prompt (no "which variant" to answer).
+    #[test]
+    fn resolve_image_prompt_compose_variant_key_semantics() {
+        // Keyed: hit → Some(key); miss → None (built-in prompt fallback).
+        let keyed = ModelConfig::from_toml_str(
+            "[tasks.chat_image_prompt_compose]\nmodel = \"m\"\n\
+             filter_prompt = { a = \"AAA\", b = \"BBB\" }\n",
+        )
+        .unwrap();
+        assert_eq!(
+            keyed.resolve_image_prompt_compose(Some("b")).unwrap().variant_key,
+            Some("b".to_string())
+        );
+        assert_eq!(
+            keyed.resolve_image_prompt_compose(Some("zzz")).unwrap().variant_key,
+            None,
+            "miss falls back to the built-in prompt — no variant to audit"
+        );
+        assert_eq!(
+            keyed.resolve_image_prompt_compose(None).unwrap().variant_key,
+            None
+        );
+        // Whitespace-padded variant is trimmed before select — key must match.
+        assert_eq!(
+            keyed.resolve_image_prompt_compose(Some(" b \n")).unwrap().variant_key,
+            Some("b".to_string())
+        );
+
+        // Indexed: hit → Some(index string).
+        let indexed = ModelConfig::from_toml_str(
+            "[tasks.chat_image_prompt_compose]\nmodel = \"m\"\n\
+             filter_prompt = [\"ZERO\", \"ONE\"]\n",
+        )
+        .unwrap();
+        assert_eq!(
+            indexed.resolve_image_prompt_compose(Some("1")).unwrap().variant_key,
+            Some("1".to_string())
+        );
+        assert_eq!(
+            indexed.resolve_image_prompt_compose(Some("9")).unwrap().variant_key,
+            None
+        );
+
+        // Plain: always None, even when a variant was supplied (select() returns
+        // the prompt regardless — there is no variant selection to audit).
+        let plain = ModelConfig::from_toml_str(
+            "[tasks.chat_image_prompt_compose]\nmodel = \"m\"\n\
+             filter_prompt = \"PLAIN\"\n",
+        )
+        .unwrap();
+        assert_eq!(
+            plain.resolve_image_prompt_compose(Some("b")).unwrap().variant_key,
+            None
+        );
+
+        // No filter_prompt at all → built-in prompt, no variant.
+        let bare = ModelConfig::from_toml_str(
+            "[tasks.chat_image_prompt_compose]\nmodel = \"m\"\n",
+        )
+        .unwrap();
+        assert_eq!(bare.resolve_image_prompt_compose(None).unwrap().variant_key, None);
     }
 
     // ─── compose_variant_log_event: the warn/debug guards, pinned directly ──

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -5947,21 +5947,33 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
         )
         .unwrap();
         assert_eq!(
-            keyed.resolve_image_prompt_compose(Some("b")).unwrap().variant_key,
+            keyed
+                .resolve_image_prompt_compose(Some("b"))
+                .unwrap()
+                .variant_key,
             Some("b".to_string())
         );
         assert_eq!(
-            keyed.resolve_image_prompt_compose(Some("zzz")).unwrap().variant_key,
+            keyed
+                .resolve_image_prompt_compose(Some("zzz"))
+                .unwrap()
+                .variant_key,
             None,
             "miss falls back to the built-in prompt — no variant to audit"
         );
         assert_eq!(
-            keyed.resolve_image_prompt_compose(None).unwrap().variant_key,
+            keyed
+                .resolve_image_prompt_compose(None)
+                .unwrap()
+                .variant_key,
             None
         );
         // Whitespace-padded variant is trimmed before select — key must match.
         assert_eq!(
-            keyed.resolve_image_prompt_compose(Some(" b \n")).unwrap().variant_key,
+            keyed
+                .resolve_image_prompt_compose(Some(" b \n"))
+                .unwrap()
+                .variant_key,
             Some("b".to_string())
         );
 
@@ -5972,11 +5984,17 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
         )
         .unwrap();
         assert_eq!(
-            indexed.resolve_image_prompt_compose(Some("1")).unwrap().variant_key,
+            indexed
+                .resolve_image_prompt_compose(Some("1"))
+                .unwrap()
+                .variant_key,
             Some("1".to_string())
         );
         assert_eq!(
-            indexed.resolve_image_prompt_compose(Some("9")).unwrap().variant_key,
+            indexed
+                .resolve_image_prompt_compose(Some("9"))
+                .unwrap()
+                .variant_key,
             None
         );
 
@@ -5988,16 +6006,20 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
         )
         .unwrap();
         assert_eq!(
-            plain.resolve_image_prompt_compose(Some("b")).unwrap().variant_key,
+            plain
+                .resolve_image_prompt_compose(Some("b"))
+                .unwrap()
+                .variant_key,
             None
         );
 
         // No filter_prompt at all → built-in prompt, no variant.
-        let bare = ModelConfig::from_toml_str(
-            "[tasks.chat_image_prompt_compose]\nmodel = \"m\"\n",
-        )
-        .unwrap();
-        assert_eq!(bare.resolve_image_prompt_compose(None).unwrap().variant_key, None);
+        let bare = ModelConfig::from_toml_str("[tasks.chat_image_prompt_compose]\nmodel = \"m\"\n")
+            .unwrap();
+        assert_eq!(
+            bare.resolve_image_prompt_compose(None).unwrap().variant_key,
+            None
+        );
     }
 
     // ─── compose_variant_log_event: the warn/debug guards, pinned directly ──

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -5870,6 +5870,20 @@ data: [DONE]\n\n";
             "composer must use variant b, got {}",
             body["messages"][0]["content"]
         );
+
+        // Spec 2026-08-02 absence semantics: no successful compose ⇒ none of
+        // the audit keys, and `prompt` is the seed subject as before.
+        let meta: serde_json::Value = sqlx::query_scalar(
+            "SELECT metadata FROM engine.chat_messages WHERE role = 'assistant'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("assistant image row persisted");
+        let img = meta["image"].as_object().expect("image marker present");
+        assert_eq!(img["prompt"], "a beach at sunset");
+        assert!(img.get("compose_variant").is_none());
+        assert!(img.get("compose_model").is_none());
+        assert!(img.get("compose_generation_id").is_none());
     }
 
     /// `prompt_variant = "raw"` must make ZERO provider calls and pass the seed
@@ -5908,6 +5922,20 @@ data: [DONE]\n\n";
             composed.contains("a beach at sunset"),
             "raw must pass the seed subject through: {composed}"
         );
+
+        // Spec 2026-08-02 absence semantics: no successful compose ⇒ none of
+        // the audit keys, and `prompt` is the seed subject as before.
+        let meta: serde_json::Value = sqlx::query_scalar(
+            "SELECT metadata FROM engine.chat_messages WHERE role = 'assistant'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("assistant image row persisted");
+        let img = meta["image"].as_object().expect("image marker present");
+        assert_eq!(img["prompt"], "a beach at sunset");
+        assert!(img.get("compose_variant").is_none());
+        assert!(img.get("compose_model").is_none());
+        assert!(img.get("compose_generation_id").is_none());
     }
 
     /// Spec 2026-08-02: a SUCCESSFUL composer call persists the audit trio to

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -158,18 +158,33 @@ fn build_image_request_frame(
     }
 }
 
-/// Minimal `metadata.image` marker for a delegated image turn. Stores ONLY the
-/// PDE seed subject (under `prompt`, the key `assistant_transcript_line` reads)
-/// and the aspect ratio — deliberately NOT the composed wire prompt, model,
-/// generation id, url, or success/failure. Preserves the PDE image-awareness
-/// transcript (§5) while leaving the draw result with the consumer. Pure.
+/// `metadata.image` marker for a delegated image turn. Always stores the PDE
+/// seed subject (under `prompt`, the key `assistant_transcript_line` reads)
+/// and the aspect ratio; when the composer LLM call SUCCEEDED it also stores
+/// the audit trio `compose_variant` / `compose_model` / `compose_generation_id`
+/// (spec 2026-08-02; absence = no successful compose this turn — raw skip,
+/// fail-open, or task not configured). Deliberately NOT stored: the composed
+/// wire prompt (the consumer's job), url, or success/failure of the draw.
+/// Pure.
 fn build_delegated_image_marker(
     seed_subject: &str,
     aspect_ratio: Option<&str>,
+    compose_variant: Option<&str>,
+    compose_model: Option<&str>,
+    compose_generation_id: Option<&str>,
 ) -> serde_json::Value {
     let mut m = serde_json::json!({ "prompt": seed_subject });
     if let Some(ar) = aspect_ratio.filter(|s| !s.is_empty()) {
         m["aspect_ratio"] = serde_json::Value::String(ar.to_string());
+    }
+    if let Some(v) = compose_variant.filter(|s| !s.is_empty()) {
+        m["compose_variant"] = serde_json::Value::String(v.to_string());
+    }
+    if let Some(v) = compose_model.filter(|s| !s.is_empty()) {
+        m["compose_model"] = serde_json::Value::String(v.to_string());
+    }
+    if let Some(v) = compose_generation_id.filter(|s| !s.is_empty()) {
+        m["compose_generation_id"] = serde_json::Value::String(v.to_string());
     }
     m
 }
@@ -3250,7 +3265,7 @@ pub fn run_stream(
                     // marker (seed subject + aspect) so the PDE stays image-aware
                     // (§5); the composed prompt and the draw result live with the
                     // consumer.
-                    let marker = build_delegated_image_marker(&subject, aspect.as_deref());
+                    let marker = build_delegated_image_marker(&subject, aspect.as_deref(), None, None, None);
                     let row = eros_engine_store::chat::AssistantInsert {
                         id: msg_uuid,
                         content: String::new(),
@@ -3571,7 +3586,7 @@ pub fn run_stream(
                         // onto the already-persisted text row so the PDE stays
                         // image-aware (§5). The text already reached the client;
                         // `final` follows below.
-                        let marker = build_delegated_image_marker(&subject, aspect.as_deref());
+                        let marker = build_delegated_image_marker(&subject, aspect.as_deref(), None, None, None);
                         if let Err(e) = chat_repo
                             .merge_assistant_image_meta(user_msg.session_id, msg_uuid, &marker)
                             .await
@@ -11647,7 +11662,7 @@ data: [DONE]\n\n"
     fn delegated_marker_preserves_image_awareness() {
         // Seed subject under `prompt` (the key assistant_transcript_line reads),
         // plus aspect — and NOTHING else (no composed prompt / model / gen id).
-        let marker = build_delegated_image_marker("beach at sunset", Some("3:4"));
+        let marker = build_delegated_image_marker("beach at sunset", Some("3:4"), None, None, None);
         assert_eq!(marker["prompt"], "beach at sunset");
         assert_eq!(marker["aspect_ratio"], "3:4");
         assert_eq!(
@@ -11663,10 +11678,42 @@ data: [DONE]\n\n"
         assert_ne!(line.trim(), "", "image turn must not be a blank line");
 
         // No aspect => still a valid one-key marker that annotates.
-        let m2 = build_delegated_image_marker("a portrait", None);
+        let m2 = build_delegated_image_marker("a portrait", None, None, None, None);
         assert_eq!(m2.as_object().unwrap().len(), 1);
         let w2 = serde_json::json!({ "image": m2 });
         assert!(assistant_transcript_line("", Some(&w2)).contains("a portrait"));
+    }
+
+    /// Spec 2026-08-02: a successful composer call adds exactly three audit
+    /// keys to the marker; absent values (no gen id) omit the key — no nulls.
+    #[test]
+    fn delegated_marker_carries_compose_audit_when_present() {
+        let m = build_delegated_image_marker(
+            "beach at sunset",
+            Some("3:4"),
+            Some("b"),
+            Some("served/model"),
+            Some("gen-xyz"),
+        );
+        assert_eq!(m["prompt"], "beach at sunset");
+        assert_eq!(m["aspect_ratio"], "3:4");
+        assert_eq!(m["compose_variant"], "b");
+        assert_eq!(m["compose_model"], "served/model");
+        assert_eq!(m["compose_generation_id"], "gen-xyz");
+        assert_eq!(m.as_object().unwrap().len(), 5);
+
+        // No generation id from the provider → key absent, not null.
+        let m2 = build_delegated_image_marker(
+            "beach at sunset",
+            None,
+            None,
+            Some("served/model"),
+            None,
+        );
+        assert_eq!(m2["compose_model"], "served/model");
+        assert!(m2.as_object().unwrap().get("compose_generation_id").is_none());
+        assert!(m2.as_object().unwrap().get("compose_variant").is_none());
+        assert_eq!(m2.as_object().unwrap().len(), 2, "prompt + compose_model only");
     }
 
     #[test]

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -11818,17 +11818,20 @@ data: [DONE]\n\n"
         assert_eq!(m.as_object().unwrap().len(), 5);
 
         // No generation id from the provider → key absent, not null.
-        let m2 = build_delegated_image_marker(
-            "beach at sunset",
-            None,
-            None,
-            Some("served/model"),
-            None,
-        );
+        let m2 =
+            build_delegated_image_marker("beach at sunset", None, None, Some("served/model"), None);
         assert_eq!(m2["compose_model"], "served/model");
-        assert!(m2.as_object().unwrap().get("compose_generation_id").is_none());
+        assert!(m2
+            .as_object()
+            .unwrap()
+            .get("compose_generation_id")
+            .is_none());
         assert!(m2.as_object().unwrap().get("compose_variant").is_none());
-        assert_eq!(m2.as_object().unwrap().len(), 2, "prompt + compose_model only");
+        assert_eq!(
+            m2.as_object().unwrap().len(),
+            2,
+            "prompt + compose_model only"
+        );
     }
 
     #[test]

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -5945,7 +5945,7 @@ data: [DONE]\n\n";
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
     async fn compose_success_persists_audit_trio(pool: PgPool) {
         use wiremock::ResponseTemplate;
-        let (reqs, _frames) = run_variant_turn(
+        let (reqs, frames) = run_variant_turn(
             &pool,
             Some("b"),
             ResponseTemplate::new(200).set_body_json(serde_json::json!({
@@ -5956,6 +5956,32 @@ data: [DONE]\n\n";
         )
         .await;
         assert_eq!(reqs.len(), 1, "composer is the only provider call");
+
+        // final-review finding — this is the only place the
+        // `ComposeOutcome.text → wire` seam is pinned; the DB `prompt` stays
+        // the seed by design (asserted below).
+        let composed_b64 = frames
+            .iter()
+            .find_map(|f| match f {
+                ProtocolFrame::ImageRequest {
+                    composed_prompt, ..
+                } => Some(composed_prompt.clone()),
+                _ => None,
+            })
+            .expect("image_request present");
+        let composed = {
+            use base64::Engine as _;
+            String::from_utf8(
+                base64::engine::general_purpose::STANDARD
+                    .decode(&composed_b64)
+                    .unwrap(),
+            )
+            .unwrap()
+        };
+        assert!(
+            composed.contains("ENRICHED SUBJECT"),
+            "composed wire prompt must carry the composer's enriched text, got {composed}"
+        );
 
         // sqlx::test gives this test its own database — the one assistant row
         // is the image turn's.

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -2300,10 +2300,25 @@ fn compose_user_payload(
     )
 }
 
+/// A SUCCESSFUL composer call's result: the enriched subject plus the audit
+/// values persisted to `metadata.image` (spec 2026-08-02). Mirrors
+/// `VisionOutcome`.
+struct ComposeOutcome {
+    text: String,
+    /// Model that actually answered: `resp.model`, falling back to the
+    /// attempted model id (same idiom as the vision audit).
+    model: String,
+    generation_id: Option<String>,
+    /// `ResolvedImagePromptCompose::variant_key`, carried so the call site
+    /// doesn't need the resolved config in scope.
+    variant: Option<String>,
+}
+
 /// Enrich the image subject via the optional composer LLM. Walks
 /// `[model] + fallback` on transport failure (error/timeout/empty); returns the
-/// trimmed enriched subject on first success, or `None` (caller falls back to
-/// the seed). Never blocks or fails the image turn. Mirrors `run_input_filter`.
+/// trimmed enriched subject plus the audit trio on first success, or `None`
+/// (caller falls back to the seed). Never blocks or fails the image turn.
+/// Mirrors `run_input_filter`.
 async fn run_image_prompt_compose(
     state: &AppState,
     c: &eros_engine_llm::model_config::ResolvedImagePromptCompose,
@@ -2312,7 +2327,7 @@ async fn run_image_prompt_compose(
     recent_scene: &str,
     aspect_ratio: Option<&str>,
     style: &str,
-) -> Option<String> {
+) -> Option<ComposeOutcome> {
     use eros_engine_llm::openrouter::{ChatMessage, ChatRequest};
     let appearance = crate::prompt::meta_str(persona, "appearance")
         .map(str::trim)
@@ -2364,7 +2379,12 @@ async fn run_image_prompt_compose(
             tracing::warn!(model = %model_id, "image-compose: empty reply; next");
             continue;
         }
-        return Some(text);
+        return Some(ComposeOutcome {
+            text,
+            model: resp.model.unwrap_or_else(|| model_id.clone()),
+            generation_id: resp.generation_id,
+            variant: c.variant_key.clone(),
+        });
     }
     None
 }
@@ -2428,6 +2448,11 @@ struct DelegatedImagePrompt {
     aspect_ratio: Option<String>,
     /// Final wire prompt — feeds the wire frame.
     composed_prompt: String,
+    /// Audit trio — `Some` only when the composer call succeeded; feeds the
+    /// marker's `compose_*` keys (spec 2026-08-02).
+    compose_variant: Option<String>,
+    compose_model: Option<String>,
+    compose_generation_id: Option<String>,
 }
 
 /// Resolve the per-turn image inputs, optionally enrich the subject via the
@@ -2449,19 +2474,24 @@ async fn build_delegated_image_prompt(
         .and_then(|v| v.as_str().map(String::from))
         .unwrap_or_else(|| "realistic".to_string());
     let variant = req_image.and_then(|i| i.prompt_variant.as_deref());
-    let final_subject = match state.model_config.resolve_image_prompt_compose(variant) {
-        Some(c) => run_image_prompt_compose(
-            state,
-            &c,
-            persona,
-            &inputs.seed_subject,
-            pde_transcript,
-            inputs.aspect_ratio.as_deref(),
-            &style_str,
-        )
-        .await
-        .unwrap_or_else(|| inputs.seed_subject.clone()),
-        None => inputs.seed_subject.clone(),
+    let compose = match state.model_config.resolve_image_prompt_compose(variant) {
+        Some(c) => {
+            run_image_prompt_compose(
+                state,
+                &c,
+                persona,
+                &inputs.seed_subject,
+                pde_transcript,
+                inputs.aspect_ratio.as_deref(),
+                &style_str,
+            )
+            .await
+        }
+        None => None,
+    };
+    let (final_subject, compose_variant, compose_model, compose_generation_id) = match compose {
+        Some(o) => (o.text, o.variant, Some(o.model), o.generation_id),
+        None => (inputs.seed_subject.clone(), None, None, None),
     };
     let composed_prompt =
         crate::pipeline::handlers::compose_image_prompt(inputs.style, persona, &final_subject);
@@ -2469,6 +2499,9 @@ async fn build_delegated_image_prompt(
         seed_subject: inputs.seed_subject,
         aspect_ratio: inputs.aspect_ratio,
         composed_prompt,
+        compose_variant,
+        compose_model,
+        compose_generation_id,
     }
 }
 
@@ -3261,11 +3294,17 @@ pub fn run_stream(
                     let subject = img.seed_subject;
                     let aspect = img.aspect_ratio;
                     let composed_prompt = img.composed_prompt;
-                    // Persist an empty-content row carrying ONLY the minimal
-                    // marker (seed subject + aspect) so the PDE stays image-aware
-                    // (§5); the composed prompt and the draw result live with the
-                    // consumer.
-                    let marker = build_delegated_image_marker(&subject, aspect.as_deref(), None, None, None);
+                    // Persist the marker (seed subject + aspect + compose
+                    // audit trio on success) so the PDE stays image-aware
+                    // (§5); the composed prompt and the draw result live with
+                    // the consumer.
+                    let marker = build_delegated_image_marker(
+                        &subject,
+                        aspect.as_deref(),
+                        img.compose_variant.as_deref(),
+                        img.compose_model.as_deref(),
+                        img.compose_generation_id.as_deref(),
+                    );
                     let row = eros_engine_store::chat::AssistantInsert {
                         id: msg_uuid,
                         content: String::new(),
@@ -3582,11 +3621,17 @@ pub fn run_stream(
                         let subject = img.seed_subject;
                         let aspect = img.aspect_ratio;
                         let composed_prompt = img.composed_prompt;
-                        // Merge ONLY the minimal marker (seed subject + aspect)
-                        // onto the already-persisted text row so the PDE stays
-                        // image-aware (§5). The text already reached the client;
-                        // `final` follows below.
-                        let marker = build_delegated_image_marker(&subject, aspect.as_deref(), None, None, None);
+                        // Merge the marker (seed subject + aspect + compose
+                        // audit trio on success) onto the already-persisted
+                        // text row so the PDE stays image-aware (§5). The text
+                        // already reached the client; `final` follows below.
+                        let marker = build_delegated_image_marker(
+                            &subject,
+                            aspect.as_deref(),
+                            img.compose_variant.as_deref(),
+                            img.compose_model.as_deref(),
+                            img.compose_generation_id.as_deref(),
+                        );
                         if let Err(e) = chat_repo
                             .merge_assistant_image_meta(user_msg.session_id, msg_uuid, &marker)
                             .await
@@ -5722,17 +5767,16 @@ data: [DONE]\n\n";
     async fn run_variant_turn(
         pool: &PgPool,
         prompt_variant: Option<&str>,
+        composer_response: wiremock::ResponseTemplate,
     ) -> (Vec<wiremock::Request>, Vec<ProtocolFrame>) {
         use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
         use futures_util::StreamExt;
         use wiremock::matchers::path as wm_path;
-        use wiremock::{Mock, MockServer, ResponseTemplate};
+        use wiremock::{Mock, MockServer};
 
-        // 500 on every call: the composer fails open to the seed subject. These
-        // tests assert on what was SENT, so the response body is irrelevant.
         let mock = MockServer::start().await;
         Mock::given(wm_path("/api/v1/chat/completions"))
-            .respond_with(ResponseTemplate::new(500))
+            .respond_with(composer_response)
             .mount(&mock)
             .await;
 
@@ -5809,7 +5853,10 @@ data: [DONE]\n\n";
     /// `PromptSpec::select`.
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
     async fn prompt_variant_selects_the_configured_composer_prompt(pool: PgPool) {
-        let (reqs, _frames) = run_variant_turn(&pool, Some("b")).await;
+        use wiremock::ResponseTemplate;
+        // 500 on every call: the composer fails open to the seed subject. This
+        // test asserts on what was SENT, so the response body is irrelevant.
+        let (reqs, _frames) = run_variant_turn(&pool, Some("b"), ResponseTemplate::new(500)).await;
         assert_eq!(
             reqs.len(),
             1,
@@ -5829,7 +5876,10 @@ data: [DONE]\n\n";
     /// subject through to the wire prompt verbatim.
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
     async fn prompt_variant_raw_skips_the_composer(pool: PgPool) {
-        let (reqs, frames) = run_variant_turn(&pool, Some("raw")).await;
+        use wiremock::ResponseTemplate;
+        // 500 on every call: "raw" must make no call at all, so the response
+        // body is irrelevant — this only proves ZERO requests were sent.
+        let (reqs, frames) = run_variant_turn(&pool, Some("raw"), ResponseTemplate::new(500)).await;
         assert!(
             reqs.is_empty(),
             "raw must make no composer call, got {} request(s)",
@@ -5858,6 +5908,43 @@ data: [DONE]\n\n";
             composed.contains("a beach at sunset"),
             "raw must pass the seed subject through: {composed}"
         );
+    }
+
+    /// Spec 2026-08-02: a SUCCESSFUL composer call persists the audit trio to
+    /// `metadata.image` — the selected variant key, the served model, and the
+    /// generation id — while `prompt` keeps the SEED subject (the composed
+    /// text goes only on the wire).
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn compose_success_persists_audit_trio(pool: PgPool) {
+        use wiremock::ResponseTemplate;
+        let (reqs, _frames) = run_variant_turn(
+            &pool,
+            Some("b"),
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "gen-xyz",
+                "model": "served/model",
+                "choices": [{"message": {"content": "ENRICHED SUBJECT"}}],
+            })),
+        )
+        .await;
+        assert_eq!(reqs.len(), 1, "composer is the only provider call");
+
+        // sqlx::test gives this test its own database — the one assistant row
+        // is the image turn's.
+        let meta: serde_json::Value = sqlx::query_scalar(
+            "SELECT metadata FROM engine.chat_messages WHERE role = 'assistant'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("assistant image row persisted");
+        let img = &meta["image"];
+        assert_eq!(
+            img["prompt"], "a beach at sunset",
+            "seed subject, not the composed text"
+        );
+        assert_eq!(img["compose_variant"], "b");
+        assert_eq!(img["compose_model"], "served/model");
+        assert_eq!(img["compose_generation_id"], "gen-xyz");
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -301,7 +301,13 @@ frame (below) — the chat stream never resolves it to a URL itself. The
 `previous`-with-no-image → `face` fallback, and the `face_ref_url` /
 `prev_image_url` reference URLs, belong to the consumer's own image-vendor
 call (the engine has no draw endpoint). The persisted `metadata.image` marker
-records only the seed subject and aspect ratio, not the reference kind.
+records the seed subject and aspect ratio, plus — only when the composer LLM
+call succeeded — the audit trio `compose_variant` (the `filter_prompt`
+key/index that was selected, absent for a plain or built-in prompt),
+`compose_model`, and `compose_generation_id`. Absence of the trio means the
+turn had no successful compose (`raw`, fail-open degradation, or composer not
+configured). The composed prompt itself is never persisted — storing it is
+the consumer's job. The reference kind is not recorded.
 
 Validation: `force` + `tips_amount_usd` on the same turn → `422`. An
 unsupported `aspect_ratio` returns `422 BadRequest` as a pre-stream error.

--- a/docs/model-config.md
+++ b/docs/model-config.md
@@ -590,7 +590,9 @@ Call site: `crates/eros-engine-server/src/pipeline/stream.rs` via
 **Audit.** A successful composer call writes three keys into the image
 turn's `chat_messages.metadata.image`: `compose_variant` (which
 `filter_prompt` key/index was selected; absent for a plain/built-in
-prompt), `compose_model` (the model that answered), and
+prompt; recorded as supplied (trimmed), not normalized — e.g. for the
+indexed shape, `"01"` selects index 1 and is audited as `"01"`),
+`compose_model` (the model that answered), and
 `compose_generation_id`. All three are absent when no compose succeeded
 (`raw`, fail-open, task not configured) — same NULL semantics as the
 affinity audit trio. Usage/cost is not persisted; reconcile via the

--- a/docs/model-config.md
+++ b/docs/model-config.md
@@ -587,6 +587,17 @@ than sit there unreachable.
 Call site: `crates/eros-engine-server/src/pipeline/stream.rs` via
 `resolve_image_prompt_compose()` in `model_config.rs`.
 
+**Audit.** A successful composer call writes three keys into the image
+turn's `chat_messages.metadata.image`: `compose_variant` (which
+`filter_prompt` key/index was selected; absent for a plain/built-in
+prompt), `compose_model` (the model that answered), and
+`compose_generation_id`. All three are absent when no compose succeeded
+(`raw`, fail-open, task not configured) — same NULL semantics as the
+affinity audit trio. Usage/cost is not persisted; reconcile via the
+generation id against your provider's logs. The composed prompt is not
+persisted (consumer-side by design). Spec:
+`docs/superpowers/specs/2026-08-02-image-compose-audit-design.md`.
+
 ### `[tasks.chat_vision]` — image input (vision pre-stage, opt-in)
 
 When a chat turn carries an `image_url`, the engine runs `resolve_vision()` to

--- a/docs/superpowers/specs/2026-08-02-image-compose-audit-design.md
+++ b/docs/superpowers/specs/2026-08-02-image-compose-audit-design.md
@@ -1,0 +1,103 @@
+# eros-engine — compose-call audit fields on the delegated image marker
+
+Follow-up to `2026-07-31-image-prompt-compose-variants-design.md`. That spec's
+`metadata.image` marker deliberately excluded the composer's model, generation
+id, and the composed wire prompt. This PR reverses the exclusion for **three
+audit fields only** — the prompt-variant actually used, the composer model, and
+the compose call's generation id — so a stored image turn can be reconciled
+against provider logs without replaying the stream. The composed prompt itself
+stays out: storing it is the consumer's job (the reference deployment already
+does), and the seed subject is already double-recorded
+(`companion_decision_events.payload.image_prompt` and `metadata.image.prompt`).
+
+---
+
+## 0. Decisions (settled during brainstorm)
+
+- **Three fields, nothing else.** `compose_variant`, `compose_model`,
+  `compose_generation_id`. No usage/cost (reconcile via generation id against
+  the OpenRouter log, the `chat_vision` precedent) and no composed prompt
+  (consumer-side by design).
+- **Success-only writes; absence = no successful compose.** `raw` skip, a
+  fail-open degradation (error/timeout/empty → seed passthrough), and a missing
+  `[tasks.chat_image_prompt_compose]` block all leave the marker exactly as
+  today. No `compose_skip_reason` — same NULL semantics as the affinity-events
+  audit trio.
+- **`compose_variant` is written only when a Keyed/Indexed key actually
+  selected the prompt** (`"b"`, `"0"`). `Plain` and the built-in fallback have
+  a single prompt — there is no "which variant" to answer — so the key is
+  absent; a requested-but-missed variant already warns via
+  `compose_variant_log_event`.
+- **Fields live inside the existing `metadata.image` marker**, not a new
+  top-level key. Both persistence paths (insert and merge) then carry them for
+  free — zero new store API. Naming follows the `vision_model` /
+  `vision_generation_id` style.
+
+---
+
+## 1. Data shape
+
+On a delegated image turn whose compose call succeeded:
+
+```json
+{
+  "image": {
+    "prompt": "<PDE seed subject>",
+    "aspect_ratio": "3:4",
+    "compose_variant": "b",
+    "compose_model": "moonshotai/kimi-k2",
+    "compose_generation_id": "gen-abc123"
+  }
+}
+```
+
+| key | value | absent when |
+|---|---|---|
+| `compose_model` | model that answered the compose call: `resp.model`, falling back to the attempted model id (mirrors `VisionOutcome`, `stream.rs:2077`) | no successful compose this turn |
+| `compose_generation_id` | the compose call's generation id verbatim | provider returned none, or no successful compose |
+| `compose_variant` | the Keyed key / Indexed index that selected the prompt | `Plain` spec, built-in fallback, or no successful compose |
+
+`prompt` (seed subject) and `aspect_ratio` are unchanged.
+
+---
+
+## 2. Changes
+
+All in `eros-engine-server` + `eros-engine-llm`; no store or migration changes.
+
+| Site (pre-PR) | Change |
+|---|---|
+| `ResolvedImagePromptCompose`, `model_config.rs:1152` | new `variant_key: Option<String>`, set by `resolve_image_prompt_compose` (`:1882`) when `PromptSpec::select` (`:204`) hits a Keyed/Indexed entry; `None` for `Plain`/built-in |
+| `run_image_prompt_compose`, `stream.rs:2291` | returns `Option<ComposeOutcome>` instead of `Option<String>`: `{ text, model, generation_id: Option<String>, variant: Option<String> }`, populated at the success exit (`:2346-2352`) where `resp.model`/`resp.generation_id` are currently dropped |
+| `DelegatedImagePrompt`, `stream.rs:2407` | three new `Option` fields; the fail-open seed path in `build_delegated_image_prompt` (`:2424`) fills `None` |
+| `build_delegated_image_marker`, `stream.rs:166` | takes the audit values, writes keys only when `Some`; doc comment rewritten — the deliberate-exclusion list shrinks to: composed prompt, url, draw outcome |
+| `stream.rs:3253` (ReplyImage insert), `stream.rs:3576` (ReplyTextImage merge) | untouched — the enlarged marker rides `AssistantInsert.metadata` and `merge_assistant_image_meta` as-is |
+| `assistant_transcript_line`, `stream.rs:2118` | untouched — reads only `prompt` / `aspect_ratio` |
+
+## 3. Error handling
+
+No new failure surface. Success-only semantics means the only new code on
+error paths is `None`-filling. Persistence failures keep the existing
+warn-and-continue behavior of `insert_assistant_batch` / merge.
+
+## 4. Tests
+
+- Unit: `build_delegated_image_marker` with and without audit values (key
+  presence/absence, no `null`s).
+- Unit: `resolve_image_prompt_compose` `variant_key` across Keyed hit, Indexed
+  hit, miss→built-in, `Plain`.
+- Integration (existing image-turn sqlx tests): after a successful compose,
+  `metadata.image` contains the three keys; with `prompt_variant = "raw"` it
+  contains none of them.
+
+## 5. Docs
+
+- `docs/api-reference.md:303` — extend the `metadata.image` shape table.
+- `docs/model-config.md` — one paragraph in the
+  `chat_image_prompt_compose` section: what is audited, absence semantics.
+
+## 6. Out of scope
+
+Composed-prompt persistence (consumer-side by design), usage/cost columns,
+`companion_decision_events` changes, version/release timing (maintainer's
+call at release time).


### PR DESCRIPTION
## Summary

When the optional image-prompt composer (`chat_image_prompt_compose`) call **succeeds**, persist an audit trio into the image turn's `chat_messages.metadata.image`:

- `compose_variant` — the `filter_prompt` key/index that selected the prompt (absent for plain/built-in; recorded as supplied, trimmed)
- `compose_model` — the model that actually answered (`resp.model`, falling back to the attempted id — the `chat_vision` idiom)
- `compose_generation_id` — the compose call's generation id verbatim

**Success-only writes**: `raw` skip, fail-open degradation, and unconfigured task leave the marker exactly as before — absence of the trio = no successful compose (same NULL semantics as the affinity audit trio). The composed prompt itself stays unpersisted (consumer-side by design). No usage/cost — reconcile via generation id against provider logs.

Spec: `docs/superpowers/specs/2026-08-02-image-compose-audit-design.md` (this PR's first commit).

## Changes

- `eros-engine-llm`: `ResolvedImagePromptCompose.variant_key` — surfaces which Keyed/Indexed variant was hit (`Plain` deliberately `None`: `select()` returns `Some` there regardless of variant)
- `eros-engine-server`: `run_image_prompt_compose` returns `ComposeOutcome` (text + model + generation_id + variant, mirroring `VisionOutcome`) instead of `Option<String>` — `resp.model`/`resp.generation_id` were previously dropped; threaded through `DelegatedImagePrompt` into `build_delegated_image_marker`
- Zero store-crate/migration changes — both persistence paths (ReplyImage insert, ReplyTextImage merge) carry the enlarged marker as-is
- Docs: `api-reference.md` marker shape, `model-config.md` audit paragraph

## Testing

- Unit: `variant_key` semantics matrix (Keyed/Indexed hit/miss, Plain, bare, whitespace-trim); marker shape with/without audit values (key absence, no nulls)
- Integration (sqlx + wiremock): success path persists the trio with `prompt` staying the **seed** subject while the enriched text reaches the wire frame; fail-open (500) and `raw` paths assert trio absence against real Postgres rows
- Full workspace suite: 1075 passed / 0 failed; fmt/clippy(-D warnings)/openapi snapshot all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)