### PR TITLE
feat(llm)!: [[providers.<name>.body]] custom body params; remove [defaults] provider prefs

### DIFF
--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -528,21 +528,38 @@ pub struct DefaultConfig {
     pub provider_sort: Option<String>,
 }
 
+/// One `[[providers.<name>.body]]` rule (spec 2026-08-02-provider-body-params):
+/// opaque params merged into the chat/completions wire body for the tasks it
+/// names. `tasks` omitted ⇒ every chat task this provider serves; `params` is
+/// TOML→JSON passthrough the engine never interprets. Rules apply in
+/// declaration order; later rules win on key conflicts, and the merged params
+/// win over engine-built wire fields. Structural validation (non-empty params,
+/// engine-owned-key refusal, task-name warnings) lives in `validate_providers`.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BodyRule {
+    #[serde(default)]
+    pub tasks: Option<Vec<String>>,
+    pub params: serde_json::Map<String, serde_json::Value>,
+}
+
 /// One `[providers]` entry (spec 2026-08-01-embedding-providers §1). URLs are
 /// complete and posted verbatim — no path joining. `headers` are sent verbatim
 /// on every request to this entry's endpoints (both `chat` and `embeddings`);
 /// `Authorization`/`Content-Type` are engine-owned and rejected at boot.
 /// `BTreeMap` so validation-error ordering is deterministic across restarts.
 ///
+/// `Eq` is dropped: `serde_json::Value` is not `Eq`.
 /// `Deserialize` is hand-written (below) rather than derived: the 0.9.3
 /// shape was a plain string, and a config still written that way must not
 /// see a generic serde "invalid type: string ..., expected struct
 /// ProviderEntry" — it should see the table form it needs to switch to.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct ProviderEntry {
     pub chat: Option<String>,
     pub embeddings: Option<String>,
     pub headers: Option<BTreeMap<String, String>>,
+    pub body: Option<Vec<BodyRule>>,
 }
 
 /// Error taught to an operator whose `[providers]` entry is still the 0.9.3
@@ -569,6 +586,8 @@ impl<'de> Deserialize<'de> for ProviderEntry {
             embeddings: Option<String>,
             #[serde(default)]
             headers: Option<BTreeMap<String, String>>,
+            #[serde(default)]
+            body: Option<Vec<BodyRule>>,
         }
 
         struct ProviderEntryVisitor;
@@ -633,6 +652,7 @@ impl<'de> Deserialize<'de> for ProviderEntry {
                     chat: table.chat,
                     embeddings: table.embeddings,
                     headers: table.headers,
+                    body: table.body,
                 })
             }
         }
@@ -644,7 +664,7 @@ impl<'de> Deserialize<'de> for ProviderEntry {
 impl ProviderEntry {
     /// True when nothing at all is declared (all-`None`).
     pub fn is_empty(&self) -> bool {
-        self.chat.is_none() && self.embeddings.is_none() && self.headers.is_none()
+        self.chat.is_none() && self.embeddings.is_none() && self.headers.is_none() && self.body.is_none()
     }
 
     /// Boot gate for the `headers` table: engine-owned names are rejected
@@ -6385,6 +6405,50 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
         assert!(map.contains_key("venice"));
         assert!(!map.contains_key("local"));
         assert_eq!(map["venice"].headers.get("X-Team").unwrap(), "companion");
+    }
+
+    #[test]
+    fn provider_body_rules_parse() {
+        let cfg = ModelConfig::from_toml_str(
+            "[providers.venice]\nchat = \"https://v/chat\"\n\
+             [[providers.venice.body]]\ntasks = [\"chat_companion\"]\n\
+             params = { venice_parameters = { include_venice_system_prompt = false } }\n\
+             [[providers.venice.body]]\n\
+             params = { reasoning = { max_tokens = 512 } }\n",
+        )
+        .unwrap();
+        let body = cfg.providers["venice"].body.as_ref().unwrap();
+        assert_eq!(body.len(), 2);
+        assert_eq!(
+            body[0].tasks.as_deref(),
+            Some(&["chat_companion".to_string()][..])
+        );
+        assert_eq!(
+            body[0].params["venice_parameters"]["include_venice_system_prompt"],
+            serde_json::Value::Bool(false)
+        );
+        assert!(body[1].tasks.is_none(), "omitted tasks parses as None");
+        assert_eq!(body[1].params["reasoning"]["max_tokens"], 512);
+    }
+
+    #[test]
+    fn provider_body_rule_unknown_key_is_rejected() {
+        let err = ModelConfig::from_toml_str(
+            "[providers.venice]\nchat = \"https://v/chat\"\n\
+             [[providers.venice.body]]\nparam = { a = 1 }\n",
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("param"), "unknown rule key must be named: {err}");
+    }
+
+    #[test]
+    fn provider_entry_with_only_body_is_not_empty() {
+        let cfg = ModelConfig::from_toml_str(
+            "[[providers.openrouter.body]]\nparams = { transforms = [\"middle-out\"] }\n",
+        )
+        .unwrap();
+        assert!(!cfg.providers["openrouter"].is_empty());
     }
 
     // ---- [tasks.embedding] routing + resolve_embedding (spec 2026-08-01-embedding-providers §2/§3/§6) ----

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -498,14 +498,13 @@ pub struct TierConfig {
     pub retry_depth: Option<u32>,
 }
 
-/// The `[defaults]` section — cross-task fallbacks and provider routing.
+/// The `[defaults]` section — cross-task fallbacks.
 ///
-/// **Construct with struct-update syntax** — `DefaultConfig { ignore_providers:
-/// vec![…], ..Default::default() }` — never a bare exhaustive literal. New
-/// optional fields are added here in minor releases (`ignore_providers`
-/// pre-v0.6.1, `provider_sort` v0.8.4) and a bare literal breaks on every such
-/// upgrade; `..Default::default()` is the supported construction pattern
-/// (issue #188).
+/// **Construct with struct-update syntax** — `DefaultConfig { fallback_model:
+/// Some(…), ..Default::default() }` — never a bare exhaustive literal. New
+/// optional fields are added here in minor releases and a bare literal breaks
+/// on every such upgrade; `..Default::default()` is the supported
+/// construction pattern (issue #188).
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct DefaultConfig {
     #[serde(default)]
@@ -514,17 +513,17 @@ pub struct DefaultConfig {
     pub fallback_temperature: Option<f64>,
     #[serde(default)]
     pub fallback_max_tokens: Option<u32>,
-    /// OpenRouter provider slugs to exclude from routing on EVERY task
-    /// (issue #84). Each slug MUST carry the @openrouter suffix (the exclusion
-    /// list acts on OpenRouter routing only). Sent as `provider.ignore` on every
-    /// outbound call; the client reads this once at boot. Empty = no exclusion.
+    /// REMOVED (spec 2026-08-02-provider-body-params) — parsed only so
+    /// `validate_providers` can refuse boot with a migration message pointing
+    /// at `[[providers.openrouter.body]]`; never read anywhere else.
     #[serde(default)]
+    #[doc(hidden)]
     pub ignore_providers: Vec<String>,
-    /// OpenRouter `provider.sort` routing preference applied on EVERY task:
-    /// `"price"` / `"throughput"` / `"latency"`. `None` (absent) omits the
-    /// field, keeping OpenRouter's default price-based load balancing. Setting
-    /// it trades cost for the chosen axis — a deployer decision, off by default.
+    /// REMOVED (spec 2026-08-02-provider-body-params) — parsed only so
+    /// `validate_providers` can refuse boot with a migration message pointing
+    /// at `[[providers.openrouter.body]]`; never read anywhere else.
     #[serde(default)]
+    #[doc(hidden)]
     pub provider_sort: Option<String>,
 }
 
@@ -2317,13 +2316,62 @@ impl ModelConfig {
         }
         Ok(())
     }
+}
 
+/// Every task name the chat/completions pipeline can present to the
+/// body-rules matcher (`ChatRequest.task`). Used ONLY for the boot-time typo
+/// warning on `[[providers.*.body]].tasks` — matching itself is plain string
+/// equality, so an unlisted name warns, never errors.
+pub const KNOWN_CHAT_TASKS: &[&str] = &[
+    "chat_companion",
+    "chat_output_filter",
+    "chat_input_filter",
+    "chat_voice",
+    "chat_image_prompt_compose",
+    "chat_product_qa",
+    "pde_decision",
+    "insight_extraction",
+    "memory_extraction",
+    "affinity_evaluation",
+    "world_director",
+    "world_stories_director",
+    "world_comment",
+    "world_reply",
+];
+
+/// Tasks that make outbound calls but build their own bodies — body rules
+/// never reach them (spec: chat/completions `WireRequest` paths only).
+const BODY_UNSUPPORTED_TASKS: &[&str] = &["chat_vision", "embedding"];
+
+/// Pure warn-decision for one `[[providers.*.body]].tasks` entry —
+/// unit-testable without a tracing subscriber.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BodyTaskWarning {
+    /// A real engine task whose body this mechanism does not cover.
+    Unsupported,
+    /// Not an engine task name at all — probably a typo.
+    Unknown,
+}
+
+fn body_rule_task_warning(task: &str) -> Option<BodyTaskWarning> {
+    if BODY_UNSUPPORTED_TASKS.contains(&task) {
+        Some(BodyTaskWarning::Unsupported)
+    } else if !KNOWN_CHAT_TASKS.contains(&task) {
+        Some(BodyTaskWarning::Unknown)
+    } else {
+        None
+    }
+}
+
+impl ModelConfig {
     /// Boot gate for the `[providers]` block and every `@provider` model slug
     /// (spec 2026-08-01-embedding-providers §2/§4/§6/§7). Checks, in order:
     /// provider-table shape (charset, reserved name, non-empty URL);
-    /// `[defaults].ignore_providers` grammar; a task-aware LITERAL full scan
-    /// of every candidate slug — `[defaults].fallback_model`, every task's and
-    /// tier's `model`/`fallback`, `[tasks.embedding]`'s `model`/`model_read`/
+    /// per-entry body-rule structure (§2026-08-02-provider-body-params);
+    /// removed `[defaults]` provider-routing prefs (tombstone refusal); a
+    /// task-aware LITERAL full scan of every candidate slug —
+    /// `[defaults].fallback_model`, every task's and tier's
+    /// `model`/`fallback`, `[tasks.embedding]`'s `model`/`model_read`/
     /// `model_write`, including every round-robin element and weighted-table
     /// key — where `@voyage` is legal only on embedding-task slugs and every
     /// other referenced provider must have a non-empty `<NAME>_API_KEY` in the
@@ -2364,8 +2412,8 @@ impl ModelConfig {
             if self.providers[name].is_empty() {
                 return Err(format!(
                     "[providers].{name}: entry is empty — declare at least one of \
-                     `chat = \"<url>\"` or `embeddings = \"<url>\"` (or `headers` on \
-                     the `openrouter` entry)"
+                     `chat = \"<url>\"` or `embeddings = \"<url>\"` (or `headers` / \
+                     `body` on the `openrouter` entry)"
                 ));
             }
             if let Some(url) = self.providers[name].chat.as_deref() {
@@ -2379,25 +2427,70 @@ impl ModelConfig {
                 }
             }
             self.providers[name].validate_headers(name)?;
-        }
 
-        // 1.5. [defaults].ignore_providers must carry @openrouter (spec §4): the
-        // knob acts on OpenRouter routing only, and the mandatory suffix makes
-        // that scope part of the syntax.
-        for entry in &self.defaults.ignore_providers {
-            let (bare, provider) = crate::provider::split_model_slug(entry)
-                .map_err(|e| format!("[defaults].ignore_providers: {e}"))?;
-            match provider {
-                Some("openrouter") if !bare.is_empty() => {}
-                _ => {
+            if let Some(rules) = &self.providers[name].body {
+                if name != "openrouter" && self.providers[name].chat.is_none() {
                     return Err(format!(
-                        "[defaults].ignore_providers: `{entry}` must be written \
-                         `<upstream-slug>@openrouter` — the exclusion list acts on \
-                         OpenRouter routing only (custom providers and Voyage never \
-                         receive provider.ignore)"
+                        "[providers].{name}: declares body rules but no `chat` URL — \
+                         body params apply to chat/completions calls only (the reserved \
+                         `openrouter` entry may omit `chat`; the built-in URL serves it)"
                     ));
                 }
+                for (i, rule) in rules.iter().enumerate() {
+                    if rule.params.is_empty() {
+                        return Err(format!(
+                            "[providers].{name}.body[{i}].params: table is empty"
+                        ));
+                    }
+                    for key in ["model", "messages", "stream"] {
+                        if rule.params.contains_key(key) {
+                            return Err(format!(
+                                "[providers].{name}.body[{i}].params: `{key}` is engine-owned \
+                                 wire structure and cannot be overridden"
+                            ));
+                        }
+                    }
+                    if let Some(tasks) = &rule.tasks {
+                        if tasks.is_empty() {
+                            return Err(format!(
+                                "[providers].{name}.body[{i}].tasks: empty array — omit the \
+                                 key to mean \"all chat tasks\""
+                            ));
+                        }
+                        for t in tasks {
+                            match body_rule_task_warning(t) {
+                                Some(BodyTaskWarning::Unsupported) => tracing::warn!(
+                                    provider = %name, task = %t,
+                                    "[providers] body rule names a task this mechanism does \
+                                     not cover — it will never apply"
+                                ),
+                                Some(BodyTaskWarning::Unknown) => tracing::warn!(
+                                    provider = %name, task = %t,
+                                    "[providers] body rule names an unknown task — matching \
+                                     is exact, check for a typo"
+                                ),
+                                None => {}
+                            }
+                        }
+                    }
+                }
             }
+        }
+
+        // 1.5. Removed [defaults] keys (spec 2026-08-02-provider-body-params):
+        // the fields still PARSE (tombstones) purely so an operator upgrading
+        // across the removal gets this message instead of a silently dead key.
+        if !self.defaults.ignore_providers.is_empty() || self.defaults.provider_sort.is_some() {
+            return Err(
+                "[defaults].ignore_providers / [defaults].provider_sort were removed: \
+                 provider routing prefs are now ordinary body params on the reserved \
+                 `openrouter` entry —\n\
+                 [[providers.openrouter.body]]\n\
+                 params = { provider = { ignore = [\"<slug>\"], sort = \"price\" } }\n\
+                 (bare OpenRouter provider slugs — no @openrouter suffix; add \
+                 tasks = [\"…\"] to scope the rule). Delete the [defaults] keys."
+                    .to_string(),
+            );
         }
 
         // 2. Literal full scan of every candidate slug. The third element flags
@@ -4777,21 +4870,6 @@ filter_prompt = "只根据产品资料作答。"
     }
 
     #[test]
-    fn defaults_ignore_providers_parses() {
-        let toml = r#"
-            [defaults]
-            ignore_providers = ["BadHost@openrouter", "AnotherHost@openrouter"]
-            [tasks.chat_companion]
-            model = "x/y"
-        "#;
-        let cfg = ModelConfig::from_toml_str(toml).expect("parse");
-        assert_eq!(
-            cfg.defaults.ignore_providers,
-            vec!["BadHost@openrouter", "AnotherHost@openrouter"]
-        );
-    }
-
-    #[test]
     fn defaults_ignore_providers_absent_is_empty() {
         let toml = r#"
             [tasks.chat_companion]
@@ -4799,6 +4877,101 @@ filter_prompt = "只根据产品资料作答。"
         "#;
         let cfg = ModelConfig::from_toml_str(toml).expect("parse");
         assert!(cfg.defaults.ignore_providers.is_empty());
+    }
+
+    #[test]
+    fn removed_defaults_prefs_refuse_boot() {
+        for src in [
+            "[defaults]\nignore_providers = [\"bad@openrouter\"]\n",
+            "[defaults]\nprovider_sort = \"latency\"\n",
+        ] {
+            let cfg = ModelConfig::from_toml_str(src).unwrap();
+            let err = cfg
+                .validate_providers_with(|_| Some("k".into()))
+                .unwrap_err();
+            assert!(
+                err.contains("[[providers.openrouter.body]]"),
+                "removal error must teach the replacement: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn body_rule_empty_params_refuses() {
+        let cfg = ModelConfig::from_toml_str(
+            "[providers.venice]\nchat = \"https://v/chat\"\n\
+             [[providers.venice.body]]\nparams = { }\n",
+        )
+        .unwrap();
+        let err = cfg
+            .validate_providers_with(|_| Some("k".into()))
+            .unwrap_err();
+        assert!(err.contains("body[0].params"), "{err}");
+    }
+
+    #[test]
+    fn body_rule_structural_keys_refuse() {
+        for key in ["model", "messages", "stream"] {
+            let cfg = ModelConfig::from_toml_str(&format!(
+                "[providers.venice]\nchat = \"https://v/chat\"\n\
+                 [[providers.venice.body]]\nparams = {{ {key} = \"x\" }}\n"
+            ))
+            .unwrap();
+            let err = cfg
+                .validate_providers_with(|_| Some("k".into()))
+                .unwrap_err();
+            assert!(err.contains("engine-owned"), "{key}: {err}");
+        }
+    }
+
+    #[test]
+    fn body_rule_empty_tasks_refuses() {
+        let cfg = ModelConfig::from_toml_str(
+            "[providers.venice]\nchat = \"https://v/chat\"\n\
+             [[providers.venice.body]]\ntasks = []\nparams = { a = 1 }\n",
+        )
+        .unwrap();
+        let err = cfg
+            .validate_providers_with(|_| Some("k".into()))
+            .unwrap_err();
+        assert!(err.contains("tasks"), "{err}");
+    }
+
+    #[test]
+    fn body_without_chat_refuses_for_custom_but_not_openrouter() {
+        let custom = ModelConfig::from_toml_str(
+            "[providers.venice]\nembeddings = \"https://v/emb\"\n\
+             [[providers.venice.body]]\nparams = { a = 1 }\n",
+        )
+        .unwrap();
+        assert!(custom
+            .validate_providers_with(|_| Some("k".into()))
+            .unwrap_err()
+            .contains("no `chat` URL"));
+
+        let openrouter =
+            ModelConfig::from_toml_str("[[providers.openrouter.body]]\nparams = { a = 1 }\n")
+                .unwrap();
+        assert!(openrouter
+            .validate_providers_with(|_| Some("k".into()))
+            .is_ok());
+    }
+
+    #[test]
+    fn body_rule_task_warning_semantics() {
+        assert_eq!(body_rule_task_warning("chat_companion"), None);
+        assert_eq!(
+            body_rule_task_warning("chat_vision"),
+            Some(BodyTaskWarning::Unsupported)
+        );
+        assert_eq!(
+            body_rule_task_warning("embedding"),
+            Some(BodyTaskWarning::Unsupported)
+        );
+        assert_eq!(
+            body_rule_task_warning("chat_companon"),
+            Some(BodyTaskWarning::Unknown)
+        );
     }
 
     #[test]
@@ -4831,56 +5004,25 @@ filter_prompt = "只根据产品资料作答。"
     }
 
     #[test]
-    fn ignore_providers_require_openrouter_suffix() {
-        let cfg =
-            ModelConfig::from_toml_str("[defaults]\nignore_providers = [\"bad-slug\"]\n").unwrap();
-        let msg = cfg.validate_providers_with(|_| None).unwrap_err();
-        assert!(
-            msg.contains("@openrouter"),
-            "must teach the new form: {msg}"
-        );
-    }
-
-    #[test]
-    fn ignore_providers_reject_other_provider_suffix() {
-        let cfg = ModelConfig::from_toml_str(
-            "[providers]\nvenice = { chat = \"https://x/c\" }\n\
-             [defaults]\nignore_providers = [\"bad-slug@venice\"]\n",
-        )
-        .unwrap();
-        assert!(cfg.validate_providers_with(|_| None).is_err());
-    }
-
-    #[test]
     fn ignore_providers_wire_slugs_are_stripped() {
+        // `validate_providers_with` now refuses whenever `ignore_providers` is
+        // non-empty (removed-defaults tombstone) — that refusal is covered by
+        // `removed_defaults_prefs_refuse_boot`. This test only pins the
+        // still-live stripping helper (dies with it in Task 3).
         let cfg = ModelConfig::from_toml_str(
             "[defaults]\nignore_providers = [\"bad-a@openrouter\", \"bad-b@openrouter\"]\n",
         )
         .unwrap();
-        // No [tasks.embedding] ⇒ the default embedding route is the built-in
-        // Voyage client, so validation now also needs VOYAGE_API_KEY.
-        assert!(cfg
-            .validate_providers_with(|k| (k == "VOYAGE_API_KEY").then(|| "k".to_string()))
-            .is_ok());
         assert_eq!(cfg.ignore_provider_wire_slugs(), vec!["bad-a", "bad-b"]);
     }
 
     #[test]
-    fn defaults_provider_sort_parses_and_defaults_none() {
-        let with = r#"
-            [defaults]
-            provider_sort = "latency"
+    fn defaults_provider_sort_absent_is_none() {
+        let toml = r#"
             [tasks.chat_companion]
             model = "x/y"
         "#;
-        let cfg = ModelConfig::from_toml_str(with).expect("parse");
-        assert_eq!(cfg.defaults.provider_sort.as_deref(), Some("latency"));
-
-        let without = r#"
-            [tasks.chat_companion]
-            model = "x/y"
-        "#;
-        let cfg = ModelConfig::from_toml_str(without).expect("parse");
+        let cfg = ModelConfig::from_toml_str(toml).expect("parse");
         assert!(cfg.defaults.provider_sort.is_none());
     }
 

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -664,7 +664,10 @@ impl<'de> Deserialize<'de> for ProviderEntry {
 impl ProviderEntry {
     /// True when nothing at all is declared (all-`None`).
     pub fn is_empty(&self) -> bool {
-        self.chat.is_none() && self.embeddings.is_none() && self.headers.is_none() && self.body.is_none()
+        self.chat.is_none()
+            && self.embeddings.is_none()
+            && self.headers.is_none()
+            && self.body.is_none()
     }
 
     /// Boot gate for the `headers` table: engine-owned names are rejected
@@ -6439,7 +6442,10 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
         )
         .unwrap_err()
         .to_string();
-        assert!(err.contains("param"), "unknown rule key must be named: {err}");
+        assert!(
+            err.contains("param"),
+            "unknown rule key must be named: {err}"
+        );
     }
 
     #[test]

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -2701,6 +2701,7 @@ impl ModelConfig {
                         base_url: chat,
                         api_key: key,
                         headers: entry.header_map(),
+                        body_rules: entry.body.clone().unwrap_or_default(),
                     },
                 ))
             })
@@ -2721,6 +2722,16 @@ impl ModelConfig {
         self.providers
             .get("openrouter")
             .map(|e| e.header_map())
+            .unwrap_or_default()
+    }
+
+    /// `[providers].openrouter.body` rules (empty when absent) — the built-in
+    /// endpoint's body rules, installed at boot via
+    /// `OpenRouterClient::with_openrouter_body_rules`.
+    pub fn openrouter_body_rules(&self) -> Vec<BodyRule> {
+        self.providers
+            .get("openrouter")
+            .and_then(|e| e.body.clone())
             .unwrap_or_default()
     }
 
@@ -6469,7 +6480,12 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
     #[test]
     fn build_providers_maps_declared_entries() {
         let cfg = ModelConfig::from_toml_str(
-            "[providers]\nvenice = { chat = \"https://x/v1\" }\nother = { chat = \"https://y/v1\" }\n",
+            "[providers.venice]\n\
+             chat = \"https://x/v1\"\n\
+             [providers.other]\n\
+             chat = \"https://y/v1\"\n\
+             [[providers.venice.body]]\n\
+             params = { reasoning = { max_tokens = 64 } }\n",
         )
         .unwrap();
         let env = |k: &str| (k == "VENICE_API_KEY").then(|| "sk-v".to_string());
@@ -6479,6 +6495,30 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
         // Unreferenced/keyless entry still present, with an empty key —
         // resolve_endpoint's runtime guard covers the (unreachable) miss.
         assert_eq!(map["other"].api_key, "");
+        // build_providers_with carries the parsed [[providers.<name>.body]]
+        // rules onto ProviderEndpoint.body_rules verbatim.
+        assert_eq!(map["venice"].body_rules.len(), 1);
+        assert_eq!(
+            map["venice"].body_rules[0].params["reasoning"]["max_tokens"],
+            64
+        );
+        assert!(map["other"].body_rules.is_empty(), "no body ⇒ empty vec");
+    }
+
+    #[test]
+    fn openrouter_body_rules_returns_parsed_rules_or_empty() {
+        let with_rules = ModelConfig::from_toml_str(
+            "[providers.openrouter]\n\
+             [[providers.openrouter.body]]\n\
+             params = { transforms = [\"middle-out\"] }\n",
+        )
+        .unwrap();
+        let rules = with_rules.openrouter_body_rules();
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].params["transforms"][0], "middle-out");
+
+        let without = ModelConfig::from_toml_str("").unwrap();
+        assert!(without.openrouter_body_rules().is_empty());
     }
 
     #[test]

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -2707,22 +2707,6 @@ impl ModelConfig {
             .collect()
     }
 
-    /// `[defaults].ignore_providers` with the mandatory `@openrouter` suffix
-    /// stripped — what `provider.ignore` carries on the wire. Call only after
-    /// `validate_providers` passed; entries that fail the grammar are skipped
-    /// (unreachable post-boot).
-    pub fn ignore_provider_wire_slugs(&self) -> Vec<String> {
-        self.defaults
-            .ignore_providers
-            .iter()
-            .filter_map(|e| {
-                crate::provider::split_model_slug(e)
-                    .ok()
-                    .map(|(bare, _)| bare)
-            })
-            .collect()
-    }
-
     /// `[providers].openrouter.chat`, if declared — the built-in chat URL
     /// override (spec §4).
     pub fn openrouter_chat_url(&self) -> Option<String> {
@@ -5001,19 +4985,6 @@ filter_prompt = "只根据产品资料作答。"
         // "4e2" parses as 400.0 (scientific notation) — well past the N >= 4
         // gate, but "e" isn't a version-number character.
         assert_eq!(voyage_model_generation("voyage-4e2"), None);
-    }
-
-    #[test]
-    fn ignore_providers_wire_slugs_are_stripped() {
-        // `validate_providers_with` now refuses whenever `ignore_providers` is
-        // non-empty (removed-defaults tombstone) — that refusal is covered by
-        // `removed_defaults_prefs_refuse_boot`. This test only pins the
-        // still-live stripping helper (dies with it in Task 3).
-        let cfg = ModelConfig::from_toml_str(
-            "[defaults]\nignore_providers = [\"bad-a@openrouter\", \"bad-b@openrouter\"]\n",
-        )
-        .unwrap();
-        assert_eq!(cfg.ignore_provider_wire_slugs(), vec!["bad-a", "bad-b"]);
     }
 
     #[test]

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -2322,6 +2322,9 @@ impl ModelConfig {
 /// body-rules matcher (`ChatRequest.task`). Used ONLY for the boot-time typo
 /// warning on `[[providers.*.body]].tasks` — matching itself is plain string
 /// equality, so an unlisted name warns, never errors.
+///
+/// When adding an engine task, add its name here AND set `ChatRequest.task`
+/// at its pipeline call site.
 pub const KNOWN_CHAT_TASKS: &[&str] = &[
     "chat_companion",
     "chat_output_filter",
@@ -5400,6 +5403,34 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
     }
 
     #[test]
+    fn from_toml_dir_preserves_provider_body_rule() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_cfg(
+            tmp.path(),
+            "providers.toml",
+            "[providers.venice]\nchat = \"https://v/chat\"\n\
+             [[providers.venice.body]]\ntasks = [\"chat_companion\"]\n\
+             params = { venice_parameters = { include_venice_system_prompt = false } }\n",
+        );
+        write_cfg(
+            tmp.path(),
+            "chat.toml",
+            "[tasks.chat_companion]\nmodel = \"p/chat\"\n",
+        );
+        let cfg = ModelConfig::from_toml_dir(tmp.path()).unwrap();
+        let body = cfg.providers["venice"].body.as_ref().unwrap();
+        assert_eq!(body.len(), 1);
+        assert_eq!(
+            body[0].tasks.as_deref(),
+            Some(&["chat_companion".to_string()][..])
+        );
+        assert_eq!(
+            body[0].params["venice_parameters"]["include_venice_system_prompt"],
+            serde_json::Value::Bool(false)
+        );
+    }
+
+    #[test]
     fn from_toml_dir_ignores_dotfiles_subdirs_and_non_toml() {
         let tmp = tempfile::tempdir().unwrap();
         write_cfg(tmp.path(), "base.toml", "[tasks.a]\nmodel = \"p/a\"\n");
@@ -6596,7 +6627,7 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
         .unwrap_err()
         .to_string();
         assert!(
-            err.contains("param"),
+            err.contains("`param`"),
             "unknown rule key must be named: {err}"
         );
     }

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -554,7 +554,7 @@ impl OpenRouterClient {
     }
 
     /// Install the `[providers]` endpoint map (multi-provider spec §3).
-    /// Consuming builder, boot-chained at boot.
+    /// Consuming builder, chained at boot.
     pub fn with_providers(
         mut self,
         providers: HashMap<String, crate::provider::ProviderEndpoint>,

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -270,20 +270,6 @@ fn is_false(b: &bool) -> bool {
     !*b
 }
 
-/// OpenRouter provider routing preferences. `allow_fallbacks` is omitted so
-/// OpenRouter applies its default (true), i.e. the model is still served by a
-/// healthy provider. `sort` is opt-in and off by default: an explicit sort
-/// disables OpenRouter's price-based load balancing (a cost decision the
-/// deployer owns), so when unset the field is omitted and the wire body is
-/// byte-identical to before.
-#[derive(Debug, Serialize)]
-struct ProviderPrefs<'a> {
-    #[serde(skip_serializing_if = "<[String]>::is_empty")]
-    ignore: &'a [String],
-    #[serde(skip_serializing_if = "Option::is_none")]
-    sort: Option<&'a str>,
-}
-
 #[derive(Debug, Serialize)]
 struct WireRequest<'a> {
     model: &'a str,
@@ -307,15 +293,13 @@ struct WireRequest<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     reasoning: Option<&'a ReasoningConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    provider: Option<ProviderPrefs<'a>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     response_format: Option<&'a serde_json::Value>,
 }
 
 impl<'a> WireRequest<'a> {
     /// Strip the OpenRouter-specific fields for a custom endpoint (spec §4):
     /// custom providers receive a strict OpenAI chat-completions subset. All
-    /// four fields carry `skip_serializing_if`, so `None` removes them from
+    /// three fields carry `skip_serializing_if`, so `None` removes them from
     /// the wire entirely — one serialization path, no drift. NOTE: when
     /// adding a field to WireRequest, decide its fate here; the
     /// `custom_endpoint_wire_is_strict_openai_subset` test enforces it.
@@ -324,7 +308,6 @@ impl<'a> WireRequest<'a> {
             self.session_id = None;
             self.metadata = None;
             self.reasoning = None;
-            self.provider = None;
         }
         self
     }
@@ -446,14 +429,6 @@ pub struct OpenRouterClient {
     http: reqwest::Client,
     api_key: String,
     base_url: String,
-    /// OpenRouter provider slugs sent as `provider.ignore` on every call.
-    /// Empty by default; set at boot via [`OpenRouterClient::with_ignore_providers`].
-    ignore_providers: Vec<String>,
-    /// OpenRouter `provider.sort` preference (`"price"` / `"throughput"` /
-    /// `"latency"`). `None` by default; set at boot via
-    /// [`OpenRouterClient::with_provider_sort`]. When `None` the field is
-    /// omitted, preserving OpenRouter's default price-based load balancing.
-    provider_sort: Option<String>,
     /// Custom `[providers]` endpoints, name → endpoint. Empty by default;
     /// installed at boot via [`OpenRouterClient::with_providers`]. Arc so the
     /// client's Clone stays cheap.
@@ -502,8 +477,6 @@ impl OpenRouterClient {
             api_key,
             base_url,
             providers: Arc::new(HashMap::new()),
-            ignore_providers: Vec::new(),
-            provider_sort: None,
         }
     }
 
@@ -532,26 +505,8 @@ impl OpenRouterClient {
         self
     }
 
-    /// Set the global provider-exclusion list (issue #84). Consuming builder so
-    /// boot can chain it: `OpenRouterClient::new(key).with_ignore_providers(list)`.
-    /// Sent as `provider.ignore` on every outbound call.
-    pub fn with_ignore_providers(mut self, providers: Vec<String>) -> Self {
-        self.ignore_providers = providers;
-        self
-    }
-
-    /// Set the global `provider.sort` routing preference (`"price"` /
-    /// `"throughput"` / `"latency"`). Consuming builder, chainable at boot.
-    /// `None` (default) omits the field. Passed through verbatim — OpenRouter
-    /// validates. NOTE: an explicit sort disables OpenRouter's default
-    /// price-based load balancing, a cost/latency tradeoff the deployer owns.
-    pub fn with_provider_sort(mut self, sort: Option<String>) -> Self {
-        self.provider_sort = sort.filter(|s| !s.is_empty());
-        self
-    }
-
     /// Install the `[providers]` endpoint map (multi-provider spec §3).
-    /// Consuming builder, boot-chained like `with_ignore_providers`.
+    /// Consuming builder, boot-chained at boot.
     pub fn with_providers(
         mut self,
         providers: HashMap<String, crate::provider::ProviderEndpoint>,
@@ -633,20 +588,6 @@ impl OpenRouterClient {
                     },
                 ))
             }
-        }
-    }
-
-    /// Build the `ProviderPrefs` for a wire body, or `None` when neither the
-    /// exclusion list nor a sort preference is set (so the `provider` key is
-    /// omitted entirely and the body is byte-identical to the no-prefs case).
-    fn provider_prefs(&self) -> Option<ProviderPrefs<'_>> {
-        if self.ignore_providers.is_empty() && self.provider_sort.is_none() {
-            None
-        } else {
-            Some(ProviderPrefs {
-                ignore: &self.ignore_providers,
-                sort: self.provider_sort.as_deref(),
-            })
         }
     }
 
@@ -789,13 +730,7 @@ impl OpenRouterClient {
                 }
             };
             let mut body = build_vision_body(&req, &bare_model);
-            if ep.name.is_none() {
-                if let Some(prefs) = self.provider_prefs() {
-                    if let Ok(v) = serde_json::to_value(&prefs) {
-                        body["provider"] = v;
-                    }
-                }
-            } else {
+            if ep.name.is_some() {
                 // Custom `[providers]` endpoints get a strict OpenAI subset
                 // (spec §4) — `reasoning` is an OpenRouter-specific extension
                 // that `build_vision_body` bakes in unconditionally, so strip
@@ -932,7 +867,6 @@ impl OpenRouterClient {
             session_id: req_session_id,
             metadata: req_metadata,
             reasoning: req_reasoning,
-            provider: self.provider_prefs(),
             response_format: req_response_format,
         }
         .for_endpoint(&ep);
@@ -1052,7 +986,6 @@ impl OpenRouterClient {
             session_id: req.session_id.as_deref(),
             metadata: req.metadata.as_ref(),
             reasoning: req.reasoning.as_ref(),
-            provider: self.provider_prefs(),
             response_format: None,
         }
         .for_endpoint(&ep);
@@ -1371,7 +1304,6 @@ mod tests {
             session_id: req.session_id.as_deref(),
             metadata: req.metadata.as_ref(),
             reasoning: None,
-            provider: None,
             response_format: None,
         };
         let s = serde_json::to_string(&wire).unwrap();
@@ -1416,7 +1348,6 @@ mod tests {
             session_id: req.session_id.as_deref(),
             metadata: req.metadata.as_ref(),
             reasoning: None,
-            provider: None,
             response_format: None,
         };
         let s = serde_json::to_string(&wire).unwrap();
@@ -2160,7 +2091,6 @@ data: [DONE]\n\n";
             session_id: None,
             metadata: None,
             reasoning: Some(&cfg),
-            provider: None,
             response_format: None,
         };
         let s = serde_json::to_string(&wire).unwrap();
@@ -2183,7 +2113,6 @@ data: [DONE]\n\n";
             session_id: None,
             metadata: None,
             reasoning: None,
-            provider: None,
             response_format: None,
         };
         let s_none = serde_json::to_string(&wire_none).unwrap();
@@ -2420,7 +2349,6 @@ data: [DONE]\n\n";
         let client =
             OpenRouterClient::with_base_url("or-key".into(), "https://unused.test/v1".into())
                 .with_openrouter_headers(openrouter_headers)
-                .with_ignore_providers(vec!["bad".into()])
                 .with_providers(std::collections::HashMap::from([(
                     "venice".to_string(),
                     crate::provider::ProviderEndpoint {
@@ -2456,7 +2384,7 @@ data: [DONE]\n\n";
         let body: serde_json::Value = serde_json::from_slice(&r.body).unwrap();
         assert_eq!(body["model"], "venice-model");
         assert_eq!(body["stream"], true);
-        for k in ["session_id", "metadata", "reasoning", "provider"] {
+        for k in ["session_id", "metadata", "reasoning"] {
             assert!(
                 body.get(k).is_none(),
                 "body field {k} leaked into the stream wire"
@@ -2569,7 +2497,6 @@ data: [DONE]\n\n";
             session_id: None,
             metadata: None,
             reasoning: None,
-            provider: None,
             response_format: Some(&rf),
         };
         let s = serde_json::to_string(&wire).unwrap();
@@ -2591,7 +2518,6 @@ data: [DONE]\n\n";
             session_id: None,
             metadata: None,
             reasoning: None,
-            provider: None,
             response_format: None,
         };
         let s_none = serde_json::to_string(&wire_none).unwrap();
@@ -2599,124 +2525,6 @@ data: [DONE]\n\n";
             !s_none.contains("response_format"),
             "absent ⇒ omitted: {s_none}"
         );
-    }
-
-    #[test]
-    fn wire_request_omits_provider_when_no_ignore_list() {
-        let wire = WireRequest {
-            model: "x/y",
-            messages: &[],
-            temperature: 0.8,
-            top_p: None,
-            frequency_penalty: None,
-            presence_penalty: None,
-            max_tokens: 100,
-            stream: false,
-            user: None,
-            session_id: None,
-            metadata: None,
-            reasoning: None,
-            provider: None,
-            response_format: None,
-        };
-        let body = serde_json::to_value(&wire).unwrap();
-        assert!(
-            body.get("provider").is_none(),
-            "provider key must be omitted when None"
-        );
-    }
-
-    #[test]
-    fn wire_request_emits_provider_ignore_when_set() {
-        let ignore = vec!["BadHost".to_string()];
-        let wire = WireRequest {
-            model: "x/y",
-            messages: &[],
-            temperature: 0.8,
-            top_p: None,
-            frequency_penalty: None,
-            presence_penalty: None,
-            max_tokens: 100,
-            stream: false,
-            user: None,
-            session_id: None,
-            metadata: None,
-            reasoning: None,
-            provider: Some(ProviderPrefs {
-                ignore: &ignore,
-                sort: None,
-            }),
-            response_format: None,
-        };
-        let body = serde_json::to_value(&wire).unwrap();
-        assert_eq!(body["provider"]["ignore"][0], "BadHost");
-        assert!(
-            body["provider"].get("sort").is_none(),
-            "sort omitted when None"
-        );
-    }
-
-    #[test]
-    fn wire_request_emits_provider_sort_when_set_without_ignore() {
-        // sort-only: `ignore` is empty so it is omitted; only `sort` appears.
-        let empty: Vec<String> = Vec::new();
-        let wire = WireRequest {
-            model: "x/y",
-            messages: &[],
-            temperature: 0.8,
-            top_p: None,
-            frequency_penalty: None,
-            presence_penalty: None,
-            max_tokens: 100,
-            stream: false,
-            user: None,
-            session_id: None,
-            metadata: None,
-            reasoning: None,
-            provider: Some(ProviderPrefs {
-                ignore: &empty,
-                sort: Some("latency"),
-            }),
-            response_format: None,
-        };
-        let body = serde_json::to_value(&wire).unwrap();
-        assert_eq!(body["provider"]["sort"], "latency");
-        assert!(
-            body["provider"].get("ignore").is_none(),
-            "empty ignore omitted"
-        );
-    }
-
-    #[test]
-    fn with_ignore_providers_sets_prefs() {
-        let c = OpenRouterClient::with_base_url("k".into(), "http://localhost".into())
-            .with_ignore_providers(vec!["BadHost".into()]);
-        let prefs = c.provider_prefs().expect("prefs present");
-        assert_eq!(prefs.ignore, ["BadHost"]);
-        assert!(prefs.sort.is_none());
-    }
-
-    #[test]
-    fn with_provider_sort_sets_prefs_and_composes_with_ignore() {
-        // sort alone → prefs present.
-        let c = OpenRouterClient::with_base_url("k".into(), "http://localhost".into())
-            .with_provider_sort(Some("throughput".into()));
-        let prefs = c.provider_prefs().expect("prefs present for sort-only");
-        assert_eq!(prefs.sort, Some("throughput"));
-        assert!(prefs.ignore.is_empty());
-
-        // empty string sort → treated as unset (no prefs when nothing else set).
-        let c = OpenRouterClient::with_base_url("k".into(), "http://localhost".into())
-            .with_provider_sort(Some(String::new()));
-        assert!(c.provider_prefs().is_none(), "empty sort is unset");
-
-        // ignore + sort compose into one prefs object.
-        let c = OpenRouterClient::with_base_url("k".into(), "http://localhost".into())
-            .with_ignore_providers(vec!["BadHost".into()])
-            .with_provider_sort(Some("latency".into()));
-        let prefs = c.provider_prefs().expect("prefs present");
-        assert_eq!(prefs.ignore, ["BadHost"]);
-        assert_eq!(prefs.sort, Some("latency"));
     }
 
     // ---- multi-provider routing: resolve_endpoint (spec §3) ----
@@ -2784,10 +2592,9 @@ data: [DONE]\n\n";
     async fn execute_at_openrouter_suffix_hits_built_in_endpoint_full_wire() {
         // Critical-finding regression test: `@openrouter` on a chat slug must
         // resolve through the SAME path as no suffix (spec §3/§4) — built-in
-        // endpoint, full OpenRouter wire (provider.ignore included), bare
-        // model on the wire — never the custom-provider subset. No
-        // `[providers]` map is installed at all, proving the alias needs no
-        // `[providers].openrouter` entry to work.
+        // endpoint, bare model on the wire — never the custom-provider
+        // subset. No `[providers]` map is installed at all, proving the
+        // alias needs no `[providers].openrouter` entry to work.
         let server = MockServer::start().await;
         Mock::given(path("/api/v1/chat/completions"))
             .respond_with(ResponseTemplate::new(200).set_body_json(ok_response()))
@@ -2797,8 +2604,7 @@ data: [DONE]\n\n";
         let client = OpenRouterClient::with_base_url(
             "test-key".into(),
             format!("{}/api/v1/chat/completions", server.uri()),
-        )
-        .with_ignore_providers(vec!["bad".into()]);
+        );
         let _ = client
             .execute(ChatRequest {
                 model: "test/model@openrouter".into(),
@@ -2820,53 +2626,39 @@ data: [DONE]\n\n";
             body["model"], "test/model",
             "wire model must be the bare id — the @openrouter suffix must not reach the wire"
         );
-        assert_eq!(
-            body["provider"]["ignore"][0], "bad",
-            "provider.ignore must be present — proves the full wire, not the custom subset"
-        );
     }
 
     #[tokio::test]
-    async fn execute_stream_as_openrouter_suffix_hits_built_in_endpoint() {
-        // Cheap parallel to the execute() alias-equivalence test above, on
-        // the streaming path — same resolve_endpoint fix, same assertions.
+    async fn builtin_wire_has_no_provider_key() {
+        // ProviderPrefs was removed (spec 2026-08-02-provider-body-params §3):
+        // the engine never builds a `provider` object; deployers who need
+        // OpenRouter routing prefs declare them as [[providers.openrouter.body]]
+        // params. Locks the built-in wire against a silent re-introduction.
         let server = MockServer::start().await;
-        let sse = "data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\ndata: [DONE]\n\n";
         Mock::given(path("/api/v1/chat/completions"))
-            .respond_with(
-                ResponseTemplate::new(200)
-                    .insert_header("content-type", "text/event-stream")
-                    .set_body_raw(sse, "text/event-stream"),
-            )
+            .respond_with(ResponseTemplate::new(200).set_body_json(ok_response()))
             .expect(1)
             .mount(&server)
             .await;
         let client = OpenRouterClient::with_base_url(
             "test-key".into(),
             format!("{}/api/v1/chat/completions", server.uri()),
-        )
-        .with_ignore_providers(vec!["bad".into()]);
-        let req = ChatRequest {
-            model: String::new(), // placeholder; execute_stream_as takes the model separately
-            messages: vec![ChatMessage {
-                role: "user".into(),
-                content: "hi".into(),
-            }],
-            temperature: 0.0,
-            max_tokens: 16,
-            ..Default::default()
-        };
-        let mut s = client
-            .execute_stream_as(&req, "test/model@openrouter")
+        );
+        client
+            .execute(ChatRequest {
+                model: "m".into(),
+                messages: vec![ChatMessage {
+                    role: "user".into(),
+                    content: "hi".into(),
+                }],
+                max_tokens: 5,
+                ..Default::default()
+            })
             .await
-            .expect("stream opens");
-        use futures_util::StreamExt as _;
-        while s.next().await.is_some() {}
-
-        let r = &server.received_requests().await.unwrap()[0];
-        let body: serde_json::Value = serde_json::from_slice(&r.body).unwrap();
-        assert_eq!(body["model"], "test/model");
-        assert_eq!(body["provider"]["ignore"][0], "bad");
+            .unwrap();
+        let reqs = server.received_requests().await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&reqs[0].body).unwrap();
+        assert!(body.get("provider").is_none(), "provider key must be gone");
     }
 
     #[test]
@@ -3215,7 +3007,6 @@ data: [DONE]\n\n";
             .await;
         let client =
             OpenRouterClient::with_base_url("or-key".into(), "https://unused.test/v1".into())
-                .with_ignore_providers(vec!["bad".into()]) // would inject body["provider"] on OpenRouter
                 .with_providers(std::collections::HashMap::from([(
                     "venice".to_string(),
                     crate::provider::ProviderEndpoint {
@@ -3278,7 +3069,6 @@ data: [DONE]\n\n";
             session_id: None,
             metadata: None,
             reasoning: None,
-            provider: None,
             response_format: None,
         };
         let s = serde_json::to_string(&wire).unwrap();
@@ -3306,7 +3096,6 @@ data: [DONE]\n\n";
             session_id: None,
             metadata: None,
             reasoning: None,
-            provider: None,
             response_format: None,
         };
         let s = serde_json::to_string(&wire).unwrap();
@@ -3330,7 +3119,6 @@ data: [DONE]\n\n";
         serde_json::Map<String, serde_json::Value>,
         ReasoningConfig,
         serde_json::Value,
-        Vec<String>,
     ) {
         let messages = vec![ChatMessage {
             role: "user".into(),
@@ -3343,8 +3131,7 @@ data: [DONE]\n\n";
             ..Default::default()
         };
         let response_format = serde_json::json!({ "type": "json_object" });
-        let ignore = vec!["bad-provider".to_string()];
-        (messages, meta, reasoning, response_format, ignore)
+        (messages, meta, reasoning, response_format)
     }
 
     #[test]
@@ -3355,7 +3142,7 @@ data: [DONE]\n\n";
         // If this test fails on a field you just added to WireRequest, add it
         // to WireRequest::for_endpoint's drop list (or the allow list, if it
         // is standard OpenAI).
-        let (messages, meta, reasoning, response_format, ignore) = full_wire_parts();
+        let (messages, meta, reasoning, response_format) = full_wire_parts();
         let http = reqwest::Client::new();
         let ep = Endpoint {
             url: "https://x",
@@ -3377,10 +3164,6 @@ data: [DONE]\n\n";
             session_id: Some("s"),
             metadata: Some(&meta),
             reasoning: Some(&reasoning),
-            provider: Some(ProviderPrefs {
-                ignore: &ignore,
-                sort: Some("latency"),
-            }),
             response_format: Some(&response_format),
         }
         .for_endpoint(&ep);
@@ -3454,7 +3237,7 @@ data: [DONE]\n\n";
     #[test]
     fn openrouter_endpoint_wire_keeps_all_fields() {
         // Regression lock: for_endpoint on the built-in endpoint drops NOTHING.
-        let (messages, meta, reasoning, response_format, ignore) = full_wire_parts();
+        let (messages, meta, reasoning, response_format) = full_wire_parts();
         let http = reqwest::Client::new();
         let ep = Endpoint {
             url: "https://x",
@@ -3476,16 +3259,12 @@ data: [DONE]\n\n";
             session_id: Some("s"),
             metadata: Some(&meta),
             reasoning: Some(&reasoning),
-            provider: Some(ProviderPrefs {
-                ignore: &ignore,
-                sort: None,
-            }),
             response_format: Some(&response_format),
         }
         .for_endpoint(&ep);
         let v = serde_json::to_value(&wire).unwrap();
         let obj = v.as_object().unwrap();
-        for k in ["session_id", "metadata", "reasoning", "provider"] {
+        for k in ["session_id", "metadata", "reasoning"] {
             assert!(
                 obj.contains_key(k),
                 "`{k}` must survive on the OpenRouter path"
@@ -3505,7 +3284,7 @@ data: [DONE]\n\n";
             .expect(1)
             .mount(&server_b)
             .await;
-        // Headers + prefs configured — none of it may reach the custom host.
+        // Headers configured — none of it may reach the custom host.
         let mut openrouter_headers = reqwest::header::HeaderMap::new();
         openrouter_headers.insert("HTTP-Referer", "https://eros.example".parse().unwrap());
         openrouter_headers.insert("X-OpenRouter-Title", "Eros".parse().unwrap());
@@ -3518,8 +3297,6 @@ data: [DONE]\n\n";
             "https://unused-openrouter.test/v1".into(),
         )
         .with_openrouter_headers(openrouter_headers)
-        .with_ignore_providers(vec!["bad".into()])
-        .with_provider_sort(Some("latency".into()))
         .with_providers(std::collections::HashMap::from([(
             "venice".to_string(),
             crate::provider::ProviderEndpoint {
@@ -3568,10 +3345,10 @@ data: [DONE]\n\n";
         ] {
             assert!(req.headers.get(h).is_none(), "header {h} leaked");
         }
-        // Bare model id + none of the four OpenRouter-only body fields.
+        // Bare model id + none of the three OpenRouter-only body fields.
         let body: serde_json::Value = serde_json::from_slice(&req.body).unwrap();
         assert_eq!(body["model"], "venice-model");
-        for k in ["session_id", "metadata", "reasoning", "provider"] {
+        for k in ["session_id", "metadata", "reasoning"] {
             assert!(body.get(k).is_none(), "body field {k} leaked");
         }
     }

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -93,6 +93,11 @@ pub struct ChatRequest {
     /// PDE-only: OpenRouter `response_format` (e.g. a json_schema object).
     /// `None` ⇒ omitted. Opaque passthrough; the caller builds the schema.
     pub response_format: Option<serde_json::Value>,
+    /// Engine task this call serves (`chat_companion`, `pde_decision`, …) —
+    /// config routing ONLY, never serialized to the wire. Selects which
+    /// `[[providers.<name>.body]]` rules apply. `None` (the `Default`) ⇒ no
+    /// task-scoped rule matches; unscoped rules still apply.
+    pub task: Option<String>,
 }
 
 /// One-shot multimodal *describe* request. Used only by the `chat_vision`
@@ -303,6 +308,14 @@ impl<'a> WireRequest<'a> {
     /// the wire entirely — one serialization path, no drift. NOTE: when
     /// adding a field to WireRequest, decide its fate here; the
     /// `custom_endpoint_wire_is_strict_openai_subset` test enforces it.
+    ///
+    /// Body rules merge AFTER this strip (spec 2026-08-02-provider-body-params
+    /// §4): a custom provider's declared `[[providers.<name>.body]]` params
+    /// may deliberately reintroduce a vendor field this strip just removed
+    /// (e.g. its own `reasoning` shape) — that is the supported way to send
+    /// provider-specific params, not a leak. The strict-subset lock
+    /// (`custom_endpoint_wire_is_strict_openai_subset`) only covers the
+    /// no-rules default.
     fn for_endpoint(mut self, ep: &Endpoint<'_>) -> Self {
         if ep.name.is_some() {
             self.session_id = None;
@@ -310,6 +323,34 @@ impl<'a> WireRequest<'a> {
             self.reasoning = None;
         }
         self
+    }
+}
+
+/// True when `rule` applies to a call serving `task` (spec
+/// 2026-08-02-provider-body-params): no `tasks` list ⇒ applies always;
+/// a task-scoped rule requires an exact, case-sensitive name match.
+fn rule_matches(rule: &crate::model_config::BodyRule, task: Option<&str>) -> bool {
+    match (&rule.tasks, task) {
+        (None, _) => true,
+        (Some(_), None) => false,
+        (Some(list), Some(t)) => list.iter().any(|x| x == t),
+    }
+}
+
+/// Merge every matching rule's params into the serialized wire body:
+/// top-level shallow, declaration order, later wins — and the merged params
+/// win over engine-built fields (that ordering is what makes the
+/// `[providers.openrouter]` `reasoning` override `[tasks.*].reasoning`).
+/// Structural keys (`model`/`messages`/`stream`) were refused at boot. Pure.
+fn apply_body_rules(
+    body: &mut serde_json::Map<String, serde_json::Value>,
+    rules: &[crate::model_config::BodyRule],
+    task: Option<&str>,
+) {
+    for rule in rules.iter().filter(|r| rule_matches(r, task)) {
+        for (k, v) in &rule.params {
+            body.insert(k.clone(), v.clone());
+        }
     }
 }
 
@@ -433,6 +474,12 @@ pub struct OpenRouterClient {
     /// installed at boot via [`OpenRouterClient::with_providers`]. Arc so the
     /// client's Clone stays cheap.
     providers: Arc<HashMap<String, crate::provider::ProviderEndpoint>>,
+    /// `[providers].openrouter.body` rules for the built-in endpoint. Empty
+    /// by default; installed at boot via
+    /// [`OpenRouterClient::with_openrouter_body_rules`]. Custom `[providers]`
+    /// endpoints carry their own rules on `ProviderEndpoint.body_rules`
+    /// instead.
+    openrouter_body_rules: Vec<crate::model_config::BodyRule>,
     /// HTTP client WITHOUT the `[providers].openrouter.headers` default
     /// headers, used for every custom-provider post. Those default headers
     /// are baked into `http` at boot via [`OpenRouterClient::with_openrouter_headers`]
@@ -477,6 +524,7 @@ impl OpenRouterClient {
             api_key,
             base_url,
             providers: Arc::new(HashMap::new()),
+            openrouter_body_rules: Vec::new(),
         }
     }
 
@@ -512,6 +560,14 @@ impl OpenRouterClient {
         providers: HashMap<String, crate::provider::ProviderEndpoint>,
     ) -> Self {
         self.providers = Arc::new(providers);
+        self
+    }
+
+    /// Install `[providers].openrouter.body` rules for the built-in endpoint
+    /// (custom providers carry theirs on `ProviderEndpoint`). Consuming
+    /// builder, boot-chained.
+    pub fn with_openrouter_body_rules(mut self, rules: Vec<crate::model_config::BodyRule>) -> Self {
+        self.openrouter_body_rules = rules;
         self
     }
 }
@@ -630,6 +686,7 @@ impl OpenRouterClient {
                     req.metadata.as_ref(),
                     req.reasoning.as_ref(),
                     req.response_format.as_ref(),
+                    req.task.as_deref(),
                 )
                 .await
             {
@@ -852,6 +909,7 @@ impl OpenRouterClient {
         req_metadata: Option<&serde_json::Map<String, serde_json::Value>>,
         req_reasoning: Option<&ReasoningConfig>,
         req_response_format: Option<&serde_json::Value>,
+        req_task: Option<&str>,
     ) -> Result<ChatResponse, LlmError> {
         let (bare_model, ep) = self.resolve_endpoint(model)?;
         let wire = WireRequest {
@@ -871,11 +929,29 @@ impl OpenRouterClient {
         }
         .for_endpoint(&ep);
 
+        let rules: &[crate::model_config::BodyRule] = match ep.name {
+            None => &self.openrouter_body_rules,
+            Some(p) => self
+                .providers
+                .get(p)
+                .map(|e| e.body_rules.as_slice())
+                .unwrap_or(&[]),
+        };
         let mut builder = ep.http.post(ep.url).bearer_auth(ep.api_key);
         if let Some(h) = ep.headers {
             builder = builder.headers(h.clone());
         }
-        let resp = builder.json(&wire).send().await?;
+        let resp = if rules.iter().any(|r| rule_matches(r, req_task)) {
+            let mut v = serde_json::to_value(&wire)
+                .map_err(|e| LlmError::Config(format!("openrouter: wire serialize: {e}")))?;
+            let map = v
+                .as_object_mut()
+                .expect("WireRequest always serializes to a JSON object");
+            apply_body_rules(map, rules, req_task);
+            builder.json(&v).send().await?
+        } else {
+            builder.json(&wire).send().await?
+        };
 
         let status = resp.status();
         if !status.is_success() {
@@ -990,6 +1066,15 @@ impl OpenRouterClient {
         }
         .for_endpoint(&ep);
 
+        let rules: &[crate::model_config::BodyRule] = match ep.name {
+            None => &self.openrouter_body_rules,
+            Some(p) => self
+                .providers
+                .get(p)
+                .map(|e| e.body_rules.as_slice())
+                .unwrap_or(&[]),
+        };
+        let req_task = req.task.as_deref();
         let started = std::time::Instant::now();
         let mut builder = ep
             .http
@@ -999,7 +1084,17 @@ impl OpenRouterClient {
         if let Some(h) = ep.headers {
             builder = builder.headers(h.clone());
         }
-        let resp = builder.json(&wire).send().await?;
+        let resp = if rules.iter().any(|r| rule_matches(r, req_task)) {
+            let mut v = serde_json::to_value(&wire)
+                .map_err(|e| LlmError::Config(format!("openrouter: wire serialize: {e}")))?;
+            let map = v
+                .as_object_mut()
+                .expect("WireRequest always serializes to a JSON object");
+            apply_body_rules(map, rules, req_task);
+            builder.json(&v).send().await?
+        } else {
+            builder.json(&wire).send().await?
+        };
 
         let status = resp.status();
         if !status.is_success() {
@@ -1126,6 +1221,60 @@ mod tests {
         })
     }
 
+    fn rule(tasks: Option<&[&str]>, params: serde_json::Value) -> crate::model_config::BodyRule {
+        crate::model_config::BodyRule {
+            tasks: tasks.map(|t| t.iter().map(|s| s.to_string()).collect()),
+            params: params.as_object().unwrap().clone(),
+        }
+    }
+
+    #[test]
+    fn rule_matching_semantics() {
+        let scoped = rule(Some(&["chat_companion"]), serde_json::json!({"a": 1}));
+        let open = rule(None, serde_json::json!({"b": 2}));
+        assert!(rule_matches(&scoped, Some("chat_companion")));
+        assert!(!rule_matches(&scoped, Some("pde_decision")));
+        assert!(
+            !rule_matches(&scoped, None),
+            "task-scoped rule never matches a task-less request"
+        );
+        assert!(rule_matches(&open, Some("anything")));
+        assert!(
+            rule_matches(&open, None),
+            "unscoped rule applies even without a task"
+        );
+    }
+
+    #[test]
+    fn apply_body_rules_merges_in_order_later_wins() {
+        let mut body = serde_json::json!({"model": "m", "temperature": 0.5})
+            .as_object()
+            .unwrap()
+            .clone();
+        let rules = [
+            rule(
+                None,
+                serde_json::json!({"venice_parameters": {"x": 1}, "temperature": 0.9}),
+            ),
+            rule(
+                Some(&["chat_companion"]),
+                serde_json::json!({"venice_parameters": {"x": 2}}),
+            ),
+            rule(Some(&["pde_decision"]), serde_json::json!({"never": true})),
+        ];
+        apply_body_rules(&mut body, &rules, Some("chat_companion"));
+        assert_eq!(
+            body["venice_parameters"]["x"], 2,
+            "later matching rule wins"
+        );
+        assert_eq!(
+            body["temperature"], 0.9,
+            "params win over engine-built fields"
+        );
+        assert_eq!(body["model"], "m", "untouched keys survive");
+        assert!(body.get("never").is_none(), "non-matching rule skipped");
+    }
+
     #[tokio::test]
     async fn client_sends_configured_openrouter_headers() {
         let server = MockServer::start().await;
@@ -1236,6 +1385,7 @@ mod tests {
                 base_url: format!("{}/v1/chat/completions", server.uri()),
                 api_key: "vk".into(),
                 headers: ep_headers,
+                body_rules: Vec::new(),
             },
         );
         let client = OpenRouterClient::with_base_url("test-key".into(), "http://unused/".into())
@@ -2355,6 +2505,7 @@ data: [DONE]\n\n";
                         base_url: format!("{}/v1/chat/completions", server_b.uri()),
                         api_key: "v-key".into(),
                         headers: reqwest::header::HeaderMap::new(),
+                        body_rules: Vec::new(),
                     },
                 )]));
         let req = ChatRequest {
@@ -2537,6 +2688,7 @@ data: [DONE]\n\n";
                     base_url: "https://venice.test/v1/chat/completions".into(),
                     api_key: "v-key".into(),
                     headers: reqwest::header::HeaderMap::new(),
+                    body_rules: Vec::new(),
                 },
             )]))
     }
@@ -2687,6 +2839,7 @@ data: [DONE]\n\n";
                         base_url: "https://venice.test/v1".into(),
                         api_key: String::new(),
                         headers: reqwest::header::HeaderMap::new(),
+                        body_rules: Vec::new(),
                     },
                 )]));
         assert!(matches!(
@@ -3013,6 +3166,7 @@ data: [DONE]\n\n";
                         base_url: format!("{}/v1/chat/completions", server_b.uri()),
                         api_key: "v-key".into(),
                         headers: reqwest::header::HeaderMap::new(),
+                        body_rules: Vec::new(),
                     },
                 )]));
         let resp = client
@@ -3303,6 +3457,7 @@ data: [DONE]\n\n";
                 base_url: format!("{}/v1/chat/completions", server_b.uri()),
                 api_key: "v-key".into(),
                 headers: reqwest::header::HeaderMap::new(),
+                body_rules: Vec::new(),
             },
         )]));
         let mut meta = serde_json::Map::new();
@@ -3373,6 +3528,7 @@ data: [DONE]\n\n";
                         base_url: format!("{}/v1/chat/completions", server_b.uri()),
                         api_key: "v-key".into(),
                         headers: reqwest::header::HeaderMap::new(),
+                        body_rules: Vec::new(),
                     },
                 )]));
         let resp = client
@@ -3414,6 +3570,7 @@ data: [DONE]\n\n";
                         base_url: format!("{}/v1/chat/completions", server_b.uri()),
                         api_key: "v-key".into(),
                         headers: reqwest::header::HeaderMap::new(),
+                        body_rules: Vec::new(),
                     },
                 )]));
         let resp = client
@@ -3457,6 +3614,7 @@ data: [DONE]\n\n";
                 base_url: format!("{}/v1/chat/completions", server_b.uri()),
                 api_key: "v-key".into(),
                 headers: reqwest::header::HeaderMap::new(),
+                body_rules: Vec::new(),
             },
         )]));
         let resp = client
@@ -3516,5 +3674,304 @@ data: [DONE]\n\n";
             .await
             .expect("chain advances past the unresolvable candidate");
         assert_eq!(resp.reply, "ok");
+    }
+
+    // ---- [[providers.*.body]] merge (spec 2026-08-02-provider-body-params) ----
+
+    #[tokio::test]
+    async fn openrouter_body_rule_applies_for_its_task_and_overrides_reasoning() {
+        let mock = MockServer::start().await;
+        Mock::given(path("/api/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ok_response()))
+            .expect(1)
+            .mount(&mock)
+            .await;
+        let client = OpenRouterClient::with_base_url(
+            "k".into(),
+            format!("{}/api/v1/chat/completions", mock.uri()),
+        )
+        .with_openrouter_body_rules(vec![rule(
+            Some(&["chat_companion"]),
+            serde_json::json!({"transforms": ["middle-out"], "reasoning": {"max_tokens": 64}}),
+        )]);
+        client
+            .execute(ChatRequest {
+                model: "m".into(),
+                messages: vec![ChatMessage {
+                    role: "user".into(),
+                    content: "hi".into(),
+                }],
+                max_tokens: 5,
+                reasoning: Some(ReasoningConfig {
+                    enabled: Some(true),
+                    ..Default::default()
+                }),
+                task: Some("chat_companion".into()),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        let body: serde_json::Value =
+            serde_json::from_slice(&mock.received_requests().await.unwrap()[0].body).unwrap();
+        assert_eq!(body["transforms"][0], "middle-out");
+        assert_eq!(
+            body["reasoning"]["max_tokens"], 64,
+            "providers-block reasoning must beat [tasks.*] reasoning"
+        );
+        assert!(body.get("enabled").is_none());
+    }
+
+    #[tokio::test]
+    async fn body_rule_skipped_for_unlisted_task() {
+        // Identical setup to the previous test, but the request serves a task
+        // the rule does not list — nothing merges, and the request's own
+        // reasoning config survives untouched.
+        let mock = MockServer::start().await;
+        Mock::given(path("/api/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ok_response()))
+            .expect(1)
+            .mount(&mock)
+            .await;
+        let client = OpenRouterClient::with_base_url(
+            "k".into(),
+            format!("{}/api/v1/chat/completions", mock.uri()),
+        )
+        .with_openrouter_body_rules(vec![rule(
+            Some(&["chat_companion"]),
+            serde_json::json!({"transforms": ["middle-out"]}),
+        )]);
+        client
+            .execute(ChatRequest {
+                model: "m".into(),
+                messages: vec![ChatMessage {
+                    role: "user".into(),
+                    content: "hi".into(),
+                }],
+                max_tokens: 5,
+                reasoning: Some(ReasoningConfig {
+                    enabled: Some(true),
+                    ..Default::default()
+                }),
+                task: Some("pde_decision".into()),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        let body: serde_json::Value =
+            serde_json::from_slice(&mock.received_requests().await.unwrap()[0].body).unwrap();
+        assert!(
+            body.get("transforms").is_none(),
+            "unlisted task must not merge"
+        );
+        assert_eq!(
+            body["reasoning"]["enabled"], true,
+            "request's own reasoning survives"
+        );
+    }
+
+    #[tokio::test]
+    async fn custom_provider_strips_then_merges() {
+        let mock = MockServer::start().await;
+        Mock::given(path("/api/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ok_response()))
+            .expect(1)
+            .mount(&mock)
+            .await;
+        let mut providers = std::collections::HashMap::new();
+        providers.insert(
+            "venice".to_string(),
+            crate::provider::ProviderEndpoint {
+                base_url: format!("{}/api/v1/chat/completions", mock.uri()),
+                api_key: "vk".into(),
+                headers: reqwest::header::HeaderMap::new(),
+                body_rules: vec![rule(
+                    None,
+                    serde_json::json!({
+                        "venice_parameters": {"include_venice_system_prompt": false},
+                        "reasoning": {"strip_thinking_response": true},
+                    }),
+                )],
+            },
+        );
+        let client = OpenRouterClient::with_base_url("k".into(), "http://unused".into())
+            .with_providers(providers);
+        let mut meta = serde_json::Map::new();
+        meta.insert("k".into(), serde_json::json!("v"));
+        client
+            .execute(ChatRequest {
+                model: "m@venice".into(),
+                messages: vec![ChatMessage {
+                    role: "user".into(),
+                    content: "hi".into(),
+                }],
+                max_tokens: 5,
+                session_id: Some("s".into()),
+                metadata: Some(meta),
+                reasoning: Some(ReasoningConfig {
+                    enabled: Some(true),
+                    ..Default::default()
+                }),
+                task: Some("chat_companion".into()),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        let body: serde_json::Value =
+            serde_json::from_slice(&mock.received_requests().await.unwrap()[0].body).unwrap();
+        assert_eq!(
+            body["venice_parameters"]["include_venice_system_prompt"],
+            serde_json::Value::Bool(false)
+        );
+        assert_eq!(
+            body["reasoning"]["strip_thinking_response"], true,
+            "the RULE's reasoning shape — the request's was stripped first"
+        );
+        assert!(
+            body.get("session_id").is_none(),
+            "strip still runs before merge"
+        );
+        assert!(body.get("metadata").is_none());
+    }
+
+    #[tokio::test]
+    async fn body_rules_apply_on_stream_path() {
+        let mock = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::path("/api/v1/chat/completions"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_raw("data: [DONE]\n\n", "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+        let client = OpenRouterClient::with_base_url(
+            "k".into(),
+            format!("{}/api/v1/chat/completions", mock.uri()),
+        )
+        .with_openrouter_body_rules(vec![rule(
+            None,
+            serde_json::json!({"transforms": ["middle-out"]}),
+        )]);
+        let req = ChatRequest {
+            model: "m".into(),
+            messages: vec![ChatMessage {
+                role: "user".into(),
+                content: "hi".into(),
+            }],
+            max_tokens: 5,
+            task: Some("chat_companion".into()),
+            ..Default::default()
+        };
+        let _stream = client.execute_stream_as(&req, "m").await.unwrap();
+        let body: serde_json::Value =
+            serde_json::from_slice(&mock.received_requests().await.unwrap()[0].body).unwrap();
+        assert_eq!(body["transforms"][0], "middle-out");
+        assert_eq!(
+            body["stream"], true,
+            "structural key untouched by the merge"
+        );
+    }
+
+    #[tokio::test]
+    async fn fallback_chain_resolves_rules_per_attempt() {
+        // Spec §2 per-attempt resolution: primary @venice fails (500), chain
+        // advances to built-in OpenRouter — each attempt carries ITS OWN
+        // provider's rules, never the other's.
+        let mock = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::path("/venice/chat"))
+            .respond_with(wiremock::ResponseTemplate::new(500))
+            .mount(&mock)
+            .await;
+        wiremock::Mock::given(wiremock::matchers::path("/or/chat"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!(
+                    {"choices": [{"message": {"content": "ok"}}]}
+                )),
+            )
+            .mount(&mock)
+            .await;
+        let mut providers = std::collections::HashMap::new();
+        providers.insert(
+            "venice".to_string(),
+            crate::provider::ProviderEndpoint {
+                base_url: format!("{}/venice/chat", mock.uri()),
+                api_key: "vk".into(),
+                headers: reqwest::header::HeaderMap::new(),
+                body_rules: vec![rule(
+                    None,
+                    serde_json::json!({"venice_parameters": {"x": 1}}),
+                )],
+            },
+        );
+        let client = OpenRouterClient::with_base_url("k".into(), format!("{}/or/chat", mock.uri()))
+            .with_providers(providers)
+            .with_openrouter_body_rules(vec![rule(
+                None,
+                serde_json::json!({"transforms": ["middle-out"]}),
+            )]);
+        client
+            .execute(ChatRequest {
+                model: "m@venice".into(),
+                fallback_model: vec!["m".into()],
+                messages: vec![ChatMessage {
+                    role: "user".into(),
+                    content: "hi".into(),
+                }],
+                max_tokens: 5,
+                task: Some("chat_companion".into()),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        let reqs = mock.received_requests().await.unwrap();
+        assert_eq!(reqs.len(), 2, "venice attempt then openrouter fallback");
+        let venice: serde_json::Value = serde_json::from_slice(&reqs[0].body).unwrap();
+        assert_eq!(venice["venice_parameters"]["x"], 1);
+        assert!(venice.get("transforms").is_none());
+        let or: serde_json::Value = serde_json::from_slice(&reqs[1].body).unwrap();
+        assert_eq!(or["transforms"][0], "middle-out");
+        assert!(or.get("venice_parameters").is_none());
+    }
+
+    #[tokio::test]
+    async fn no_rules_wire_key_set_is_unchanged() {
+        // No rules configured ⇒ the serialized path is untouched and the key
+        // set is exactly today's minimal wire for this request shape.
+        let mock = MockServer::start().await;
+        Mock::given(path("/api/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ok_response()))
+            .expect(1)
+            .mount(&mock)
+            .await;
+        let client = OpenRouterClient::with_base_url(
+            "k".into(),
+            format!("{}/api/v1/chat/completions", mock.uri()),
+        );
+        client
+            .execute(ChatRequest {
+                model: "m".into(),
+                messages: vec![ChatMessage {
+                    role: "user".into(),
+                    content: "hi".into(),
+                }],
+                max_tokens: 5,
+                task: Some("chat_companion".into()),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        let body: serde_json::Value =
+            serde_json::from_slice(&mock.received_requests().await.unwrap()[0].body).unwrap();
+        let mut keys: Vec<&str> = body
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            ["max_tokens", "messages", "model", "temperature"],
+            "task must never serialize; no rules ⇒ no extra keys"
+        );
     }
 }

--- a/crates/eros-engine-llm/src/provider.rs
+++ b/crates/eros-engine-llm/src/provider.rs
@@ -20,6 +20,9 @@ pub struct ProviderEndpoint {
     pub api_key: String,
     /// Config-declared custom headers, applied per-request. Empty by default.
     pub headers: reqwest::header::HeaderMap,
+    /// `[[providers.<name>.body]]` rules, applied per-request to chat bodies.
+    /// Empty by default.
+    pub body_rules: Vec<crate::model_config::BodyRule>,
 }
 
 impl fmt::Debug for ProviderEndpoint {
@@ -27,12 +30,15 @@ impl fmt::Debug for ProviderEndpoint {
     /// a panic message via `{:?}`, so it's redacted here rather than relying
     /// on every caller to remember not to print the field directly. Header
     /// VALUES may be sensitive too (e.g. a proxy auth token), so the whole
-    /// `headers` map is redacted rather than printed key-by-key.
+    /// `headers` map is redacted rather than printed key-by-key. `params`
+    /// are deployer config, not secrets, so `body_rules` is kept quiet as a
+    /// count rather than redacted outright.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ProviderEndpoint")
             .field("base_url", &self.base_url)
             .field("api_key", &"<redacted>")
             .field("headers", &"<redacted>")
+            .field("body_rules", &self.body_rules.len())
             .finish()
     }
 }
@@ -148,6 +154,7 @@ mod tests {
             base_url: "https://api.venice.ai/chat/completions".to_string(),
             api_key: "sk-live-SUPER-SECRET-KEY".to_string(),
             headers: reqwest::header::HeaderMap::new(),
+            body_rules: Vec::new(),
         };
         let dbg = format!("{ep:?}");
         assert!(
@@ -167,6 +174,7 @@ mod tests {
             base_url: "https://api.venice.ai/chat/completions".to_string(),
             api_key: "sk-live-key".to_string(),
             headers,
+            body_rules: Vec::new(),
         };
         let dbg = format!("{ep:?}");
         assert!(

--- a/crates/eros-engine-server/src/main.rs
+++ b/crates/eros-engine-server/src/main.rs
@@ -357,7 +357,8 @@ async fn run_server() -> Result<()> {
         eros_engine_llm::openrouter::OpenRouterClient::new(openrouter_key)
             .with_openrouter_chat_url(model_config.openrouter_chat_url())
             .with_openrouter_headers(model_config.openrouter_header_map())
-            .with_providers(model_config.build_providers()),
+            .with_providers(model_config.build_providers())
+            .with_openrouter_body_rules(model_config.openrouter_body_rules()),
     );
 
     // Computed once at boot, before model_config is moved into the state

--- a/crates/eros-engine-server/src/main.rs
+++ b/crates/eros-engine-server/src/main.rs
@@ -350,17 +350,14 @@ async fn run_server() -> Result<()> {
     };
 
     // OpenRouter client is constructed after model_config so we can wire in the
-    // global provider routing prefs from [defaults] (exclusion list + optional
-    // sort), the [providers] endpoint map, and the [providers].openrouter
-    // entry (chat URL override + default headers, replacing the old
-    // OPENROUTER_BASE_URL / OPENROUTER_APP_* env vars).
+    // [providers] endpoint map and the [providers].openrouter entry (chat URL
+    // override + default headers, replacing the old OPENROUTER_BASE_URL /
+    // OPENROUTER_APP_* env vars).
     let openrouter = Arc::new(
         eros_engine_llm::openrouter::OpenRouterClient::new(openrouter_key)
             .with_openrouter_chat_url(model_config.openrouter_chat_url())
             .with_openrouter_headers(model_config.openrouter_header_map())
-            .with_providers(model_config.build_providers())
-            .with_ignore_providers(model_config.ignore_provider_wire_slugs())
-            .with_provider_sort(model_config.defaults.provider_sort.clone()),
+            .with_providers(model_config.build_providers()),
     );
 
     // Computed once at boot, before model_config is moved into the state

--- a/crates/eros-engine-server/src/pipeline/dreaming.rs
+++ b/crates/eros-engine-server/src/pipeline/dreaming.rs
@@ -215,6 +215,7 @@ async fn classify_session(
         max_tokens: resolved.max_tokens,
         user: Some(SYSTEM_AUDIT_USER.into()),
         reasoning: resolved.reasoning,
+        task: Some(MEMORY_TASK.into()),
         ..Default::default()
     };
     let raw = state

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -267,6 +267,7 @@ fn assemble_chat_request(
         session_id: audit_session,
         metadata: audit_metadata,
         reasoning: resolved.reasoning,
+        task: Some(CHAT_TASK.into()),
         ..Default::default()
     }
 }

--- a/crates/eros-engine-server/src/pipeline/post_process.rs
+++ b/crates/eros-engine-server/src/pipeline/post_process.rs
@@ -661,6 +661,7 @@ async fn evaluate_affinity(
         max_tokens: resolved.max_tokens,
         user: audit_user.map(String::from),
         reasoning: resolved.reasoning,
+        task: Some(AFFINITY_TASK.into()),
         ..Default::default()
     };
 
@@ -878,6 +879,7 @@ async fn extract_facts(
         max_tokens: resolved.max_tokens,
         user: audit_user.map(String::from),
         reasoning: resolved.reasoning,
+        task: Some(INSIGHT_TASK.into()),
         ..Default::default()
     };
 
@@ -969,6 +971,7 @@ async fn extract_structured_insights(
         max_tokens: resolved.max_tokens,
         user: audit_user.map(String::from),
         reasoning: resolved.reasoning,
+        task: Some(INSIGHT_TASK.into()),
         ..Default::default()
     };
 

--- a/crates/eros-engine-server/src/pipeline/story.rs
+++ b/crates/eros-engine-server/src/pipeline/story.rs
@@ -325,6 +325,7 @@ async fn direct_story(
         user: Some(STORY_AUDIT_USER.into()),
         reasoning: resolved.reasoning.clone(),
         response_format: resolved.structured_output.then(story_response_format),
+        task: Some(STORY_TASK.into()),
         ..Default::default()
     };
     let raw = state

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -1396,6 +1396,7 @@ async fn run_output_filter(
             temperature: f.temperature as f32,
             max_tokens: f.max_tokens,
             reasoning: f.reasoning.clone(),
+            task: Some("chat_output_filter".into()),
             ..Default::default()
         };
         let resp = match tokio::time::timeout(FILTER_TIMEOUT, state.openrouter.execute(req)).await {
@@ -1681,6 +1682,7 @@ async fn run_pde_decision(
             max_tokens: p.max_tokens,
             reasoning: p.reasoning.clone(),
             response_format: response_format.clone(),
+            task: Some("pde_decision".into()),
             ..Default::default()
         };
         let resp = match tokio::time::timeout(FILTER_TIMEOUT, client.execute(req)).await {
@@ -2232,6 +2234,7 @@ async fn run_input_filter(
             temperature: f.temperature as f32,
             max_tokens: f.max_tokens,
             reasoning: f.reasoning.clone(),
+            task: Some("chat_input_filter".into()),
             ..Default::default()
         };
         let resp = match tokio::time::timeout(FILTER_TIMEOUT, state.openrouter.execute(req)).await {
@@ -2360,6 +2363,7 @@ async fn run_image_prompt_compose(
             temperature: c.temperature as f32,
             max_tokens: c.max_tokens,
             reasoning: c.reasoning.clone(),
+            task: Some("chat_image_prompt_compose".into()),
             ..Default::default()
         };
         let resp = match tokio::time::timeout(FILTER_TIMEOUT, state.openrouter.execute(req)).await {
@@ -3101,6 +3105,7 @@ pub fn run_stream(
                     temperature: p.temperature as f32,
                     max_tokens: p.max_tokens,
                     reasoning: p.reasoning.clone(),
+                    task: Some("chat_product_qa".into()),
                     ..Default::default()
                 };
                 'candidates: for model_id in candidates {
@@ -5999,6 +6004,105 @@ data: [DONE]\n\n";
         assert_eq!(img["compose_variant"], "b");
         assert_eq!(img["compose_model"], "served/model");
         assert_eq!(img["compose_generation_id"], "gen-xyz");
+    }
+
+    /// Spec 2026-08-02-provider-body-params: an [[providers.openrouter.body]]
+    /// rule scoped to a task reaches that task's wire body end-to-end
+    /// (config parse → boot accessor → client → per-attempt merge).
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn provider_body_rule_reaches_the_wire_for_its_task(pool: PgPool) {
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+        use futures_util::StreamExt;
+        use wiremock::matchers::path as wm_path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "choices": [{"message": {"content": "ENRICHED"}}],
+            })))
+            .mount(&mock)
+            .await;
+
+        let user_id = Uuid::new_v4();
+        let (_g, instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = std::sync::Arc::new(
+            eros_engine_llm::model_config::ModelConfig::from_toml_str(
+                "[tasks.chat_companion]\nmodel = \"primary\"\n\
+                 [tasks.chat_image_prompt_compose]\nmodel = \"composer\"\n\
+                 [[providers.openrouter.body]]\n\
+                 tasks = [\"chat_image_prompt_compose\"]\n\
+                 params = { venice_parameters = { include_venice_system_prompt = false } }\n",
+            )
+            .unwrap(),
+        );
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            )
+            .with_openrouter_body_rules(state.model_config.openrouter_body_rules()),
+        );
+
+        let chat_repo = ChatRepo { pool: &pool };
+        let user_message_id = match chat_repo
+            .upsert_user_message_idempotent(
+                session_id,
+                "hi",
+                "01J9000000000000000000000B",
+                "user",
+                None,
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
+
+        let _frames: Vec<ProtocolFrame> = run_stream(
+            std::sync::Arc::new(state),
+            PersistedUserMessage {
+                user_message_id,
+                session_id,
+                user_id,
+                instance_id,
+                content: "hi".into(),
+                prompt_traits: vec![],
+                audit: None,
+                tier: None,
+                memory_scope: Default::default(),
+                affinity_scope: Default::default(),
+                tips_amount_usd: None,
+                image_url: None,
+                image: Some(crate::routes::companion_stream::ImageReplyParams {
+                    force: true,
+                    mode: crate::routes::companion_stream::ImageMode::ImageOnly,
+                    image_prompt: Some("a beach at sunset".into()),
+                    ..Default::default()
+                }),
+                history_anchor: Default::default(),
+            },
+            None,
+        )
+        .collect()
+        .await;
+
+        let reqs = mock.received_requests().await.expect("recorded requests");
+        assert_eq!(
+            reqs.len(),
+            1,
+            "image-only turn makes exactly one call (the composer)"
+        );
+        let body: serde_json::Value = serde_json::from_slice(&reqs[0].body).unwrap();
+        assert_eq!(
+            body["venice_parameters"]["include_venice_system_prompt"],
+            serde_json::Value::Bool(false),
+            "task-scoped body rule must reach the composer wire"
+        );
+        assert_eq!(body["messages"][0]["role"], "system", "engine body intact");
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/crates/eros-engine-server/src/pipeline/voice.rs
+++ b/crates/eros-engine-server/src/pipeline/voice.rs
@@ -197,6 +197,7 @@ pub fn run_voice_turn(
             temperature: resolved.temperature as f32,
             max_tokens: resolved.max_tokens,
             reasoning: resolved.reasoning.clone(),
+            task: Some("chat_voice".into()),
             ..Default::default()
         };
 

--- a/crates/eros-engine-server/src/pipeline/world.rs
+++ b/crates/eros-engine-server/src/pipeline/world.rs
@@ -307,6 +307,7 @@ async fn direct_world(
         response_format: resolved
             .structured_output
             .then(|| world_director_response_format(town)),
+        task: Some(WORLD_TASK.into()),
         ..Default::default()
     };
     let raw = state

--- a/crates/eros-engine-server/src/pipeline/world_town.rs
+++ b/crates/eros-engine-server/src/pipeline/world_town.rs
@@ -209,6 +209,7 @@ async fn run_comment_round(
         response_format: resolved
             .structured_output
             .then(world_comment_response_format),
+        task: Some("world_comment".into()),
         ..Default::default()
     };
     let raw = state
@@ -319,6 +320,7 @@ async fn run_reply(
         max_tokens: resolved.max_tokens,
         user: Some(WORLD_AUDIT_USER.into()),
         reasoning: resolved.reasoning.clone(),
+        task: Some("world_reply".into()),
         ..Default::default()
     };
     let raw = state

--- a/docs/model-config.md
+++ b/docs/model-config.md
@@ -485,6 +485,11 @@ input filter has no triggers, timing, or tiers).
 | `affinity_evaluation` | `pipeline::post_process` (per-turn 6-axis affinity delta; runs after each Reply turn, fire-and-forget) | live |
 | `memory_extraction` | dreaming sweeper (session-end memory consolidation; off when task block absent) | live (opt-in) |
 | `chat_input_filter` | `pipeline::stream` (user-input rewrite filter; activated by `input_filter` on `[tasks.chat_companion]` and this task block; off by default) | live (opt-in) |
+| `chat_voice` | `pipeline::voice::run_voice_turn`, reached from `routes::voice` (`POST /comp/voice/{session_id}/turn/stream`) via `resolve_voice()` (voice-channel companion reply; a blank `filter_prompt` does NOT disable it — falls back to the built-in directive; off when the task block is absent) | live (opt-in) |
+| `world_director` | `pipeline::world::sweeper` via `resolve_world_director()` (background per-owner world-state director round; off when the task block is absent/blank, `WORLD_DISABLED` is set, or `WORLD_TICK_SECS=0`) | live (opt-in) |
+| `world_stories_director` | `pipeline::story::run_stories_scan`, invoked from `pipeline::world::sweeper` via `resolve_world_stories_director()` (per-owner story round, gated on `world_director` also being configured; off when the task block is absent/blank or `WORLD_STORIES_DISABLED` is set) | live (opt-in) |
+| `world_comment` | `pipeline::world_town::sweeper` via `resolve_world_comment()` (hourly world-town comment round; off when the task block is absent/blank, `WORLD_DISABLED`, or `WORLD_TOWN_DISABLED` is set) | live (opt-in) |
+| `world_reply` | `pipeline::world_town::sweeper` via `resolve_world_reply()` (debounced/cooldown/capped responder reply to user comments on world-town posts; off when the task block is absent/blank, `WORLD_DISABLED`, or `WORLD_TOWN_DISABLED` is set) | live (opt-in) |
 | `embedding` | `EmbeddingRouter::from_config()` at boot (`main.rs`), via `ModelConfig::resolve_embedding()` — routes `embed_query`/`embed_document`/`embed_documents` to native Voyage, the built-in OpenRouter embeddings endpoint, or a custom `[providers]` entry; absent block = native Voyage `voyage-4-lite` | live |
 
 A `[tasks.<name>]` entry is only meaningful if the engine actually calls `model_config.resolve("<name>", ...)` somewhere. The current call sites are:

--- a/docs/model-config.md
+++ b/docs/model-config.md
@@ -70,7 +70,6 @@ Field details:
 | `defaults.fallback_model` | `String` | no | Hard fallback if the task config provides no model. If still missing, code uses the compiled-in default `x-ai/grok-4-mini`. |
 | `defaults.fallback_temperature` | `f64` | no | Same precedence; compiled-in default `0.5`. |
 | `defaults.fallback_max_tokens` | `u32` | no | Same precedence; compiled-in default `200`. |
-| `defaults.ignore_providers` | `Array<String>` | no | OpenRouter provider slugs to exclude from routing on **every** task. Each entry must carry the `@openrouter` suffix (`"some-bad-provider-slug@openrouter"`) — a bare slug, any other `@<provider>` suffix, or malformed `@` grammar refuses to boot. The suffix is stripped before the wire: sent as `provider.ignore` (bare slug) on each outbound OpenRouter call only; custom providers and Voyage never receive it. `allow_fallbacks` remains `true` so the model is still served by any healthy provider. Use this when a specific provider returns garbled output for a model (e.g. undecoded byte-BPE text — issue #84). Find the offending slug via the OpenRouter generation API. Empty or absent means no exclusion. |
 | `tasks.<name>.model` | `String` \| `Array<String>` \| `Table<String,f64>` | yes | Primary model. String = fixed; array = round-robin; table = weighted random. See "Primary model selection". |
 | `tasks.<name>.fallback` | `String` | no | Secondary model used by `OpenRouterClient` if the primary call fails. |
 | `tasks.<name>.temperature` | `f64` | no | Per-task sampling temperature. No per-tier override. |
@@ -79,6 +78,11 @@ Field details:
 | `tasks.<name>.tiers.<tier>` | sub-table | no | Per-tier overrides. May set `model`, `fallback`, and/or `allow_traits`. Does not override `temperature` or `max_tokens`. |
 | `tasks.chat_companion.input_filter` | `bool` \| `f64` | no | Global trigger for the user-input rewrite filter. Task-level only on `chat_companion` (no per-tier override). `false`/absent = off, `true` = every turn, `0.8` = ~80% of turns (a number outside `[0.0, 1.0]` is rejected). See "`input_filter`". |
 | `tasks.<name>.description` | `String` | no | Documentation field, ignored by code. |
+
+**`defaults.ignore_providers` and `defaults.provider_sort` are removed.** A
+leftover key of either name refuses to boot with a migration message
+pointing at the `[[providers.<name>.body]]` replacement — see "custom body
+parameters" under `[providers]` below.
 
 ### `[providers]` — custom chat/embeddings endpoints (opt-in)
 
@@ -149,10 +153,10 @@ Rules, all enforced at boot (the engine refuses to boot on any violation):
   `output_regex` `models`, and `output_filter` trigger `models` match on the
   id *without* `@provider`.
 - **Wire shape**: custom providers receive a strict OpenAI-compatible
-  subset. `[defaults].ignore_providers`, `[defaults].provider_sort`, and
-  per-task `reasoning` are **inert** on custom providers; they receive
-  exactly this entry's own declared `headers`, never the OpenRouter
-  attribution headers.
+  subset. Per-task `reasoning` is **inert** on custom providers — they
+  receive exactly this entry's own declared `headers` and any
+  `[[providers.<name>.body]]` rules declared on that same entry (see
+  below), never the OpenRouter attribution headers.
 - **Audit**: rows served by a custom provider record
   `model = "<upstream echo>@<name>"` and the provider's own `generation_id`
   verbatim — a `generation_id` join against OpenRouter's logs misses for
@@ -176,9 +180,10 @@ headers    = { "HTTP-Referer" = "https://eros.example", "X-OpenRouter-Title" = "
   error when referenced, because there is no built-in default to fall back
   to.
 - The override changes the URL **only**. Traffic through it remains the
-  full OpenRouter wire: `provider.ignore`, `provider_sort`, and per-task
-  `reasoning` are all still sent — unlike custom providers, which keep
-  receiving the strict OpenAI subset.
+  full OpenRouter wire: per-task `reasoning` is still sent, and any
+  `[[providers.openrouter.body]]` rules (see below) merge into the request
+  body — unlike custom providers, which keep receiving the strict OpenAI
+  subset with `reasoning` inert.
 - **Attribution headers now live here, and nowhere else.** No
   `[providers.openrouter]` entry, or one without `headers`, means no
   attribution headers are sent. The `OPENROUTER_APP_REFERER` /
@@ -194,23 +199,40 @@ headers    = { "HTTP-Referer" = "https://eros.example", "X-OpenRouter-Title" = "
   not read and causes no boot error — it's just an unrelated env var now.
 - `voyage` remains undeclarable in `[providers]` (see above).
 
-#### `[defaults].ignore_providers` — `@openrouter` required
+#### `[[providers.<name>.body]]` — custom body parameters
+
+Deployer-defined JSON merged into the chat/completions request body, per
+task. `params` is passed through verbatim (TOML → JSON) — the engine never
+interprets it. `tasks` scopes the rule to specific engine task names
+(exact, case-sensitive; see the task table below); omit it to apply to
+every chat task this provider serves. Rules apply in declaration order,
+later rules win on key conflicts, and merged params win over engine-built
+fields — declaring `reasoning` on the `openrouter` entry therefore
+overrides `[tasks.*].reasoning` for the scoped tasks. `model`, `messages`,
+and `stream` are engine-owned and refuse to boot. A rule naming
+`chat_vision` or `embedding` warns and never applies (those calls build
+their own bodies). Custom providers must declare `chat` to use body rules;
+the reserved `openrouter` entry may declare rules alone.
 
 ```toml
-[defaults]
-ignore_providers = ["some-bad-provider-slug@openrouter"]
+[providers.venice]
+chat = "https://api.venice.ai/api/v1/chat/completions"
+
+[[providers.venice.body]]
+tasks  = ["chat_companion", "chat_output_filter"]
+params = { venice_parameters = { include_venice_system_prompt = false } }
+
+[[providers.openrouter.body]]
+params = { provider = { ignore = ["some-bad-provider"], sort = "price" } }
 ```
 
-Every entry must parse (the same `@`-suffix grammar as a model slug) to a
-non-empty upstream slug plus provider `openrouter`; a bare entry, any other
-`@<provider>` suffix, or malformed `@` grammar refuses to boot naming the
-entry and the required form. The wire is unchanged: `provider.ignore`
-carries the bare upstream slug, on OpenRouter traffic only — the mandatory
-suffix makes that scope part of the syntax; custom providers and Voyage
-never receive `provider.ignore`. `[defaults].provider_sort` is untouched (it
-has no per-entry syntax to scope). Breaking change for configs written
-before this suffix existed — the fix is appending `@openrouter` to each
-entry.
+The second example is the replacement for the removed
+`[defaults].ignore_providers` / `[defaults].provider_sort` keys: OpenRouter
+routing prefs are now ordinary body params (bare OpenRouter provider slugs,
+no `@openrouter` suffix), scopable per task like any other rule. The old
+keys refuse to boot with this migration message. Note the removed keys also
+fed the `chat_vision` body; body rules do not cover vision, so vision calls
+no longer send `provider` prefs at all.
 
 ### `model_name_display_override` (chat task only)
 
@@ -900,6 +922,14 @@ What may still change without notice:
   `[tasks.<name>]` was removed (dims are hard-coded 512; a leftover
   `dimensions = 512` line is now an inert unknown key). See "`[providers]`"
   and "`[tasks.embedding]` — active" above.
+- **`[defaults].ignore_providers` and `[defaults].provider_sort` are
+  removed** (the entry above described their earlier mandatory
+  `@openrouter`-suffix form). OpenRouter routing prefs are now
+  `[[providers.<name>.body]]` rules on the `openrouter` entry — see
+  "`[[providers.<name>.body]]` — custom body parameters" above. A leftover
+  key refuses to boot with a migration message. The removed keys also fed
+  the `chat_vision` request body; body rules are chat-only, so vision calls
+  no longer send `provider` prefs.
 
 ## What this config does NOT control
 

--- a/docs/model-config.md
+++ b/docs/model-config.md
@@ -879,6 +879,10 @@ After the primary is selected, any occurrence of that exact id is removed from t
 For the duration of `0.x`, the OSS engine commits to:
 
 1. **No removed fields.** Existing field names in `[defaults]` and `[tasks.<name>]` will not disappear.
+   (Exceptions to date, both documented above: `[tasks.embedding].dimensions`
+   — removed, now a silently-ignored inert unknown key; `[defaults].ignore_providers`
+   / `.provider_sort` — removed, a leftover key refuses to boot with a
+   migration message.)
 2. **No renamed fields.** `fallback` will not become `fallback_model`. `model` will not become `primary_model`. Etc.
 3. **No newly required fields.** Anything added is optional with a sensible default.
 4. **No removed task names from this list:** `chat_companion`, `insight_extraction`, `pde_decision`, `embedding`.

--- a/docs/model-config.zh.md
+++ b/docs/model-config.zh.md
@@ -737,6 +737,9 @@ model = { "x-ai/grok-4.20" = 0.8, "z-ai/glm-4.7-flash" = 0.2 }  # weighted rando
 在 `0.x` 期间，OSS 引擎承诺：
 
 1. **不删除字段。** `[defaults]` 和 `[tasks.<name>]` 中现有的字段名不会消失。
+   （目前的例外，均已在上文记录：`[tasks.embedding].dimensions`——已移除，
+   现在是被静默忽略的未知 key；`[defaults].ignore_providers` /
+   `.provider_sort`——已移除，残留 key 会拒绝启动并给出迁移提示。）
 2. **不重命名字段。** `fallback` 不会变为 `fallback_model`，`model` 不会变为 `primary_model`，以此类推。
 3. **不新增必填字段。** 任何新增字段都是可选的，并具有合理默认值。
 4. **不从此列表中删除任务名：**`chat_companion`、`insight_extraction`、`pde_decision`、`embedding`。

--- a/docs/model-config.zh.md
+++ b/docs/model-config.zh.md
@@ -425,6 +425,11 @@ SSE `final` frame 的 `filtered` 字段在客户端收到的是非原始输出�
 | `affinity_evaluation` | `pipeline::post_process`（每轮六轴 affinity delta；每个 Reply 轮次后以 fire-and-forget 方式运行） | live |
 | `memory_extraction` | dreaming sweeper（会话结束时进行 memory 整合；任务块缺失时关闭） | live（opt-in） |
 | `chat_input_filter` | `pipeline::stream`（用户输入改写 filter；由 `[tasks.chat_companion]` 上的 `input_filter` 和此任务块共同激活；默认关闭） | live（opt-in） |
+| `chat_voice` | `pipeline::voice::run_voice_turn`，由 `routes::voice`（`POST /comp/voice/{session_id}/turn/stream`）经 `resolve_voice()` 到达（语音通道的伴侣回复；`filter_prompt` 为空白**不会**关闭该任务——会回退到内置 directive；任务块缺失时关闭） | live（opt-in） |
+| `world_director` | `pipeline::world::sweeper`，经由 `resolve_world_director()`（后台按 owner 逐一执行的世界状态 director 轮次；任务块缺失/空白、设置了 `WORLD_DISABLED`，或 `WORLD_TICK_SECS=0` 时关闭） | live（opt-in） |
+| `world_stories_director` | `pipeline::story::run_stories_scan`，由 `pipeline::world::sweeper` 调用，经由 `resolve_world_stories_director()`（按 owner 逐一执行的故事轮次，还要求 `world_director` 已配置；任务块缺失/空白，或设置了 `WORLD_STORIES_DISABLED` 时关闭） | live（opt-in） |
+| `world_comment` | `pipeline::world_town::sweeper`，经由 `resolve_world_comment()`（每小时一次的 world-town 评论轮次；任务块缺失/空白，或设置了 `WORLD_DISABLED`、`WORLD_TOWN_DISABLED` 时关闭） | live（opt-in） |
+| `world_reply` | `pipeline::world_town::sweeper`，经由 `resolve_world_reply()`（对 world-town 帖子上用户评论的去抖/冷却/限额 responder 回复；任务块缺失/空白，或设置了 `WORLD_DISABLED`、`WORLD_TOWN_DISABLED` 时关闭） | live（opt-in） |
 | `embedding` | 启动时的 `EmbeddingRouter::from_config()`（`main.rs`），经由 `ModelConfig::resolve_embedding()`——把 `embed_query`/`embed_document`/`embed_documents` 路由到原生 Voyage、内置 OpenRouter embeddings 端点、或某个 `[providers]` 条目；块缺失 = 原生 Voyage `voyage-4-lite` | live |
 
 只有当引擎确实在某处调用 `model_config.resolve("<name>", ...)` 时，`[tasks.<name>]` 条目才有意义。当前调用点如下：

--- a/docs/model-config.zh.md
+++ b/docs/model-config.zh.md
@@ -70,7 +70,6 @@ allow_traits = ["tag_a"]                    # optional, overrides task-level all
 | `defaults.fallback_model` | `String` | 否 | 任务配置未提供 model 时使用的最终 fallback。若仍然缺失，代码使用编译时内置默认值 `x-ai/grok-4-mini`。 |
 | `defaults.fallback_temperature` | `f64` | 否 | 优先级相同；编译时内置默认值为 `0.5`。 |
 | `defaults.fallback_max_tokens` | `u32` | 否 | 优先级相同；编译时内置默认值为 `200`。 |
-| `defaults.ignore_providers` | `Array<String>` | 否 | 要从**每个**任务的路由中排除的 OpenRouter provider slug。每个条目必须带 `@openrouter` 后缀（`"some-bad-provider-slug@openrouter"`）——裸 slug、其他 `@<provider>` 后缀、或格式错误的 `@` 语法都会拒绝启动。发到 wire 前会剥掉后缀：只作为 `provider.ignore`（裸 slug）发给 OpenRouter 调用；自定义 provider 和 Voyage 永远不会收到它。`allow_fallbacks` 仍为 `true`，因此模型仍可由任意健康的 provider 提供。某个 provider 为模型返回乱码时（例如未解码的 byte-BPE 文本——issue #84），可使用此字段。通过 OpenRouter generation API 查找有问题的 slug。为空或缺失表示不排除任何 provider。 |
 | `tasks.<name>.model` | `String` \| `Array<String>` \| `Table<String,f64>` | 是 | 主模型。字符串 = 固定；数组 = round-robin；表 = weighted 随机。参见“主模型选择”。 |
 | `tasks.<name>.fallback` | `String` | 否 | 主调用失败时由 `OpenRouterClient` 使用的次要模型。 |
 | `tasks.<name>.temperature` | `f64` | 否 | 每任务的采样 temperature。无 per-tier 覆盖。 |
@@ -79,6 +78,10 @@ allow_traits = ["tag_a"]                    # optional, overrides task-level all
 | `tasks.<name>.tiers.<tier>` | 子表 | 否 | Per-tier 覆盖。可设置 `model`、`fallback` 和/或 `allow_traits`。不覆盖 `temperature` 或 `max_tokens`。 |
 | `tasks.chat_companion.input_filter` | `bool` \| `f64` | 否 | 用户输入改写 filter 的全局 trigger。仅可在 `chat_companion` 的任务级配置中设置（无 per-tier 覆盖）。`false`/缺失 = 关闭，`true` = 每轮执行，`0.8` = 约 80% 的轮次执行（超出 `[0.0, 1.0]` 的数字会被拒绝）。参见“`input_filter`”。 |
 | `tasks.<name>.description` | `String` | 否 | 文档字段，代码忽略。 |
+
+**`defaults.ignore_providers` 和 `defaults.provider_sort` 已移除。** 残留
+其中任一 key 会拒绝启动，报错信息指向 `[[providers.<name>.body]]` 替代
+方案——参见下文 `[providers]` 一节的“自定义 body 参数”。
 
 ### `[providers]` — 自定义 chat/embeddings 端点（opt-in）
 
@@ -142,10 +145,10 @@ model = "bge-m3@local"               # 由 [providers].local.embeddings 提供�
 - **按模型匹配的表用裸 id**：`model_name_display_override`、`output_regex`
   的 `models`、`output_filter` trigger 的 `models`，匹配时都不带
   `@provider`。
-- **wire 形态**：自定义 provider 收到严格的 OpenAI 兼容子集。
-  `[defaults].ignore_providers`、`[defaults].provider_sort` 和任务级
-  `reasoning` 对自定义 provider **不生效**；它们只收到该条目自己声明的
-  `headers`，绝不会收到 OpenRouter 归因标头。
+- **wire 形态**：自定义 provider 收到严格的 OpenAI 兼容子集。任务级
+  `reasoning` 对自定义 provider **不生效**——它们只收到该条目自己声明的
+  `headers`，以及该条目自己声明的 `[[providers.<name>.body]]` 规则（见
+  下文），绝不会收到 OpenRouter 归因标头。
 - **审计**：自定义 provider 服务的行记录
   `model = "<上游回显>@<name>"`，`generation_id` 原样存 provider 返回的
   id——用 `generation_id` 去 join OpenRouter 日志时这些行会 miss，
@@ -166,9 +169,10 @@ headers    = { "HTTP-Referer" = "https://eros.example", "X-OpenRouter-Title" = "
   `https://openrouter.ai/api/v1/embeddings`）。这条“部分覆盖”规则只对
   `openrouter` 生效——普通条目缺 key 且被引用时是启动报错，因为它没有内置
   默认值可以兜底。
-- 覆盖**只**改变 URL。流量走的仍然是完整的 OpenRouter wire：
-  `provider.ignore`、`provider_sort`、任务级 `reasoning` 全部照常发送——
-  和只收到严格 OpenAI 子集的自定义 provider 不同。
+- 覆盖**只**改变 URL。流量走的仍然是完整的 OpenRouter wire：任务级
+  `reasoning` 照常发送，任何 `[[providers.openrouter.body]]` 规则（见
+  下文）也会合并进请求体——和只收到严格 OpenAI 子集、`reasoning` 不生效
+  的自定义 provider 不同。
 - **归因 header 现在只从这里来。** 没有 `[providers.openrouter]` 条目，
   或有条目但没写 `headers`，就不发任何归因 header。
   `OPENROUTER_APP_REFERER` / `OPENROUTER_APP_TITLE` /
@@ -183,21 +187,37 @@ headers    = { "HTTP-Referer" = "https://eros.example", "X-OpenRouter-Title" = "
   一个无关的环境变量。
 - `voyage` 仍不能在 `[providers]` 中声明（见上文）。
 
-#### `[defaults].ignore_providers` — 必须带 `@openrouter`
+#### `[[providers.<name>.body]]` — 自定义 body 参数
+
+部署方自定义的 JSON，按任务合并进 chat/completions 请求体。`params` 原样
+透传（TOML → JSON）——引擎从不解读它的内容。`tasks` 把规则限定到指定的
+引擎任务名（精确匹配，区分大小写；任务名表见下文）；省略则应用于该
+provider 服务的所有 chat 任务。规则按声明顺序生效，后面的规则在 key 冲突
+时获胜，且合并进的 params 会覆盖引擎自己构建的字段——例如在 `openrouter`
+条目上声明 `reasoning`，就会覆盖被该规则限定的任务上的
+`[tasks.*].reasoning`。`model`、`messages`、`stream` 是引擎自有字段，声明
+它们会拒绝启动。规则若指名 `chat_vision` 或 `embedding` 会记录警告且永不
+生效（这两类调用自己构建请求体）。自定义 provider 必须声明 `chat` 才能使用
+body 规则；保留名 `openrouter` 条目可以只声明规则而不覆盖端点。
 
 ```toml
-[defaults]
-ignore_providers = ["some-bad-provider-slug@openrouter"]
+[providers.venice]
+chat = "https://api.venice.ai/api/v1/chat/completions"
+
+[[providers.venice.body]]
+tasks  = ["chat_companion", "chat_output_filter"]
+params = { venice_parameters = { include_venice_system_prompt = false } }
+
+[[providers.openrouter.body]]
+params = { provider = { ignore = ["some-bad-provider"], sort = "price" } }
 ```
 
-每个条目都必须能解析出（与模型 slug 相同的 `@` 后缀语法）一个非空的上游
-slug 加 provider `openrouter`；裸条目、其他 `@<provider>` 后缀、或格式
-错误的 `@` 语法都会拒绝启动，并点名该条目和正确写法。wire 行为不变：
-`provider.ignore` 只带裸上游 slug，只发给 OpenRouter 流量——强制后缀把这个
-作用范围写进了语法本身；自定义 provider 和 Voyage 永远不会收到
-`provider.ignore`。`[defaults].provider_sort` 不受影响（它没有 per-entry
-语法可限定范围）。对在这个后缀出现之前写好的配置是破坏性变更——修复方式
-是给每个条目加上 `@openrouter`。
+第二个例子就是被移除的 `[defaults].ignore_providers` /
+`[defaults].provider_sort` 的替代写法：OpenRouter 路由偏好现在是普通的
+body 参数（裸 OpenRouter provider slug，不带 `@openrouter` 后缀），可以像
+任何其他规则一样按任务限定范围。旧的两个 key 会拒绝启动，并给出这条迁移
+提示。注意被移除的两个 key 以前也会喂给 `chat_vision` 的请求体；body 规则
+不覆盖 vision，所以 vision 调用现在完全不再发送 `provider` 偏好。
 
 ### `model_name_display_override`（仅限 chat 任务）
 
@@ -747,6 +767,12 @@ model = { "x-ai/grok-4.20" = 0.8, "z-ai/glm-4.7-flash" = 0.2 }  # weighted rando
   `[tasks.<name>]` 上的 `dimensions` 字段已移除（维度固定为 512；已有配置
   里残留的 `dimensions = 512` 行现在是被忽略的未知 key）。详见上文
   “`[providers]`”和“`[tasks.embedding]` — 已激活”。
+- **`[defaults].ignore_providers` 和 `[defaults].provider_sort` 已移除**
+  （上一条记录了它们早先强制带 `@openrouter` 后缀的写法）。OpenRouter
+  路由偏好现在是 `openrouter` 条目上的 `[[providers.<name>.body]]` 规则——
+  参见上文“`[[providers.<name>.body]]` — 自定义 body 参数”。残留 key 会
+  拒绝启动并给出迁移提示。被移除的两个 key 以前也会喂给 `chat_vision` 的
+  请求体；body 规则只覆盖 chat，所以 vision 调用不再发送 `provider` 偏好。
 
 ## 此配置不控制的内容
 

--- a/docs/superpowers/specs/2026-08-02-provider-body-params-design.md
+++ b/docs/superpowers/specs/2026-08-02-provider-body-params-design.md
@@ -116,7 +116,12 @@ whole top-level key (`model_config.rs:1405`).
 | `ProviderPrefs`, `provider_prefs()` | `openrouter.rs:279`, `:642` |
 | `WireRequest.provider` | field within `openrouter.rs:287-313` |
 | `OpenRouterClient::with_ignore_providers`, `::with_provider_sort` (+ fields) | `openrouter.rs:513-561` region |
+| vision-body prefs injection (`execute_vision` merges `provider_prefs()` into the built-in-endpoint vision body) | `openrouter.rs:791-797` |
 | boot wiring of the two builders | `main.rs:357-364` |
+
+Consequence of the vision row (found during planning): `chat_vision` calls
+lose `provider.ignore`/`sort` entirely — body rules are chat-only and do not
+replace them there. Accepted; revisit only if a vision routing need appears.
 
 ## 4. Tests
 

--- a/docs/superpowers/specs/2026-08-02-provider-body-params-design.md
+++ b/docs/superpowers/specs/2026-08-02-provider-body-params-design.md
@@ -1,0 +1,148 @@
+# eros-engine — per-provider custom body parameters; remove provider prefs from `[defaults]`
+
+`[providers.<name>]` gains **body rules**: deployer-defined JSON merged into
+the chat/completions wire body, scoped per task. Motivating case: Venice's
+`venice_parameters` extension block. The same mechanism is the designated home
+for OpenRouter-specific body fields going forward — the built-in wire path is
+to keep only OpenAI-compatible fields (`temperature` and friends), with
+`reasoning` as the one grandfathered exception. As the first step of that
+migration, `defaults.ignore_providers` and `defaults.provider_sort` are
+**removed** (breaking, no forward compat): both are OpenRouter-specific
+(`provider.ignore` / `provider.sort`, one wire object) and are now expressed
+as an ordinary body rule on `[providers.openrouter]`.
+
+Related: `2026-07-31-multi-llm-providers-design.md` (the `[providers]` block),
+`2026-08-01-embedding-providers-design.md`.
+
+---
+
+## 0. Decisions (settled during brainstorm)
+
+- **The reserved `openrouter` entry participates.** Any `[providers.<name>]`
+  may declare body rules; there is no custom-only carve-out.
+- **`[tasks.*].reasoning` survives as a forward-compat exception**, and is sent
+  only on the built-in OpenRouter path (custom providers already strip it —
+  reasoning shapes differ per vendor, so custom providers declare their own via
+  body rules). When `[providers.openrouter]` rules also produce a `reasoning`
+  key, **the providers block wins** — which falls out of the merge order for
+  free.
+- **chat/completions only** (streaming + non-streaming). `chat_vision`'s
+  hand-rolled body and both embedding paths are out of scope.
+- **Rules array, not a single param set.** Per-task granularity is required by
+  the migration direction: `[tasks.*].reasoning` is per-task today, so its
+  providers-block successor must be expressible per task.
+- **Providers block wins on key conflicts, uniformly.** No per-field special
+  cases; deployers may override `temperature` etc. Only the structural keys
+  `model` / `messages` / `stream` are refused (at boot).
+- **`ignore_providers` and `provider_sort` are removed together** and leftover
+  keys refuse boot with a migration hint — the
+  `[tasks.chat_image_generation]` removal precedent
+  (`2026-08-01-remove-image-draw-endpoint-design.md`).
+- **All validation at boot; zero new runtime failure surface.** Runtime is
+  lookup + merge; no match means no merge.
+
+---
+
+## 1. Config surface
+
+```toml
+[providers.venice]
+chat = "https://api.venice.ai/api/v1/chat/completions"
+
+[[providers.venice.body]]
+tasks  = ["chat_companion", "chat_output_filter"]   # omitted = every chat task this provider serves
+params = { venice_parameters = { include_venice_system_prompt = false } }
+
+[[providers.venice.body]]
+tasks  = ["chat_companion"]
+params = { reasoning = { max_tokens = 512 } }        # later rule wins on key conflict
+
+[[providers.openrouter.body]]                        # reserved name participates
+tasks  = ["chat_companion"]
+params = { provider = { ignore = ["deepinfra"], sort = "price" }, transforms = ["middle-out"] }
+```
+
+`ProviderEntry` (`model_config.rs:541`) gains `body: Option<Vec<BodyRule>>`;
+`BodyRule { tasks: Option<Vec<String>>, params: <non-empty table> }`. `params`
+is opaque TOML→JSON passthrough — the engine never interprets it. Task match
+is exact, case-sensitive string equality.
+
+**Boot refusals** (in `validate_providers`, `main.rs:305`):
+
+| condition |
+|---|
+| `params` empty, or containing `model` / `messages` / `stream` |
+| `tasks = []` (empty array; omit the key to mean "all") |
+| a custom provider declares `body` but no `chat` url (`openrouter` exempt — built-in url) |
+| `defaults.ignore_providers` or `defaults.provider_sort` present — error text shows the `[providers.openrouter]` body-rule replacement |
+
+**Boot warnings** (not fatal): a `tasks` entry that is not a known engine task
+name (typo guard, against a small const list of engine task names introduced
+by this PR), or names a task this mechanism does not cover (`chat_vision`,
+`embedding`).
+
+Dir-mode config merge needs nothing new — `[providers]` already merges as one
+whole top-level key (`model_config.rs:1405`).
+
+## 2. Data flow
+
+- `ChatRequest` (`openrouter.rs:64`) gains `task: Option<String>` — config
+  routing only, never serialized. Every pipeline call site sets it from its
+  existing `*_TASK` const; `..Default::default()` paths stay `None` (= no
+  rules apply). Sites: `handlers.rs:257` (chat), `post_process.rs:653`
+  (affinity), `:864`, `:961` (insight), `dreaming.rs:201` (memory),
+  `stream.rs:1368` (output filter), `:1652` (PDE), `:2204` (input filter),
+  `:2317` (compose), `:3051` (product QA), `voice.rs:194`, `world.rs:290`,
+  `world_town.rs:192`, `:305`, `story.rs:310`.
+- Boot: `build_providers` (`model_config.rs:2556`) carries rules into
+  `ProviderEndpoint`; the `openrouter` entry's rules travel on a separate
+  client field (it is not in the custom-providers map).
+- Merge point — `call_once` (`openrouter.rs:906`) and `execute_stream_as`
+  (`:1023`), after `resolve_endpoint`: existing `for_endpoint` stripping runs
+  first (custom providers still lose `session_id` / `metadata` / `reasoning`),
+  then rules matching the request's task are merged into the serialized
+  `WireRequest` as a top-level shallow merge, declaration order, later wins.
+  When no rule matches, the wire bytes are identical to today.
+- **Per-attempt resolution**: a fallback chain crossing providers (primary
+  `@venice`, fallback OpenRouter) looks up rules per attempt, against the
+  provider actually being called.
+
+## 3. Removed
+
+| Item | Site (pre-PR) |
+|---|---|
+| `DefaultConfig.ignore_providers`, `.provider_sort` | `model_config.rs:509-529` |
+| `ModelConfig::ignore_provider_wire_slugs` | `model_config.rs:2585-2612` region |
+| `ProviderPrefs`, `provider_prefs()` | `openrouter.rs:279`, `:642` |
+| `WireRequest.provider` | field within `openrouter.rs:287-313` |
+| `OpenRouterClient::with_ignore_providers`, `::with_provider_sort` (+ fields) | `openrouter.rs:513-561` region |
+| boot wiring of the two builders | `main.rs:357-364` |
+
+## 4. Tests
+
+- Config: rule parsing (single / multiple / omitted `tasks`); each boot
+  refusal; both warnings; dir-mode merge with rules.
+- Wire (existing wiremock/serialization harness): merge applied for an
+  enabled task; not applied for an unlisted task; later rule wins;
+  `[providers.openrouter]` `reasoning` overrides `[tasks.*].reasoning`;
+  custom-provider stripping runs before merge
+  (`custom_endpoint_wire_is_strict_openai_subset` adapted — `provider` field
+  gone); streaming path merges identically; cross-provider fallback resolves
+  per attempt.
+
+## 5. Docs
+
+- `docs/model-config.md` — body-rules subsection under `[providers]`
+  (shape, merge semantics, reasoning exception, structural-key refusals);
+  `[defaults]` section drops the two keys and shows the migration snippet.
+- `examples/model_config.toml` — commented body-rule example; drop the two
+  defaults keys.
+- OpenAPI untouched (config-side only). **Breaking config change** — release
+  notes entry when the maintainer cuts the release.
+
+## 6. Out of scope / non-goals
+
+Vision and embedding bodies; the per-request audit passthroughs (`user`,
+`metadata`, `session_id`); per-tier granularity; completing the
+"built-in path is OpenAI-only" migration (this PR only lands the `reasoning`
+exception and the provider-prefs removal); version/release timing.

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -6,22 +6,10 @@
 # If the selected primary also appears in `fallback`, it is auto-skipped.
 
 # ── Global defaults (optional) ───────────────────────────────────────────────
-# Cross-task settings. `ignore_providers` excludes OpenRouter provider slugs
-# from routing on EVERY task (issue #84: one provider returned undecoded
-# byte-level-BPE text for thedrummer/cydonia-24b-v4.1). Sent as provider.ignore
-# on every call; allow_fallbacks stays true so the model is still served by a
-# healthy provider. Find the offending slug via OpenRouter's generation API.
-# Empty/unset = no exclusion.
-#
-# `provider_sort` (optional) sets OpenRouter's provider routing sort on EVERY
-# task: "price" | "throughput" | "latency". Unset (default) keeps OpenRouter's
-# price-based load balancing. Setting it trades cost for the chosen axis —
-# "latency" favours TTFT for chat; note it disables price load-balancing, so
-# watch cost and success rate separately.
-#[defaults]
-#ignore_providers = ["some-bad-provider-slug@openrouter"]
-# Entries MUST carry the @openrouter suffix — the exclusion list acts on OpenRouter routing only.
-#provider_sort = "latency"
+# OpenRouter routing prefs (formerly [defaults].ignore_providers /
+# [defaults].provider_sort here) are removed — they're now
+# [[providers.<name>.body]] rules. See the example under "Custom providers"
+# below.
 #
 # ── Custom providers (optional) ──────────────────────────────────────────────
 # Route model slugs to your own endpoints. Each entry is a table with up to
@@ -61,10 +49,24 @@
 #   literal "@" inside a model id is escaped "\@" (in TOML: "weird\\@vendor/m").
 # - Model-keyed tables (`display`, `output_regex` models, `output_filter`
 #   trigger models) always use the BARE id, never "id@provider".
-# - Custom providers receive a strict OpenAI-compatible request:
-#   [defaults].ignore_providers / provider_sort and per-task `reasoning` are
-#   inert for them; they receive exactly the headers you declare.
+# - Custom providers receive a strict OpenAI-compatible request: per-task
+#   `reasoning` is inert for them; they receive exactly the headers (and any
+#   [[providers.<name>.body]] rules, see below) you declare for that entry.
 # - Under MODEL_CONFIG_DIR, [providers] merges as ONE top-level key.
+#
+# Per-provider custom body parameters (chat/completions only). `params` is
+# merged into the request body verbatim; `tasks` scopes the rule (omit = all
+# chat tasks on this provider). Later rules win; params win over engine
+# fields. model/messages/stream are engine-owned (boot refusal).
+#[[providers.venice.body]]
+#tasks  = ["chat_companion"]
+#params = { venice_parameters = { include_venice_system_prompt = false } }
+#
+# OpenRouter routing prefs (the former [defaults].ignore_providers /
+# provider_sort) are now body params on the reserved openrouter entry —
+# bare provider slugs, no @openrouter suffix:
+#[[providers.openrouter.body]]
+#params = { provider = { ignore = ["some-bad-provider"], sort = "latency" } }
 #
 # One-off repair of rows already persisted with byte-BPE garble (run manually,
 # NOT a migration — the engine refuses to own downstream prod data). Repairs the


### PR DESCRIPTION
## Summary

**New:** `[[providers.<name>.body]]` config rules — deployer-defined JSON merged into the chat/completions wire body, scoped per engine task:

```toml
[providers.venice]
chat = "https://api.venice.ai/api/v1/chat/completions"

[[providers.venice.body]]
tasks  = ["chat_companion"]                    # omit = every chat task this provider serves
params = { venice_parameters = { include_venice_system_prompt = false } }
```

- Merge: top-level shallow, declaration order, later rules win, **params win over engine-built fields** — declaring `reasoning` on `[providers.openrouter]` therefore overrides `[tasks.*].reasoning` for the scoped tasks. `model`/`messages`/`stream` are engine-owned (boot refusal).
- The reserved `openrouter` entry participates; custom providers still get the strict-OpenAI-subset strip first, then their declared params merge (the supported way to reintroduce vendor fields).
- Per-attempt resolution: a fallback chain crossing providers gets each provider's own rules per attempt.
- No matching rule ⇒ wire bytes byte-identical to before (locked by test).
- `ChatRequest` gains a never-serialized `task` field, set at all 15 pipeline call sites; boot warns on unknown/uncovered task names in rules (`chat_vision`/`embedding` build their own bodies and never match).

**Removed (breaking):** `defaults.ignore_providers`, `defaults.provider_sort`, and the whole `ProviderPrefs` wire object. Leftover keys refuse boot with a migration message teaching the replacement:

```toml
[[providers.openrouter.body]]
params = { provider = { ignore = ["some-bad-provider"], sort = "price" } }
```

Note: the vision body also carried provider prefs — it loses them entirely (body rules are chat-only; accepted consequence recorded in spec §3). Stability-commitments doc records the removals as explicit exceptions.

Spec: `docs/superpowers/specs/2026-08-02-provider-body-params-design.md` (this PR's first commits).

## Testing

- Config: rule parsing (single/multi/omitted tasks, deny-unknown-fields), four boot refusals, warn semantics (pure-fn), dir-mode whole-key merge lock, shipped-example boot gates.
- Wire (wiremock): enabled-task merge + reasoning override, unlisted-task skip, later-rule-wins, strip-then-merge for custom providers, stream-path parity, cross-provider fallback per-attempt isolation, no-provider-key lock, no-rules exact key-set lock.
- E2E through the real pipeline (`run_stream`): an `[[providers.openrouter.body]]` rule scoped to `chat_image_prompt_compose` reaches the composer's wire body.
- Full workspace suite: 1086 passed / 0 failed; fmt / clippy(-D warnings) / openapi snapshot clean.
- Docs: en + zh + example swept; migration path teachable from the boot error alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)