### PR TITLE
feat(image)!: engine-counted image facts, composer captions, seedless generate-mode composer

### DIFF
--- a/crates/eros-engine-core/src/pde.rs
+++ b/crates/eros-engine-core/src/pde.rs
@@ -50,7 +50,7 @@ pub fn decide(input: &DecisionInput) -> ActionPlan {
             energy_cost: ENERGY_COST_REPLY,
             context_hints: vec![],
             reply_tone: None,
-            image_prompt: None,
+            image_caption: None,
             image_ref: ImageRef::Face,
             aspect_ratio: None,
         };
@@ -69,7 +69,7 @@ pub fn decide(input: &DecisionInput) -> ActionPlan {
             energy_cost: ENERGY_COST_GHOST,
             context_hints: vec![],
             reply_tone: None,
-            image_prompt: None,
+            image_caption: None,
             image_ref: ImageRef::Face,
             aspect_ratio: None,
         };
@@ -84,7 +84,7 @@ pub fn decide(input: &DecisionInput) -> ActionPlan {
             energy_cost: ENERGY_COST_PROACTIVE,
             context_hints: vec![],
             reply_tone: None,
-            image_prompt: None,
+            image_caption: None,
             image_ref: ImageRef::Face,
             aspect_ratio: None,
         };
@@ -100,7 +100,7 @@ pub fn decide(input: &DecisionInput) -> ActionPlan {
             energy_cost: ENERGY_COST_APP_OPEN,
             context_hints: vec![],
             reply_tone: None,
-            image_prompt: None,
+            image_caption: None,
             image_ref: ImageRef::Face,
             aspect_ratio: None,
         };
@@ -114,7 +114,7 @@ pub fn decide(input: &DecisionInput) -> ActionPlan {
         energy_cost: ENERGY_COST_REPLY,
         context_hints: vec![],
         reply_tone: None,
-        image_prompt: None,
+        image_caption: None,
         image_ref: ImageRef::Face,
         aspect_ratio: None,
     }
@@ -135,7 +135,6 @@ pub fn plan_for(
     action: ActionType,
     hints: Vec<String>,
     reply_tone: Option<String>,
-    image_prompt: Option<String>,
     image_ref: ImageRef,
     aspect_ratio: Option<String>,
 ) -> ActionPlan {
@@ -153,7 +152,7 @@ pub fn plan_for(
             } else {
                 reply_tone
             },
-            image_prompt,
+            image_caption: None,
             image_ref,
             aspect_ratio,
         },
@@ -164,7 +163,7 @@ pub fn plan_for(
             energy_cost: ENERGY_COST_GHOST,
             context_hints: vec![],
             reply_tone: None,
-            image_prompt: None,
+            image_caption: None,
             image_ref: ImageRef::Face,
             aspect_ratio: None,
         },
@@ -178,7 +177,7 @@ pub fn plan_for(
             energy_cost: 0.0,
             context_hints: vec![],
             reply_tone: None,
-            image_prompt: None,
+            image_caption: None,
             image_ref: ImageRef::Face,
             aspect_ratio: None,
         },
@@ -476,7 +475,6 @@ mod tests {
             ActionType::ReplyText,
             vec!["有点开心".into()],
             None,
-            None,
             ImageRef::Face,
             None,
         );
@@ -493,7 +491,6 @@ mod tests {
             &input,
             ActionType::Ghost,
             vec!["想躲".into()],
-            None,
             None,
             ImageRef::Face,
             None,
@@ -512,23 +509,24 @@ mod tests {
             ActionType::ReplyTextImage,
             vec![],
             None,
-            Some("a selfie in a cafe".to_string()),
             ImageRef::Face,
             None,
         );
         assert_eq!(plan.action_type, ActionType::ReplyTextImage);
-        assert_eq!(plan.image_prompt.as_deref(), Some("a selfie in a cafe"));
+        assert_eq!(
+            plan.image_caption, None,
+            "no caption exists at decision time — the composer has not run"
+        );
 
         let ghost = plan_for(
             &input,
             ActionType::Ghost,
             vec![],
             None,
-            Some("ignored".into()),
             ImageRef::Face,
             None,
         );
-        assert_eq!(ghost.image_prompt, None, "ghost carries no image prompt");
+        assert_eq!(ghost.image_caption, None, "ghost carries no image prompt");
     }
 
     #[test]
@@ -539,7 +537,6 @@ mod tests {
             ActionType::ReplyImage,
             vec![],
             None,
-            Some("a subject".into()),
             ImageRef::Previous,
             Some("9:16".into()),
         );
@@ -552,7 +549,6 @@ mod tests {
             ActionType::Ghost,
             vec![],
             None,
-            Some("ignored".into()),
             ImageRef::Previous,
             Some("9:16".into()),
         );
@@ -570,7 +566,6 @@ mod tests {
             ActionType::ReplyText,
             vec![],
             tone.clone(),
-            None,
             ImageRef::Face,
             None,
         );
@@ -581,7 +576,6 @@ mod tests {
             ActionType::ReplyTextImage,
             vec![],
             tone.clone(),
-            Some("selfie".into()),
             ImageRef::Face,
             None,
         );
@@ -592,7 +586,6 @@ mod tests {
             ActionType::ReplyImage,
             vec![],
             tone.clone(),
-            Some("selfie".into()),
             ImageRef::Face,
             None,
         );
@@ -606,7 +599,6 @@ mod tests {
             ActionType::Ghost,
             vec![],
             tone,
-            None,
             ImageRef::Face,
             None,
         );
@@ -627,7 +619,6 @@ mod tests {
             ActionType::ProductQa,
             vec!["ignored".into()],
             Some("ignored".into()),
-            None,
             ImageRef::Face,
             None,
         );

--- a/crates/eros-engine-core/src/types.rs
+++ b/crates/eros-engine-core/src/types.rs
@@ -157,9 +157,12 @@ pub struct ActionPlan {
     /// turns (reply_text / reply_text_image); `None` everywhere else — rule
     /// PDE, fail-open, tips, ghost, reply_image.
     pub reply_tone: Option<String>,
-    /// Subject for the image executor (`reply_image`/`reply_text_image`); `None`
-    /// for text/ghost/proactive. Carried from the PDE verdict or a forced turn.
-    pub image_prompt: Option<String>,
+    /// What the picture showed, for post-process affinity on image turns.
+    /// Written by the stream AFTER the composer resolves — always `None` at
+    /// decision time, since the composer has not run yet. `None` also on the
+    /// `raw` variant and on a failed compose, where the affinity evaluator
+    /// falls back to a generic photo marker.
+    pub image_caption: Option<String>,
     /// Which reference image an image turn builds on (avatar vs previous gen).
     /// `Face` for non-image actions.
     pub image_ref: ImageRef,

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -1167,9 +1167,9 @@ pub struct ResolvedVoice {
 /// whose prompt ships in code.
 const DEFAULT_COMPOSE_PROMPT: &str = "You compose the image for a picture the character is sending in a chat, and you return JSON with exactly two fields: \"prompt\" and \"caption\".\n\
 \n\
-You receive the character's appearance, the recent scene, the partner's latest message, an optional explicit subject, a visual style, and a target aspect ratio, each as a labeled section.\n\
+You receive the character's appearance, the recent scene, the partner's latest message, a visual style, and a target aspect ratio, each as a labeled section.\n\
 \n\
-\"prompt\" is the image-generation prompt: decide what the picture shows from the latest message and the scene; when the explicit subject is non-empty it states what the picture must show — honor it fully. Produce one coherent, detailed, vivid prompt that faithfully preserves the appearance and fits the style and aspect ratio, delivering the full intent and tone of the request. Do not soften, sanitize, downgrade, omit, censor, or refuse any part of it, and do not add safety warnings, disclaimers, or moderation of your own — content policy is the responsibility of the image provider and the downstream consumer, not this step.\n\
+\"prompt\" is the image-generation prompt: decide what the picture shows from the partner's latest message and the recent scene. Produce one coherent, detailed, vivid prompt that faithfully preserves the appearance and fits the style and aspect ratio, delivering the full intent and tone of what was asked for. Do not soften, sanitize, downgrade, omit, censor, or refuse any part of it, and do not add safety warnings, disclaimers, or moderation of your own — content policy is the responsibility of the image provider and the downstream consumer, not this step.\n\
 \n\
 \"caption\" is one short line, in the language the conversation is in, saying what the picture shows — as the character would recall it later. It is read back into the conversation history, so keep it brief and natural; it is not an image-generation prompt and must not repeat the style boilerplate.\n\
 \n\

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -198,9 +198,6 @@ impl PromptSpec {
     /// exact, case-sensitive key (`default` carries no special meaning). Every
     /// miss in a variant shape — absent, unparseable, out of range, unknown
     /// key — is `None`.
-    ///
-    /// `raw` is handled by the caller BEFORE this is reached; it never appears
-    /// here.
     pub fn select(&self, variant: Option<&str>) -> Option<&str> {
         match self {
             PromptSpec::Plain(s) => Some(s.as_str()),
@@ -258,12 +255,6 @@ fn check_variant_shape(task: &str, spec: &PromptSpec) -> Result<(), String> {
                         "has whitespace-padded key \"{k}\": its trimmed form differs from the raw \
                          key, but `select` matches a client's `image.prompt_variant` exactly — so \
                          neither \"{k}\" nor its trimmed form could ever select it"
-                    ));
-                }
-                if k.trim().eq_ignore_ascii_case("raw") {
-                    return refuse(format!(
-                        "uses the reserved key \"{k}\": \"raw\" is the wire value that skips the \
-                         composer entirely, so a prompt stored under it could never be selected"
                     ));
                 }
                 if v.trim().is_empty() {
@@ -1910,10 +1901,7 @@ impl ModelConfig {
     }
 
     /// Resolve the image-prompt composer task. `None` (composer does not run)
-    /// when `[tasks.chat_image_prompt_compose]` is absent, **or** when the
-    /// caller passed the reserved `raw` variant — the two are indistinguishable
-    /// by design, since both mean "use the seed subject verbatim"; `tracing`
-    /// tells them apart.
+    /// for exactly one reason: `[tasks.chat_image_prompt_compose]` is absent.
     ///
     /// `variant` is the client's per-turn `image.prompt_variant`, already
     /// trimmed by the caller. Selection is delegated to `PromptSpec::select`:
@@ -1928,10 +1916,6 @@ impl ModelConfig {
     ) -> Option<ResolvedImagePromptCompose> {
         const COMPOSE_TASK: &str = "chat_image_prompt_compose";
         let variant = variant.map(str::trim).filter(|v| !v.is_empty());
-        if variant.is_some_and(|v| v.eq_ignore_ascii_case("raw")) {
-            tracing::debug!("image-compose: variant \"raw\" — skipping composer");
-            return None;
-        }
         let task_cfg = self.tasks.get(COMPOSE_TASK)?;
         let selected = task_cfg
             .filter_prompt
@@ -2291,11 +2275,9 @@ impl ModelConfig {
     /// dead config — refuse to boot rather than let it silently no-op.
     ///
     /// Also enforces the structural rules for a variant container: non-empty,
-    /// no blank or whitespace-padded keys, no blank values, and no reserved
-    /// `raw` key (`raw` is the wire escape that skips the composer, so a
-    /// config key by that name could never be selected — and a padded key
-    /// like `" a "` could never be selected either, since `select` matches a
-    /// client's variant exactly).
+    /// no blank or whitespace-padded keys, no blank values (a padded key like
+    /// `" a "` could never be selected, since `select` matches a client's
+    /// variant exactly).
     ///
     /// Task names are visited in sorted order so the reported failure is
     /// deterministic across restarts (`self.tasks` is a `HashMap`).
@@ -6002,16 +5984,16 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
     }
 
     #[test]
-    fn raw_is_a_reserved_key_case_insensitively() {
+    fn raw_is_an_ordinary_variant_key_and_boots() {
+        // "raw" used to be refused as a reserved wire escape. With no seed to
+        // draw verbatim, the escape is gone and the key is configurable.
         for key in ["raw", "Raw", "RAW"] {
-            let src = format!(
-                "[tasks.chat_image_prompt_compose]\nmodel = \"m\"\n\
-                 filter_prompt = {{ {key} = \"aaa\", b = \"bbb\" }}\n"
+            let toml = format!(
+                "[tasks.chat_image_prompt_compose]\nmodel = \"m\"\nfilter_prompt = {{ {key} = \"RAW PROMPT\" }}\n"
             );
-            let e = cfg(&src)
-                .validate_prompt_variants()
-                .expect_err("reserved key must refuse to boot");
-            assert!(e.contains("reserved"), "{e}");
+            let cfg = ModelConfig::from_toml_str(&toml).expect("parses");
+            cfg.validate_prompt_variants()
+                .unwrap_or_else(|e| panic!("key {key:?} must boot now: {e}"));
         }
     }
 
@@ -6167,38 +6149,71 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
     }
 
     #[test]
-    fn raw_skips_the_composer_in_every_shape() {
-        let sources = [
-            "[tasks.chat_image_prompt_compose]\nmodel = \"m\"\nfilter_prompt = [\"AAA\"]\n",
-            "[tasks.chat_image_prompt_compose]\nmodel = \"m\"\nfilter_prompt = { a = \"AAA\" }\n",
-            "[tasks.chat_image_prompt_compose]\nmodel = \"m\"\nfilter_prompt = \"custom\"\n",
-            // No filter_prompt at all (built-in prompt) — raw still wins.
-            "[tasks.chat_image_prompt_compose]\nmodel = \"m\"\n",
-        ];
-        for src in sources {
-            let c = cfg(src);
-            for v in ["raw", "Raw", "RAW"] {
-                assert!(
-                    c.resolve_image_prompt_compose(Some(v)).is_none(),
-                    "{v} must skip the composer for: {src}"
-                );
-            }
-            // Sanity: without `raw` the composer is still resolved.
-            assert!(c.resolve_image_prompt_compose(None).is_some(), "{src}");
-        }
+    fn raw_variant_selects_a_configured_prompt() {
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.chat_image_prompt_compose]\nmodel = \"m\"\nfilter_prompt = { raw = \"RAW PROMPT\" }\n",
+        )
+        .expect("parses");
+        let r = cfg
+            .resolve_image_prompt_compose(Some("raw"))
+            .expect("composer resolves — \"raw\" no longer skips it");
+        assert_eq!(r.compose_prompt, "RAW PROMPT");
+        assert_eq!(r.variant_key.as_deref(), Some("raw"));
     }
 
     #[test]
-    fn raw_returns_none_whether_or_not_the_composer_is_configured() {
-        // NOTE: this does NOT pin the "raw check precedes the task lookup"
-        // ordering — `self.tasks.get(COMPOSE_TASK)?` early-returns `None` for
-        // an absent task regardless of which check runs first, so this test
-        // passes under both orderings. It only pins that `raw` still yields
-        // `None` (composer does not run) when the task block is absent, same
-        // as when it's present — a real behavior, just not evidence of order.
-        let c = cfg("[tasks.chat_companion]\nmodel = \"m\"\n");
-        assert!(c.resolve_image_prompt_compose(Some("raw")).is_none());
-        assert!(c.resolve_image_prompt_compose(None).is_none());
+    fn raw_variant_without_a_matching_key_falls_back_to_the_builtin() {
+        // An unknown variant is a miss, never a skip and never an error.
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.chat_image_prompt_compose]\nmodel = \"m\"\nfilter_prompt = { a = \"A PROMPT\" }\n",
+        )
+        .expect("parses");
+        let r = cfg
+            .resolve_image_prompt_compose(Some("raw"))
+            .expect("composer still resolves");
+        assert_eq!(r.compose_prompt, DEFAULT_COMPOSE_PROMPT);
+        assert_eq!(r.variant_key, None);
+    }
+
+    #[test]
+    fn compose_resolves_none_only_when_the_task_is_absent() {
+        let absent =
+            ModelConfig::from_toml_str("[tasks.chat_companion]\nmodel = \"m\"\n").expect("parses");
+        assert!(absent.resolve_image_prompt_compose(None).is_none());
+        assert!(absent.resolve_image_prompt_compose(Some("raw")).is_none());
+
+        let present =
+            ModelConfig::from_toml_str("[tasks.chat_image_prompt_compose]\nmodel = \"m\"\n")
+                .expect("parses");
+        assert!(present.resolve_image_prompt_compose(None).is_some());
+        assert!(present.resolve_image_prompt_compose(Some("raw")).is_some());
+        assert!(present
+            .resolve_image_prompt_compose(Some("anything"))
+            .is_some());
+    }
+
+    #[test]
+    fn no_variant_uses_the_builtin_for_variant_shapes() {
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.chat_image_prompt_compose]\nmodel = \"m\"\nfilter_prompt = { a = \"A PROMPT\" }\n",
+        )
+        .expect("parses");
+        let r = cfg.resolve_image_prompt_compose(None).expect("resolves");
+        assert_eq!(r.compose_prompt, DEFAULT_COMPOSE_PROMPT);
+
+        // A PLAIN filter_prompt is the deployment's single chosen prompt, not a
+        // variant miss — it still wins with no variant supplied.
+        let plain = ModelConfig::from_toml_str(
+            "[tasks.chat_image_prompt_compose]\nmodel = \"m\"\nfilter_prompt = \"PLAIN PROMPT\"\n",
+        )
+        .expect("parses");
+        assert_eq!(
+            plain
+                .resolve_image_prompt_compose(None)
+                .unwrap()
+                .compose_prompt,
+            "PLAIN PROMPT"
+        );
     }
 
     #[test]
@@ -6211,19 +6226,6 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
                 .compose_prompt,
             DEFAULT_COMPOSE_PROMPT
         );
-    }
-
-    #[test]
-    fn raw_variant_is_trimmed_before_the_raw_comparison() {
-        // Pins that the incoming variant is trimmed BEFORE the "raw" match,
-        // not after: `filter_prompt` is a non-blank Plain string here, so if
-        // trimming happened later (or not at all), " raw \n" would fail the
-        // exact `eq_ignore_ascii_case("raw")` comparison, fall through to
-        // normal selection, and this would resolve to `Some(..)` with
-        // compose_prompt = "custom" instead of `None`.
-        let c =
-            cfg("[tasks.chat_image_prompt_compose]\nmodel = \"m\"\nfilter_prompt = \"custom\"\n");
-        assert!(c.resolve_image_prompt_compose(Some(" raw \n")).is_none());
     }
 
     /// `variant_key` surfaces WHICH variant selected the prompt — the audit

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -1902,6 +1902,13 @@ impl ModelConfig {
         Ok(())
     }
 
+    /// Whether a `[tasks.<name>]` section exists at all, independent of its
+    /// contents. Used by capability gates that must distinguish "not configured"
+    /// from "configured but inert this turn".
+    pub fn has_task(&self, name: &str) -> bool {
+        self.tasks.contains_key(name)
+    }
+
     /// Resolve the image-prompt composer task. `None` (composer does not run)
     /// when `[tasks.chat_image_prompt_compose]` is absent, **or** when the
     /// caller passed the reserved `raw` variant — the two are indistinguishable

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -1154,16 +1154,26 @@ pub struct ResolvedVoice {
 /// Generic, product-identity-free default prompt for the image-prompt composer.
 /// Used when the task is enabled but supplies no `filter_prompt`; deployments
 /// override it via `[tasks.chat_image_prompt_compose].filter_prompt`. Keep the
-/// text identity-free — no product name or brand. Its stance is EXPAND-ONLY: it
-/// must not soften, downgrade, or refuse, and must not add its own
+/// text identity-free — no product name or brand.
+///
+/// Its stance is GENERATE (not expand): the judge no longer writes a seed, so
+/// this step decides what the picture shows from the turn's context. It must
+/// not soften, downgrade, or refuse, and must not add its own
 /// content-moderation layer — content policy is enforced by the image provider
-/// and the downstream consumer, not this step. This is the one engine task whose
-/// prompt ships in code.
-const DEFAULT_COMPOSE_PROMPT: &str = "You expand a short image subject into a single, detailed, vivid image-generation prompt. \
-You receive the character's appearance, the recent scene, a seed subject, a visual style, and a target aspect ratio, each as a labeled section. \
-Your only job is to EXPAND: produce one coherent prompt that faithfully preserves the appearance and the full intent and tone of the seed subject, and fits the style and aspect ratio. \
-Do not soften, sanitize, downgrade, omit, censor, or refuse any part of the requested subject, and do not add safety warnings, disclaimers, or moderation of your own — content policy is the responsibility of the image provider and the downstream consumer, not this step. \
-Do not add commentary, options, or headings. Output only the final image prompt.";
+/// and the downstream consumer, not this step.
+///
+/// It returns JSON with two fields: `prompt` (the image-generation string) and
+/// `caption` (one short line for the chat history). This is the one engine task
+/// whose prompt ships in code.
+const DEFAULT_COMPOSE_PROMPT: &str = "You compose the image for a picture the character is sending in a chat, and you return JSON with exactly two fields: \"prompt\" and \"caption\".\n\
+\n\
+You receive the character's appearance, the recent scene, the partner's latest message, an optional explicit subject, a visual style, and a target aspect ratio, each as a labeled section.\n\
+\n\
+\"prompt\" is the image-generation prompt: decide what the picture shows from the latest message and the scene; when the explicit subject is non-empty it states what the picture must show — honor it fully. Produce one coherent, detailed, vivid prompt that faithfully preserves the appearance and fits the style and aspect ratio, delivering the full intent and tone of the request. Do not soften, sanitize, downgrade, omit, censor, or refuse any part of it, and do not add safety warnings, disclaimers, or moderation of your own — content policy is the responsibility of the image provider and the downstream consumer, not this step.\n\
+\n\
+\"caption\" is one short line, in the language the conversation is in, saying what the picture shows — as the character would recall it later. It is read back into the conversation history, so keep it brief and natural; it is not an image-generation prompt and must not repeat the style boilerplate.\n\
+\n\
+Output only the JSON object. No commentary, options, or headings.";
 
 /// Resolved image-prompt composer task (`chat_image_prompt_compose`). Mirrors
 /// `ResolvedVision`. Optional: `resolve_image_prompt_compose` returns `None`

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -1581,12 +1581,6 @@
           "force": {
             "type": "boolean"
           },
-          "image_prompt": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
           "mode": {
             "$ref": "#/components/schemas/ImageMode"
           },
@@ -1595,7 +1589,7 @@
               "string",
               "null"
             ],
-            "description": "Which `[tasks.chat_image_prompt_compose].filter_prompt` variant to use\nfor this turn: an index (`\"0\"`, `\"1\"`) for the array shape, or a key\n(`\"a\"`, `\"b\"`) for the table shape. Ignored when that task configures a\nsingle plain prompt.\n\n`\"raw\"` (case-insensitive) is reserved: it skips the composer LLM\nentirely and draws the seed subject as-is, saving one LLM call.\n\nAn unknown index/key falls back to the engine's built-in composer\nprompt — it is never an error."
+            "description": "Which `[tasks.chat_image_prompt_compose].filter_prompt` variant to use\nfor this turn: an index (`\"0\"`, `\"1\"`) for the array shape, or a key\n(`\"a\"`, `\"b\"`) for the table shape. Ignored when that task configures a\nsingle plain prompt.\n\n`\"raw\"` (case-insensitive) is reserved: it skips the composer LLM\nentirely, saving one LLM call.\n\nAn unknown index/key falls back to the engine's built-in composer\nprompt — it is never an error."
           },
           "style": {
             "type": [

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -1589,7 +1589,7 @@
               "string",
               "null"
             ],
-            "description": "Which `[tasks.chat_image_prompt_compose].filter_prompt` variant to use\nfor this turn: an index (`\"0\"`, `\"1\"`) for the array shape, or a key\n(`\"a\"`, `\"b\"`) for the table shape. Ignored when that task configures a\nsingle plain prompt.\n\n`\"raw\"` (case-insensitive) is reserved: it skips the composer LLM\nentirely, saving one LLM call.\n\nAn unknown index/key falls back to the engine's built-in composer\nprompt — it is never an error."
+            "description": "Which `[tasks.chat_image_prompt_compose].filter_prompt` variant to use\nfor this turn: an index (`\"0\"`, `\"1\"`) for the array shape, or a key\n(`\"a\"`, `\"b\"`) for the table shape. Ignored when that task configures a\nsingle plain prompt.\n\n`\"raw\"` carries no special meaning — it selects a prompt only if a\ndeployment actually configures one under that key.\n\nAn unknown index/key falls back to the engine's built-in composer\nprompt — it is never an error."
           },
           "style": {
             "type": [

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -110,19 +110,25 @@ pub(crate) fn effective_user_text(msg: &eros_engine_store::chat::ChatMessage) ->
 }
 
 /// Model-facing text for an assistant history row: the stored `content`, with a
-/// `[你给对方发送了一张照片：{prompt}]` marker appended when `metadata.image.prompt`
-/// is present. Used by `assemble_chat_request` so the model knows it previously
+/// `[你给对方发送了一张照片：{caption}]` marker appended when `metadata.image` is
+/// present. Used by `assemble_chat_request` so the model knows it previously
 /// sent an image in that turn.
 pub(crate) fn model_facing_assistant_text(msg: eros_engine_store::chat::ChatMessage) -> String {
     let mut text = msg.content;
-    if let Some(prompt) = msg
-        .metadata
-        .as_ref()
-        .and_then(|md| md.get("image"))
-        .and_then(|img| img.get("prompt"))
-        .and_then(|p| p.as_str())
-    {
-        let marker = format!("[你给对方发送了一张照片：{prompt}]");
+    if let Some(img) = msg.metadata.as_ref().and_then(|md| md.get("image")) {
+        let caption = img
+            .get("caption")
+            .and_then(|p| p.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty());
+        // Caption, never `prompt`: the prompt is the image-generation string
+        // (style boilerplate + appearance + subject) and injecting it here put
+        // long English prompt text into a Chinese roleplay history, which
+        // models then echoed. No caption ⇒ bare marker, no fallback.
+        let marker = match caption {
+            Some(c) => format!("[你给对方发送了一张照片：{c}]"),
+            None => "[你给对方发送了一张照片]".to_string(),
+        };
         if text.trim().is_empty() {
             text = marker;
         } else {
@@ -1967,26 +1973,32 @@ mod tests {
     }
 
     #[test]
-    fn assistant_row_with_image_prompt_appends_marker() {
+    fn assistant_row_with_image_caption_appends_marker() {
         let row = assistant_row(
             "这是我的回复",
-            Some(serde_json::json!({ "image": { "prompt": "smiling in a cafe" } })),
+            Some(serde_json::json!({ "image": {
+                "prompt": "Photorealistic, ultra-detailed, smiling in a cafe",
+                "caption": "在咖啡店笑着"
+            }})),
         );
         let out = model_facing_assistant_text(row);
         assert!(out.contains("这是我的回复"));
-        assert!(out.contains("[你给对方发送了一张照片：smiling in a cafe]"));
-        // marker is appended after two newlines
-        assert!(out.contains("这是我的回复\n\n[你给对方发送了一张照片：smiling in a cafe]"));
+        assert!(out.contains("[你给对方发送了一张照片：在咖啡店笑着]"));
+        assert!(
+            !out.contains("Photorealistic"),
+            "the image prompt must never reach the chat model's history: {out}"
+        );
+        assert!(out.contains("这是我的回复\n\n[你给对方发送了一张照片：在咖啡店笑着]"));
     }
 
     #[test]
-    fn assistant_row_empty_content_with_image_prompt_uses_marker_only() {
+    fn assistant_row_without_caption_uses_bare_marker() {
         let row = assistant_row(
             "",
-            Some(serde_json::json!({ "image": { "prompt": "sunset on the beach" } })),
+            Some(serde_json::json!({ "image": { "prompt": "a long english image prompt" } })),
         );
         let out = model_facing_assistant_text(row);
-        assert_eq!(out, "[你给对方发送了一张照片：sunset on the beach]");
+        assert_eq!(out, "[你给对方发送了一张照片]");
     }
 
     #[test]
@@ -1995,13 +2007,21 @@ mod tests {
         assert_eq!(model_facing_assistant_text(row), "普通回复");
     }
 
+    /// Even when `image` carries neither `prompt` nor `caption` (e.g. an older
+    /// row shape, or a `url`-only marker), the mere presence of the `image`
+    /// key means a picture was sent — the bare marker still appends. This
+    /// mirrors `assistant_transcript_line`'s guard (keyed on `image` presence,
+    /// not on any particular field inside it).
     #[test]
-    fn assistant_row_image_metadata_without_prompt_unchanged() {
+    fn assistant_row_image_metadata_without_caption_or_prompt_appends_bare_marker() {
         let row = assistant_row(
             "普通回复",
             Some(serde_json::json!({ "image": { "url": "https://x/y.png" } })),
         );
-        assert_eq!(model_facing_assistant_text(row), "普通回复");
+        assert_eq!(
+            model_facing_assistant_text(row),
+            "普通回复\n\n[你给对方发送了一张照片]"
+        );
     }
 
     /// End-to-end check of the cutoff semantics that `fetch_recent_turn_pairs`

--- a/crates/eros-engine-server/src/pipeline/post_process.rs
+++ b/crates/eros-engine-server/src/pipeline/post_process.rs
@@ -102,19 +102,19 @@ pub async fn run(
             .collect::<Vec<_>>()
             .join("\n");
 
-        // For reply_image the assistant text is empty; use the plan's image_prompt
-        // as the assistant-content proxy so the photo-send still moves affinity.
-        // Subjectless image turns (blank image_prompt) fall back to a generic
+        // For reply_image the assistant text is empty; use the picture's
+        // caption as the assistant-content proxy so the photo-send still
+        // moves affinity. Captionless image turns fall back to a generic
         // photo marker so they are still evaluated rather than tripping the
         // `empty_assistant` gate.
         let eval_text = affinity_eval_text(
             plan.action_type,
             &assistant_msg,
-            plan.image_prompt.as_deref(),
+            plan.image_caption.as_deref(),
         );
 
         // Semantic eval gate: Reply turns only, with a non-trivial user message
-        // and a non-empty produced assistant message (or image_prompt proxy for
+        // and a non-empty produced assistant message (or image_caption proxy for
         // reply_image). Other actions (Proactive / Ghost) keep rule-only deltas
         // in v1. `pre_skip == None` ⇒ the gate passes and an eval call is
         // attempted; otherwise it carries the reason the trio will be NULL
@@ -515,25 +515,28 @@ const AFFINITY_EVAL_MIN_CHARS: usize = 4;
 /// rule-only deltas (the spec §4.5 "timeout → default" path).
 const AFFINITY_EVAL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
-/// The companion-reply text the affinity evaluator scores. Non-empty produced
-/// text wins. For an image turn with no produced text, use the judge's subject
-/// (`image_prompt`); if that is also blank, use a generic photo marker so a
-/// subjectless generated image is still evaluated rather than tripping the
-/// `empty_assistant` gate. Non-image turns with empty text yield "" (still skip).
+/// The text the affinity evaluator scores as "what the assistant said".
+///
+/// Image turns carry no assistant text, so the picture's caption stands in —
+/// otherwise a photo-send would trip the `empty_assistant` gate and never move
+/// affinity. A caption is a short natural-language line in the conversation's
+/// language, which is exactly the register the first-person evaluator reads.
+/// Captionless image turns (legacy rows, `raw` variant, failed compose) fall
+/// back to a generic photo marker so they are still evaluated.
 fn affinity_eval_text(
     action: ActionType,
     assistant_msg: &str,
-    image_prompt: Option<&str>,
+    image_caption: Option<&str>,
 ) -> String {
     if !assistant_msg.trim().is_empty() {
         return assistant_msg.to_string();
     }
     if matches!(action, ActionType::ReplyImage | ActionType::ReplyTextImage) {
-        let subject = image_prompt.map(str::trim).unwrap_or("");
-        if subject.is_empty() {
+        let caption = image_caption.map(str::trim).unwrap_or("");
+        if caption.is_empty() {
             return "[发送了一张照片]".to_string(); // consistent with the engine's Chinese image markers
         }
-        return subject.to_string();
+        return caption.to_string();
     }
     String::new()
 }
@@ -576,8 +579,9 @@ fn eval_skip_reason(
         // called. Exhaustiveness only.
         ActionType::ProductQa => Some("product_qa"),
         // Image variants route through the same gate as ReplyText. For reply_image
-        // the caller passes `image_prompt` as the assistant-content proxy so an
-        // image-send still moves affinity (assistant_empty=false when prompt is set).
+        // the caller passes `image_caption` as the assistant-content proxy so an
+        // image-send still moves affinity (assistant_empty=false when the caption
+        // is set — and the generic photo marker keeps it false even when it isn't).
         ActionType::ReplyText | ActionType::ReplyImage | ActionType::ReplyTextImage => {
             if user_msg_chars < AFFINITY_EVAL_MIN_CHARS {
                 Some("short_user_msg")
@@ -1348,7 +1352,7 @@ mod tests {
             None
         );
         // reply_image with empty assistant text but the caller supplies a non-empty
-        // proxy (assistant_empty=false because image_prompt is used) → not skipped
+        // proxy (assistant_empty=false because image_caption is used) → not skipped
         assert_eq!(eval_skip_reason(ActionType::ReplyImage, 10, false), None);
         // image reply with empty proxy → empty_assistant
         assert_eq!(
@@ -1372,27 +1376,28 @@ mod tests {
     }
 
     #[test]
-    fn affinity_eval_text_prefers_text_then_subject_then_marker() {
-        // produced text always wins
+    fn affinity_eval_text_prefers_text_then_caption_then_marker() {
+        // assistant text wins whenever present
         assert_eq!(
-            affinity_eval_text(ActionType::ReplyTextImage, "hi there", Some("a cat")),
-            "hi there"
+            affinity_eval_text(ActionType::ReplyTextImage, "我在这儿", Some("在天台")),
+            "我在这儿"
         );
-        // image turn, no text, with subject → subject
+        // image turn with no text: the caption is the proxy
         assert_eq!(
-            affinity_eval_text(ActionType::ReplyImage, "", Some("a selfie")),
-            "a selfie"
+            affinity_eval_text(ActionType::ReplyImage, "", Some("在天台看夕阳")),
+            "在天台看夕阳"
         );
-        // image turn, no text, no subject → generic marker (still evaluated)
+        // image turn with no text and no caption: generic marker, so the turn
+        // is still evaluated rather than tripping the empty_assistant gate
         assert_eq!(
             affinity_eval_text(ActionType::ReplyImage, "", None),
             "[发送了一张照片]"
         );
         assert_eq!(
-            affinity_eval_text(ActionType::ReplyImage, "", Some("  ")),
+            affinity_eval_text(ActionType::ReplyImage, "", Some("   ")),
             "[发送了一张照片]"
         );
-        // non-image empty text → empty (genuine empty reply still skips)
+        // non-image action with no text stays empty
         assert_eq!(affinity_eval_text(ActionType::ReplyText, "", None), "");
     }
 
@@ -1873,7 +1878,7 @@ mod tests {
             energy_cost: 0.0,
             context_hints: Vec::new(),
             reply_tone: None,
-            image_prompt: None,
+            image_caption: None,
             image_ref: eros_engine_core::types::ImageRef::Face,
             aspect_ratio: None,
         };

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -2619,9 +2619,20 @@ struct DelegatedImagePrompt {
 struct AbortOnDrop<T>(Option<tokio::task::JoinHandle<T>>);
 
 impl<T> AbortOnDrop<T> {
-    /// Take the handle to await it. Once taken, the guard no longer aborts.
-    fn take(&mut self) -> Option<tokio::task::JoinHandle<T>> {
-        self.0.take()
+    /// Await the guarded task WITHOUT releasing the guard. `JoinHandle` is
+    /// `Unpin`, so a `&mut` await works — and because the handle never leaves
+    /// the guard, a caller dropped mid-await (client disconnect at exactly the
+    /// join point) still aborts the in-flight task. Taking the handle out
+    /// first would open that window: between `take()` and the await's
+    /// completion, a drop would detach the raw `JoinHandle` and the task would
+    /// run on with no consumer. After a completed await the handle stays put;
+    /// aborting a finished task is a no-op, so the drop-time abort is
+    /// harmless.
+    async fn join(&mut self) -> Option<Result<T, tokio::task::JoinError>> {
+        match self.0.as_mut() {
+            Some(h) => Some(h.await),
+            None => None,
+        }
     }
 }
 
@@ -3898,24 +3909,24 @@ pub fn run_stream(
                         let img_mid = ulid_string(Ulid::from(msg_uuid));
                         // The composer was spawned before the chat call; by now
                         // it has almost always finished, so this await is ~free.
-                        // A panicked or cancelled task degrades exactly like a
+                        // Awaited THROUGH the guard so a client disconnect at
+                        // this exact point still aborts the in-flight call. A
+                        // panicked or cancelled task degrades exactly like a
                         // failed compose — never a dropped frame.
-                        let img = match compose_handle.take() {
-                            Some(h) => match h.await {
-                                Ok(v) => v,
-                                Err(e) => {
-                                    tracing::warn!("image-compose task failed: {e}");
-                                    build_delegated_image_prompt(
-                                        &state,
-                                        &input.persona,
-                                        &plan,
-                                        req_image,
-                                        &pde_transcript.transcript,
-                                        &effective_user_msg,
-                                    )
-                                    .await
-                                }
-                            },
+                        let img = match compose_handle.join().await {
+                            Some(Ok(v)) => v,
+                            Some(Err(e)) => {
+                                tracing::warn!("image-compose task failed: {e}");
+                                build_delegated_image_prompt(
+                                    &state,
+                                    &input.persona,
+                                    &plan,
+                                    req_image,
+                                    &pde_transcript.transcript,
+                                    &effective_user_msg,
+                                )
+                                .await
+                            }
                             None => {
                                 build_delegated_image_prompt(
                                     &state,
@@ -6948,7 +6959,7 @@ data: [DONE]\n\n";
     /// at the end of the burst is trivially satisfied and proves nothing about
     /// ordering under a REAL in-flight call. This test configures the composer
     /// AND gives its mocked response a delay that outlasts the (instant, mocked)
-    /// chat burst, so the join at `compose_handle.take().unwrap().await`
+    /// chat burst, so the join at `compose_handle.join().await`
     /// genuinely waits on a still-running task — the actual race the concurrent
     /// spawn in `run_stream` is meant to survive. Asserts the wire frame order
     /// still holds (`meta → delta* → done → image_request → final`) and that

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -158,22 +158,27 @@ fn build_image_request_frame(
     }
 }
 
-/// `metadata.image` marker for a delegated image turn. Always stores the PDE
-/// seed subject (under `prompt`, the key `assistant_transcript_line` reads)
-/// and the aspect ratio; when the composer LLM call SUCCEEDED it also stores
-/// the audit trio `compose_variant` / `compose_model` / `compose_generation_id`
-/// (spec 2026-08-02; absence = no successful compose this turn — raw skip,
+/// `metadata.image` marker for a delegated image turn. Always stores the
+/// composer's subject (under `prompt`, the key `assistant_transcript_line`
+/// reads) and the aspect ratio; stores `caption` when the composer produced
+/// one; when the composer LLM call SUCCEEDED it also stores the audit trio
+/// `compose_variant` / `compose_model` / `compose_generation_id` (spec
+/// 2026-08-02; absence = no successful compose this turn — raw skip,
 /// fail-open, or task not configured). Deliberately NOT stored: the composed
 /// wire prompt (the consumer's job), url, or success/failure of the draw.
 /// Pure.
 fn build_delegated_image_marker(
-    seed_subject: &str,
+    subject: &str,
+    caption: Option<&str>,
     aspect_ratio: Option<&str>,
     compose_variant: Option<&str>,
     compose_model: Option<&str>,
     compose_generation_id: Option<&str>,
 ) -> serde_json::Value {
-    let mut m = serde_json::json!({ "prompt": seed_subject });
+    let mut m = serde_json::json!({ "prompt": subject });
+    if let Some(c) = caption.filter(|s| !s.trim().is_empty()) {
+        m["caption"] = serde_json::Value::String(c.to_string());
+    }
     if let Some(ar) = aspect_ratio.filter(|s| !s.is_empty()) {
         m["aspect_ratio"] = serde_json::Value::String(ar.to_string());
     }
@@ -2352,26 +2357,64 @@ async fn run_input_filter(
     None // chain exhausted → keep
 }
 
-/// Assemble the composer's user message from the appearance, recent scene, seed
-/// subject, style, and aspect ratio. Pure (kept separate so it is testable
-/// without a network call).
+/// Assemble the composer's user message from the appearance, recent scene,
+/// latest user message, seed subject, style, and aspect ratio. Pure (kept
+/// separate so it is testable without a network call).
 fn compose_user_payload(
     appearance: &str,
     recent_scene: &str,
+    latest_user_msg: &str,
     seed_subject: &str,
     style: &str,
     aspect_ratio: &str,
 ) -> String {
     format!(
-        "[人物外观]\n{appearance}\n\n[最近场景]\n{recent_scene}\n\n[画面主题种子]\n{seed_subject}\n\n[风格]\n{style}\n\n[画幅]\n{aspect_ratio}"
+        "[人物外观]\n{appearance}\n\n[最近场景]\n{recent_scene}\n\n[对方最新消息]\n{latest_user_msg}\n\n[画面主题种子]\n{seed_subject}\n\n[风格]\n{style}\n\n[画幅]\n{aspect_ratio}"
     )
 }
 
-/// A SUCCESSFUL composer call's result: the enriched subject plus the audit
-/// values persisted to `metadata.image` (spec 2026-08-02). Mirrors
-/// `VisionOutcome`.
+/// The composer's JSON contract.
+#[derive(serde::Deserialize)]
+struct ComposeReply {
+    prompt: String,
+    #[serde(default)]
+    caption: Option<String>,
+}
+
+/// Parse a composer reply into `(prompt, caption)`.
+///
+/// Direct JSON first, then a balanced JSON block in prose (same ladder as
+/// `parse_pde_verdict`). **A reply that is neither becomes the prompt with no
+/// caption** — deliberate, and load-bearing for migration: a deployment that
+/// ships this version without rewriting its EXPAND-era composer `filter_prompt`
+/// still gets working images (degraded, since that prompt aims at a seed that
+/// is now usually empty), just bare markers until the prompt is updated.
+///
+/// A blank caption is normalised to `None`; callers must not persist `""`.
+fn parse_compose_reply(raw: &str) -> (String, Option<String>) {
+    let parsed = serde_json::from_str::<ComposeReply>(raw).ok().or_else(|| {
+        super::find_json_block(raw).and_then(|b| serde_json::from_str::<ComposeReply>(b).ok())
+    });
+    match parsed {
+        Some(r) => {
+            let caption = r
+                .caption
+                .map(|c| c.trim().to_string())
+                .filter(|c| !c.is_empty());
+            (r.prompt.trim().to_string(), caption)
+        }
+        None => (raw.trim().to_string(), None),
+    }
+}
+
+/// A SUCCESSFUL composer call's result: the picture subject, the short caption
+/// for history-facing renders, plus the audit values persisted to
+/// `metadata.image` (spec 2026-08-02). Mirrors `VisionOutcome`.
 struct ComposeOutcome {
-    text: String,
+    prompt: String,
+    /// One short line describing what the picture shows, for the chat history
+    /// and the judge transcript. `None` when the model gave none.
+    caption: Option<String>,
     /// Model that actually answered: `resp.model`, falling back to the
     /// attempted model id (same idiom as the vision audit).
     model: String,
@@ -2381,17 +2424,19 @@ struct ComposeOutcome {
     variant: Option<String>,
 }
 
-/// Enrich the image subject via the optional composer LLM. Walks
-/// `[model] + fallback` on transport failure (error/timeout/empty); returns the
-/// trimmed enriched subject plus the audit trio on first success, or `None`
-/// (caller falls back to the seed). Never blocks or fails the image turn.
-/// Mirrors `run_input_filter`.
+/// Generate the image prompt (and its caption) via the optional composer LLM.
+/// Walks `[model] + fallback` on transport failure (error/timeout/empty);
+/// returns the parsed prompt/caption plus the audit trio on first success, or
+/// `None` (caller falls back to the seed). Never blocks or fails the image
+/// turn. Mirrors `run_input_filter`.
+#[allow(clippy::too_many_arguments)]
 async fn run_image_prompt_compose(
     state: &AppState,
     c: &eros_engine_llm::model_config::ResolvedImagePromptCompose,
     persona: &eros_engine_core::persona::CompanionPersona,
     seed_subject: &str,
     recent_scene: &str,
+    latest_user_msg: &str,
     aspect_ratio: Option<&str>,
     style: &str,
 ) -> Option<ComposeOutcome> {
@@ -2405,8 +2450,13 @@ async fn run_image_prompt_compose(
     } else {
         recent_scene
     };
+    let latest = if latest_user_msg.trim().is_empty() {
+        "（无）"
+    } else {
+        latest_user_msg
+    };
     let ar = aspect_ratio.unwrap_or("（未指定）");
-    let user_payload = compose_user_payload(appearance, scene, seed_subject, style, ar);
+    let user_payload = compose_user_payload(appearance, scene, latest, seed_subject, style, ar);
     let chain: Vec<String> = std::iter::once(c.model.clone())
         .chain(c.fallback_model.iter().cloned())
         .collect();
@@ -2447,8 +2497,14 @@ async fn run_image_prompt_compose(
             tracing::warn!(model = %model_id, "image-compose: empty reply; next");
             continue;
         }
+        let (prompt, caption) = parse_compose_reply(&text);
+        if prompt.is_empty() {
+            tracing::warn!(model = %model_id, "image-compose: empty prompt after parse; next");
+            continue;
+        }
         return Some(ComposeOutcome {
-            text,
+            prompt,
+            caption,
             model: resp.model.unwrap_or_else(|| model_id.clone()),
             generation_id: resp.generation_id,
             variant: c.variant_key.clone(),
@@ -2510,8 +2566,15 @@ fn resolve_image_turn_inputs(
 /// absent: it is consumed internally by `compose_image_prompt` and neither
 /// caller uses it afterwards.
 struct DelegatedImagePrompt {
-    /// Seed subject — feeds `build_delegated_image_marker`.
+    /// Seed subject — feeds `build_delegated_image_marker`'s `prompt` key. This
+    /// is deliberately the SEED, not the composer's enriched/generated text
+    /// (that lives only in `composed_prompt`, on the wire): keeps the
+    /// persisted marker compact regardless of composer outcome.
     seed_subject: String,
+    /// Short description of the picture, persisted as `metadata.image.caption`
+    /// and read by every history-facing render. `None` on a failed compose or
+    /// when the task is not configured.
+    caption: Option<String>,
     /// Effective aspect ratio — feeds the marker and the wire frame.
     aspect_ratio: Option<String>,
     /// Final wire prompt — feeds the wire frame.
@@ -2535,6 +2598,7 @@ async fn build_delegated_image_prompt(
     plan: &eros_engine_core::types::ActionPlan,
     req_image: Option<&crate::routes::companion_stream::ImageReplyParams>,
     pde_transcript: &str,
+    latest_user_msg: &str,
 ) -> DelegatedImagePrompt {
     let inputs = resolve_image_turn_inputs(plan, req_image);
     let style_str = serde_json::to_value(inputs.style)
@@ -2550,6 +2614,7 @@ async fn build_delegated_image_prompt(
                 persona,
                 &inputs.seed_subject,
                 pde_transcript,
+                latest_user_msg,
                 inputs.aspect_ratio.as_deref(),
                 &style_str,
             )
@@ -2557,14 +2622,22 @@ async fn build_delegated_image_prompt(
         }
         None => None,
     };
-    let (final_subject, compose_variant, compose_model, compose_generation_id) = match compose {
-        Some(o) => (o.text, o.variant, Some(o.model), o.generation_id),
-        None => (inputs.seed_subject.clone(), None, None, None),
-    };
+    let (final_subject, caption, compose_variant, compose_model, compose_generation_id) =
+        match compose {
+            Some(o) => (
+                o.prompt,
+                o.caption,
+                o.variant,
+                Some(o.model),
+                o.generation_id,
+            ),
+            None => (inputs.seed_subject.clone(), None, None, None, None),
+        };
     let composed_prompt =
         crate::pipeline::handlers::compose_image_prompt(inputs.style, persona, &final_subject);
     DelegatedImagePrompt {
         seed_subject: inputs.seed_subject,
+        caption,
         aspect_ratio: inputs.aspect_ratio,
         composed_prompt,
         compose_variant,
@@ -3358,17 +3431,19 @@ pub fn run_stream(
                         &plan,
                         req_image,
                         &pde_transcript.transcript,
+                        &user_msg.content,
                     )
                     .await;
                     let subject = img.seed_subject;
                     let aspect = img.aspect_ratio;
                     let composed_prompt = img.composed_prompt;
-                    // Persist the marker (seed subject + aspect + compose
+                    // Persist the marker (subject + caption + aspect + compose
                     // audit trio on success) so the PDE stays image-aware
                     // (§5); the composed prompt and the draw result live with
                     // the consumer.
                     let marker = build_delegated_image_marker(
                         &subject,
+                        img.caption.as_deref(),
                         aspect.as_deref(),
                         img.compose_variant.as_deref(),
                         img.compose_model.as_deref(),
@@ -3686,17 +3761,19 @@ pub fn run_stream(
                             &plan,
                             req_image,
                             &pde_transcript.transcript,
+                            &user_msg.content,
                         )
                         .await;
                         let subject = img.seed_subject;
                         let aspect = img.aspect_ratio;
                         let composed_prompt = img.composed_prompt;
-                        // Merge the marker (seed subject + aspect + compose
+                        // Merge the marker (subject + caption + aspect + compose
                         // audit trio on success) onto the already-persisted
                         // text row so the PDE stays image-aware (§5). The text
                         // already reached the client; `final` follows below.
                         let marker = build_delegated_image_marker(
                             &subject,
+                            img.caption.as_deref(),
                             aspect.as_deref(),
                             img.compose_variant.as_deref(),
                             img.compose_model.as_deref(),
@@ -4022,6 +4099,7 @@ mod tests {
         let p = compose_user_payload(
             "freckled, red hair",
             "（无）",
+            "（无）",
             "on a rooftop",
             "realistic",
             "9:16",
@@ -4031,6 +4109,77 @@ mod tests {
         assert!(p.contains("on a rooftop"));
         assert!(p.contains("realistic"));
         assert!(p.contains("9:16"));
+    }
+
+    #[test]
+    fn compose_user_payload_includes_latest_user_message() {
+        let p = compose_user_payload(
+            "freckled, red hair",
+            "（无）",
+            "给我看看你现在的样子",
+            "on a rooftop",
+            "realistic",
+            "9:16",
+        );
+        assert!(p.contains("[对方最新消息]\n给我看看你现在的样子"), "{p}");
+        assert!(p.contains("[画面主题种子]\non a rooftop"), "{p}");
+    }
+
+    #[test]
+    fn parse_compose_reply_reads_direct_json() {
+        let (p, c) =
+            parse_compose_reply(r#"{"prompt":"on a rooftop at dusk","caption":"在天台看夕阳"}"#);
+        assert_eq!(p, "on a rooftop at dusk");
+        assert_eq!(c.as_deref(), Some("在天台看夕阳"));
+    }
+
+    #[test]
+    fn parse_compose_reply_salvages_json_in_prose() {
+        let raw = "Sure! Here you go:\n{\"prompt\":\"a selfie in a cafe\",\"caption\":\"咖啡店自拍\"}\nHope that helps.";
+        let (p, c) = parse_compose_reply(raw);
+        assert_eq!(p, "a selfie in a cafe");
+        assert_eq!(c.as_deref(), Some("咖啡店自拍"));
+    }
+
+    #[test]
+    fn parse_compose_reply_plain_text_becomes_prompt_with_no_caption() {
+        // Migration fallback: an EXPAND-era composer prompt still yields a
+        // working image prompt, just no caption.
+        let (p, c) = parse_compose_reply("  a windswept portrait on the cliffs  ");
+        assert_eq!(p, "a windswept portrait on the cliffs");
+        assert_eq!(c, None);
+    }
+
+    #[test]
+    fn parse_compose_reply_blank_caption_is_none() {
+        let (p, c) = parse_compose_reply(r#"{"prompt":"x","caption":"   "}"#);
+        assert_eq!(p, "x");
+        assert_eq!(c, None, "a blank caption is absent, not empty-string");
+    }
+
+    #[test]
+    fn delegated_image_marker_carries_caption_when_present() {
+        let m = build_delegated_image_marker(
+            "on a rooftop",
+            Some("在天台"),
+            Some("3:4"),
+            None,
+            None,
+            None,
+        );
+        assert_eq!(m["prompt"], "on a rooftop");
+        assert_eq!(m["caption"], "在天台");
+        assert_eq!(m["aspect_ratio"], "3:4");
+    }
+
+    #[test]
+    fn delegated_image_marker_omits_absent_caption() {
+        let m = build_delegated_image_marker("on a rooftop", None, None, None, None, None);
+        assert_eq!(m["prompt"], "on a rooftop");
+        assert!(
+            m.get("caption").is_none(),
+            "absent caption must not be written: {m}"
+        );
     }
 
     // ─── resolve_image_turn_inputs ───────────────────────────────────────
@@ -12090,9 +12239,11 @@ data: [DONE]\n\n"
 
     #[test]
     fn delegated_marker_preserves_image_awareness() {
-        // Seed subject under `prompt` (the key assistant_transcript_line reads),
-        // plus aspect — and NOTHING else (no composed prompt / model / gen id).
-        let marker = build_delegated_image_marker("beach at sunset", Some("3:4"), None, None, None);
+        // Subject under `prompt` (the key assistant_transcript_line reads),
+        // plus aspect — and NOTHING else (no caption / composed prompt / model
+        // / gen id).
+        let marker =
+            build_delegated_image_marker("beach at sunset", None, Some("3:4"), None, None, None);
         assert_eq!(marker["prompt"], "beach at sunset");
         assert_eq!(marker["aspect_ratio"], "3:4");
         assert_eq!(
@@ -12108,7 +12259,7 @@ data: [DONE]\n\n"
         assert_ne!(line.trim(), "", "image turn must not be a blank line");
 
         // No aspect => still a valid one-key marker that annotates.
-        let m2 = build_delegated_image_marker("a portrait", None, None, None, None);
+        let m2 = build_delegated_image_marker("a portrait", None, None, None, None, None);
         assert_eq!(m2.as_object().unwrap().len(), 1);
         let w2 = serde_json::json!({ "image": m2 });
         assert!(assistant_transcript_line("", Some(&w2)).contains("a portrait"));
@@ -12120,6 +12271,7 @@ data: [DONE]\n\n"
     fn delegated_marker_carries_compose_audit_when_present() {
         let m = build_delegated_image_marker(
             "beach at sunset",
+            None,
             Some("3:4"),
             Some("b"),
             Some("served/model"),
@@ -12133,8 +12285,14 @@ data: [DONE]\n\n"
         assert_eq!(m.as_object().unwrap().len(), 5);
 
         // No generation id from the provider → key absent, not null.
-        let m2 =
-            build_delegated_image_marker("beach at sunset", None, None, Some("served/model"), None);
+        let m2 = build_delegated_image_marker(
+            "beach at sunset",
+            None,
+            None,
+            None,
+            Some("served/model"),
+            None,
+        );
         assert_eq!(m2["compose_model"], "served/model");
         assert!(m2
             .as_object()

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -3607,6 +3607,14 @@ pub fn run_stream(
                 // Skip tipped turns too: a tip persists as role='gift_user' whose
                 // "(打赏 $X)" marker / typed message should reach the model as-is,
                 // not be rewritten by the filter — running it would waste the call.
+                //
+                // The text the model will actually see this turn. The input
+                // filter persists its rewrite and `build_reply_request` re-reads
+                // it from the DB; the composer runs concurrently and must not
+                // pay a second read, so track it locally. Keeping the composer
+                // on the SAME text as the chat model is what stops the picture
+                // drifting from the reply.
+                let mut effective_user_msg = user_msg.content.clone();
                 if user_msg.tips_amount_usd.is_none() {
                     // Per-turn probability gate: `input_filter = 0.8` ⇒ fire on
                     // ~80% of turns; `true` ⇒ probability 1.0 ⇒ always (gen::<f64>()
@@ -3636,6 +3644,7 @@ pub fn run_stream(
                         if let Some(rw) =
                             run_input_filter(&state, &f, &transcript, &user_msg.content).await
                         {
+                            effective_user_msg = rw.rewritten_text.clone();
                             if let Err(e) = chat_repo
                                 .set_user_input_rewrite(
                                     user_msg.user_message_id,
@@ -3651,6 +3660,38 @@ pub fn run_stream(
                         }
                     }
                 }
+                // ── Concurrent image composition (reply_text_image only) ──────
+                // Fired here, after the input filter (so the composer sees the
+                // same text as the chat model) and before build_reply_request —
+                // which alone does a 20-row history fetch, an embedding call and
+                // memory/world recall before the chat stream even starts. One
+                // short composer call hides completely underneath, taking the
+                // turn's serial LLM hops from 3 to 2.
+                //
+                // `reply_image` is deliberately excluded: it has no text task to
+                // overlap with and returns early via `image_only_done`.
+                let compose_handle: Option<tokio::task::JoinHandle<DelegatedImagePrompt>> =
+                    if matches!(plan.action_type, ActionType::ReplyTextImage) {
+                        let state_c = (*state).clone();
+                        let persona_c = input.persona.clone();
+                        let plan_c = plan.clone();
+                        let req_image_c = req_image.cloned();
+                        let scene_c = pde_transcript.transcript.clone();
+                        let latest_c = effective_user_msg.clone();
+                        Some(tokio::spawn(async move {
+                            build_delegated_image_prompt(
+                                &state_c,
+                                &persona_c,
+                                &plan_c,
+                                req_image_c.as_ref(),
+                                &scene_c,
+                                &latest_c,
+                            )
+                            .await
+                        }))
+                    } else {
+                        None
+                    };
                 let req_res = crate::pipeline::handlers::build_reply_request(
                     &state, &input, &plan,
                     user_msg.session_id, user_msg.user_id, user_msg.instance_id,
@@ -3659,6 +3700,9 @@ pub fn run_stream(
                 let (req, injected_tags) = match req_res {
                     Ok(r) => r,
                     Err(e) => {
+                        if let Some(h) = compose_handle.as_ref() {
+                            h.abort();
+                        }
                         yield ProtocolFrame::Error {
                             code: StreamErrorCode::Internal,
                             retryable: false,
@@ -3775,15 +3819,38 @@ pub fn run_stream(
                     if let Some(last) = produced.last() {
                         let msg_uuid = last.message_id;
                         let img_mid = ulid_string(Ulid::from(msg_uuid));
-                        let img = build_delegated_image_prompt(
-                            &state,
-                            &input.persona,
-                            &plan,
-                            req_image,
-                            &pde_transcript.transcript,
-                            &user_msg.content,
-                        )
-                        .await;
+                        // The composer was spawned before the chat call; by now
+                        // it has almost always finished, so this await is ~free.
+                        // A panicked or cancelled task degrades exactly like a
+                        // failed compose — never a dropped frame.
+                        let img = match compose_handle {
+                            Some(h) => match h.await {
+                                Ok(v) => v,
+                                Err(e) => {
+                                    tracing::warn!("image-compose task failed: {e}");
+                                    build_delegated_image_prompt(
+                                        &state,
+                                        &input.persona,
+                                        &plan,
+                                        req_image,
+                                        &pde_transcript.transcript,
+                                        &effective_user_msg,
+                                    )
+                                    .await
+                                }
+                            },
+                            None => {
+                                build_delegated_image_prompt(
+                                    &state,
+                                    &input.persona,
+                                    &plan,
+                                    req_image,
+                                    &pde_transcript.transcript,
+                                    &effective_user_msg,
+                                )
+                                .await
+                            }
+                        };
                         let subject = img.subject;
                         let aspect = img.aspect_ratio;
                         let composed_prompt = img.composed_prompt;

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -2360,18 +2360,17 @@ async fn run_input_filter(
 }
 
 /// Assemble the composer's user message from the appearance, recent scene,
-/// latest user message, seed subject, style, and aspect ratio. Pure (kept
-/// separate so it is testable without a network call).
+/// latest user message, style, and aspect ratio. Pure (kept separate so it is
+/// testable without a network call).
 fn compose_user_payload(
     appearance: &str,
     recent_scene: &str,
     latest_user_msg: &str,
-    seed_subject: &str,
     style: &str,
     aspect_ratio: &str,
 ) -> String {
     format!(
-        "[人物外观]\n{appearance}\n\n[最近场景]\n{recent_scene}\n\n[对方最新消息]\n{latest_user_msg}\n\n[画面主题种子]\n{seed_subject}\n\n[风格]\n{style}\n\n[画幅]\n{aspect_ratio}"
+        "[人物外观]\n{appearance}\n\n[最近场景]\n{recent_scene}\n\n[对方最新消息]\n{latest_user_msg}\n\n[风格]\n{style}\n\n[画幅]\n{aspect_ratio}"
     )
 }
 
@@ -2429,14 +2428,12 @@ struct ComposeOutcome {
 /// Generate the image prompt (and its caption) via the optional composer LLM.
 /// Walks `[model] + fallback` on transport failure (error/timeout/empty);
 /// returns the parsed prompt/caption plus the audit trio on first success, or
-/// `None` (caller falls back to the seed). Never blocks or fails the image
-/// turn. Mirrors `run_input_filter`.
-#[allow(clippy::too_many_arguments)]
+/// `None` (caller falls back to an empty subject — the portrait path). Never
+/// blocks or fails the image turn. Mirrors `run_input_filter`.
 async fn run_image_prompt_compose(
     state: &AppState,
     c: &eros_engine_llm::model_config::ResolvedImagePromptCompose,
     persona: &eros_engine_core::persona::CompanionPersona,
-    seed_subject: &str,
     recent_scene: &str,
     latest_user_msg: &str,
     aspect_ratio: Option<&str>,
@@ -2458,7 +2455,7 @@ async fn run_image_prompt_compose(
         latest_user_msg
     };
     let ar = aspect_ratio.unwrap_or("（未指定）");
-    let user_payload = compose_user_payload(appearance, scene, latest, seed_subject, style, ar);
+    let user_payload = compose_user_payload(appearance, scene, latest, style, ar);
     let chain: Vec<String> = std::iter::once(c.model.clone())
         .chain(c.fallback_model.iter().cloned())
         .collect();
@@ -2515,18 +2512,22 @@ async fn run_image_prompt_compose(
     None
 }
 
-/// The three per-turn image inputs, resolved from plan → request.
+/// The two per-turn image inputs, resolved from plan → request. There is no
+/// subject field: the composer decides what the picture shows from turn
+/// context alone.
 struct ImageTurnInputs {
-    seed_subject: String,
     style: eros_engine_llm::model_config::StyleKey,
     aspect_ratio: Option<String>,
 }
 
-/// Pure: resolve the seed subject, style, and aspect ratio for a delegated
-/// image turn. Precedence per field:
-/// - subject: `req_image.image_prompt` → `""` (the judge no longer writes one)
-/// - style:   `req_image.style` → type default (`Realistic`)
-/// - aspect:  `plan.aspect_ratio` → `req_image.aspect_ratio` → `None`
+/// Pure: resolve the style and aspect ratio for a delegated image turn.
+/// Precedence per field:
+/// - style:  `req_image.style` → type default (`Realistic`)
+/// - aspect: `plan.aspect_ratio` → `req_image.aspect_ratio` → `None`
+///
+/// There is no subject input here: the judge no longer writes a seed (#212
+/// Task 4) and the client can no longer supply one either (#212 Task 5) — the
+/// composer decides what the picture shows from turn context alone.
 ///
 /// Blank strings count as absent at the plan and request levels. There are no
 /// config-level defaults: the engine carries no image configuration, so style
@@ -2535,11 +2536,6 @@ fn resolve_image_turn_inputs(
     plan: &eros_engine_core::types::ActionPlan,
     req_image: Option<&crate::routes::companion_stream::ImageReplyParams>,
 ) -> ImageTurnInputs {
-    let seed_subject = req_image
-        .and_then(|i| i.image_prompt.as_deref())
-        .filter(|s| !s.trim().is_empty())
-        .unwrap_or("")
-        .to_string();
     let style = req_image.and_then(|i| i.style).unwrap_or_default();
     let aspect_ratio = plan
         .aspect_ratio
@@ -2552,7 +2548,6 @@ fn resolve_image_turn_inputs(
         })
         .map(str::to_string);
     ImageTurnInputs {
-        seed_subject,
         style,
         aspect_ratio,
     }
@@ -2566,8 +2561,9 @@ struct DelegatedImagePrompt {
     /// `prompt` key. The composer's decided subject on the compose path
     /// (spec 2026-08-02: this is deliberately the SHORT subject, not the
     /// composed wire string — that lives only in `composed_prompt`, below, and
-    /// is never persisted); the client's explicit override on `raw` (composer
-    /// skipped); empty on a failed compose.
+    /// is never persisted); empty when the composer is skipped (not
+    /// configured, or `raw`) or the compose call fails — there is no seed left
+    /// to fall back to, so an empty subject is the portrait fallback (#212).
     subject: String,
     /// Short description of the picture, persisted as `metadata.image.caption`
     /// and read by every history-facing render. `None` on a failed compose or
@@ -2584,12 +2580,14 @@ struct DelegatedImagePrompt {
     compose_generation_id: Option<String>,
 }
 
-/// Resolve the per-turn image inputs, optionally enrich the subject via the
-/// composer LLM, and wrap the result into the final wire prompt.
+/// Resolve the per-turn image inputs, generate the subject via the composer
+/// LLM, and wrap the result into the final wire prompt.
 ///
 /// The composer is skipped entirely when it is not configured. It is fail-open
-/// throughout: a model error, timeout, or empty reply degrades to the seed
-/// subject and never blocks the image turn.
+/// throughout: a model error, timeout, or empty reply degrades to an empty
+/// subject — there is nothing left to fall back to — and never blocks the
+/// image turn. `compose_image_prompt` turns that empty subject into a plain
+/// persona-appearance portrait prompt (#212).
 async fn build_delegated_image_prompt(
     state: &AppState,
     persona: &eros_engine_core::persona::CompanionPersona,
@@ -2610,7 +2608,6 @@ async fn build_delegated_image_prompt(
                 state,
                 &c,
                 persona,
-                &inputs.seed_subject,
                 pde_transcript,
                 latest_user_msg,
                 inputs.aspect_ratio.as_deref(),
@@ -2629,7 +2626,7 @@ async fn build_delegated_image_prompt(
                 Some(o.model),
                 o.generation_id,
             ),
-            None => (inputs.seed_subject.clone(), None, None, None, None),
+            None => (String::new(), None, None, None, None),
         };
     let composed_prompt =
         crate::pipeline::handlers::compose_image_prompt(inputs.style, persona, &final_subject);
@@ -3088,9 +3085,9 @@ pub fn run_stream(
 
         // Forced-image override — wins over the PDE/ghost result. Applied AFTER
         // the kill-switch so a client-forced image is never suppressed to ghost.
-        // ImageOnly ⇒ ReplyImage; otherwise (TextImage) ⇒ ReplyTextImage. The
-        // client's explicit subject still reaches the composer via
-        // `resolve_image_turn_inputs`, which reads `req_image.image_prompt`.
+        // ImageOnly ⇒ ReplyImage; otherwise (TextImage) ⇒ ReplyTextImage. There
+        // is no subject to carry through here — the composer decides what the
+        // picture shows from turn context alone (`resolve_image_turn_inputs`).
         if force_image {
             let action = match req_image.map(|i| &i.mode) {
                 Some(crate::routes::companion_stream::ImageMode::ImageOnly) => {
@@ -4102,13 +4099,11 @@ mod tests {
             "freckled, red hair",
             "（无）",
             "（无）",
-            "on a rooftop",
             "realistic",
             "9:16",
         );
         assert!(p.contains("freckled, red hair"));
         assert!(p.contains("（无）"));
-        assert!(p.contains("on a rooftop"));
         assert!(p.contains("realistic"));
         assert!(p.contains("9:16"));
     }
@@ -4119,12 +4114,29 @@ mod tests {
             "freckled, red hair",
             "（无）",
             "给我看看你现在的样子",
-            "on a rooftop",
             "realistic",
             "9:16",
         );
         assert!(p.contains("[对方最新消息]\n给我看看你现在的样子"), "{p}");
-        assert!(p.contains("[画面主题种子]\non a rooftop"), "{p}");
+    }
+
+    #[test]
+    fn compose_user_payload_has_no_seed_section() {
+        let p = compose_user_payload(
+            "freckled, red hair",
+            "（无）",
+            "给我看看你现在的样子",
+            "realistic",
+            "9:16",
+        );
+        assert!(
+            !p.contains("画面主题种子"),
+            "the seed concept is deleted — no seed section may render: {p}"
+        );
+        assert!(p.contains("[对方最新消息]\n给我看看你现在的样子"), "{p}");
+        assert!(p.contains("[人物外观]\nfreckled, red hair"), "{p}");
+        assert!(p.contains("[风格]\nrealistic"), "{p}");
+        assert!(p.contains("[画幅]\n9:16"), "{p}");
     }
 
     #[test]
@@ -4201,12 +4213,10 @@ mod tests {
     }
 
     fn img_params(
-        image_prompt: Option<&str>,
         style: Option<eros_engine_llm::model_config::StyleKey>,
         aspect: Option<&str>,
     ) -> crate::routes::companion_stream::ImageReplyParams {
         crate::routes::companion_stream::ImageReplyParams {
-            image_prompt: image_prompt.map(str::to_string),
             style,
             aspect_ratio: aspect.map(str::to_string),
             ..Default::default()
@@ -4214,28 +4224,10 @@ mod tests {
     }
 
     #[test]
-    fn image_turn_subject_comes_only_from_request() {
-        // The judge no longer writes a seed; the request is the only source.
-        let params = img_params(Some("from request"), None, None);
-        let r = resolve_image_turn_inputs(&img_plan(None), Some(&params));
-        assert_eq!(r.seed_subject, "from request");
-
-        // neither ⇒ empty string
-        let r = resolve_image_turn_inputs(&img_plan(None), None);
-        assert_eq!(r.seed_subject, "");
-
-        // blank request value ⇒ falls through to empty string too, not the
-        // blank string itself (the request-level blank filter must still fire).
-        let blank_params = img_params(Some("   "), None, None);
-        let r = resolve_image_turn_inputs(&img_plan(None), Some(&blank_params));
-        assert_eq!(r.seed_subject, "");
-    }
-
-    #[test]
     fn image_turn_style_prefers_request_then_default() {
         use eros_engine_llm::model_config::StyleKey;
 
-        let params = img_params(None, Some(StyleKey::SemiRealistic), None);
+        let params = img_params(Some(StyleKey::SemiRealistic), None);
         let r = resolve_image_turn_inputs(&img_plan(None), Some(&params));
         assert_eq!(r.style, StyleKey::SemiRealistic, "request wins");
 
@@ -4245,7 +4237,7 @@ mod tests {
 
     #[test]
     fn image_turn_aspect_prefers_plan_then_request_then_none() {
-        let params = img_params(None, None, Some("16:9"));
+        let params = img_params(None, Some("16:9"));
 
         let r = resolve_image_turn_inputs(&img_plan(Some("3:4")), Some(&params));
         assert_eq!(r.aspect_ratio.as_deref(), Some("3:4"), "plan wins");
@@ -4261,7 +4253,7 @@ mod tests {
         assert_eq!(r.aspect_ratio, None, "nothing anywhere ⇒ None");
 
         // Blank request value ⇒ the request-level blank filter still fires.
-        let blank_params = img_params(None, None, Some("  "));
+        let blank_params = img_params(None, Some("  "));
         let r = resolve_image_turn_inputs(&img_plan(None), Some(&blank_params));
         assert_eq!(r.aspect_ratio, None, "blank request ⇒ None");
     }
@@ -5969,7 +5961,6 @@ data: [DONE]\n\n";
                 image: Some(crate::routes::companion_stream::ImageReplyParams {
                     force: true,
                     mode: crate::routes::companion_stream::ImageMode::ImageOnly,
-                    image_prompt: Some("a beach at sunset".into()),
                     ..Default::default()
                 }),
                 history_anchor: Default::default(),
@@ -6006,7 +5997,8 @@ data: [DONE]\n\n";
             .expect("meta present");
         assert_eq!(action, FrameActionType::ReplyImage);
         assert!(model.is_none(), "delegated meta carries no model");
-        // image_request: face ref + base64 composed wire prompt containing the subject.
+        // image_request: face ref + base64 composed wire prompt (no composer
+        // configured and no seed left ⇒ portrait fallback: style preset only).
         let (composed_b64, image_ref) = frames
             .iter()
             .find_map(|f| match f {
@@ -6028,13 +6020,15 @@ data: [DONE]\n\n";
             )
             .unwrap()
         };
-        assert!(
-            composed.contains("a beach at sunset"),
-            "composed wire prompt should contain the subject: {composed}"
+        assert_eq!(
+            composed,
+            eros_engine_llm::model_config::STYLE_REALISTIC,
+            "no composer configured and no seed ⇒ portrait fallback (style preset only): {composed}"
         );
 
-        // Persistence: minimal marker only (seed subject under `prompt`), and NOT
-        // the composed wire prompt / model / generation_id / url.
+        // Persistence: minimal marker only (empty subject under `prompt`,
+        // portrait fallback), and NOT the composed wire prompt / model /
+        // generation_id / url.
         let meta_row: Option<serde_json::Value> = sqlx::query_scalar(
             "SELECT metadata FROM engine.chat_messages \
              WHERE session_id = $1 AND role = 'assistant' \
@@ -6046,8 +6040,8 @@ data: [DONE]\n\n";
         .unwrap();
         let img = meta_row.expect("assistant row has metadata")["image"].clone();
         assert_eq!(
-            img["prompt"], "a beach at sunset",
-            "marker keeps the seed subject"
+            img["prompt"], "",
+            "no compose configured and no seed ⇒ empty subject (portrait fallback)"
         );
         assert!(img.get("model").is_none(), "marker must not store a model");
         assert!(
@@ -6058,7 +6052,7 @@ data: [DONE]\n\n";
         assert_ne!(
             img["prompt"],
             serde_json::json!(composed),
-            "the composed wire prompt must not be persisted (only the seed subject)"
+            "the composed wire prompt (style preset) must not be persisted as the marker subject"
         );
     }
 
@@ -6150,7 +6144,6 @@ data: [DONE]\n\n";
                 image: Some(crate::routes::companion_stream::ImageReplyParams {
                     force: true,
                     mode: crate::routes::companion_stream::ImageMode::ImageOnly,
-                    image_prompt: Some("a beach at sunset".into()),
                     prompt_variant: prompt_variant.map(str::to_string),
                     ..Default::default()
                 }),
@@ -6171,8 +6164,9 @@ data: [DONE]\n\n";
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
     async fn prompt_variant_selects_the_configured_composer_prompt(pool: PgPool) {
         use wiremock::ResponseTemplate;
-        // 500 on every call: the composer fails open to the seed subject. This
-        // test asserts on what was SENT, so the response body is irrelevant.
+        // 500 on every call: the composer fails open to an empty subject —
+        // there is no seed left to fall back to. This test asserts on what was
+        // SENT, so the response body is irrelevant.
         let (reqs, _frames) = run_variant_turn(&pool, Some("b"), ResponseTemplate::new(500)).await;
         assert_eq!(
             reqs.len(),
@@ -6189,7 +6183,7 @@ data: [DONE]\n\n";
         );
 
         // Spec 2026-08-02 absence semantics: no successful compose ⇒ none of
-        // the audit keys, and `prompt` is the seed subject as before.
+        // the audit keys, and `prompt` is the empty subject (portrait fallback).
         let meta: serde_json::Value = sqlx::query_scalar(
             "SELECT metadata FROM engine.chat_messages WHERE role = 'assistant'",
         )
@@ -6197,14 +6191,17 @@ data: [DONE]\n\n";
         .await
         .expect("assistant image row persisted");
         let img = meta["image"].as_object().expect("image marker present");
-        assert_eq!(img["prompt"], "a beach at sunset");
+        assert_eq!(img["prompt"], "");
         assert!(img.get("compose_variant").is_none());
         assert!(img.get("compose_model").is_none());
         assert!(img.get("compose_generation_id").is_none());
     }
 
-    /// `prompt_variant = "raw"` must make ZERO provider calls and pass the seed
-    /// subject through to the wire prompt verbatim.
+    /// `prompt_variant = "raw"` must still make ZERO provider calls (this
+    /// task does not touch the `"raw"` short-circuit itself — see #212 Task 6
+    /// for its eventual removal). With the client-side seed deleted there is
+    /// nothing left to draw "as-is": the turn now degrades to the same
+    /// empty-subject portrait fallback as a failed compose.
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
     async fn prompt_variant_raw_skips_the_composer(pool: PgPool) {
         use wiremock::ResponseTemplate;
@@ -6235,13 +6232,14 @@ data: [DONE]\n\n";
             )
             .unwrap()
         };
-        assert!(
-            composed.contains("a beach at sunset"),
-            "raw must pass the seed subject through: {composed}"
+        assert_eq!(
+            composed,
+            eros_engine_llm::model_config::STYLE_REALISTIC,
+            "raw skips the composer and there is no seed ⇒ portrait fallback: {composed}"
         );
 
         // Spec 2026-08-02 absence semantics: no successful compose ⇒ none of
-        // the audit keys, and `prompt` is the seed subject as before.
+        // the audit keys, and `prompt` is the empty subject (portrait fallback).
         let meta: serde_json::Value = sqlx::query_scalar(
             "SELECT metadata FROM engine.chat_messages WHERE role = 'assistant'",
         )
@@ -6249,7 +6247,7 @@ data: [DONE]\n\n";
         .await
         .expect("assistant image row persisted");
         let img = meta["image"].as_object().expect("image marker present");
-        assert_eq!(img["prompt"], "a beach at sunset");
+        assert_eq!(img["prompt"], "");
         assert!(img.get("compose_variant").is_none());
         assert!(img.get("compose_model").is_none());
         assert!(img.get("compose_generation_id").is_none());
@@ -6459,7 +6457,6 @@ data: [DONE]\n\n";
                 image: Some(crate::routes::companion_stream::ImageReplyParams {
                     force: true,
                     mode: crate::routes::companion_stream::ImageMode::ImageOnly,
-                    image_prompt: Some("a beach at sunset".into()),
                     ..Default::default()
                 }),
                 history_anchor: Default::default(),
@@ -6561,7 +6558,6 @@ data: [DONE]\n\n";
                 image: Some(crate::routes::companion_stream::ImageReplyParams {
                     force: true,
                     // default mode = TextImage ⇒ ReplyTextImage
-                    image_prompt: Some("in a red dress".into()),
                     ..Default::default()
                 }),
                 history_anchor: Default::default(),
@@ -6622,7 +6618,8 @@ data: [DONE]\n\n";
         assert_eq!(action, FrameActionType::ReplyTextImage);
 
         // The minimal marker was MERGED onto the assistant TEXT row (content
-        // non-empty), carrying only the seed subject.
+        // non-empty), carrying only the empty subject (no composer configured
+        // and no seed left ⇒ portrait fallback).
         let row: (String, Option<serde_json::Value>) = sqlx::query_as(
             "SELECT content, metadata FROM engine.chat_messages \
              WHERE session_id = $1 AND role = 'assistant' \
@@ -6634,7 +6631,7 @@ data: [DONE]\n\n";
         .unwrap();
         assert!(!row.0.is_empty(), "the text reply row has content");
         let img = row.1.expect("row has metadata")["image"].clone();
-        assert_eq!(img["prompt"], "in a red dress");
+        assert_eq!(img["prompt"], "");
         assert!(img.get("model").is_none(), "marker must not store a model");
         assert!(
             img.get("generation_id").is_none(),

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -2153,25 +2153,33 @@ const INPUT_FILTER_CONTEXT_TURNS: i64 = 8;
 
 /// Render an assistant transcript line. Image turns persist empty `content`
 /// with the image facts under `metadata.image`; surface a terse marker so the
-/// judge / input filter see that an image was sent (and what it depicted)
+/// judge / input filter see that an image was sent (and roughly what it showed)
 /// instead of a blank `AI:` line. Non-image assistant rows fall back to
 /// `content`. Pure.
+///
+/// The description comes from `metadata.image.caption` — a short line written
+/// by the composer for exactly this purpose. It is deliberately NOT
+/// `metadata.image.prompt`: that is the image-generation subject, which leads
+/// with style-preset and appearance boilerplate and is long enough that echoing
+/// it dominated the judge's context. When no caption exists (rows written before
+/// captions shipped, a composer reply that carried none, a failed compose) the
+/// marker stays bare rather than falling back to the prompt — the anti-spam
+/// brake rides on `[近期图片]`'s counts, which do not depend on this text.
 fn assistant_transcript_line(content: &str, metadata: Option<&serde_json::Value>) -> String {
     if let Some(img) = metadata.and_then(|m| m.get("image")) {
-        let subject = img
-            .get("prompt")
+        let caption = img
+            .get("caption")
             .and_then(|v| v.as_str())
             .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .unwrap_or("（无描述）");
+            .filter(|s| !s.is_empty());
         let ar = img
             .get("aspect_ratio")
             .and_then(|v| v.as_str())
             .unwrap_or("");
-        return if ar.is_empty() {
-            format!("（发送了一张图片：{subject}）")
-        } else {
-            format!("（发送了一张图片：{subject}，画幅 {ar}）")
+        return match (caption, ar.is_empty()) {
+            (None, _) => "（发送了一张图片）".to_string(),
+            (Some(c), true) => format!("（发送了一张图片：{c}）"),
+            (Some(c), false) => format!("（发送了一张图片：{c}，画幅 {ar}）"),
         };
     }
     content.to_string()
@@ -4490,27 +4498,41 @@ mod tests {
 
     #[test]
     fn assistant_transcript_line_marks_image_turns() {
-        // image turn: empty content, facts under metadata.image
-        let meta =
-            serde_json::json!({"image":{"prompt":"on the beach at sunset","aspect_ratio":"3:4"}});
+        // image turn with a caption: the CAPTION surfaces, never the prompt
+        let meta = serde_json::json!({"image":{
+            "prompt":"Photorealistic, ultra-detailed, on the beach at sunset",
+            "caption":"在沙滩看日落",
+            "aspect_ratio":"3:4"
+        }});
         let line = assistant_transcript_line("", Some(&meta));
+        assert!(line.contains("在沙滩看日落"), "caption surfaced: {line}");
         assert!(
-            line.contains("on the beach at sunset"),
-            "subject surfaced: {line}"
+            !line.contains("Photorealistic"),
+            "the image prompt must never reach the transcript: {line}"
         );
         assert!(line.contains("3:4"), "aspect surfaced: {line}");
-        assert_ne!(line.trim(), "", "image turn must not be a blank line");
 
-        // image turn without aspect_ratio: still marks, no panic
-        let meta2 = serde_json::json!({"image":{"prompt":"a portrait"}});
-        assert!(assistant_transcript_line("", Some(&meta2)).contains("a portrait"));
+        // image turn WITHOUT a caption: bare marker, never a prompt fallback
+        let meta2 = serde_json::json!({"image":{"prompt":"a very long english image prompt"}});
+        let line2 = assistant_transcript_line("", Some(&meta2));
+        assert_eq!(
+            line2, "（发送了一张图片）",
+            "bare marker when caption absent: {line2}"
+        );
+
+        // blank caption counts as absent
+        let meta3 = serde_json::json!({"image":{"prompt":"x","caption":"  "}});
+        assert_eq!(
+            assistant_transcript_line("", Some(&meta3)),
+            "（发送了一张图片）"
+        );
 
         // plain text turn: content passes through unchanged
         assert_eq!(assistant_transcript_line("hi there", None), "hi there");
 
         // metadata present but no image key: content passes through
-        let meta3 = serde_json::json!({"tip": 5});
-        assert_eq!(assistant_transcript_line("hello", Some(&meta3)), "hello");
+        let meta4 = serde_json::json!({"tip": 5});
+        assert_eq!(assistant_transcript_line("hello", Some(&meta4)), "hello");
     }
 
     /// Build a `JudgeTranscript` from (role, content, metadata) triples,
@@ -6316,6 +6338,69 @@ data: [DONE]\n\n";
         assert_eq!(img["compose_variant"], "b");
         assert_eq!(img["compose_model"], "served/model");
         assert_eq!(img["compose_generation_id"], "gen-xyz");
+    }
+
+    /// Sibling of `compose_success_persists_audit_trio`, but the mock composer
+    /// returns real JSON (`{"prompt":..., "caption":...}`) instead of plain
+    /// text, so `caption` is actually populated end to end. Proves the seam
+    /// neither the parser unit tests (`parse_compose_reply`) nor the marker
+    /// unit tests (`assistant_transcript_line` / `model_facing_assistant_text`)
+    /// exercise on their own: a real composer reply persists `caption` to the
+    /// row, and both history-facing renders surface it — never the prompt.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn compose_success_with_json_caption_surfaces_in_both_renders(pool: PgPool) {
+        use wiremock::ResponseTemplate;
+        let (reqs, _frames) = run_variant_turn(
+            &pool,
+            Some("b"),
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "gen-cap",
+                "model": "served/model",
+                "choices": [{"message": {"content":
+                    r#"{"prompt":"on a rooftop at dusk","caption":"在天台看夕阳"}"#
+                }}],
+            })),
+        )
+        .await;
+        assert_eq!(reqs.len(), 1, "composer is the only provider call");
+
+        // sqlx::test gives this test its own database — the one assistant row
+        // is the image turn's.
+        let row: eros_engine_store::chat::ChatMessage =
+            sqlx::query_as("SELECT * FROM engine.chat_messages WHERE role = 'assistant'")
+                .fetch_one(&pool)
+                .await
+                .expect("assistant image row persisted");
+
+        let img = &row.metadata.as_ref().expect("metadata present")["image"];
+        assert_eq!(img["prompt"], "on a rooftop at dusk");
+        assert_eq!(
+            img["caption"], "在天台看夕阳",
+            "composer's caption persisted"
+        );
+
+        // Both history-facing renders surface the caption, never the prompt.
+        let content = row.content.clone();
+        let metadata = row.metadata.clone();
+        let transcript_line = assistant_transcript_line(&content, metadata.as_ref());
+        assert!(
+            transcript_line.contains("在天台看夕阳"),
+            "judge transcript surfaces the caption: {transcript_line}"
+        );
+        assert!(
+            !transcript_line.contains("rooftop"),
+            "the prompt must never reach the judge transcript: {transcript_line}"
+        );
+
+        let model_text = crate::pipeline::handlers::model_facing_assistant_text(row);
+        assert!(
+            model_text.contains("在天台看夕阳"),
+            "chat history surfaces the caption: {model_text}"
+        );
+        assert!(
+            !model_text.contains("rooftop"),
+            "the prompt must never reach the chat model's history: {model_text}"
+        );
     }
 
     /// Spec 2026-08-02-provider-body-params: an [[providers.openrouter.body]]
@@ -12245,9 +12330,9 @@ data: [DONE]\n\n"
 
     #[test]
     fn delegated_marker_preserves_image_awareness() {
-        // Subject under `prompt` (the key assistant_transcript_line reads),
-        // plus aspect — and NOTHING else (no caption / composed prompt / model
-        // / gen id).
+        // Subject under `prompt` (persisted, but NOT what
+        // `assistant_transcript_line` reads — see below), plus aspect — and
+        // NOTHING else (no caption / composed prompt / model / gen id).
         let marker =
             build_delegated_image_marker("beach at sunset", None, Some("3:4"), None, None, None);
         assert_eq!(marker["prompt"], "beach at sunset");
@@ -12257,18 +12342,26 @@ data: [DONE]\n\n"
             2,
             "marker must be minimal"
         );
-        // The §5 regression guard: transcript still annotates it as a prior image.
+        // The §5 regression guard: transcript still annotates it as a prior
+        // image. With no caption, that annotation is the bare marker — the
+        // subject/aspect do NOT surface (caption contract: never fall back
+        // to `prompt`).
         let wrapped = serde_json::json!({ "image": marker });
         let line = assistant_transcript_line("", Some(&wrapped));
-        assert!(line.contains("beach at sunset"), "subject surfaced: {line}");
-        assert!(line.contains("3:4"), "aspect surfaced: {line}");
+        assert_eq!(
+            line, "（发送了一张图片）",
+            "bare marker when caption absent: {line}"
+        );
         assert_ne!(line.trim(), "", "image turn must not be a blank line");
 
-        // No aspect => still a valid one-key marker that annotates.
+        // No aspect => still a valid one-key marker that annotates (bare, same reason).
         let m2 = build_delegated_image_marker("a portrait", None, None, None, None, None);
         assert_eq!(m2.as_object().unwrap().len(), 1);
         let w2 = serde_json::json!({ "image": m2 });
-        assert!(assistant_transcript_line("", Some(&w2)).contains("a portrait"));
+        assert_eq!(
+            assistant_transcript_line("", Some(&w2)),
+            "（发送了一张图片）"
+        );
     }
 
     /// Spec 2026-08-02: a successful composer call adds exactly three audit

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -6247,49 +6247,40 @@ data: [DONE]\n\n";
         assert!(img.get("compose_generation_id").is_none());
     }
 
-    /// `prompt_variant = "raw"` must still make ZERO provider calls (this
-    /// task does not touch the `"raw"` short-circuit itself — see #212 Task 6
-    /// for its eventual removal). With the client-side seed deleted there is
-    /// nothing left to draw "as-is": the turn now degrades to the same
-    /// empty-subject portrait fallback as a failed compose.
+    /// `prompt_variant = "raw"` used to be a reserved wire escape that skipped
+    /// the composer entirely. That escape is gone (#212 Task 6): with no seed
+    /// to draw verbatim, `"raw"` is an ordinary variant name. `run_variant_turn`
+    /// configures only `a` and `b`, so `"raw"` is a miss like any unconfigured
+    /// key — the composer still runs, on the built-in prompt.
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
-    async fn prompt_variant_raw_skips_the_composer(pool: PgPool) {
+    async fn prompt_variant_raw_falls_back_to_builtin_when_unconfigured(pool: PgPool) {
         use wiremock::ResponseTemplate;
-        // 500 on every call: "raw" must make no call at all, so the response
-        // body is irrelevant — this only proves ZERO requests were sent.
-        let (reqs, frames) = run_variant_turn(&pool, Some("raw"), ResponseTemplate::new(500)).await;
-        assert!(
-            reqs.is_empty(),
-            "raw must make no composer call, got {} request(s)",
-            reqs.len()
-        );
-
-        let composed_b64 = frames
-            .iter()
-            .find_map(|f| match f {
-                ProtocolFrame::ImageRequest {
-                    composed_prompt, ..
-                } => Some(composed_prompt.clone()),
-                _ => None,
-            })
-            .expect("image_request present");
-        let composed = {
-            use base64::Engine as _;
-            String::from_utf8(
-                base64::engine::general_purpose::STANDARD
-                    .decode(&composed_b64)
-                    .unwrap(),
-            )
-            .unwrap()
-        };
+        // 500 on every call: the composer fails open to an empty subject —
+        // there is no seed left to fall back to. This test asserts on what was
+        // SENT, so the response body is irrelevant.
+        let (reqs, _frames) =
+            run_variant_turn(&pool, Some("raw"), ResponseTemplate::new(500)).await;
         assert_eq!(
-            composed,
-            eros_engine_llm::model_config::STYLE_REALISTIC,
-            "raw skips the composer and there is no seed ⇒ portrait fallback: {composed}"
+            reqs.len(),
+            1,
+            "\"raw\" no longer skips the composer — it still makes the one provider call"
+        );
+        let body: serde_json::Value =
+            serde_json::from_slice(&reqs[0].body).expect("composer request body is json");
+        assert_eq!(body["messages"][0]["role"], "system");
+        let sent = body["messages"][0]["content"]
+            .as_str()
+            .expect("system content is a string");
+        assert_ne!(sent, "PROMPT_A");
+        assert_ne!(sent, "PROMPT_B");
+        assert!(
+            sent.contains("You compose the image for a picture"),
+            "unconfigured \"raw\" key must fall back to the built-in prompt, got {sent}"
         );
 
-        // Spec 2026-08-02 absence semantics: no successful compose ⇒ none of
-        // the audit keys, and `prompt` is the empty subject (portrait fallback).
+        // Same fail-open shape as a configured-variant compose failure: no
+        // successful compose ⇒ none of the audit keys, and `prompt` is the
+        // empty subject (portrait fallback).
         let meta: serde_json::Value = sqlx::query_scalar(
             "SELECT metadata FROM engine.chat_messages WHERE role = 'assistant'",
         )

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -2259,8 +2259,12 @@ async fn build_input_filter_transcript(
     session_id: Uuid,
     current_user_message_id: Uuid,
 ) -> JudgeTranscript {
+    // +1: the turn being processed is already persisted, so it always occupies
+    // the newest fetched slot and is then excluded below. Fetching exactly the
+    // window size would leave 7 prior messages while `[近期图片]` tells the
+    // judge it counted 8 — an every-turn off-by-one on the anti-spam facts.
     let rows = chat_repo
-        .history(session_id, INPUT_FILTER_CONTEXT_TURNS, 0)
+        .history(session_id, INPUT_FILTER_CONTEXT_TURNS + 1, 0)
         .await
         .unwrap_or_default();
     let mut acc = JudgeTranscriptAcc::default();
@@ -4686,6 +4690,151 @@ mod tests {
         // metadata present but no image key: content passes through
         let meta4 = serde_json::json!({"tip": 5});
         assert_eq!(assistant_transcript_line("hello", Some(&meta4)), "hello");
+    }
+
+    /// Codex-review P2 regression (PR #216): the current turn is already
+    /// persisted when the transcript is built, so it always occupies the
+    /// newest fetched slot before being excluded — fetching exactly the window
+    /// size left 7 prior messages while `[近期图片]` told the judge it counted
+    /// 8. Seeds exactly 8 prior rows whose OLDEST is an image turn: with the
+    /// off-by-one that image fell out of the window and the count read 0.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn transcript_window_covers_the_full_advertised_eight(pool: PgPool) {
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+        let user_id = Uuid::new_v4();
+        let (_g, _instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+
+        // 8 prior rows, oldest first at now()-8min … now()-1min. Row 0 (the
+        // oldest, exactly 8th-most-recent prior) is the image turn.
+        for i in 0..8i32 {
+            let (role, content, meta) = if i == 0 {
+                (
+                    "assistant",
+                    "",
+                    Some(serde_json::json!({"image":{"prompt":"x","caption":"在沙滩"}})),
+                )
+            } else if i % 2 == 1 {
+                ("user", "文字消息", None)
+            } else {
+                ("assistant", "文字回复", None)
+            };
+            sqlx::query(
+                "INSERT INTO engine.chat_messages (session_id, role, content, metadata, sent_at) \
+                 VALUES ($1, $2, $3, $4, now() - make_interval(mins => $5))",
+            )
+            .bind(session_id)
+            .bind(role)
+            .bind(content)
+            .bind(meta)
+            .bind(8 - i)
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+        let chat_repo = ChatRepo { pool: &pool };
+        let current = match chat_repo
+            .upsert_user_message_idempotent(
+                session_id,
+                "hi",
+                "01J9000000000000000000000C",
+                "user",
+                None,
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
+
+        let t = build_input_filter_transcript(&chat_repo, session_id, current).await;
+        assert_eq!(
+            t.images_in_window, 1,
+            "the 8th-most-recent prior message is an image and must be counted: {t:?}"
+        );
+        assert!(
+            !t.last_assistant_is_image,
+            "the newest assistant row is text: {t:?}"
+        );
+        assert_eq!(
+            t.transcript.lines().count(),
+            8,
+            "the judge must see the full advertised 8 prior messages: {}",
+            t.transcript
+        );
+        assert!(
+            !t.transcript.contains("hi"),
+            "the current turn must be excluded: {}",
+            t.transcript
+        );
+    }
+
+    /// Channel-marked rows (voice / product_qa) are out of companion context:
+    /// they must neither render in the transcript nor count as images. Pins
+    /// the exclusion the counting facts now silently depend on.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn transcript_excludes_channel_rows_from_text_and_counts(pool: PgPool) {
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+        let user_id = Uuid::new_v4();
+        let (_g, _instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+
+        sqlx::query(
+            "INSERT INTO engine.chat_messages (session_id, role, content, sent_at) \
+             VALUES ($1, 'user', '普通消息', now() - interval '3 minutes')",
+        )
+        .bind(session_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+        // A voice-channel image row: out of companion context entirely.
+        sqlx::query(
+            "INSERT INTO engine.chat_messages (session_id, role, content, metadata, channel, sent_at) \
+             VALUES ($1, 'assistant', '语音旁路', '{\"image\":{\"prompt\":\"v\"}}', 'voice', now() - interval '2 minutes')",
+        )
+        .bind(session_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO engine.chat_messages (session_id, role, content, metadata, sent_at) \
+             VALUES ($1, 'assistant', '', '{\"image\":{\"prompt\":\"y\",\"caption\":\"在天台\"}}', now() - interval '1 minute')",
+        )
+        .bind(session_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let chat_repo = ChatRepo { pool: &pool };
+        let current = match chat_repo
+            .upsert_user_message_idempotent(
+                session_id,
+                "hi",
+                "01J9000000000000000000000D",
+                "user",
+                None,
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
+
+        let t = build_input_filter_transcript(&chat_repo, session_id, current).await;
+        assert_eq!(
+            t.images_in_window, 1,
+            "the voice-channel image row must not count: {t:?}"
+        );
+        assert!(
+            t.last_assistant_is_image,
+            "the newest COMPANION assistant row is the image turn: {t:?}"
+        );
+        assert!(
+            !t.transcript.contains("语音旁路"),
+            "channel rows must not render: {}",
+            t.transcript
+        );
+        assert!(t.transcript.contains("普通消息"), "{}", t.transcript);
     }
 
     /// Build a `JudgeTranscript` from (role, content, metadata) triples,

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -2566,11 +2566,13 @@ fn resolve_image_turn_inputs(
 /// absent: it is consumed internally by `compose_image_prompt` and neither
 /// caller uses it afterwards.
 struct DelegatedImagePrompt {
-    /// Seed subject — feeds `build_delegated_image_marker`'s `prompt` key. This
-    /// is deliberately the SEED, not the composer's enriched/generated text
-    /// (that lives only in `composed_prompt`, on the wire): keeps the
-    /// persisted marker compact regardless of composer outcome.
-    seed_subject: String,
+    /// What described the picture — feeds `build_delegated_image_marker`'s
+    /// `prompt` key. The composer's decided subject on the compose path
+    /// (spec 2026-08-02: this is deliberately the SHORT subject, not the
+    /// composed wire string — that lives only in `composed_prompt`, below, and
+    /// is never persisted); the client's explicit override on `raw` (composer
+    /// skipped); empty on a failed compose.
+    subject: String,
     /// Short description of the picture, persisted as `metadata.image.caption`
     /// and read by every history-facing render. `None` on a failed compose or
     /// when the task is not configured.
@@ -2636,7 +2638,7 @@ async fn build_delegated_image_prompt(
     let composed_prompt =
         crate::pipeline::handlers::compose_image_prompt(inputs.style, persona, &final_subject);
     DelegatedImagePrompt {
-        seed_subject: inputs.seed_subject,
+        subject: final_subject,
         caption,
         aspect_ratio: inputs.aspect_ratio,
         composed_prompt,
@@ -3434,7 +3436,7 @@ pub fn run_stream(
                         &user_msg.content,
                     )
                     .await;
-                    let subject = img.seed_subject;
+                    let subject = img.subject;
                     let aspect = img.aspect_ratio;
                     let composed_prompt = img.composed_prompt;
                     // Persist the marker (subject + caption + aspect + compose
@@ -3764,7 +3766,7 @@ pub fn run_stream(
                             &user_msg.content,
                         )
                         .await;
-                        let subject = img.seed_subject;
+                        let subject = img.subject;
                         let aspect = img.aspect_ratio;
                         let composed_prompt = img.composed_prompt;
                         // Merge the marker (subject + caption + aspect + compose
@@ -6249,10 +6251,14 @@ data: [DONE]\n\n";
         assert!(img.get("compose_generation_id").is_none());
     }
 
-    /// Spec 2026-08-02: a SUCCESSFUL composer call persists the audit trio to
-    /// `metadata.image` — the selected variant key, the served model, and the
-    /// generation id — while `prompt` keeps the SEED subject (the composed
-    /// text goes only on the wire).
+    /// Spec 2026-08-02 (revised): a SUCCESSFUL composer call persists the
+    /// audit trio to `metadata.image` — the selected variant key, the served
+    /// model, and the generation id — AND `prompt` now carries the composer's
+    /// subject, not the pre-compose seed. The original design pinned `prompt`
+    /// to the seed to keep the DB row short; that job now belongs to
+    /// `caption`, so `prompt` is free to reflect what the composer actually
+    /// decided. The composed WIRE prompt (style preset + appearance + this
+    /// subject) is still never persisted — it goes out on the wire only.
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
     async fn compose_success_persists_audit_trio(pool: PgPool) {
         use wiremock::ResponseTemplate;
@@ -6268,9 +6274,9 @@ data: [DONE]\n\n";
         .await;
         assert_eq!(reqs.len(), 1, "composer is the only provider call");
 
-        // final-review finding — this is the only place the
-        // `ComposeOutcome.text → wire` seam is pinned; the DB `prompt` stays
-        // the seed by design (asserted below).
+        // The composer's plain-text reply ("ENRICHED SUBJECT", no JSON) parses
+        // as the whole reply becoming `prompt` with no caption (migration
+        // fallback) — so both the wire and the DB below carry it.
         let composed_b64 = frames
             .iter()
             .find_map(|f| match f {
@@ -6304,8 +6310,8 @@ data: [DONE]\n\n";
         .expect("assistant image row persisted");
         let img = &meta["image"];
         assert_eq!(
-            img["prompt"], "a beach at sunset",
-            "seed subject, not the composed text"
+            img["prompt"], "ENRICHED SUBJECT",
+            "prompt is the composer's subject, not the pre-compose seed"
         );
         assert_eq!(img["compose_variant"], "b");
         assert_eq!(img["compose_model"], "served/model");

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -1884,7 +1884,7 @@ fn render_product_qa_pairs(pairs: &[(String, String)]) -> String {
 
 /// Build the judge's user payload from the shared transcript + the decision input.
 fn build_pde_ctx(
-    transcript: &str,
+    t: &JudgeTranscript,
     input: &eros_engine_core::types::DecisionInput,
     image_available: bool,
     product_qa_recent: Option<&str>,
@@ -1895,10 +1895,10 @@ fn build_pde_ctx(
         eros_engine_core::types::Event::UserMessage { content, .. } => content.as_str(),
         _ => "",
     };
-    let transcript = if transcript.trim().is_empty() {
+    let transcript = if t.transcript.trim().is_empty() {
         "（无）"
     } else {
-        transcript
+        t.transcript.as_str()
     };
     let brief = build_persona_brief(&input.persona);
     let persona_block = if brief.is_empty() {
@@ -1909,6 +1909,15 @@ fn build_pde_ctx(
     // Always emit the image-capability line — the negative is a signal too, so
     // the judge gets a clear "no images this turn" rather than a missing line.
     let image_flag = if image_available { "是" } else { "否" };
+    // Engine-counted facts: the judge cannot reliably count image markers in
+    // the transcript, so state both numbers explicitly and tell it to trust
+    // this line over the markers.
+    let img_count = t.images_in_window;
+    let last_img = if t.last_assistant_is_image {
+        "是"
+    } else {
+        "否"
+    };
     // Product-QA lines render ONLY when the task is enabled this deployment —
     // old judge prompts see zero drift and pay zero tokens (unlike 图片能力,
     // whose negative is itself a signal). `Some("")` = enabled, no history yet.
@@ -1923,7 +1932,9 @@ fn build_pde_ctx(
         "{persona_block}[最近对话]\n{transcript}\n\n\
          [关系状态] warmth={:.2} trust={:.2} intrigue={:.2} intimacy={:.2} patience={:.2} tension={:.2}\n\
          [信号] message_count={} hours_since_last_message={:.1} ghost_streak={} hours_since_last_ghost={}\n\
-         [图片能力] 本轮可发图={image_flag}\n{product_qa_section}\n\
+         [图片能力] 本轮可发图={image_flag}\n\
+         [近期图片] 最近{INPUT_FILTER_CONTEXT_TURNS}条消息内已发图={img_count} 张；上一条 AI 消息是图片={last_img}（以本行计数为准，对话记录里的图片标记仅供参考）\n\
+         {product_qa_section}\n\
          [用户最新消息]\n{latest}",
         a.warmth,
         a.trust,
@@ -2124,7 +2135,15 @@ struct InputRewrite {
     f_generation_id: Option<String>,
 }
 
-/// Recent rows fed to the rewrite LLM as `[最近对话]` context.
+/// Rows fed to the rewrite LLM as `[最近对话]` context, and the window the
+/// judge's `[近期图片]` counts cover.
+///
+/// NOTE the name is a misnomer kept for compatibility: `ChatRepo::history`
+/// applies `LIMIT` to **rows**, so this is the last 8 *messages* (roughly 4
+/// exchanges), not 8 turns. Anything rendered for a model must say messages.
+/// Renaming it and changing the window are both explicit non-goals of the
+/// image-context design — the issue's bench inherited exactly this window, so
+/// its measured numbers only transfer while the window holds.
 const INPUT_FILTER_CONTEXT_TURNS: i64 = 8;
 
 /// Render an assistant transcript line. Image turns persist empty `content`
@@ -2153,18 +2172,70 @@ fn assistant_transcript_line(content: &str, metadata: Option<&serde_json::Value>
     content.to_string()
 }
 
-/// Build the compact transcript block for the input filter, excluding the turn
-/// being rewritten. Best-effort: a DB error yields an empty transcript.
+/// The judge/input-filter context: the rendered transcript plus the two image
+/// facts the engine can compute exactly and the judge cannot count reliably.
+#[derive(Debug, Default, Clone)]
+struct JudgeTranscript {
+    transcript: String,
+    /// Assistant rows in the window carrying `metadata.image`.
+    images_in_window: usize,
+    /// The newest assistant row in the window is an image turn.
+    last_assistant_is_image: bool,
+}
+
+/// Row-by-row accumulator behind `JudgeTranscript`, split out so the counting
+/// is unit-testable without a database.
+#[derive(Debug, Default)]
+struct JudgeTranscriptAcc {
+    lines: Vec<String>,
+    images_in_window: usize,
+    last_assistant_is_image: bool,
+}
+
+impl JudgeTranscriptAcc {
+    /// Fold one already-filtered row (caller has skipped the current turn and
+    /// channel-marked rows). Rows arrive oldest→newest, so the assistant flag
+    /// is simply overwritten and ends up reflecting the newest assistant row.
+    fn push(&mut self, role: &str, content: &str, metadata: Option<&serde_json::Value>) {
+        let (label, text): (&str, String) = match role {
+            "user" | "gift_user" => ("用户", content.to_string()),
+            "assistant" => {
+                let is_image = metadata.and_then(|m| m.get("image")).is_some();
+                if is_image {
+                    self.images_in_window += 1;
+                }
+                self.last_assistant_is_image = is_image;
+                ("AI", assistant_transcript_line(content, metadata))
+            }
+            _ => return,
+        };
+        self.lines.push(format!("{label}: {text}"));
+    }
+
+    fn finish(self) -> JudgeTranscript {
+        JudgeTranscript {
+            transcript: self.lines.join("\n"),
+            images_in_window: self.images_in_window,
+            last_assistant_is_image: self.last_assistant_is_image,
+        }
+    }
+}
+
+/// Build the compact transcript block for the input filter and the PDE judge,
+/// excluding the turn being rewritten, and count the window's image turns
+/// while the rows are in hand (no second round trip). Best-effort: a DB error
+/// yields an empty transcript and zero counts — which reads to the judge as
+/// "no recent images", the same signal an empty transcript gives today.
 async fn build_input_filter_transcript(
     chat_repo: &ChatRepo<'_>,
     session_id: Uuid,
     current_user_message_id: Uuid,
-) -> String {
+) -> JudgeTranscript {
     let rows = chat_repo
         .history(session_id, INPUT_FILTER_CONTEXT_TURNS, 0)
         .await
         .unwrap_or_default();
-    let mut lines = Vec::new();
+    let mut acc = JudgeTranscriptAcc::default();
     for m in rows {
         if m.id == current_user_message_id {
             continue;
@@ -2177,20 +2248,13 @@ async fn build_input_filter_transcript(
         // User/gift rows use the EFFECTIVE text (a prior turn's own rewrite when
         // present) so the filter sees the same conversation the chat model does;
         // assistant rows use content (their pre_filter_content means the opposite).
-        let (label, text): (&str, String) = match m.role.as_str() {
-            "user" | "gift_user" => (
-                "用户",
-                crate::pipeline::handlers::effective_user_text(&m).to_string(),
-            ),
-            "assistant" => (
-                "AI",
-                assistant_transcript_line(&m.content, m.metadata.as_ref()),
-            ),
-            _ => continue,
+        let text = match m.role.as_str() {
+            "user" | "gift_user" => crate::pipeline::handlers::effective_user_text(&m).to_string(),
+            _ => m.content.clone(),
         };
-        lines.push(format!("{label}: {text}"));
+        acc.push(&m.role, &text, m.metadata.as_ref());
     }
-    lines.join("\n")
+    acc.finish()
 }
 
 /// Run the input-filter LLM over the raw user input with recent context.
@@ -2883,10 +2947,10 @@ pub fn run_stream(
         // Shared history transcript: built once, reused by the judge here AND the
         // input filter below (which previously fetched its own). `resolved_pde` is
         // already None on tip turns, so this only fires for a real judge turn.
-        let pde_transcript: String = if resolved_pde.is_some() {
+        let pde_transcript: JudgeTranscript = if resolved_pde.is_some() {
             build_input_filter_transcript(&chat_repo, user_msg.session_id, user_msg.user_message_id).await
         } else {
-            String::new()
+            JudgeTranscript::default()
         };
         let mut killswitch_hints: Vec<String> = Vec::new();
         let (mut plan, pde_run): (eros_engine_core::types::ActionPlan, Option<PdeDecisionRun>) =
@@ -3293,7 +3357,7 @@ pub fn run_stream(
                         &input.persona,
                         &plan,
                         req_image,
-                        &pde_transcript,
+                        &pde_transcript.transcript,
                     )
                     .await;
                     let subject = img.seed_subject;
@@ -3464,8 +3528,8 @@ pub fn run_stream(
                         // Two round-trips per reply turn — acceptable, not a hot loop.
                         // Reuse the PDE's transcript when it was built this turn;
                         // otherwise fetch (input-filter-only turns: PDE off).
-                        let transcript = if !pde_transcript.is_empty() {
-                            pde_transcript.clone()
+                        let transcript = if !pde_transcript.transcript.is_empty() {
+                            pde_transcript.transcript.clone()
                         } else {
                             build_input_filter_transcript(
                                 &chat_repo,
@@ -3473,6 +3537,7 @@ pub fn run_stream(
                                 user_msg.user_message_id,
                             )
                             .await
+                            .transcript
                         };
                         if let Some(rw) =
                             run_input_filter(&state, &f, &transcript, &user_msg.content).await
@@ -3620,7 +3685,7 @@ pub fn run_stream(
                             &input.persona,
                             &plan,
                             req_image,
-                            &pde_transcript,
+                            &pde_transcript.transcript,
                         )
                         .await;
                         let subject = img.seed_subject;
@@ -4295,6 +4360,98 @@ mod tests {
         // metadata present but no image key: content passes through
         let meta3 = serde_json::json!({"tip": 5});
         assert_eq!(assistant_transcript_line("hello", Some(&meta3)), "hello");
+    }
+
+    /// Build a `JudgeTranscript` from (role, content, metadata) triples,
+    /// exercising the same folding logic the DB path uses.
+    fn judge_transcript_from_parts(
+        rows: &[(&str, &str, Option<serde_json::Value>)],
+    ) -> JudgeTranscript {
+        let mut acc = JudgeTranscriptAcc::default();
+        for (role, content, meta) in rows {
+            acc.push(role, content, meta.as_ref());
+        }
+        acc.finish()
+    }
+
+    #[test]
+    fn judge_transcript_counts_images_and_last_flag() {
+        // 3 assistant rows, 2 of them image turns, newest one an image.
+        let rows = vec![
+            (
+                "assistant",
+                "",
+                Some(serde_json::json!({"image":{"prompt":"a"}})),
+            ),
+            ("assistant", "just text", None),
+            (
+                "assistant",
+                "",
+                Some(serde_json::json!({"image":{"prompt":"b"}})),
+            ),
+        ];
+        let t = judge_transcript_from_parts(&rows);
+        assert_eq!(t.images_in_window, 2);
+        assert!(t.last_assistant_is_image);
+    }
+
+    #[test]
+    fn judge_transcript_last_flag_false_when_newest_is_text() {
+        let rows = vec![
+            (
+                "assistant",
+                "",
+                Some(serde_json::json!({"image":{"prompt":"a"}})),
+            ),
+            ("assistant", "just text", None),
+        ];
+        let t = judge_transcript_from_parts(&rows);
+        assert_eq!(t.images_in_window, 1);
+        assert!(!t.last_assistant_is_image, "newest assistant row is text");
+    }
+
+    #[test]
+    fn judge_transcript_empty_is_zero() {
+        let t = judge_transcript_from_parts(&[]);
+        assert_eq!(t.images_in_window, 0);
+        assert!(!t.last_assistant_is_image);
+        assert_eq!(t.transcript, "");
+    }
+
+    #[test]
+    fn pde_ctx_renders_recent_image_facts_in_messages_not_turns() {
+        let input = fixture_decision_input();
+        let t = JudgeTranscript {
+            transcript: "用户：hi\nMia：hey".into(),
+            images_in_window: 2,
+            last_assistant_is_image: true,
+        };
+        let ctx = build_pde_ctx(&t, &input, true, None);
+        assert!(
+            ctx.contains("[近期图片] 最近8条消息内已发图=2 张；上一条 AI 消息是图片=是"),
+            "facts line must render with a message-based unit: {ctx}"
+        );
+        assert!(
+            ctx.contains("以本行计数为准"),
+            "the override clause must render: {ctx}"
+        );
+        // The unit must NOT claim turns — the window is rows.
+        assert!(!ctx.contains("轮内已发图"), "unit must not say 轮: {ctx}");
+    }
+
+    #[test]
+    fn pde_ctx_renders_recent_image_facts_negative_case() {
+        let input = fixture_decision_input();
+        let t = JudgeTranscript {
+            transcript: "用户：hi".into(),
+            images_in_window: 0,
+            last_assistant_is_image: false,
+        };
+        let ctx = build_pde_ctx(&t, &input, false, None);
+        assert!(
+            ctx.contains("[近期图片] 最近8条消息内已发图=0 张；上一条 AI 消息是图片=否"),
+            "the negative case is a signal too and must always render: {ctx}"
+        );
     }
 
     #[test]
@@ -10240,6 +10397,26 @@ data: [DONE]\n\n";
         }
     }
 
+    fn fixture_decision_input() -> eros_engine_core::types::DecisionInput {
+        use eros_engine_core::types::{DecisionInput, Event};
+        DecisionInput {
+            event: Event::UserMessage {
+                content: "在吗".into(),
+                message_id: Uuid::new_v4(),
+                prompt_traits: vec![],
+                audit: None,
+                tier: None,
+                memory_scope: Default::default(),
+                affinity_scope: Default::default(),
+                tips_amount_usd: None,
+                history_anchor: Default::default(),
+            },
+            affinity: test_affinity(),
+            persona: test_persona(),
+            signals: test_signals(),
+        }
+    }
+
     #[test]
     fn persona_brief_renders_all_fields() {
         let mut p = test_persona(); // name = "Mia"
@@ -10294,7 +10471,11 @@ data: [DONE]\n\n";
             persona: p,
             signals: test_signals(),
         };
-        let ctx = build_pde_ctx("用户：hi\nMia：hey", &input, true, None);
+        let t = JudgeTranscript {
+            transcript: "用户：hi\nMia：hey".into(),
+            ..Default::default()
+        };
+        let ctx = build_pde_ctx(&t, &input, true, None);
         let persona_at = ctx.find("[角色人格]").expect("persona block present");
         let rel_at = ctx.find("[关系状态]").expect("relationship block present");
         assert!(
@@ -10346,7 +10527,7 @@ data: [DONE]\n\n";
             persona: p,
             signals: test_signals(),
         };
-        let ctx = build_pde_ctx("", &input, false, None);
+        let ctx = build_pde_ctx(&JudgeTranscript::default(), &input, false, None);
         assert!(!ctx.contains("[角色人格]"), "no persona block: {ctx}");
         assert!(
             ctx.starts_with("[最近对话]"),
@@ -10366,17 +10547,21 @@ data: [DONE]\n\n";
     #[test]
     fn pde_ctx_renders_product_qa_blocks_only_when_enabled() {
         let input = pde_test_input();
+        let t = JudgeTranscript {
+            transcript: "t".into(),
+            ..Default::default()
+        };
         // feature off → no lines at all
-        let off = build_pde_ctx("t", &input, true, None);
+        let off = build_pde_ctx(&t, &input, true, None);
         assert!(!off.contains("[产品咨询]"));
         assert!(!off.contains("[最近产品咨询]"));
         // on, no history → availability line only
-        let on_empty = build_pde_ctx("t", &input, true, Some(""));
+        let on_empty = build_pde_ctx(&t, &input, true, Some(""));
         assert!(on_empty.contains("[产品咨询] 本轮可答产品问题=是"));
         assert!(!on_empty.contains("[最近产品咨询]"));
         // on, with history → both blocks, before [用户最新消息]
         let recent = render_product_qa_pairs(&[("这是什么".into(), "这是……".into())]);
-        let on_recent = build_pde_ctx("t", &input, true, Some(&recent));
+        let on_recent = build_pde_ctx(&t, &input, true, Some(&recent));
         assert!(on_recent.contains("[最近产品咨询]\n用户: 这是什么\n回答: 这是……"));
         assert!(on_recent.find("[产品咨询]").unwrap() < on_recent.find("[用户最新消息]").unwrap());
     }

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -3701,8 +3701,7 @@ pub fn run_stream(
                         if let Some(rw) =
                             run_input_filter(&state, &f, &transcript, &user_msg.content).await
                         {
-                            effective_user_msg = rw.rewritten_text.clone();
-                            if let Err(e) = chat_repo
+                            match chat_repo
                                 .set_user_input_rewrite(
                                     user_msg.user_message_id,
                                     &rw.rewritten_text,
@@ -3712,7 +3711,19 @@ pub fn run_stream(
                                 )
                                 .await
                             {
-                                tracing::warn!("stream: input-filter rewrite persist failed: {e}");
+                                // The chat model reads the effective text back
+                                // from the DB row (build_reply_request), so the
+                                // composer may track the rewrite only once it is
+                                // persisted — on a failed write the chat model
+                                // will see the ORIGINAL text, and handing the
+                                // composer the unpersisted rewrite would let the
+                                // picture drift from the reply.
+                                Ok(()) => effective_user_msg = rw.rewritten_text.clone(),
+                                Err(e) => {
+                                    tracing::warn!(
+                                        "stream: input-filter rewrite persist failed: {e}"
+                                    );
+                                }
                             }
                         }
                     }

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -2435,7 +2435,9 @@ fn parse_compose_reply(raw: &str) -> (String, Option<String>) {
 struct ComposeOutcome {
     prompt: String,
     /// One short line describing what the picture shows, for the chat history
-    /// and the judge transcript. `None` when the model gave none.
+    /// and the judge transcript. `None` when the model gave none — including
+    /// when the reply wasn't JSON at all (the migration fallback in
+    /// `parse_compose_reply`, where the whole reply becomes `prompt` instead).
     caption: Option<String>,
     /// Model that actually answered: `resp.model`, falling back to the
     /// attempted model id (same idiom as the vision audit).
@@ -2653,7 +2655,9 @@ async fn build_delegated_image_prompt(
         .and_then(|v| v.as_str().map(String::from))
         .unwrap_or_else(|| "realistic".to_string());
     let variant = req_image.and_then(|i| i.prompt_variant.as_deref());
-    let compose = match state.model_config.resolve_image_prompt_compose(variant) {
+    let resolved_compose = state.model_config.resolve_image_prompt_compose(variant);
+    let composer_configured = resolved_compose.is_some();
+    let compose = match resolved_compose {
         Some(c) => {
             run_image_prompt_compose(
                 state,
@@ -2677,7 +2681,30 @@ async fn build_delegated_image_prompt(
                 Some(o.model),
                 o.generation_id,
             ),
-            None => (String::new(), None, None, None, None),
+            None => {
+                // Loud on purpose: this is the ONE path where the capability
+                // gate (`本轮可发图=否` when the composer isn't configured) is
+                // bypassed — a forced image turn (`image.force = true`) always
+                // reaches here regardless of gate state. A deployment that
+                // upgraded past #212 without configuring
+                // `[tasks.chat_image_prompt_compose]` would otherwise silently
+                // get a generic persona-portrait prompt on every forced image,
+                // with zero log lines anywhere else on this path. Still a warn,
+                // not an error: the portrait fallback is the sanctioned
+                // fail-open degradation, not a bug.
+                tracing::warn!(
+                    composer_configured,
+                    "image-compose: no subject produced this turn; falling back to a generic \
+                     persona-portrait prompt ({})",
+                    if composer_configured {
+                        "composer chain failed — see the preceding image-compose warn for the \
+                         model and reason"
+                    } else {
+                        "no [tasks.chat_image_prompt_compose] configured"
+                    }
+                );
+                (String::new(), None, None, None, None)
+            }
         };
     let composed_prompt =
         crate::pipeline::handlers::compose_image_prompt(inputs.style, persona, &final_subject);
@@ -6780,6 +6807,221 @@ data: [DONE]\n\n";
             "marker must not store a generation id"
         );
         assert!(img.get("url").is_none(), "marker must not store a url");
+    }
+
+    /// Review finding (2026-08-02, issue #212 fix wave): the sibling test above
+    /// configures NO `chat_image_prompt_compose` task, so the concurrently
+    /// spawned compose task resolves `None` and returns instantly — the join
+    /// at the end of the burst is trivially satisfied and proves nothing about
+    /// ordering under a REAL in-flight call. This test configures the composer
+    /// AND gives its mocked response a delay that outlasts the (instant, mocked)
+    /// chat burst, so the join at `compose_handle.take().unwrap().await`
+    /// genuinely waits on a still-running task — the actual race the concurrent
+    /// spawn in `run_stream` is meant to survive. Asserts the wire frame order
+    /// still holds (`meta → delta* → done → image_request → final`) and that
+    /// the `image_request` frame plus the persisted marker carry the racing
+    /// composer's real output, not the empty-subject portrait fallback.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn reply_text_image_concurrent_composer_races_chat_burst(pool: PgPool) {
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+        use futures_util::StreamExt;
+        use wiremock::matchers::{body_string_contains, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+
+        // Chat burst: streams back immediately, no delay. The composer mock
+        // below is delayed well past this, so by the time `run_stream` reaches
+        // the join point the compose task is still in flight — the join must
+        // actually wait on it rather than observe an already-resolved handle.
+        let chat_body = "\
+data: {\"choices\":[{\"delta\":{\"content\":\"I would absolutely love that for you, \"}}]}\n\n\
+data: {\"choices\":[{\"delta\":{\"content\":\"let me slip into something far more comfortable and show you every bit of it\"}}],\"usage\":{\"prompt_tokens\":2,\"completion_tokens\":9,\"total_tokens\":11},\"id\":\"gen-r\",\"model\":\"primary\"}\n\n\
+data: [DONE]\n\n";
+        // Route the two calls by the MODEL ID present in the request body so the
+        // two mocks are MUTUALLY EXCLUSIVE (mount order/precedence cannot matter):
+        // chat call body contains "primary"; composer call body contains "composer".
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("\"model\":\"primary\""))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(chat_body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("\"model\":\"composer\""))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_delay(std::time::Duration::from_millis(150))
+                    .set_body_json(serde_json::json!({
+                        "id": "gen-compose-race",
+                        "model": "served/composer-model",
+                        "choices": [{"message": {"content":
+                            r#"{"prompt":"CONCURRENT COMPOSED SUBJECT","caption":"并发合成的图片"}"#
+                        }}],
+                    })),
+            )
+            .mount(&mock)
+            .await;
+
+        let user_id = Uuid::new_v4();
+        let (_g, instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = std::sync::Arc::new(
+            eros_engine_llm::model_config::ModelConfig::from_toml_str(
+                "[tasks.chat_companion]\nmodel = \"primary\"\n\
+                 [tasks.chat_image_prompt_compose]\nmodel = \"composer\"\n",
+            )
+            .unwrap(),
+        );
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+
+        let chat_repo = ChatRepo { pool: &pool };
+        let user_message_id = match chat_repo
+            .upsert_user_message_idempotent(
+                session_id,
+                "hi",
+                "01J9222222222222222222222A",
+                "user",
+                None,
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
+
+        let frames: Vec<ProtocolFrame> = run_stream(
+            std::sync::Arc::new(state),
+            PersistedUserMessage {
+                user_message_id,
+                session_id,
+                user_id,
+                instance_id,
+                content: "hi".into(),
+                prompt_traits: vec![],
+                audit: None,
+                tier: None,
+                memory_scope: Default::default(),
+                affinity_scope: Default::default(),
+                tips_amount_usd: None,
+                image_url: None,
+                image: Some(crate::routes::companion_stream::ImageReplyParams {
+                    force: true,
+                    // default mode = TextImage ⇒ ReplyTextImage
+                    ..Default::default()
+                }),
+                history_anchor: Default::default(),
+            },
+            None,
+        )
+        .collect()
+        .await;
+
+        let reqs = mock.received_requests().await.expect("recorded requests");
+        assert_eq!(
+            reqs.len(),
+            2,
+            "reply_text_image makes exactly two provider calls: chat + composer, {reqs:?}"
+        );
+
+        let types: Vec<String> = frames
+            .iter()
+            .map(|f| {
+                serde_json::to_value(f).unwrap()["type"]
+                    .as_str()
+                    .unwrap()
+                    .to_string()
+            })
+            .collect();
+        // meta(reply_text_image) → delta* → done → image_request → final,
+        // preserved even though the composer is still running when the chat
+        // burst's `done` frame is emitted.
+        assert_eq!(types.first().map(String::as_str), Some("meta"), "{types:?}");
+        assert_eq!(types.last().map(String::as_str), Some("final"), "{types:?}");
+        assert!(
+            types.iter().any(|t| t == "delta"),
+            "text burst delta present: {types:?}"
+        );
+        let ir_pos = types
+            .iter()
+            .position(|t| t == "image_request")
+            .expect("image_request present");
+        let done_pos = types
+            .iter()
+            .position(|t| t == "done")
+            .expect("done present");
+        assert!(
+            done_pos < ir_pos,
+            "image_request comes after done even with a real in-flight composer: {types:?}"
+        );
+        assert_eq!(
+            types[ir_pos + 1],
+            "final",
+            "image_request immediately before final"
+        );
+        assert_eq!(
+            types
+                .iter()
+                .filter(|t| t.as_str() == "image_request")
+                .count(),
+            1,
+            "exactly one image_request"
+        );
+
+        // The image_request frame carries the COMPOSER'S output (the wire
+        // prompt embeds the enriched subject) — not the empty-subject portrait
+        // fallback the no-composer sibling test exercises.
+        let composed_b64 = frames
+            .iter()
+            .find_map(|f| match f {
+                ProtocolFrame::ImageRequest {
+                    composed_prompt, ..
+                } => Some(composed_prompt.clone()),
+                _ => None,
+            })
+            .expect("image_request present");
+        let composed = {
+            use base64::Engine as _;
+            String::from_utf8(
+                base64::engine::general_purpose::STANDARD
+                    .decode(&composed_b64)
+                    .unwrap(),
+            )
+            .unwrap()
+        };
+        assert!(
+            composed.contains("CONCURRENT COMPOSED SUBJECT"),
+            "composed wire prompt must carry the racing composer's subject, got {composed}"
+        );
+
+        // The marker MERGED onto the assistant text row carries the composer's
+        // actual subject/caption/audit trio — proof the join actually picked up
+        // the still-in-flight task's result rather than racing past it.
+        let row: (String, Option<serde_json::Value>) = sqlx::query_as(
+            "SELECT content, metadata FROM engine.chat_messages \
+             WHERE session_id = $1 AND role = 'assistant' \
+             ORDER BY sent_at DESC LIMIT 1",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert!(!row.0.is_empty(), "the text reply row has content");
+        let img = row.1.expect("row has metadata")["image"].clone();
+        assert_eq!(img["prompt"], "CONCURRENT COMPOSED SUBJECT");
+        assert_eq!(img["caption"], "并发合成的图片");
+        assert_eq!(img["compose_model"], "served/composer-model");
+        assert_eq!(img["compose_generation_id"], "gen-compose-race");
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -1518,7 +1518,8 @@ impl PdeAction {
 }
 
 /// Parsed judge verdict. `inner_state` is sanitized (`sanitize_inner_state`)
-/// before it reaches the prompt; `image_prompt`/`reason` are never injected.
+/// before it reaches the prompt; `reason` is never injected. The judge writes
+/// no image prompt — composition belongs to `chat_image_prompt_compose` (#212).
 #[derive(Debug, Clone, serde::Deserialize)]
 pub(crate) struct PdeVerdict {
     action: PdeAction,
@@ -1528,8 +1529,6 @@ pub(crate) struct PdeVerdict {
     /// inner_state before injection). `None` on old prompts / null verdicts.
     #[serde(default)]
     tone: Option<String>,
-    #[serde(default)]
-    image_prompt: Option<String>,
     #[serde(default)]
     reason: Option<String>,
     #[serde(default)]
@@ -1621,13 +1620,12 @@ fn pde_response_format() -> serde_json::Value {
             "schema": {
                 "type": "object",
                 "additionalProperties": false,
-                "required": ["action", "inner_state", "tone", "image_prompt", "reason", "image_ref", "aspect_ratio"],
+                "required": ["action", "inner_state", "tone", "reason", "image_ref", "aspect_ratio"],
                 "properties": {
                     "action": { "type": "string",
                         "enum": ["reply_text", "ghost", "reply_image", "reply_text_image", "product_qa"] },
                     "inner_state": { "type": "string" },
                     "tone": { "type": ["string", "null"] },
-                    "image_prompt": { "type": ["string", "null"] },
                     "reason": { "type": ["string", "null"] },
                     "image_ref": { "type": "string", "enum": ["face", "previous"] },
                     "aspect_ratio": { "type": ["string", "null"],
@@ -1809,7 +1807,6 @@ fn apply_ghosting_killswitch(
             ActionType::ReplyText,
             hints,
             None,
-            None,
             eros_engine_core::types::ImageRef::Face,
             None,
         )
@@ -1964,8 +1961,6 @@ struct VerdictAudit<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     tone: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    image_prompt: Option<&'a str>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     reason: Option<&'a str>,
     image_ref: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1978,7 +1973,6 @@ impl<'a> From<&'a PdeVerdict> for VerdictAudit<'a> {
             action: v.action.as_str(),
             inner_state: &v.inner_state,
             tone: v.tone.as_deref(),
-            image_prompt: v.image_prompt.as_deref(),
             reason: v.reason.as_deref(),
             image_ref: match v.image_ref {
                 eros_engine_core::types::ImageRef::Face => "face",
@@ -2530,7 +2524,7 @@ struct ImageTurnInputs {
 
 /// Pure: resolve the seed subject, style, and aspect ratio for a delegated
 /// image turn. Precedence per field:
-/// - subject: `plan.image_prompt` → `req_image.image_prompt` → `""`
+/// - subject: `req_image.image_prompt` → `""` (the judge no longer writes one)
 /// - style:   `req_image.style` → type default (`Realistic`)
 /// - aspect:  `plan.aspect_ratio` → `req_image.aspect_ratio` → `None`
 ///
@@ -2541,15 +2535,9 @@ fn resolve_image_turn_inputs(
     plan: &eros_engine_core::types::ActionPlan,
     req_image: Option<&crate::routes::companion_stream::ImageReplyParams>,
 ) -> ImageTurnInputs {
-    let seed_subject = plan
-        .image_prompt
-        .as_deref()
+    let seed_subject = req_image
+        .and_then(|i| i.image_prompt.as_deref())
         .filter(|s| !s.trim().is_empty())
-        .or_else(|| {
-            req_image
-                .and_then(|i| i.image_prompt.as_deref())
-                .filter(|s| !s.trim().is_empty())
-        })
         .unwrap_or("")
         .to_string();
     let style = req_image.and_then(|i| i.style).unwrap_or_default();
@@ -3067,23 +3055,20 @@ pub fn run_stream(
                                 .as_deref()
                                 .map(sanitize_inner_state)
                                 .filter(|s| !s.is_empty());
-                            // Capture the judge's image prompt while `v` is still
-                            // borrowed here (the run/verdict is moved into the
-                            // audit task below). Only image actions carry it.
+                            // Only image actions carry the judge's image_ref /
+                            // aspect_ratio; `v` is still borrowed here (the
+                            // run/verdict is moved into the audit task below).
                             let is_image = matches!(
                                 action,
                                 ActionType::ReplyImage | ActionType::ReplyTextImage
                             );
-                            let img_prompt = if is_image { v.image_prompt.clone() } else { None };
                             let img_ref = if is_image {
                                 v.image_ref
                             } else {
                                 eros_engine_core::types::ImageRef::Face
                             };
                             let img_aspect = if is_image { v.aspect_ratio.clone() } else { None };
-                            pde::plan_for(
-                                &input, action, hints, tone, img_prompt, img_ref, img_aspect,
-                            )
+                            pde::plan_for(&input, action, hints, tone, img_ref, img_aspect)
                         }
                         _ => pde::decide(&input), // fail-open
                     };
@@ -3103,8 +3088,9 @@ pub fn run_stream(
 
         // Forced-image override — wins over the PDE/ghost result. Applied AFTER
         // the kill-switch so a client-forced image is never suppressed to ghost.
-        // ImageOnly ⇒ ReplyImage; otherwise (TextImage) ⇒ ReplyTextImage. Carries
-        // the client-supplied image prompt (not the judge's).
+        // ImageOnly ⇒ ReplyImage; otherwise (TextImage) ⇒ ReplyTextImage. The
+        // client's explicit subject still reaches the composer via
+        // `resolve_image_turn_inputs`, which reads `req_image.image_prompt`.
         if force_image {
             let action = match req_image.map(|i| &i.mode) {
                 Some(crate::routes::companion_stream::ImageMode::ImageOnly) => {
@@ -3117,7 +3103,6 @@ pub fn run_stream(
                 action,
                 plan.context_hints.clone(),
                 plan.reply_tone.clone(),
-                req_image.and_then(|i| i.image_prompt.clone()),
                 eros_engine_core::types::ImageRef::Face,
                 None,
             );
@@ -3427,6 +3412,7 @@ pub fn run_stream(
                 let mut image_only_done = false;
                 let mut image_only_produced: Vec<crate::pipeline::post_process::ProducedMessage> =
                     Vec::new();
+                let mut image_only_caption: Option<String> = None;
 
                 if matches!(plan.action_type, ActionType::ReplyImage) {
                     // Delegate-only: compose the prompt and emit `image_request`;
@@ -3459,6 +3445,7 @@ pub fn run_stream(
                         img.compose_model.as_deref(),
                         img.compose_generation_id.as_deref(),
                     );
+                    image_only_caption = img.caption.clone();
                     let row = eros_engine_store::chat::AssistantInsert {
                         id: msg_uuid,
                         content: String::new(),
@@ -3482,7 +3469,8 @@ pub fn run_stream(
                         tracing::warn!("stream(image): persist failed: {e}");
                     }
                     // full_text="" so insight/memory extraction skips this row;
-                    // affinity uses plan.image_prompt as the proxy.
+                    // affinity uses plan.image_caption (set below, from the
+                    // picture's caption) as the proxy.
                     image_only_produced.push(crate::pipeline::post_process::ProducedMessage {
                         message_id: msg_uuid,
                         full_text: String::new(),
@@ -3528,7 +3516,8 @@ pub fn run_stream(
                     yield final_frame;
 
                     let state_bg = (*state).clone();
-                    let plan_bg = plan.clone();
+                    let mut plan_bg = plan.clone();
+                    plan_bg.image_caption = image_only_caption;
                     let event_bg = Event::UserMessage {
                         content: user_msg.content.clone(),
                         message_id: user_msg.user_message_id,
@@ -3761,6 +3750,7 @@ pub fn run_stream(
                 // order: meta → delta* → done → image → final. On image failure
                 // (or zero images / empty produced) we emit NO Image frame — the
                 // text reply already reached the client, so the turn is complete.
+                let mut image_caption: Option<String> = None;
                 if matches!(plan.action_type, ActionType::ReplyTextImage) {
                     if let Some(last) = produced.last() {
                         let msg_uuid = last.message_id;
@@ -3777,6 +3767,7 @@ pub fn run_stream(
                         let subject = img.subject;
                         let aspect = img.aspect_ratio;
                         let composed_prompt = img.composed_prompt;
+                        image_caption = img.caption.clone();
                         // Merge the marker (subject + caption + aspect + compose
                         // audit trio on success) onto the already-persisted
                         // text row so the PDE stays image-aware (§5). The text
@@ -3827,6 +3818,7 @@ pub fn run_stream(
                 if plan_bg.action_type == ActionType::ReplyImage {
                     plan_bg.action_type = ActionType::ReplyText;
                 }
+                plan_bg.image_caption = image_caption;
                 let event_bg = Event::UserMessage {
                     content: user_msg.content.clone(),
                     message_id: user_msg.user_message_id,
@@ -4194,10 +4186,7 @@ mod tests {
 
     // ─── resolve_image_turn_inputs ───────────────────────────────────────
 
-    fn img_plan(
-        image_prompt: Option<&str>,
-        aspect: Option<&str>,
-    ) -> eros_engine_core::types::ActionPlan {
+    fn img_plan(aspect: Option<&str>) -> eros_engine_core::types::ActionPlan {
         eros_engine_core::types::ActionPlan {
             action_type: ActionType::ReplyImage,
             reply_style: eros_engine_core::types::ReplyStyle::Neutral,
@@ -4205,7 +4194,7 @@ mod tests {
             energy_cost: 0.0,
             context_hints: vec![],
             reply_tone: None,
-            image_prompt: image_prompt.map(str::to_string),
+            image_caption: None,
             image_ref: eros_engine_core::types::ImageRef::Face,
             aspect_ratio: aspect.map(str::to_string),
         }
@@ -4225,26 +4214,20 @@ mod tests {
     }
 
     #[test]
-    fn image_turn_subject_prefers_plan_then_request_then_empty() {
+    fn image_turn_subject_comes_only_from_request() {
+        // The judge no longer writes a seed; the request is the only source.
         let params = img_params(Some("from request"), None, None);
-
-        // plan wins
-        let r = resolve_image_turn_inputs(&img_plan(Some("from plan"), None), Some(&params));
-        assert_eq!(r.seed_subject, "from plan");
-
-        // blank plan subject falls through to the request
-        let r = resolve_image_turn_inputs(&img_plan(Some("   "), None), Some(&params));
+        let r = resolve_image_turn_inputs(&img_plan(None), Some(&params));
         assert_eq!(r.seed_subject, "from request");
 
         // neither ⇒ empty string
-        let r = resolve_image_turn_inputs(&img_plan(None, None), None);
+        let r = resolve_image_turn_inputs(&img_plan(None), None);
         assert_eq!(r.seed_subject, "");
 
-        // blank request value, plan absent ⇒ falls through to empty string
-        // too, not the blank string itself (the request-level blank filter
-        // must still fire).
+        // blank request value ⇒ falls through to empty string too, not the
+        // blank string itself (the request-level blank filter must still fire).
         let blank_params = img_params(Some("   "), None, None);
-        let r = resolve_image_turn_inputs(&img_plan(None, None), Some(&blank_params));
+        let r = resolve_image_turn_inputs(&img_plan(None), Some(&blank_params));
         assert_eq!(r.seed_subject, "");
     }
 
@@ -4253,10 +4236,10 @@ mod tests {
         use eros_engine_llm::model_config::StyleKey;
 
         let params = img_params(None, Some(StyleKey::SemiRealistic), None);
-        let r = resolve_image_turn_inputs(&img_plan(None, None), Some(&params));
+        let r = resolve_image_turn_inputs(&img_plan(None), Some(&params));
         assert_eq!(r.style, StyleKey::SemiRealistic, "request wins");
 
-        let r = resolve_image_turn_inputs(&img_plan(None, None), None);
+        let r = resolve_image_turn_inputs(&img_plan(None), None);
         assert_eq!(r.style, StyleKey::default(), "no request ⇒ type default");
     }
 
@@ -4264,22 +4247,22 @@ mod tests {
     fn image_turn_aspect_prefers_plan_then_request_then_none() {
         let params = img_params(None, None, Some("16:9"));
 
-        let r = resolve_image_turn_inputs(&img_plan(None, Some("3:4")), Some(&params));
+        let r = resolve_image_turn_inputs(&img_plan(Some("3:4")), Some(&params));
         assert_eq!(r.aspect_ratio.as_deref(), Some("3:4"), "plan wins");
 
-        let r = resolve_image_turn_inputs(&img_plan(None, Some("  ")), Some(&params));
+        let r = resolve_image_turn_inputs(&img_plan(Some("  ")), Some(&params));
         assert_eq!(
             r.aspect_ratio.as_deref(),
             Some("16:9"),
             "blank plan ⇒ request"
         );
 
-        let r = resolve_image_turn_inputs(&img_plan(None, None), None);
+        let r = resolve_image_turn_inputs(&img_plan(None), None);
         assert_eq!(r.aspect_ratio, None, "nothing anywhere ⇒ None");
 
         // Blank request value ⇒ the request-level blank filter still fires.
         let blank_params = img_params(None, None, Some("  "));
-        let r = resolve_image_turn_inputs(&img_plan(None, None), Some(&blank_params));
+        let r = resolve_image_turn_inputs(&img_plan(None), Some(&blank_params));
         assert_eq!(r.aspect_ratio, None, "blank request ⇒ None");
     }
 
@@ -4807,7 +4790,6 @@ mod tests {
             ActionType::Ghost,
             vec![],
             None,
-            None,
             eros_engine_core::types::ImageRef::Face,
             None,
         );
@@ -4837,7 +4819,6 @@ mod tests {
             &input,
             acted,
             hints.clone(),
-            None,
             None,
             eros_engine_core::types::ImageRef::Face,
             None,
@@ -6094,11 +6075,12 @@ data: [DONE]\n\n";
     /// returns `None` for an unconfigured task, so there is no config-side gate
     /// to lean on here. A longer message (e.g. "draw me", 7 chars) clears the
     /// length gate, and because `ReplyImage` proxies the assistant text with
-    /// `plan.image_prompt` (non-blank here), it would also clear the
-    /// empty-assistant gate — so the eval call fires, racing the test's
-    /// `mock.received_requests()` against a `tokio::spawn`ed task. Keeping the
-    /// content short makes "the composer is the only possible call" true by
-    /// construction, not by scheduling luck.
+    /// `plan.image_caption` — falling back to a generic marker when the
+    /// caption is absent, so the proxy text is always non-blank — it would
+    /// also clear the empty-assistant gate — so the eval call fires, racing
+    /// the test's `mock.received_requests()` against a `tokio::spawn`ed task.
+    /// Keeping the content short makes "the composer is the only possible
+    /// call" true by construction, not by scheduling luck.
     async fn run_variant_turn(
         pool: &PgPool,
         prompt_variant: Option<&str>,
@@ -10815,7 +10797,7 @@ data: [DONE]\n\n";
         assert_eq!(v["json_schema"]["name"], "pde_verdict");
         assert_eq!(v["json_schema"]["strict"], true);
         let req = v["json_schema"]["schema"]["required"].as_array().unwrap();
-        assert_eq!(req.len(), 7, "all seven properties required: {v}");
+        assert_eq!(req.len(), 6, "all six properties required: {v}");
         assert!(
             req.iter().any(|x| x == "image_ref"),
             "image_ref required: {v}"
@@ -10838,6 +10820,33 @@ data: [DONE]\n\n";
             actions.iter().any(|x| x == "product_qa"),
             "product_qa in action enum: {v}"
         );
+    }
+
+    #[test]
+    fn pde_response_format_has_no_image_prompt() {
+        let f = pde_response_format();
+        let schema = &f["json_schema"]["schema"];
+        let required = schema["required"].as_array().expect("required array");
+        assert!(
+            !required.iter().any(|v| v == "image_prompt"),
+            "the judge must not be asked for an image prompt: {required:?}"
+        );
+        assert!(
+            schema["properties"].get("image_prompt").is_none(),
+            "image_prompt must be gone from properties"
+        );
+        // The two enums the judge still owns stay.
+        assert!(schema["properties"].get("image_ref").is_some());
+        assert!(schema["properties"].get("aspect_ratio").is_some());
+    }
+
+    #[test]
+    fn parse_pde_verdict_ignores_stray_image_prompt() {
+        // A non-strict provider may still emit the old key; it must not break parsing.
+        let j = r#"{"action":"reply_image","inner_state":"x","image_prompt":"leftover","image_ref":"previous","aspect_ratio":"9:16"}"#;
+        let v = parse_pde_verdict(j).expect("verdict parses despite the stray key");
+        assert_eq!(v.action, PdeAction::ReplyImage);
+        assert_eq!(v.aspect_ratio.as_deref(), Some("9:16"));
     }
 
     fn test_resolved_pde(models: Vec<String>) -> eros_engine_llm::model_config::ResolvedPde {

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -2601,6 +2601,36 @@ struct DelegatedImagePrompt {
     compose_generation_id: Option<String>,
 }
 
+/// Guards a speculatively-spawned `tokio::task::JoinHandle` so it is aborted
+/// if it's ever dropped without being joined. Dropping a `JoinHandle` on its
+/// own does NOT cancel the task — it keeps running to completion in the
+/// background, discarding its result. `reply_text_image` spawns the image
+/// composer early (concurrently with the chat call) so its latency hides
+/// underneath, but the turn that spawned it can end several ways before
+/// reaching the join point (an error frame, a ghost-fallback turn with no
+/// produced row to attach an image to, the whole stream being dropped by a
+/// disconnected client, ...). None of those turns will ever emit an image
+/// frame, so an in-flight compose call at that point has no consumer left —
+/// letting it run to completion would just waste an LLM round trip. Wrapping
+/// the handle in this guard means every current AND future early exit aborts
+/// the task automatically, instead of requiring each one to remember to.
+struct AbortOnDrop<T>(Option<tokio::task::JoinHandle<T>>);
+
+impl<T> AbortOnDrop<T> {
+    /// Take the handle to await it. Once taken, the guard no longer aborts.
+    fn take(&mut self) -> Option<tokio::task::JoinHandle<T>> {
+        self.0.take()
+    }
+}
+
+impl<T> Drop for AbortOnDrop<T> {
+    fn drop(&mut self) {
+        if let Some(h) = &self.0 {
+            h.abort();
+        }
+    }
+}
+
 /// Resolve the per-turn image inputs, generate the subject via the composer
 /// LLM, and wrap the result into the final wire prompt.
 ///
@@ -3670,7 +3700,7 @@ pub fn run_stream(
                 //
                 // `reply_image` is deliberately excluded: it has no text task to
                 // overlap with and returns early via `image_only_done`.
-                let compose_handle: Option<tokio::task::JoinHandle<DelegatedImagePrompt>> =
+                let mut compose_handle: AbortOnDrop<DelegatedImagePrompt> =
                     if matches!(plan.action_type, ActionType::ReplyTextImage) {
                         let state_c = (*state).clone();
                         let persona_c = input.persona.clone();
@@ -3678,7 +3708,7 @@ pub fn run_stream(
                         let req_image_c = req_image.cloned();
                         let scene_c = pde_transcript.transcript.clone();
                         let latest_c = effective_user_msg.clone();
-                        Some(tokio::spawn(async move {
+                        AbortOnDrop(Some(tokio::spawn(async move {
                             build_delegated_image_prompt(
                                 &state_c,
                                 &persona_c,
@@ -3688,9 +3718,9 @@ pub fn run_stream(
                                 &latest_c,
                             )
                             .await
-                        }))
+                        })))
                     } else {
-                        None
+                        AbortOnDrop(None)
                     };
                 let req_res = crate::pipeline::handlers::build_reply_request(
                     &state, &input, &plan,
@@ -3700,9 +3730,13 @@ pub fn run_stream(
                 let (req, injected_tags) = match req_res {
                     Ok(r) => r,
                     Err(e) => {
-                        if let Some(h) = compose_handle.as_ref() {
-                            h.abort();
-                        }
+                        // Dropping `compose_handle` here (via the enclosing
+                        // `return` below) aborts the spawned compose task
+                        // through `AbortOnDrop`'s `Drop` impl — no manual
+                        // `.abort()` needed, and every OTHER early exit
+                        // between here and the join point (chat-burst error,
+                        // ghost fallback with no produced row, client
+                        // disconnect) gets the same coverage for free.
                         yield ProtocolFrame::Error {
                             code: StreamErrorCode::Internal,
                             retryable: false,
@@ -3823,7 +3857,7 @@ pub fn run_stream(
                         // it has almost always finished, so this await is ~free.
                         // A panicked or cancelled task degrades exactly like a
                         // failed compose — never a dropped frame.
-                        let img = match compose_handle {
+                        let img = match compose_handle.take() {
                             Some(h) => match h.await {
                                 Ok(v) => v,
                                 Err(e) => {

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -1756,6 +1756,27 @@ async fn run_pde_decision(
     }
 }
 
+/// Whether an image action is possible this turn.
+///
+/// Two independent facts must both hold: the request carries an `image` block
+/// (the consumer signalling "I handle images this turn" — the engine holds no
+/// image configuration and never draws), and `[tasks.chat_image_prompt_compose]`
+/// is configured. The composer became mandatory when the judge stopped writing
+/// seeds (#212): with no seed and no composer, nothing can produce an image
+/// prompt at all.
+///
+/// The check is the task section's PRESENCE, deliberately not a
+/// `resolve_image_prompt_compose(..)` call: that resolver reaches
+/// `self.resolve(COMPOSE_TASK, None)`, which advances the round-robin model
+/// cursor as a side effect, so calling it merely to answer a capability
+/// question would skew which model later image turns actually pick.
+fn image_capability_available(
+    executor_available: bool,
+    model_config: &eros_engine_llm::model_config::ModelConfig,
+) -> bool {
+    executor_available && model_config.has_task("chat_image_prompt_compose")
+}
+
 /// Map the judge's proposed action to the acted `ActionType`, applying the
 /// hard-safety ghost guardrail (`ghost::ghost_permitted`) and the image-degrade.
 /// Does NOT apply the `ghosting` kill-switch (that is a path-wide final gate).
@@ -2977,9 +2998,11 @@ pub fn run_stream(
         // Delegate-only: the chat stream never draws, so image-action
         // availability keys on the PRESENCE of the request `image` block (the
         // consumer signalling "I handle images this turn"). The engine holds
-        // no image configuration at all.
+        // no image configuration at all. Image capability = that PLUS a
+        // composer configured to write the prompt (#212).
         let req_image = user_msg.image.as_ref();
-        let image_executor_available = req_image.is_some();
+        let image_executor_available =
+            image_capability_available(req_image.is_some(), &state.model_config);
         let force_image = req_image.is_some_and(|i| i.force) && !is_tip;
         // Skip resolution on tip turns: the judge won't run, and resolve_pde()
         // advances the round-robin model cursor as a side effect — resolving on a
@@ -4758,6 +4781,33 @@ mod tests {
             guard_action(PdeAction::ReplyTextImage, &aff, &sig, false, false),
             ActionType::ReplyText
         );
+    }
+
+    #[test]
+    fn image_capability_requires_a_configured_composer() {
+        use eros_engine_llm::model_config::ModelConfig;
+        // Executor present (request carries an `image` block) but no composer task.
+        let no_composer =
+            ModelConfig::from_toml_str("[tasks.chat_companion]\nmodel = \"m\"\n").expect("parses");
+        assert!(
+            !image_capability_available(true, &no_composer),
+            "no composer task ⇒ no image capability: nothing can write a prompt"
+        );
+        // Composer configured ⇒ capability follows the executor.
+        let with_composer =
+            ModelConfig::from_toml_str("[tasks.chat_image_prompt_compose]\nmodel = \"m\"\n")
+                .expect("parses");
+        assert!(image_capability_available(true, &with_composer));
+        assert!(
+            !image_capability_available(false, &with_composer),
+            "no executor ⇒ no capability, unchanged"
+        );
+        // A variant-shaped filter_prompt is still a configured composer.
+        let variants = ModelConfig::from_toml_str(
+            "[tasks.chat_image_prompt_compose]\nmodel = \"m\"\nfilter_prompt = { a = \"X\" }\n",
+        )
+        .expect("parses");
+        assert!(image_capability_available(true, &variants));
     }
 
     #[test]

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -3092,10 +3092,15 @@ pub fn run_stream(
         };
         let product_qa_recent: Option<String> =
             product_qa_available.then(|| render_product_qa_pairs(&product_qa_pairs));
-        // Shared history transcript: built once, reused by the judge here AND the
-        // input filter below (which previously fetched its own). `resolved_pde` is
-        // already None on tip turns, so this only fires for a real judge turn.
-        let pde_transcript: JudgeTranscript = if resolved_pde.is_some() {
+        // Shared history transcript: built once, reused by the judge here, the
+        // input filter below (which previously fetched its own), AND the image
+        // composer's `[最近场景]`. Fetched whenever any of them can need it this
+        // turn: a judge turn (`resolved_pde` — already None on tips), or a
+        // forced image turn. The composer generates from the recent scene now
+        // that no seed exists, so a forced image with the judge disabled must
+        // not lose that context; rule-based `pde::decide` never picks image
+        // actions, so `force_image` is the only judge-less image path.
+        let pde_transcript: JudgeTranscript = if resolved_pde.is_some() || force_image {
             build_input_filter_transcript(&chat_repo, user_msg.session_id, user_msg.user_message_id).await
         } else {
             JudgeTranscript::default()
@@ -6345,6 +6350,123 @@ data: [DONE]\n\n";
 
         let reqs = mock.received_requests().await.expect("recorded requests");
         (reqs, frames)
+    }
+
+    /// Codex-review P1 regression (PR #216): a forced image turn with the PDE
+    /// judge DISABLED must still fetch the history transcript. The composer
+    /// generates from the recent scene now that no seed exists, so leaving the
+    /// transcript fetch keyed on `resolved_pde.is_some()` alone would hand the
+    /// composer `[最近场景]\n（无）` on every judge-less deployment — silently
+    /// stripping its main context. Rule-based `pde::decide` never picks image
+    /// actions, so `force_image` is the only judge-less image path and the one
+    /// this pins.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn forced_image_without_pde_still_feeds_the_scene(pool: PgPool) {
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+        use futures_util::StreamExt;
+        use wiremock::matchers::path as wm_path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&mock)
+            .await;
+
+        let user_id = Uuid::new_v4();
+        let (_g, instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+
+        // A prior exchange the composer's scene must carry.
+        for (role, content) in [
+            ("user", "我们明天去天台看日落吧"),
+            ("assistant", "好呀，我先去踩个点"),
+        ] {
+            sqlx::query(
+                "INSERT INTO engine.chat_messages (session_id, role, content) VALUES ($1, $2, $3)",
+            )
+            .bind(session_id)
+            .bind(role)
+            .bind(content)
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        // Composer configured, judge NOT — `resolve_pde()` is None, so before
+        // the fix the transcript was never fetched on this path.
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = std::sync::Arc::new(
+            eros_engine_llm::model_config::ModelConfig::from_toml_str(
+                "[tasks.chat_companion]\nmodel = \"primary\"\n\
+                 [tasks.chat_image_prompt_compose]\nmodel = \"composer\"\nfilter_prompt = \"COMPOSE\"\n",
+            )
+            .unwrap(),
+        );
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+
+        let chat_repo = ChatRepo { pool: &pool };
+        let user_message_id = match chat_repo
+            .upsert_user_message_idempotent(
+                session_id,
+                "hi",
+                "01J9000000000000000000000B",
+                "user",
+                None,
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
+
+        let _frames: Vec<ProtocolFrame> = run_stream(
+            std::sync::Arc::new(state),
+            PersistedUserMessage {
+                user_message_id,
+                session_id,
+                user_id,
+                instance_id,
+                content: "hi".into(),
+                prompt_traits: vec![],
+                audit: None,
+                tier: None,
+                memory_scope: Default::default(),
+                affinity_scope: Default::default(),
+                tips_amount_usd: None,
+                image_url: None,
+                image: Some(crate::routes::companion_stream::ImageReplyParams {
+                    force: true,
+                    mode: crate::routes::companion_stream::ImageMode::ImageOnly,
+                    ..Default::default()
+                }),
+                history_anchor: Default::default(),
+            },
+            None,
+        )
+        .collect()
+        .await;
+
+        let reqs = mock.received_requests().await.expect("recorded requests");
+        assert_eq!(reqs.len(), 1, "the composer is the only provider call");
+        let body: serde_json::Value =
+            serde_json::from_slice(&reqs[0].body).expect("composer request body is json");
+        let payload = body["messages"][1]["content"]
+            .as_str()
+            .expect("composer user payload");
+        assert!(
+            payload.contains("天台看日落"),
+            "the composer's scene must carry the prior exchange: {payload}"
+        );
+        assert!(
+            !payload.contains("[最近场景]\n（无）"),
+            "the scene must not be empty when history exists: {payload}"
+        );
     }
 
     /// `image.prompt_variant = "b"` must send variant b's text as the

--- a/crates/eros-engine-server/src/routes/companion_stream.rs
+++ b/crates/eros-engine-server/src/routes/companion_stream.rs
@@ -101,8 +101,8 @@ pub struct ImageReplyParams {
     /// (`"a"`, `"b"`) for the table shape. Ignored when that task configures a
     /// single plain prompt.
     ///
-    /// `"raw"` (case-insensitive) is reserved: it skips the composer LLM
-    /// entirely, saving one LLM call.
+    /// `"raw"` carries no special meaning — it selects a prompt only if a
+    /// deployment actually configures one under that key.
     ///
     /// An unknown index/key falls back to the engine's built-in composer
     /// prompt — it is never an error.

--- a/crates/eros-engine-server/src/routes/companion_stream.rs
+++ b/crates/eros-engine-server/src/routes/companion_stream.rs
@@ -95,8 +95,6 @@ pub struct ImageReplyParams {
     #[schema(value_type = Option<String>)]
     pub style: Option<StyleKey>,
     #[serde(default)]
-    pub image_prompt: Option<String>,
-    #[serde(default)]
     pub aspect_ratio: Option<String>,
     /// Which `[tasks.chat_image_prompt_compose].filter_prompt` variant to use
     /// for this turn: an index (`"0"`, `"1"`) for the array shape, or a key
@@ -104,7 +102,7 @@ pub struct ImageReplyParams {
     /// single plain prompt.
     ///
     /// `"raw"` (case-insensitive) is reserved: it skips the composer LLM
-    /// entirely and draws the seed subject as-is, saving one LLM call.
+    /// entirely, saving one LLM call.
     ///
     /// An unknown index/key falls back to the engine's built-in composer
     /// prompt — it is never an error.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -273,7 +273,6 @@ curl -N -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/js
           "force": true,
           "mode": "text_image",
           "style": "realistic",
-          "image_prompt": "warm candid selfie, soft indoor light",
           "aspect_ratio": "3:4"
         }
       }' \
@@ -291,9 +290,8 @@ draws on the chat stream).
 | `force` | `bool` | `false` | Override the PDE decision for this turn — force an image. When `false` the PDE decides. |
 | `mode` | `"text_image"` \| `"image_only"` | `"text_image"` | `text_image` = text reply + image; `image_only` = image only (no text). `image_only` permits an empty `content` field. |
 | `style` | `"realistic"` \| `"semi_realistic"` \| `"anime"` | `"realistic"` | One of the three engine-owned style presets; `"realistic"` is the engine's built-in default. |
-| `image_prompt` | `String` | PDE judge / user text | Subject for the forced path. On the PDE path the judge's own `image_prompt` is used. |
 | `aspect_ratio` | `String` | none | Allowed: `1:1`, `3:4`, `4:3`, `9:16`, `16:9`; absent when omitted (PDE plan → request → absent). Returns `422` if invalid. |
-| `prompt_variant` | `String` | none | Selects a `[tasks.chat_image_prompt_compose].filter_prompt` variant: an index (`"0"`, `"1"`) or a key (`"a"`, `"b"`), depending on how that task is configured (see [model-config.md](model-config.md)). `"raw"` (case-insensitive) skips the composer LLM entirely and draws the seed subject as-is. An index/key that doesn't match falls back to the engine's built-in composer prompt — never a `422` or other error. Ignored when the task isn't configured, or configures a single plain prompt. |
+| `prompt_variant` | `String` | none | Selects a `[tasks.chat_image_prompt_compose].filter_prompt` variant: an index (`"0"`, `"1"`) or a key (`"a"`, `"b"`), depending on how that task is configured (see [model-config.md](model-config.md)). `"raw"` (case-insensitive) skips the composer LLM entirely, saving one LLM call. An index/key that doesn't match falls back to the engine's built-in composer prompt — never a `422` or other error. Ignored when the task isn't configured, or configures a single plain prompt. |
 
 **Reference selection (`image_ref`).** The PDE verdict carries `image_ref`
 (`"face"` | `"previous"`, default `"face"`) and rides on the `image_request`
@@ -301,7 +299,7 @@ frame (below) — the chat stream never resolves it to a URL itself. The
 `previous`-with-no-image → `face` fallback, and the `face_ref_url` /
 `prev_image_url` reference URLs, belong to the consumer's own image-vendor
 call (the engine has no draw endpoint). The persisted `metadata.image` marker
-records the seed subject and aspect ratio, plus — only when the composer LLM
+records the composer's picture subject and the aspect ratio, plus — only when the composer LLM
 call succeeded — the audit trio `compose_variant` (the `filter_prompt`
 key/index that was selected, absent for a plain or built-in prompt),
 `compose_model`, and `compose_generation_id`. Absence of the trio means the

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -291,7 +291,7 @@ draws on the chat stream).
 | `mode` | `"text_image"` \| `"image_only"` | `"text_image"` | `text_image` = text reply + image; `image_only` = image only (no text). `image_only` permits an empty `content` field. |
 | `style` | `"realistic"` \| `"semi_realistic"` \| `"anime"` | `"realistic"` | One of the three engine-owned style presets; `"realistic"` is the engine's built-in default. |
 | `aspect_ratio` | `String` | none | Allowed: `1:1`, `3:4`, `4:3`, `9:16`, `16:9`; absent when omitted (PDE plan → request → absent). Returns `422` if invalid. |
-| `prompt_variant` | `String` | none | Selects a `[tasks.chat_image_prompt_compose].filter_prompt` variant: an index (`"0"`, `"1"`) or a key (`"a"`, `"b"`), depending on how that task is configured (see [model-config.md](model-config.md)). `"raw"` (case-insensitive) skips the composer LLM entirely, saving one LLM call. An index/key that doesn't match falls back to the engine's built-in composer prompt — never a `422` or other error. Ignored when the task isn't configured, or configures a single plain prompt. |
+| `prompt_variant` | `String` | none | Selects a `[tasks.chat_image_prompt_compose].filter_prompt` variant: an index (`"0"`, `"1"`) or a key (`"a"`, `"b"`), depending on how that task is configured (see [model-config.md](model-config.md)). `"raw"` carries no special meaning: it selects a prompt only if the deployment configures a variant under that literal key, exactly like any other name. An index/key that doesn't match — `"raw"` included — falls back to the engine's built-in composer prompt, never a `422` or other error. Ignored when the task isn't configured, or configures a single plain prompt. |
 
 **Reference selection (`image_ref`).** The PDE verdict carries `image_ref`
 (`"face"` | `"previous"`, default `"face"`) and rides on the `image_request`
@@ -299,13 +299,16 @@ frame (below) — the chat stream never resolves it to a URL itself. The
 `previous`-with-no-image → `face` fallback, and the `face_ref_url` /
 `prev_image_url` reference URLs, belong to the consumer's own image-vendor
 call (the engine has no draw endpoint). The persisted `metadata.image` marker
-records the composer's picture subject and the aspect ratio, plus — only when the composer LLM
-call succeeded — the audit trio `compose_variant` (the `filter_prompt`
-key/index that was selected, absent for a plain or built-in prompt),
-`compose_model`, and `compose_generation_id`. Absence of the trio means the
-turn had no successful compose (`raw`, fail-open degradation, or composer not
-configured). The composed prompt itself is never persisted — storing it is
-the consumer's job. The reference kind is not recorded.
+records the composer's picture subject, the aspect ratio, and its `caption`
+(the short line the composer returned alongside the prompt, or `None` when it
+gave none — the chat history and the judge transcript read back only the
+caption, never the long prompt), plus — only when the composer LLM call
+succeeded — the audit trio `compose_variant` (the `filter_prompt` key/index
+that was selected, absent for a plain or built-in prompt), `compose_model`,
+and `compose_generation_id`. Absence of the trio means the turn had no
+successful compose (fail-open degradation, or composer not configured). The
+composed prompt itself is never persisted — storing it is the consumer's job.
+The reference kind is not recorded.
 
 Validation: `force` + `tips_amount_usd` on the same turn → `422`. An
 unsupported `aspect_ratio` returns `422 BadRequest` as a pre-stream error.

--- a/docs/api-reference.zh.md
+++ b/docs/api-reference.zh.md
@@ -265,9 +265,9 @@ curl -N -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/js
 | `mode` | `"text_image"` \| `"image_only"` | `"text_image"` | `text_image` = 文字 + 图片；`image_only` = 仅图片（允许空 `content`）。 |
 | `style` | `"realistic"` \| `"semi_realistic"` \| `"anime"` | `"realistic"` | 引擎内置三种风格预设之一；`"realistic"` 是引擎内置默认值。 |
 | `aspect_ratio` | `String` | 无 | 允许值：`1:1`、`3:4`、`4:3`、`9:16`、`16:9`；省略时不存在（PDE 计划 → 请求 → 不存在）。非法时返回 `422`。 |
-| `prompt_variant` | `String` | 无 | 选择 `[tasks.chat_image_prompt_compose].filter_prompt` 的一个变体：按下标（`"0"`、`"1"`）或按 key（`"a"`、`"b"`），取决于该任务的配置形态（见 [model-config.zh.md](model-config.zh.md)）。`"raw"`（大小写不敏感）会完全跳过改写器 LLM，节省一次 LLM 调用。下标/key 没命中时回退到引擎内置的改写器提示词——绝不报 `422` 或其他错误。该任务未配置，或配置为单一纯字符串提示词时，此字段被忽略。 |
+| `prompt_variant` | `String` | 无 | 选择 `[tasks.chat_image_prompt_compose].filter_prompt` 的一个变体：按下标（`"0"`、`"1"`）或按 key（`"a"`、`"b"`），取决于该任务的配置形态（见 [model-config.zh.md](model-config.zh.md)）。`"raw"` 不带任何特殊含义：只有当该部署把某个变体配置在这个字面量 key 下时才会命中，和其他任意变体名一样。下标/key 没命中——包括未配置的 `"raw"`——都会回退到引擎内置的合成器提示词，绝不报 `422` 或其他错误。该任务未配置，或配置为单一纯字符串提示词时，此字段被忽略。 |
 
-**参考图选择（`image_ref`）。** PDE verdict 带有 `image_ref`（`"face"` \| `"previous"`，默认 `"face"`），并附带在下方的 `image_request` 帧中——聊天流本身不会把它解析成实际 URL。`previous` 且无可用图时回退到 `face` 的规则，以及 `face_ref_url` / `prev_image_url` 参考图 URL，都属于消费方自己调用的图像供应商（引擎没有绘图端点）。持久化的 `metadata.image` 标记只记录改写器决定的图片主题与画幅，不记录参考类型。
+**参考图选择（`image_ref`）。** PDE verdict 带有 `image_ref`（`"face"` \| `"previous"`，默认 `"face"`），并附带在下方的 `image_request` 帧中——聊天流本身不会把它解析成实际 URL。`previous` 且无可用图时回退到 `face` 的规则，以及 `face_ref_url` / `prev_image_url` 参考图 URL，都属于消费方自己调用的图像供应商（引擎没有绘图端点）。持久化的 `metadata.image` 标记记录合成器决定的图片主题、画幅，以及它的 `caption`（合成器随 prompt 一起返回的一句话描述；没有则为 `None`——聊天历史和 judge transcript 只读回 caption，从不读回那段长 prompt），不记录参考类型。
 
 校验：同一轮同时有 `force` 和 `tips_amount_usd` → `422`。`aspect_ratio` 不在允许集时，作为 pre-stream 错误返回 `422 BadRequest`。
 

--- a/docs/api-reference.zh.md
+++ b/docs/api-reference.zh.md
@@ -248,7 +248,6 @@ curl -N -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/js
           "force": true,
           "mode": "text_image",
           "style": "realistic",
-          "image_prompt": "温暖随拍自拍，室内柔光",
           "aspect_ratio": "3:4"
         }
       }' \
@@ -265,11 +264,10 @@ curl -N -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/js
 | `force` | `bool` | `false` | 强制本轮发图，覆盖 PDE 决策。`false` 时由 PDE 决定。 |
 | `mode` | `"text_image"` \| `"image_only"` | `"text_image"` | `text_image` = 文字 + 图片；`image_only` = 仅图片（允许空 `content`）。 |
 | `style` | `"realistic"` \| `"semi_realistic"` \| `"anime"` | `"realistic"` | 引擎内置三种风格预设之一；`"realistic"` 是引擎内置默认值。 |
-| `image_prompt` | `String` | PDE 判断 / 用户文本 | 强制路径的图片主题。PDE 路径使用判断器自己的 `image_prompt`。 |
 | `aspect_ratio` | `String` | 无 | 允许值：`1:1`、`3:4`、`4:3`、`9:16`、`16:9`；省略时不存在（PDE 计划 → 请求 → 不存在）。非法时返回 `422`。 |
-| `prompt_variant` | `String` | 无 | 选择 `[tasks.chat_image_prompt_compose].filter_prompt` 的一个变体：按下标（`"0"`、`"1"`）或按 key（`"a"`、`"b"`），取决于该任务的配置形态（见 [model-config.zh.md](model-config.zh.md)）。`"raw"`（大小写不敏感）会完全跳过改写器 LLM，直接用种子主题原样出图。下标/key 没命中时回退到引擎内置的改写器提示词——绝不报 `422` 或其他错误。该任务未配置，或配置为单一纯字符串提示词时，此字段被忽略。 |
+| `prompt_variant` | `String` | 无 | 选择 `[tasks.chat_image_prompt_compose].filter_prompt` 的一个变体：按下标（`"0"`、`"1"`）或按 key（`"a"`、`"b"`），取决于该任务的配置形态（见 [model-config.zh.md](model-config.zh.md)）。`"raw"`（大小写不敏感）会完全跳过改写器 LLM，节省一次 LLM 调用。下标/key 没命中时回退到引擎内置的改写器提示词——绝不报 `422` 或其他错误。该任务未配置，或配置为单一纯字符串提示词时，此字段被忽略。 |
 
-**参考图选择（`image_ref`）。** PDE verdict 带有 `image_ref`（`"face"` \| `"previous"`，默认 `"face"`），并附带在下方的 `image_request` 帧中——聊天流本身不会把它解析成实际 URL。`previous` 且无可用图时回退到 `face` 的规则，以及 `face_ref_url` / `prev_image_url` 参考图 URL，都属于消费方自己调用的图像供应商（引擎没有绘图端点）。持久化的 `metadata.image` 标记只记录种子提示词与画幅，不记录参考类型。
+**参考图选择（`image_ref`）。** PDE verdict 带有 `image_ref`（`"face"` \| `"previous"`，默认 `"face"`），并附带在下方的 `image_request` 帧中——聊天流本身不会把它解析成实际 URL。`previous` 且无可用图时回退到 `face` 的规则，以及 `face_ref_url` / `prev_image_url` 参考图 URL，都属于消费方自己调用的图像供应商（引擎没有绘图端点）。持久化的 `metadata.image` 标记只记录改写器决定的图片主题与画幅，不记录参考类型。
 
 校验：同一轮同时有 `force` 和 `tips_amount_usd` → `422`。`aspect_ratio` 不在允许集时，作为 pre-stream 错误返回 `422 BadRequest`。
 

--- a/docs/model-config.md
+++ b/docs/model-config.md
@@ -479,7 +479,7 @@ input filter has no triggers, timing, or tiers).
 | `insight_extraction` | `pipeline::post_process::extract_facts` and `extract_structured_insights` (fact mining + JSONB merge) | live |
 | `chat_output_filter` | `pipeline::handlers::ReplyHandler` (optional second-pass rewrite of the chat reply before delivery) | live |
 | `pde_decision` | `pipeline::stream` (opt-in LLM judge via `run_pde_decision`, called from `run_stream`; rules engine used when `filter_prompt` is absent or the LLM call fails) | live (opt-in) |
-| `chat_image_prompt_compose` | `pipeline::stream` (opt-in image-prompt composer; expands the PDE seed subject before image generation; activated when this task block is present) | live (opt-in) |
+| `chat_image_prompt_compose` | `pipeline::stream` (image-prompt composer; **required for image turns** — the PDE judge writes no seed, so without this task the engine reports 可发图=否 and downgrades image actions. Generates the prompt from turn context and returns JSON `{prompt, caption}`; `caption` is persisted to `metadata.image.caption` and is what history-facing renders read) | live (required for images) |
 | `chat_vision` | `pipeline::stream` via `resolve_vision()` (vision pre-stage: describes an `image_url` attachment into JSON before the reply prompt; off when task block absent or `filter_prompt` blank) | live (opt-in) |
 | `chat_product_qa` | `pipeline::stream` via `resolve_product_qa()` (out-of-character product-QA executor for the PDE `product_qa` action; off when task block absent or `filter_prompt` blank; also requires the LLM PDE) | live (opt-in) |
 | `affinity_evaluation` | `pipeline::post_process` (per-turn 6-axis affinity delta; runs after each Reply turn, fire-and-forget; **takes no `filter_prompt`** — the prompt is engine-owned and setting the key refuses to boot, see issue #210) | live |
@@ -496,7 +496,7 @@ A `[tasks.<name>]` entry is only meaningful if the engine actually calls `model_
 
 - `crates/eros-engine-server/src/pipeline/handlers.rs` → `chat_companion`, `chat_output_filter`
 - `crates/eros-engine-server/src/pipeline/post_process.rs` → `insight_extraction`, `affinity_evaluation`
-- `crates/eros-engine-server/src/pipeline/stream.rs` → `pde_decision` via `run_pde_decision` inside `run_stream` (only when `filter_prompt` is set); `chat_image_prompt_compose` via `resolve_image_prompt_compose()` (image-prompt composer, opt-in, resolved lazily only on image turns); `chat_vision` via `resolve_vision()` (vision pre-stage, opt-in); `chat_product_qa` via `resolve_product_qa()` (product-QA executor, opt-in); `chat_input_filter` via `resolve_input_filter()` (input rewrite, opt-in); `memory_extraction` via the dreaming sweeper
+- `crates/eros-engine-server/src/pipeline/stream.rs` → `pde_decision` via `run_pde_decision` inside `run_stream` (only when `filter_prompt` is set); `chat_image_prompt_compose` via `resolve_image_prompt_compose()` (image-prompt composer, required for image turns, resolved lazily only on image turns); `chat_vision` via `resolve_vision()` (vision pre-stage, opt-in); `chat_product_qa` via `resolve_product_qa()` (product-QA executor, opt-in); `chat_input_filter` via `resolve_input_filter()` (input rewrite, opt-in); `memory_extraction` via the dreaming sweeper
 
 `embedding` doesn't go through the generic `resolve()` path above — it has
 its own resolver, `ModelConfig::resolve_embedding()`, called once at boot
@@ -508,10 +508,10 @@ active" below.
 By default the engine uses the built-in rule engine (`eros-engine-core/src/pde.rs`) to decide the per-turn action (reply / ghost / proactive). Setting `filter_prompt` in this block switches on an LLM judge:
 
 - The LLM receives the recent conversation, relationship state, and conversation signals, and returns a JSON verdict with:
-  - `action`: `"reply_text"` | `"ghost"` | `"reply_image"` | `"reply_text_image"` | `"product_qa"` (image variants are available when the request includes an `image` block — the consumer signalling it handles images this turn; otherwise they degrade to `reply_text`. The chat stream never draws — it emits an `image_request` frame and the consumer calls its own image vendor. `product_qa` is available only when `[tasks.chat_product_qa]` is fully enabled — see below; unavailable proposals degrade to `reply_text`, never upgrade.)
+  - `action`: `"reply_text"` | `"ghost"` | `"reply_image"` | `"reply_text_image"` | `"product_qa"` (image variants are available when the request includes an `image` block AND `[tasks.chat_image_prompt_compose]` is configured — both must hold, since the judge itself writes no image prompt; otherwise they degrade to `reply_text`. The chat stream never draws — it emits an `image_request` frame and the consumer calls its own image vendor. `product_qa` is available only when `[tasks.chat_product_qa]` is fully enabled — see below; unavailable proposals degrade to `reply_text`, never upgrade.)
   - `inner_state`: a short mood/tone description folded into the reply prompt
   - `tone` (optional): a short delivery directive for this turn's reply — injected into the reply prompt as a `[reply_tone]` section on text-bearing actions; omitted when absent
-  - `image_prompt`, `reason`: optional
+  - `reason`: optional
 - **Fail-open:** any LLM timeout or error falls back to the rule engine — the LLM judge never blocks a chat response.
 - **Hard-safety guardrails** (enforced after the LLM verdict, before the rule-engine fallback): never ghost in the first 10 messages, never ghost twice in a row, one-hour ghost cooldown.
 - Every judge call is audited to `companion_decision_events`.
@@ -520,23 +520,47 @@ By default the engine uses the built-in rule engine (`eros-engine-core/src/pde.r
 
 **`ghosting` field** (bool, default `true`): a safety switch for downstream products. Set `ghosting = false` to disable ghosting across the _entire_ PDE path — LLM verdict, rule fallback, and the pure rule engine — so the companion never goes silent. Useful for products where silent turns are undesirable.
 
-### `[tasks.chat_image_prompt_compose]` — image-prompt composer (opt-in)
+### `[tasks.chat_image_prompt_compose]` — image-prompt composer (required for image turns)
 
-The PDE writes a terse seed `image_prompt` while also choosing the action and
-`inner_state` on a tight token budget. When this task block is present, the
-engine runs a dedicated composer **after** an image action is decided and
-**before** generation: it sends the model the persona appearance, the recent
-scene, the PDE seed subject, the chosen style, and the target aspect ratio, and
-uses the expanded result as the image subject (carried in the `image_request`
-frame's `composed_prompt`; the persisted `metadata.image.prompt` marker keeps
-the PDE seed subject). The PDE's original seed is preserved separately in the
-decision audit.
+The PDE judge no longer writes an image-prompt seed — it only decides the
+action, `inner_state`, and (on an image action) the reference/aspect-ratio
+inputs. Producing the actual image prompt is entirely this task's job: when an
+image action is decided, the engine runs the composer **after** the decision
+and **before** generation, feeding it the persona appearance, the recent
+scene, the partner's latest message, the chosen style, and the target aspect
+ratio. The composer **generates** the prompt from that context — it does not
+expand a seed, because none exists anymore.
 
-The feature is **off by default** and activates only when this block exists.
-It is **fail-open**: on composer failure / timeout / empty output the engine
-falls back to the PDE seed unchanged, so it never blocks or fails the image
-turn. The task is resolved **lazily, only on image turns**, so it never advances
-a `model` round-robin cursor on text/ghost turns.
+**This task is now REQUIRED for image turns.** Without
+`[tasks.chat_image_prompt_compose]` configured, the engine has no way to
+produce an image prompt at all: it reports `本轮可发图=否` (image capability
+false) to the judge and downgrades any `reply_image` / `reply_text_image`
+proposal to `reply_text`. Configure this block to make image turns possible.
+
+**Wire contract.** The composer must reply with JSON carrying exactly two
+fields:
+
+```json
+{"prompt": "<image-generation prompt>", "caption": "<one short line>"}
+```
+
+`prompt` is the image subject the engine uses for generation. `caption` is a
+short, natural-language line describing the picture — it is what gets
+persisted to `metadata.image.caption` and is the only thing the chat history
+and the judge transcript ever read back; the long `prompt` is never injected
+into either. A reply that fails to parse as JSON (or as a JSON block embedded
+in prose) is used **as the prompt, with no caption** — so an old EXPAND-era
+`filter_prompt`, written for the pre-#212 seed-expansion contract, still
+produces images (degraded: no caption, and a prompt written to expand a seed
+that is now always empty). Rewrite it to the contract above to get captions
+back.
+
+The feature is **fail-open**: on composer failure / timeout / empty reply the
+engine falls back to an empty subject — `compose_image_prompt` turns that into
+a plain persona-appearance portrait prompt — so a broken composer degrades
+image quality rather than blocking or failing the image turn. The task is
+resolved **lazily, only on image turns**, so it never advances a `model`
+round-robin cursor on text/ghost turns.
 
 ```toml
 [tasks.chat_image_prompt_compose]
@@ -562,11 +586,13 @@ max_tokens   = 700
 
 **Built-in default prompt.** Unlike every other task (whose prompt must come from
 config), the composer ships a generic, **product-identity-free** built-in
-default. Its stance is **expand-only**: it faithfully expands the seed subject and
-appearance into a detailed prompt and does **not** soften, downgrade, censor, or
-refuse, and adds no content-moderation layer of its own — moderation is delegated
-to the image-model provider and the downstream deployment, not this step. A
-non-blank `filter_prompt` overrides it; a blank/absent one falls back to it.
+default. It **generates** the prompt and caption straight from context —
+persona appearance, recent scene, the partner's latest message, style, aspect
+ratio — and does **not** soften, downgrade, censor, or refuse, and adds no
+content-moderation layer of its own — moderation is delegated to the
+image-model provider and the downstream deployment, not this step. A
+non-blank `filter_prompt` overrides it (and must honor the JSON contract
+above); a blank/absent one falls back to it.
 
 **Variants.** This is the **only** task whose `filter_prompt` accepts more than a
 plain string. The consumer picks one per chat turn via `image.prompt_variant` on
@@ -602,9 +628,12 @@ variant the caller asked for and didn't get is worth surfacing. There is no
 reserved `default` key: writing `default = "…"` defines an ordinary variant,
 selected only by a literal `prompt_variant = "default"`.
 
-`prompt_variant = "raw"` (case-insensitive) skips the composer LLM entirely and
-draws the seed subject as-is — one fewer LLM call for that turn. `raw` is
-reserved: a table key literally named `raw` (any casing) refuses to boot.
+`prompt_variant = "raw"` carries **no special meaning**. It is an ordinary
+variant name like any other: it selects a prompt only if this deployment
+configures a variant under that literal key (any casing), and an unknown
+index or key — `"raw"` included, if unconfigured — falls back to the built-in
+prompt above like any other miss, never an error. `raw` is not reserved: a
+table key literally named `raw` boots fine.
 
 Variants are honored on this task only. An array/table `filter_prompt` on any
 other task, or inside **any** `[tasks.*.tiers.*]` block (this task's own tiers
@@ -614,16 +643,22 @@ than sit there unreachable.
 Call site: `crates/eros-engine-server/src/pipeline/stream.rs` via
 `resolve_image_prompt_compose()` in `model_config.rs`.
 
-**Audit.** A successful composer call writes three keys into the image
+**Audit.** A successful composer call — including the non-JSON fallback path
+above, which still counts as success — writes three keys into the image
 turn's `chat_messages.metadata.image`: `compose_variant` (which
 `filter_prompt` key/index was selected; absent for a plain/built-in
 prompt; recorded as supplied (trimmed), not normalized — e.g. for the
 indexed shape, `"01"` selects index 1 and is audited as `"01"`),
 `compose_model` (the model that answered), and
-`compose_generation_id`. All three are absent when no compose succeeded
-(`raw`, fail-open, task not configured) — same NULL semantics as the
-affinity audit trio. Usage/cost is not persisted; reconcile via the
-generation id against your provider's logs. The composed prompt is not
+`compose_generation_id`. All three are absent only when the composer call
+itself failed (fail-open degradation) or the task isn't configured — same
+NULL semantics as the affinity audit trio (`raw` carries no special meaning
+anymore, so it is not a distinct case here). The composer's `caption` is
+persisted separately as `metadata.image.caption`: set whenever the reply
+parsed as JSON with a non-blank `caption` field, and `None` otherwise —
+including on a successful-but-non-JSON reply, where the whole reply becomes
+`prompt` with no caption. Usage/cost is not persisted; reconcile via the
+generation id against your provider's logs. The long `prompt` itself is not
 persisted (consumer-side by design). Spec:
 `docs/superpowers/specs/2026-08-02-image-compose-audit-design.md`.
 

--- a/docs/model-config.md
+++ b/docs/model-config.md
@@ -516,7 +516,7 @@ By default the engine uses the built-in rule engine (`eros-engine-core/src/pde.r
 - **Hard-safety guardrails** (enforced after the LLM verdict, before the rule-engine fallback): never ghost in the first 10 messages, never ghost twice in a row, one-hour ghost cooldown.
 - Every judge call is audited to `companion_decision_events`.
 
-**Image-availability context line.** The judge context always carries exactly one line — `[图片能力] 本轮可发图=是` when an image action is available this turn (the request carries an `image` block), or `[图片能力] 本轮可发图=否` otherwise. Prompt authors should treat `本轮可发图=否` as a hard constraint (never choose `reply_image` / `reply_text_image` — they would be degraded by `guard_action` anyway, wasting tokens and skewing audits), and `本轮可发图=是` as the gate that *permits* image actions, then decide by persona/context (the engine does not force an image just because one is possible). Keep the token string `[图片能力] 本轮可发图=是/否` verbatim if a downstream overlay references it.
+**Image-availability context line.** The judge context always carries exactly one line — `[图片能力] 本轮可发图=是` when an image action is available this turn (the request carries an `image` block AND `[tasks.chat_image_prompt_compose]` is configured — both must hold), or `[图片能力] 本轮可发图=否` otherwise. Prompt authors should treat `本轮可发图=否` as a hard constraint (never choose `reply_image` / `reply_text_image` — they would be degraded by `guard_action` anyway, wasting tokens and skewing audits), and `本轮可发图=是` as the gate that *permits* image actions, then decide by persona/context (the engine does not force an image just because one is possible). Keep the token string `[图片能力] 本轮可发图=是/否` verbatim if a downstream overlay references it.
 
 **`ghosting` field** (bool, default `true`): a safety switch for downstream products. Set `ghosting = false` to disable ghosting across the _entire_ PDE path — LLM verdict, rule fallback, and the pure rule engine — so the companion never goes silent. Useful for products where silent turns are undesirable.
 
@@ -658,8 +658,16 @@ persisted separately as `metadata.image.caption`: set whenever the reply
 parsed as JSON with a non-blank `caption` field, and `None` otherwise —
 including on a successful-but-non-JSON reply, where the whole reply becomes
 `prompt` with no caption. Usage/cost is not persisted; reconcile via the
-generation id against your provider's logs. The long `prompt` itself is not
-persisted (consumer-side by design). Spec:
+generation id against your provider's logs. `metadata.image.prompt` — the
+composer's `prompt` field, the actual image-generation subject — **is**
+persisted on every image turn; it's the field `build_delegated_image_marker`
+writes and the audit trio above rides alongside. What is genuinely not
+persisted is the fully **composed wire prompt** (style preset + persona
+appearance + this subject, assembled by `compose_image_prompt`): that string
+goes out only on the `image_request` frame's `composed_prompt` field,
+base64-encoded, and is never written to a row. An operator auditing the
+database will find the image-generation subject on every image turn — just
+not the wire-ready, style-and-appearance-wrapped version of it. Spec:
 `docs/superpowers/specs/2026-08-02-image-compose-audit-design.md`.
 
 ### `[tasks.chat_vision]` — image input (vision pre-stage, opt-in)

--- a/docs/model-config.zh.md
+++ b/docs/model-config.zh.md
@@ -419,7 +419,7 @@ SSE `final` frame 的 `filtered` 字段在客户端收到的是非原始输出�
 | `insight_extraction` | `pipeline::post_process::extract_facts` 和 `extract_structured_insights`（事实挖掘 + JSONB 合并） | live |
 | `chat_output_filter` | `pipeline::handlers::ReplyHandler`（交付前对 chat 回复进行可选的二次改写） | live |
 | `pde_decision` | `pipeline::stream`（通过 `run_pde_decision` 实现的 opt-in LLM 判断器，由 `run_stream` 调用；缺少 `filter_prompt` 或 LLM 调用失败时使用规则引擎） | live（opt-in） |
-| `chat_image_prompt_compose` | `pipeline::stream`（opt-in 图片提示词改写器；在图片生成前扩写 PDE 的种子主题；存在此任务块时激活） | live（opt-in） |
+| `chat_image_prompt_compose` | `pipeline::stream`（出图 prompt 合成器；**图片轮次必需** —— PDE judge 不再写种子，未配置该任务时引擎报 可发图=否 并把图片动作降级为纯文本。它从当轮上下文生成 prompt，返回 JSON `{prompt, caption}`；`caption` 落到 `metadata.image.caption`，是聊天历史与 judge transcript 实际读取的字段） | live（图片必需） |
 | `chat_vision` | `pipeline::stream`，通过 `resolve_vision()`（视觉预处理阶段：在 reply prompt 前将 `image_url` 附件描述为 JSON；任务块缺失或 `filter_prompt` 为空白时关闭） | live（opt-in） |
 | `chat_product_qa` | `pipeline::stream`，通过 `resolve_product_qa()`（PDE `product_qa` 动作的出戏产品问答执行器；任务块缺失或 `filter_prompt` 为空白时关闭；还需要 LLM PDE 已启用） | live（opt-in） |
 | `affinity_evaluation` | `pipeline::post_process`（每轮六轴 affinity delta；每个 Reply 轮次后以 fire-and-forget 方式运行；**不接受 `filter_prompt`** —— 该 prompt 由引擎持有，设置该键会拒绝启动，见 issue #210） | live |
@@ -436,7 +436,7 @@ SSE `final` frame 的 `filtered` 字段在客户端收到的是非原始输出�
 
 - `crates/eros-engine-server/src/pipeline/handlers.rs` → `chat_companion`、`chat_output_filter`
 - `crates/eros-engine-server/src/pipeline/post_process.rs` → `insight_extraction`、`affinity_evaluation`
-- `crates/eros-engine-server/src/pipeline/stream.rs` → `pde_decision`，通过 `run_stream` 内的 `run_pde_decision`（仅当设置了 `filter_prompt`）；`chat_image_prompt_compose`，通过 `resolve_image_prompt_compose()`（图片提示词改写器，opt-in，仅在图片轮次按需解析）；`chat_vision`，通过 `resolve_vision()`（视觉预处理阶段，opt-in）；`chat_product_qa`，通过 `resolve_product_qa()`（产品问答执行器，opt-in）；`chat_input_filter`，通过 `resolve_input_filter()`（输入改写，opt-in）；`memory_extraction`，通过 dreaming sweeper
+- `crates/eros-engine-server/src/pipeline/stream.rs` → `pde_decision`，通过 `run_stream` 内的 `run_pde_decision`（仅当设置了 `filter_prompt`）；`chat_image_prompt_compose`，通过 `resolve_image_prompt_compose()`（出图 prompt 合成器，图片轮次必需，仅在图片轮次按需解析）；`chat_vision`，通过 `resolve_vision()`（视觉预处理阶段，opt-in）；`chat_product_qa`，通过 `resolve_product_qa()`（产品问答执行器，opt-in）；`chat_input_filter`，通过 `resolve_input_filter()`（输入改写，opt-in）；`memory_extraction`，通过 dreaming sweeper
 
 `embedding` 不走上面这条通用 `resolve()` 路径——它有自己的解析器
 `ModelConfig::resolve_embedding()`，在 `main.rs` 启动时调用一次来构建
@@ -447,10 +447,10 @@ SSE `final` frame 的 `filtered` 字段在客户端收到的是非原始输出�
 默认情况下，引擎使用内置规则引擎（`eros-engine-core/src/pde.rs`）决定每轮动作（reply / ghost / proactive）。在此块中设置 `filter_prompt` 会启用 LLM 判断器：
 
 - LLM 接收最近的对话、关系状态和对话信号，并返回 JSON verdict，其中包含：
-  - `action`：`"reply_text"` \| `"ghost"` \| `"reply_image"` \| `"reply_text_image"` \| `"product_qa"`（请求包含 `image` 块时图片变体才可用——调用方以此声明本轮由自己处理图片；否则降级为 `reply_text`。聊天流从不绘图——只发出 `image_request` 帧，由调用方自行调用图像供应商。`product_qa` 仅当 `[tasks.chat_product_qa]` 完全启用时才可用——见下文；不可用时降级为 `reply_text`，绝不升级。）
+  - `action`：`"reply_text"` \| `"ghost"` \| `"reply_image"` \| `"reply_text_image"` \| `"product_qa"`（图片变体需要同时满足两个条件——请求包含 `image` 块，且 `[tasks.chat_image_prompt_compose]` 已配置，因为判断器本身不写图片 prompt；否则降级为 `reply_text`。聊天流从不绘图——只发出 `image_request` 帧，由调用方自行调用图像供应商。`product_qa` 仅当 `[tasks.chat_product_qa]` 完全启用时才可用——见下文；不可用时降级为 `reply_text`，绝不升级。）
   - `inner_state`：融入 reply prompt 的简短情绪/语气描述
   - `tone`（选填）：这一轮回复该用的语气/口吻，一句话——在文本类动作上注入 reply prompt 的 `[reply_tone]` 区块；缺省则不注入
-  - `image_prompt`、`reason`：可选
+  - `reason`：可选
 - **Fail-open：**任何 LLM 超时或错误都会回退到规则引擎——LLM 判断器绝不会阻塞 chat 响应。
 - **硬安全 guardrail**（在 LLM verdict 之后、规则引擎 fallback 之前强制执行）：前 10 条消息绝不 ghost，绝不连续 ghost 两次，ghost cooldown 为一小时。
 - 每次判断器调用都会记录到 `companion_decision_events` 以供审计。
@@ -459,11 +459,21 @@ SSE `final` frame 的 `filtered` 字段在客户端收到的是非原始输出�
 
 **`ghosting` 字段**（bool，默认 `true`）：面向下游产品的安全开关。设置 `ghosting = false` 可在*整个* PDE 路径上禁用 ghosting——包括 LLM verdict、规则 fallback 和纯规则引擎——从而确保 companion 永不沉默。适用于不希望出现静默轮次的产品。
 
-### `[tasks.chat_image_prompt_compose]` — 图片提示词改写器（opt-in）
+### `[tasks.chat_image_prompt_compose]` — 出图 prompt 合成器（图片轮次必需）
 
-PDE 在选动作、定 `inner_state` 的同时，还要在很紧的 token 预算里写一个简短的种子 `image_prompt`。配置此任务块后，引擎会在**决定出图之后、生成之前**单独跑一次改写器：把人格外观、最近场景、PDE 种子主题、所选 style 和目标宽高比交给该模型，用扩写后的结果作为图片主体（随 `image_request` 帧的 `composed_prompt` 下发；持久化的 `metadata.image.prompt` 标记保留 PDE 种子提示词）。PDE 的原始种子单独保留在决策审计里。
+PDE judge 不再写图片 prompt 种子——它只负责决定动作、`inner_state`，以及（图片动作时）参考图/宽高比这类输入。真正产出图片 prompt 完全是这个任务的工作：图片动作一旦决定，引擎会在**决定之后、生成之前**跑一次合成器，把人格外观、最近场景、对方最新消息、所选 style、目标宽高比交给它。合成器**从这份上下文生成** prompt——它不再扩写种子，因为种子已经不存在了。
 
-该功能**默认关闭**，仅当此块存在时激活。它是 **fail-open** 的：改写器失败 / 超时 / 输出为空时，引擎回退到 PDE 种子原值，绝不阻塞或失败图片轮次。该任务**仅在图片轮次按需解析**，因此不会在文本/ghost 轮次推进 `model` 的 round-robin 游标。
+**这个任务现在是图片轮次的必需项。** 不配置 `[tasks.chat_image_prompt_compose]`，引擎就没有任何办法产出图片 prompt：它会向判断器报告 `本轮可发图=否`（图片能力为假），并把任何 `reply_image` / `reply_text_image` 提案降级为 `reply_text`。要让图片轮次可用，必须配置这个块。
+
+**线上契约。** 合成器必须回复恰好两个字段的 JSON：
+
+```json
+{"prompt": "<image-generation prompt>", "caption": "<one short line>"}
+```
+
+`prompt` 是引擎用来出图的图片主体。`caption` 是一句自然语言描述这张图片的简短文字——它会落到 `metadata.image.caption`，也是聊天历史和 judge transcript 唯一会读回的字段；长的 `prompt` 从不注入这两者中的任何一个。回复解析不出 JSON（包括嵌在散文里的 JSON block）时，整段回复原样当作 `prompt` 使用，没有 caption——所以一个还停留在 #212 之前"扩写种子"契约上的旧 `filter_prompt`，依然能出图（降级：没有 caption，且 prompt 是照着一个如今永远为空的种子写的）。按上面的契约改写它，才能拿回 caption。
+
+该功能是 **fail-open** 的：合成器失败 / 超时 / 输出为空时，引擎回退到空主体——`compose_image_prompt` 会把空主体变成一句纯人格外观的肖像 prompt——所以合成器故障只会降低出图质量，绝不阻塞或失败图片轮次。该任务**仅在图片轮次按需解析**，因此不会在文本/ghost 轮次推进 `model` 的 round-robin 游标。
 
 ```toml
 [tasks.chat_image_prompt_compose]
@@ -479,15 +489,15 @@ max_tokens   = 700
 
 | 字段 | 类型 | 默认值 | 说明 |
 |---|---|---|---|
-| `model` | `ModelSpec`（字符串 \| 数组 \| 表） | 缺失 | 改写器模型（与 `chat_companion.model` 同样三种形态）。 |
+| `model` | `ModelSpec`（字符串 \| 数组 \| 表） | 缺失 | 合成器模型（与 `chat_companion.model` 同样三种形态）。 |
 | `fallback` | `String` \| `Array<String>` | `[]` | 顺序重试链（FallbackSpec），按 `retry_depth` 截断。 |
 | `retry_depth` | `u32` | `1` | primary + 这么多个 fallback。 |
-| `temperature` | `f64` | 任务默认 | 改写器调用的采样温度。 |
-| `max_tokens` | `u32` | 任务默认 | 改写器调用的 token 上限。 |
+| `temperature` | `f64` | 任务默认 | 合成器调用的采样温度。 |
+| `max_tokens` | `u32` | 任务默认 | 合成器调用的 token 上限。 |
 | `reasoning` | 表 | 缺失 | 可选 reasoning 控制，转发给 OpenRouter。 |
 | `filter_prompt` | `String` \| `Array<String>` \| `Table<String, String>` | **内置默认** | **可选**（不同于其他任务）。空白/缺失 ⇒ 引擎内置的 `DEFAULT_COMPOSE_PROMPT`。数组/表两种形态见下方"变体"。 |
 
-**内置默认提示词。** 不同于其他每个任务（提示词必须来自配置），改写器自带一个通用、**不含产品身份**的内置默认。它的立场是**只扩写**：忠实地把种子主题和外观扩成详细提示词，**不**软化、不降级、不审查、不拒绝，也不自带内容审核层——审核交给画图模型供应商和下游部署，不在这一步。非空 `filter_prompt` 覆盖它；空白/缺失则回退到它。
+**内置默认提示词。** 不同于其他每个任务（提示词必须来自配置），合成器自带一个通用、**不含产品身份**的内置默认。它**从上下文生成** prompt 和 caption——人格外观、最近场景、对方最新消息、style、宽高比——**不**软化、不降级、不审查、不拒绝，也不自带内容审核层——审核交给画图模型供应商和下游部署，不在这一步。非空 `filter_prompt` 覆盖它（且必须遵守上面的 JSON 契约）；空白/缺失则回退到它。
 
 **变体（variants）。** 这是**唯一**一个 `filter_prompt` 接受纯字符串以外形态的任务。前端在每个 chat 轮次通过发消息请求体上的 `image.prompt_variant` 挑一个。三种形态：
 
@@ -497,7 +507,7 @@ filter_prompt = ["…", "…"]                # 按下标选：prompt_variant = 
 filter_prompt = { a = "…", b = "…" }      # 按 key 选：  prompt_variant = "a" / "b"
 ```
 
-改写器提示词通常又长又多段，而 TOML 1.0.0 本就不建议把 inline table 拆成多行——所以按
+合成器提示词通常又长又多段，而 TOML 1.0.0 本就不建议把 inline table 拆成多行——所以按
 key 选的形态也可以写成标准（非 inline）表，一个 key 一个 section：
 
 ```toml
@@ -512,11 +522,13 @@ b = """
 
 没有命中都会回退到上面的**内置**提示词，不存在"取第一项"这种行为——但两种"没命中"的记录方式不同。**没传** `prompt_variant` 属于静默回退（最常见的情况：既然没人要求选变体，也就没什么好警告的）。**明确传了但没命中**的变体——下标越界、key 不存在——同样回退，但会额外记一条 `warn` 日志，因为调用方指定了变体却没用上，值得被看到。也没有保留的 `default` key：写 `default = "…"` 只是定义了一个普通变体，只有字面量 `prompt_variant = "default"` 才会命中它。
 
-`prompt_variant = "raw"`（大小写不敏感）会完全跳过改写器 LLM，直接用种子主题原样出图——这一轮少一次 LLM 调用。`raw` 是保留字：表里若出现字面量为 `raw` 的 key（任意大小写）会拒绝启动。
+`prompt_variant = "raw"` 不带任何特殊含义。它和其他任意变体名一样，只有当该部署把某个变体配置在这个字面量 key 下（不论大小写）时才会命中；下标/key 没命中——包括未配置的 `"raw"`——都会像其他任何 miss 一样回退到上面的内置提示词，绝不报错。`raw` 不再是保留字：表里出现字面量为 `raw` 的 key 可以正常启动。
 
-变体只在这一个任务上生效。任何其他任务的数组/表形态 `filter_prompt`，或**任何** `[tasks.*.tiers.*]` 块（包括本任务自己的 tiers——改写器解析时永远不走 tier）里的数组/表形态，都会拒绝启动，而不是留在那里永远选不到。
+变体只在这一个任务上生效。任何其他任务的数组/表形态 `filter_prompt`，或**任何** `[tasks.*.tiers.*]` 块（包括本任务自己的 tiers——合成器解析时永远不走 tier）里的数组/表形态，都会拒绝启动，而不是留在那里永远选不到。
 
 调用点：`crates/eros-engine-server/src/pipeline/stream.rs`，通过 `model_config.rs` 中的 `resolve_image_prompt_compose()`。
+
+**审计。** 一次成功的合成器调用——包括上面提到的"非 JSON 回退路径"，它同样算作成功——会向图片轮次的 `chat_messages.metadata.image` 写入三个键：`compose_variant`（命中了 `filter_prompt` 的哪个 key/下标；纯字符串或内置提示词时缺失；按调用方传入的值记录（已 trim），不做归一化——例如索引形态里 `"01"` 命中下标 1，审计时仍记为 `"01"`）、`compose_model`（实际应答的模型），以及 `compose_generation_id`。只有当合成器调用本身失败（fail-open 降级）或该任务未配置时，三者才会缺失——语义与 affinity 审计三元组的 NULL 语义一致（`raw` 已不带特殊含义，因此不再是这里的独立情形）。合成器的 `caption` 单独持久化为 `metadata.image.caption`：只要回复解析为带非空 `caption` 字段的 JSON 就会被设置，否则为 `None`——包括"成功但非 JSON"的回复，此时整段回复变成 `prompt`，没有 caption。用量/费用不落库；请用 generation id 去你的供应商日志里对账。长的 `prompt` 本身不持久化（按设计交给消费方自己留存）。设计文档：`docs/superpowers/specs/2026-08-02-image-compose-audit-design.md`。
 
 ### `[tasks.chat_vision]` — 图片输入（视觉预处理阶段，opt-in）
 

--- a/docs/model-config.zh.md
+++ b/docs/model-config.zh.md
@@ -455,7 +455,7 @@ SSE `final` frame 的 `filtered` 字段在客户端收到的是非原始输出�
 - **硬安全 guardrail**（在 LLM verdict 之后、规则引擎 fallback 之前强制执行）：前 10 条消息绝不 ghost，绝不连续 ghost 两次，ghost cooldown 为一小时。
 - 每次判断器调用都会记录到 `companion_decision_events` 以供审计。
 
-**图片能力上下文行。** 判断器上下文每轮必带一行——当本轮图片动作可用（请求带有 `image` 块）时为 `[图片能力] 本轮可发图=是`，否则为 `[图片能力] 本轮可发图=否`。prompt 作者应把 `本轮可发图=否` 当作硬约束（绝不要选 `reply_image` / `reply_text_image`——它们会被 `guard_action` 降级，白费 token 还会污染审计），把 `本轮可发图=是` 当作*允许*发图的开关，再按人格/语境决定要不要发（引擎不会因为"能发"就强制发图）。若下游 overlay 引用了这个 token，请逐字保留 `[图片能力] 本轮可发图=是/否`。
+**图片能力上下文行。** 判断器上下文每轮必带一行——当本轮图片动作可用（请求带有 `image` 块，且 `[tasks.chat_image_prompt_compose]` 已配置——两者缺一不可）时为 `[图片能力] 本轮可发图=是`，否则为 `[图片能力] 本轮可发图=否`。prompt 作者应把 `本轮可发图=否` 当作硬约束（绝不要选 `reply_image` / `reply_text_image`——它们会被 `guard_action` 降级，白费 token 还会污染审计），把 `本轮可发图=是` 当作*允许*发图的开关，再按人格/语境决定要不要发（引擎不会因为"能发"就强制发图）。若下游 overlay 引用了这个 token，请逐字保留 `[图片能力] 本轮可发图=是/否`。
 
 **`ghosting` 字段**（bool，默认 `true`）：面向下游产品的安全开关。设置 `ghosting = false` 可在*整个* PDE 路径上禁用 ghosting——包括 LLM verdict、规则 fallback 和纯规则引擎——从而确保 companion 永不沉默。适用于不希望出现静默轮次的产品。
 
@@ -528,7 +528,7 @@ b = """
 
 调用点：`crates/eros-engine-server/src/pipeline/stream.rs`，通过 `model_config.rs` 中的 `resolve_image_prompt_compose()`。
 
-**审计。** 一次成功的合成器调用——包括上面提到的"非 JSON 回退路径"，它同样算作成功——会向图片轮次的 `chat_messages.metadata.image` 写入三个键：`compose_variant`（命中了 `filter_prompt` 的哪个 key/下标；纯字符串或内置提示词时缺失；按调用方传入的值记录（已 trim），不做归一化——例如索引形态里 `"01"` 命中下标 1，审计时仍记为 `"01"`）、`compose_model`（实际应答的模型），以及 `compose_generation_id`。只有当合成器调用本身失败（fail-open 降级）或该任务未配置时，三者才会缺失——语义与 affinity 审计三元组的 NULL 语义一致（`raw` 已不带特殊含义，因此不再是这里的独立情形）。合成器的 `caption` 单独持久化为 `metadata.image.caption`：只要回复解析为带非空 `caption` 字段的 JSON 就会被设置，否则为 `None`——包括"成功但非 JSON"的回复，此时整段回复变成 `prompt`，没有 caption。用量/费用不落库；请用 generation id 去你的供应商日志里对账。长的 `prompt` 本身不持久化（按设计交给消费方自己留存）。设计文档：`docs/superpowers/specs/2026-08-02-image-compose-audit-design.md`。
+**审计。** 一次成功的合成器调用——包括上面提到的"非 JSON 回退路径"，它同样算作成功——会向图片轮次的 `chat_messages.metadata.image` 写入三个键：`compose_variant`（命中了 `filter_prompt` 的哪个 key/下标；纯字符串或内置提示词时缺失；按调用方传入的值记录（已 trim），不做归一化——例如索引形态里 `"01"` 命中下标 1，审计时仍记为 `"01"`）、`compose_model`（实际应答的模型），以及 `compose_generation_id`。只有当合成器调用本身失败（fail-open 降级）或该任务未配置时，三者才会缺失——语义与 affinity 审计三元组的 NULL 语义一致（`raw` 已不带特殊含义，因此不再是这里的独立情形）。合成器的 `caption` 单独持久化为 `metadata.image.caption`：只要回复解析为带非空 `caption` 字段的 JSON 就会被设置，否则为 `None`——包括"成功但非 JSON"的回复，此时整段回复变成 `prompt`，没有 caption。用量/费用不落库；请用 generation id 去你的供应商日志里对账。`metadata.image.prompt`——合成器的 `prompt` 字段，也就是真正的出图主体——**会**持久化在每个图片轮次上；它正是 `build_delegated_image_marker` 写入、与上面审计三元组同行的那个字段。真正不持久化的是完整拼装出的**线上 wire prompt**（style 预设 + 人格外观 + 这个主体，由 `compose_image_prompt` 拼装而成）：这段字符串只出现在 `image_request` 帧的 `composed_prompt` 字段里，base64 编码后发出，从不写入任何数据行。运营方审计数据库时，能在每个图片轮次上找到出图主体本身——只是找不到那个已经套上 style 与外观外壳、供应商真正收到的完整版本。设计文档：`docs/superpowers/specs/2026-08-02-image-compose-audit-design.md`。
 
 ### `[tasks.chat_vision]` — 图片输入（视觉预处理阶段，opt-in）
 

--- a/docs/superpowers/specs/2026-08-02-pde-image-context-compose-design.md
+++ b/docs/superpowers/specs/2026-08-02-pde-image-context-compose-design.md
@@ -399,7 +399,22 @@ Serial LLM hops on the turn drop from 3 to 2.
   (same chain). This is now the ONLY degraded image path — a turn either gets a
   composed picture or a portrait.
 - A panicked or cancelled composer task surfaces at the join as
-  `Err(JoinError)` and maps to the same degradation — never a dropped frame.
+  `Err(JoinError)`. **Implemented differently from this section's original
+  plan** (amended post-review, 2026-08-02 fix wave): rather than mapping
+  straight to the portrait-fallback degradation above, the join's `Err(e)` arm
+  logs a warn and re-runs `build_delegated_image_prompt` **sequentially**,
+  right there — a second, synchronous attempt at a real composed picture
+  before falling through to the empty-subject/portrait path (only if that
+  second attempt also fails to produce one). This is strictly more robust than
+  "maps to the same degradation": a `JoinError` is usually an orthogonal
+  scheduler event (a panic, or an abort racing a not-yet-observed success), not
+  evidence that the composer itself is broken, so unconditionally discarding
+  its chance at a real picture would degrade turns that a plain retry could
+  have saved — never a dropped frame either way. The cost is a second LLM call
+  and a serial hop on this (rare) path. The reviewer that closed issue #212
+  judged this behavior preferable to the original plan, so this document was
+  amended to describe it rather than changing the code to match the original
+  plan.
 - If the text path returns early before the join (e.g. `build_reply_request`
   fails and the stream yields `Error` and returns), the handle is dropped.
   **Dropping a `JoinHandle` does not cancel the task**: it runs to completion

--- a/docs/superpowers/specs/2026-08-02-pde-image-context-compose-design.md
+++ b/docs/superpowers/specs/2026-08-02-pde-image-context-compose-design.md
@@ -249,6 +249,37 @@ the frame carries what is needed to draw (prompt, aspect ratio, image ref);
 the caption belongs to chat history and a downstream that wants it reads it
 from the message row.
 
+### The affinity proxy moves to the caption
+
+`ActionPlan.image_prompt` has a consumer beyond image composition:
+`affinity_eval_text` (`post_process.rs:523`, called at `post_process.rs:113`)
+uses it as the assistant-content proxy on image turns, so a photo-send still
+moves affinity instead of tripping the `empty_assistant` gate.
+
+With the judge no longer writing a seed, that field would be `None` on every
+judge-driven image turn and every photo would evaluate as the generic
+`[发送了一张照片]`. The caption is the natural — and strictly better —
+replacement: a short natural-language line, in the conversation's language,
+describing what the picture showed, which is exactly what the first-person
+affinity evaluator (#210) wants to read.
+
+So:
+
+- `ActionPlan.image_prompt` is **renamed** `image_caption`, redocumented as
+  "what the picture showed, for post-process affinity", and `plan_for` loses
+  its `image_prompt` parameter (nothing can supply a caption at decision time —
+  the composer has not run yet).
+- The stream sets `plan_bg.image_caption` after the composer resolves, on both
+  image paths, at the point it already mutates the plan before spawning
+  post-process (`stream.rs:3675`).
+- `affinity_eval_text` reads `image_caption`. Its existing blank/absent
+  behaviour is unchanged: it falls back to `[发送了一张照片]`, which is exactly
+  §2's bare-marker rule expressed for the affinity path.
+
+Note this makes the plan's field genuinely unused for composition —
+`resolve_image_turn_inputs` reads `req_image.image_prompt` directly, and the
+forced-image path was already passing that same value through the plan.
+
 ### Concurrency on `reply_text_image`
 
 Today the composer runs only after the text stream's `done`
@@ -349,6 +380,10 @@ Serial LLM hops on the turn drop from 3 to 2.
 - Metadata: `prompt` is the composer subject, `caption` present on the compose
   path and omitted on the `raw` and failure paths; no `composed_prompt` key is
   written; the `image_request` frame carries no caption.
+- Affinity proxy: `affinity_eval_text` returns the caption on an image turn
+  when one exists, and `[发送了一张照片]` when it does not; `plan_bg.image_caption`
+  is populated on both the `reply_image` and `reply_text_image` paths before
+  post-process is spawned.
 - Concurrency: `latest_user_msg` equals the input filter's rewrite when one
   fired and the raw content when none did; `reply_text_image` sqlx stream test
   asserts frame order `meta → delta* → done → image → final` is unchanged with

--- a/docs/superpowers/specs/2026-08-02-pde-image-context-compose-design.md
+++ b/docs/superpowers/specs/2026-08-02-pde-image-context-compose-design.md
@@ -1,0 +1,368 @@
+# eros-engine — engine-counted image facts, composer-authored captions, seedless generate-mode composer
+
+Three changes to the PDE image path, one PR. The engine becomes the single
+source of truth for "how many images went out recently", so the judge stops
+counting transcript markers it cannot count reliably. The composer starts
+emitting a short `caption` alongside the image prompt, and every
+history-facing render switches to it — separating "what the picture showed"
+(short, for looking back) from "what to draw" (long, for the image provider).
+And the judge stops writing image-prompt seeds entirely:
+`chat_image_prompt_compose` flips from seed-EXPAND to context-GENERATE,
+becomes a required stage of the image path, and runs concurrently with the
+chat call on `reply_text_image`.
+
+Closes #212. Background: eros-audit report 38 and the issue's replay bench
+(n=32 turns/arm, production traffic): engine-counted facts rescued the judges
+that cannot count (venice 8/10 → 3/10 over-send with ≥2 images in window);
+judges soften explicit user requests when asked to write seeds (hermes 7/12,
+glm 8/11 softened); 0/32 verdicts leaked image descriptions once the schema
+stopped asking; and image-prompt echo was 71% of the judge's
+conversation-history characters from only 12.8% of turns.
+
+---
+
+## 0. Decisions (settled during brainstorm)
+
+- **A + B + C ship together.** B without A would make over-sending worse (the
+  issue measured the existing hold-back rule keying on the marker being
+  *visible*), so the facts line lands in the same change that shortens what
+  the markers carry.
+- **No backwards compatibility with the old PDE contract.** The verdict schema
+  drops `image_prompt` unconditionally. A deployment that has not configured
+  `[tasks.chat_image_prompt_compose]` loses image capability: the judge is
+  told 可发图=否 and image actions are guarded away. **Breaking change**,
+  flagged in release notes and the shipped config example. Rationale:
+  production already proved the judge-written seed unusable (especially on
+  NSFW turns — acceptable image output essentially always required the
+  composer anyway), so making the composer mandatory removes the wasted double
+  composition rather than preserving it as a degraded fallback. It also
+  single-sources the audit trail: with one composition there is no longer a
+  "was it the seed or the composer?" question to investigate, and a downstream
+  operator controls image content through exactly one knob — the composer's
+  `filter_prompt`.
+- **The composer emits `{prompt, caption}`, not plain text.** This reverses the
+  earlier "composer output stays plain text" position. The reason that
+  position existed — not wanting to break deployed composer `filter_prompt`s —
+  is already spent: the EXPAND→GENERATE rewrite obliges every deployment to
+  rewrite that prompt regardless, so a second output field costs nothing
+  extra. Producing the caption here is also the only place it can be produced
+  without either an extra LLM call or a lossy after-the-fact summarisation:
+  the model writing the picture already knows what the picture shows.
+- **The engine does NOT persist the composed (wire) prompt.** It goes out on
+  the `image_request` frame; whether to store it is the downstream consumer's
+  call (ours keeps it in its own images table). The engine persists only what
+  its own chat pipeline needs to read back.
+- **`aspect_ratio` and `image_ref` stay judge-owned.** The measured harm was
+  all in the seed (softening + double composition); the two enums are cheap
+  decisions the judge handles fine. They are also *not* moved into the
+  composer's JSON — a picture's framing is a turn-level interaction decision,
+  not part of describing the picture.
+- **`reply_text_image` must fan out**: composer and chat fire concurrently and
+  assemble at the end. Today they are serial (the composer starts only after
+  the text stream's `done`), adding a full LLM round trip to the turn.
+- **`ReasoningConfig.effort` is a non-goal**: provider-specific reasoning
+  params are already coverable via `[[providers.<name>.body]]` custom body
+  params (#213).
+
+## 1. A — engine-counted image facts in the judge context
+
+`build_input_filter_transcript` (`stream.rs:2158`) currently returns `String`.
+It becomes a struct:
+
+```rust
+struct JudgeTranscript {
+    transcript: String,
+    /// Assistant rows in the window carrying `metadata.image`
+    /// (channel-marked rows already excluded by the existing skip).
+    images_in_window: usize,
+    /// The newest assistant row in the window is an image turn.
+    last_assistant_is_image: bool,
+}
+```
+
+Both facts are computed from the same `history()` rows the transcript is
+already built from — zero extra round trips.
+
+`build_pde_ctx` (`stream.rs:1886`) gains the two facts and always emits, right
+after `[图片能力]` (the negative is a signal too, same precedent):
+
+```
+[近期图片] 最近{INPUT_FILTER_CONTEXT_TURNS}条消息内已发图={k} 张；上一条 AI 消息是图片={是|否}（以本行计数为准，对话记录里的图片标记仅供参考）
+```
+
+**The unit is messages, not turns.** `ChatRepo::history(session_id, limit,
+offset)` applies `LIMIT` to rows (`chat.rs:244`), so
+`INPUT_FILTER_CONTEXT_TURNS = 8` is the last 8 *messages* — roughly 4
+exchanges. The constant's name is a pre-existing misnomer; renaming it is out
+of scope here, but the rendered line must not repeat the error, and a comment
+at the constant should record it. The window size is deliberately unchanged:
+the issue's bench replayed `build_pde_ctx` and therefore inherited this exact
+8-row window, so its measured numbers transfer only as long as the window
+does.
+
+The trailing clause is the engine-side half of "these numbers override the
+transcript"; judge prompts (config-owned) can lean on it but don't have to.
+
+## 2. B — history-facing renders read `caption`
+
+Two renders currently read `metadata.image.prompt`:
+
+- `assistant_transcript_line` (`stream.rs:2135`) → the PDE judge and the input
+  filter, as `（发送了一张图片：{prompt}，画幅 {ar}）`.
+- `model_facing_assistant_text` (`handlers.rs:116`) → **the chat model's own
+  conversation history**, as `[你给对方发送了一张照片：{prompt}]`, untruncated.
+
+Both switch to `metadata.image.caption`. That is the whole of change B — there
+is no truncation step. A caption is short because it was written to be short,
+so the 71%-of-history-characters problem is fixed at the point of production
+rather than by cutting a long string at a fixed offset. Truncation was also
+never safe here: under §3 the composer's `prompt` leads with the style preset
+and appearance (`compose_image_prompt`, `handlers.rs:277`, joins
+`{style_preset}\n{appearance}\n{subject}`), so a fixed-length head of it is
+boilerplate identical across every image of every persona in that style.
+
+The aspect-ratio clause in the transcript render stays (it is ~8 chars and
+occasionally decision-relevant).
+
+**When `caption` is absent, both renders emit the bare marker** —
+`（发送了一张图片）` / `[你给对方发送了一张照片]` — and never fall back to
+`prompt`. Three situations reach this path, and the same rule covers all
+three: rows persisted before this change; a composer reply that parsed but
+carried no usable caption; and a fully-failed compose (§4). Falling back to
+`prompt` would reintroduce exactly the long-string injection this change
+removes, silently and precisely when the composer is misbehaving. The cost is
+that for those turns the judge cannot see *what* the last picture showed —
+acceptable, because the anti-spam brake now rides on §1's counts, which are
+computed from `metadata.image` presence and are unaffected by a missing
+caption.
+
+## 3. C — seedless verdict, generate-mode composer with captions
+
+### Verdict schema
+
+`pde_response_format` (`stream.rs:1610`) drops `image_prompt` from
+`properties` and `required`, unconditionally. `PdeVerdict` drops the field;
+`aspect_ratio` and `image_ref` stay. Judge prompts that still mention seeds
+have nothing to write them into (strict schema), and a stray `image_prompt`
+key from a non-strict provider deserializes away harmlessly.
+
+### Composer becomes required for image capability
+
+The effective image availability for a turn becomes
+`image_executor_available && [tasks.chat_image_prompt_compose] exists`. The
+gate is the **task section's presence** (a config-level fact), NOT a
+`resolve_image_prompt_compose(..)` call — that resolver also returns `None`
+for the reserved `raw` variant, which must not read as "no image capability".
+Without the composer task, `[图片能力] 本轮可发图=否` and `guard_action`
+downgrades image verdicts exactly as it does today when the executor is
+absent.
+
+The `raw` variant keeps its meaning: composer skipped, the client's
+`req_image.image_prompt` used verbatim — now the only remaining seed source.
+`raw` produces no caption (nothing wrote one), so its rows render the bare
+marker per §2.
+
+### Composer contract: EXPAND → GENERATE, and a second output field
+
+`compose_user_payload` (`stream.rs:2294`) gains the partner's latest message —
+the information the seed used to carry (the shared transcript deliberately
+excludes the current turn):
+
+```
+[人物外观]\n{appearance}\n\n[最近场景]\n{recent_scene}\n\n[对方最新消息]\n{latest_user_msg}\n\n[画面主题种子]\n{seed_subject}\n\n[风格]\n{style}\n\n[画幅]\n{aspect_ratio}
+```
+
+`seed_subject` now resolves from `req_image.image_prompt` only (an explicit
+client override; usually empty — rendered as 「（无）」 like the other empty
+sections). `resolve_image_turn_inputs` loses its `plan.image_prompt` arm.
+
+The composer returns JSON:
+
+```json
+{"prompt": "...", "caption": "..."}
+```
+
+`prompt` is the picture subject (the seed's successor — what
+`compose_image_prompt` then wraps with style and appearance). `caption` is one
+short line describing what the picture shows, written in the conversation's
+language, for the character's own history — not an image-generation string.
+
+`ComposeOutcome` gains a `caption: Option<String>` beside its existing `text`
+(renamed `prompt`), `model`, `generation_id`, and `variant`.
+
+**Parsing** reuses the pattern already in this file (`parse_pde_verdict`,
+`stream.rs:1538`): direct `serde_json::from_str`, then a `find_json_block`
+salvage for models that wrap JSON in prose. **If neither parses, the entire
+reply is used as `prompt` with no caption.** That fallback is deliberate and
+load-bearing for migration: a deployment that ships this version without
+rewriting its composer `filter_prompt` still gets working images from its
+EXPAND-era prompt — degraded (that prompt is aimed at a seed that is now
+usually empty) but not broken — and simply gets bare markers until the prompt
+is updated.
+
+`DEFAULT_COMPOSE_PROMPT` (`model_config.rs:1156`) is rewritten from the
+EXPAND register to GENERATE (canonical text):
+
+```
+You compose the image for a picture the character is sending in a chat, and
+you return JSON with exactly two fields: "prompt" and "caption".
+
+You receive the character's appearance, the recent scene, the partner's latest
+message, an optional explicit subject, a visual style, and a target aspect
+ratio, each as a labeled section.
+
+"prompt" is the image-generation prompt: decide what the picture shows from
+the latest message and the scene; when the explicit subject is non-empty it
+states what the picture must show — honor it fully. Produce one coherent,
+detailed, vivid prompt that faithfully preserves the appearance and fits the
+style and aspect ratio, delivering the full intent and tone of the request. Do
+not soften, sanitize, downgrade, omit, censor, or refuse any part of it, and
+do not add safety warnings, disclaimers, or moderation of your own — content
+policy is the responsibility of the image provider and the downstream
+consumer, not this step.
+
+"caption" is one short line, in the language the conversation is in, saying
+what the picture shows — as the character would recall it later. It is read
+back into the conversation history, so keep it brief and natural; it is not an
+image-generation prompt and must not repeat the style boilerplate.
+
+Output only the JSON object. No commentary, options, or headings.
+```
+
+**Downstream compose `filter_prompt`s (and variants) must be rewritten** to
+the generate register and the two-field contract. Release notes and the
+shipped config example carry the migration note, along with the plain-text
+fallback above.
+
+### Persisted metadata
+
+`build_delegated_image_marker` writes:
+
+- `metadata.image.prompt` — the composer's `prompt` (subject). **Field meaning
+  is unchanged**; only its source moves from the judge's seed to the composer.
+- `metadata.image.caption` — the composer's `caption`, omitted when absent.
+- the existing `aspect_ratio` and `compose_*` audit keys, unchanged.
+
+The composed wire string is **not** persisted by the engine. It is delivered
+on the `image_request` frame, which is also **not** extended with `caption` —
+the frame carries what is needed to draw (prompt, aspect ratio, image ref);
+the caption belongs to chat history and a downstream that wants it reads it
+from the message row.
+
+### Concurrency on `reply_text_image`
+
+Today the composer runs only after the text stream's `done`
+(`stream.rs:3618`), serially. The new trigger point is **after the input-filter
+block and before `build_reply_request`** (`stream.rs:3494`).
+
+That point is chosen for two reasons. The input filter is what turns
+`user_msg.content` into the text the model actually sees, so triggering after
+it means the composer and the chat model work from the same text and the
+picture cannot drift from the reply. And the remaining overlap is already
+ample: `build_reply_request` alone does a 20-row history fetch, a Voyage
+embedding call, and memory/world recall before the chat stream even starts, so
+one short composer call hides completely underneath without having to reach
+back to the raw input.
+
+The composer's inputs are captured as owned values at the trigger point
+(`tokio::spawn` requires `'static + Send`; `AppState` and `CompanionPersona`
+are both `Clone`):
+
+```rust
+struct ComposeJob {
+    state: AppState,
+    persona: CompanionPersona,
+    recent_scene: String,          // pde_transcript
+    latest_user_msg: String,       // the EFFECTIVE text (see below)
+    seed_subject: Option<String>,  // req_image.image_prompt only
+    style: StyleKey,
+    aspect_ratio: Option<String>,
+    variant: Option<String>,       // req_image.prompt_variant
+    cfg: ResolvedImagePromptCompose,
+}
+```
+
+`latest_user_msg` must be tracked locally through the input-filter block: the
+rewrite is currently persisted and then dropped (`build_reply_request` re-reads
+it from the database), so the block keeps a local `String` — initialised from
+`user_msg.content`, replaced when `run_input_filter` returns a rewrite — rather
+than paying a second read.
+
+Spawn only when `plan.action_type == ReplyTextImage`. `ReplyImage` keeps its
+single sequential call: it has no text task to overlap with and returns early
+via `image_only_done`.
+
+The `Option<JoinHandle<DelegatedImagePrompt>>` is held across the chat
+stream's yields. At `stream.rs:3618` the `build_delegated_image_prompt(..).await`
+call becomes `handle.await`; every line after it — marker merge, image frame,
+final frame — is unchanged, so the wire frame order is byte-identical:
+
+```
+meta → delta* → done → image → final
+        ↑                ↑
+   chat streaming,    join here (usually already complete)
+   composer running
+```
+
+Serial LLM hops on the turn drop from 3 to 2.
+
+## 4. Error handling
+
+- A and B are pure rendering; no new failure paths. A DB error still yields an
+  empty transcript — and now zero counts, rendering as `已发图=0 张`, the same
+  "no recent images" signal an empty transcript gives the judge today.
+- The composer keeps its fail-open chain (per-model timeout → next model). With
+  no seed to fall back to, a fully-failed compose degrades to an empty subject:
+  `compose_image_prompt(style, persona, "")` yields a persona-appearance
+  portrait prompt, and no caption is persisted (bare marker, §2). Logged at
+  warn. The degraded *outcome* changes from "the judge's softened seed" to
+  "generic portrait"; the failure *rate* is unchanged (same chain).
+- A panicked or cancelled composer task surfaces at the join as
+  `Err(JoinError)` and maps to the same degradation — never a dropped frame.
+- If the text path returns early before the join (e.g. `build_reply_request`
+  fails and the stream yields `Error` and returns), the handle is dropped.
+  **Dropping a `JoinHandle` does not cancel the task**: it runs to completion
+  and its result is discarded. The request is already in flight, so aborting
+  saves no tokens; calling `handle.abort()` on those explicit error paths is
+  tidiness, not correctness.
+
+## 5. Testing
+
+- Count computation: image-metadata rows counted, channel-marked rows
+  excluded, current-turn excluded; `last_assistant_is_image` in both
+  polarities.
+- `[近期图片]` renders in both polarities and always appears when the PDE runs;
+  the rendered unit says messages, and the count matches a fixture whose row
+  count differs from its turn count.
+- Caption rendering: both consumers use `caption` when present; both emit the
+  bare marker when it is absent, for each of the three entry points (legacy row
+  with only `prompt`, parsed reply without a caption, failed compose). A
+  regression test asserts `prompt` is never rendered into either consumer.
+- Schema: `image_prompt` absent from `pde_response_format`; verdict parse
+  tolerates a stray `image_prompt` key from a non-strict provider.
+- Composer parsing: direct JSON; JSON wrapped in prose; and a plain-text reply
+  → whole reply becomes `prompt`, caption `None`.
+- Image availability: composer task absent ⇒ 可发图=否 and image actions
+  guarded to text; present ⇒ 是. The `raw` variant must NOT read as absent.
+- Composer payload includes `[对方最新消息]`; the seed section renders 「（无）」
+  when there is no client override.
+- Metadata: `prompt` is the composer subject, `caption` present on the compose
+  path and omitted on the `raw` and failure paths; no `composed_prompt` key is
+  written; the `image_request` frame carries no caption.
+- Concurrency: `latest_user_msg` equals the input filter's rewrite when one
+  fired and the raw content when none did; `reply_text_image` sqlx stream test
+  asserts frame order `meta → delta* → done → image → final` is unchanged with
+  the concurrent composer, and that a composer failure still yields an image
+  frame carrying the portrait fallback.
+- `reply_image` path unchanged.
+
+## 6. Non-goals
+
+- `ReasoningConfig.effort` (#213 already covers provider reasoning params via
+  custom body params).
+- Regenerate-on-empty for chat replies (report 38 §10) — separate concern,
+  separate issue.
+- Moving `aspect_ratio` / `image_ref` into the composer's JSON — rejected in §0.
+- Renaming `INPUT_FILTER_CONTEXT_TURNS` or changing the window size.
+- Persisting the composed wire prompt engine-side — rejected in §0.
+- Downstream model selection and bench re-runs — operator-side.

--- a/docs/superpowers/specs/2026-08-02-pde-image-context-compose-design.md
+++ b/docs/superpowers/specs/2026-08-02-pde-image-context-compose-design.md
@@ -57,6 +57,18 @@ conversation-history characters from only 12.8% of turns.
   decisions the judge handles fine. They are also *not* moved into the
   composer's JSON — a picture's framing is a turn-level interaction decision,
   not part of describing the picture.
+- **The seed concept is deleted outright, not just relocated.** With the judge
+  no longer writing one, the only other seed source was the client
+  (`image.image_prompt`) — and clients neither need nor are permitted to hand
+  the engine a prompt. So that request field goes too, the composer payload
+  loses its `[画面主题种子]` section, and `resolve_image_turn_inputs` stops
+  resolving a subject at all. The composer generates from context, full stop.
+- **`"raw"` stops being a reserved `prompt_variant`.** It existed to mean "skip
+  the composer and draw the seed verbatim", which is incoherent once no seed
+  exists. After this change `"raw"` is an ordinary variant name: it hits only
+  if a deployment actually configures a variant keyed `raw`, and misses like
+  any other unknown key. The boot gate that refused such a key is removed with
+  it.
 - **`reply_text_image` must fan out**: composer and chat fire concurrently and
   assemble at the end. Today they are serial (the composer starts only after
   the text stream's `done`), adding a full LLM round trip to the turn.
@@ -151,30 +163,60 @@ key from a non-strict provider deserializes away harmlessly.
 The effective image availability for a turn becomes
 `image_executor_available && [tasks.chat_image_prompt_compose] exists`. The
 gate is the **task section's presence** (a config-level fact), NOT a
-`resolve_image_prompt_compose(..)` call — that resolver also returns `None`
-for the reserved `raw` variant, which must not read as "no image capability".
+`resolve_image_prompt_compose(..)` call: that resolver reaches
+`self.resolve(COMPOSE_TASK, None)`, which advances the round-robin model
+cursor as a side effect, so calling it merely to answer a capability question
+would skew which model later image turns actually pick.
+
 Without the composer task, `[图片能力] 本轮可发图=否` and `guard_action`
 downgrades image verdicts exactly as it does today when the executor is
 absent.
 
-The `raw` variant keeps its meaning: composer skipped, the client's
-`req_image.image_prompt` used verbatim — now the only remaining seed source.
-`raw` produces no caption (nothing wrote one), so its rows render the bare
-marker per §2.
+### `"raw"` is no longer a reserved variant
+
+`resolve_image_prompt_compose` currently short-circuits to `None` when the
+client's `prompt_variant` is `"raw"` (case-insensitive), meaning "skip the
+composer, draw the seed as-is"; `check_variant_shape` correspondingly refuses
+to boot on a config that defines a variant keyed `raw`. Both go away.
+
+With no seed there is nothing to draw as-is, so the escape hatch is
+incoherent. After this change `"raw"` is an ordinary variant name: it selects
+a prompt only if a deployment actually configures one under that key, and
+otherwise misses like any unknown key — falling back to the built-in prompt,
+which is never an error. The boot refusal is deleted so that key becomes
+configurable.
+
+Removing the short-circuit also makes `resolve_image_prompt_compose` return
+`None` for exactly one reason — the task section is absent — which is what
+lets the capability gate above be stated so simply.
+
+**No `prompt_variant` supplied** already resolves to the built-in prompt for
+the variant shapes (`PromptSpec::select` returns `None` for `Indexed`/`Keyed`
+without a variant), and to the configured string for a `Plain` `filter_prompt`
+— a plain prompt is the deployment's single chosen prompt, not a variant miss.
+That behaviour is unchanged and needs no code.
 
 ### Composer contract: EXPAND → GENERATE, and a second output field
 
 `compose_user_payload` (`stream.rs:2294`) gains the partner's latest message —
 the information the seed used to carry (the shared transcript deliberately
-excludes the current turn):
+excludes the current turn) — and **loses the seed section entirely**:
 
 ```
-[人物外观]\n{appearance}\n\n[最近场景]\n{recent_scene}\n\n[对方最新消息]\n{latest_user_msg}\n\n[画面主题种子]\n{seed_subject}\n\n[风格]\n{style}\n\n[画幅]\n{aspect_ratio}
+[人物外观]\n{appearance}\n\n[最近场景]\n{recent_scene}\n\n[对方最新消息]\n{latest_user_msg}\n\n[风格]\n{style}\n\n[画幅]\n{aspect_ratio}
 ```
 
-`seed_subject` now resolves from `req_image.image_prompt` only (an explicit
-client override; usually empty — rendered as 「（无）」 like the other empty
-sections). `resolve_image_turn_inputs` loses its `plan.image_prompt` arm.
+`resolve_image_turn_inputs` stops resolving a subject at all: its
+`plan.image_prompt` arm goes with the judge's seed, and its
+`req_image.image_prompt` arm goes with the request field (below). What remains
+is style and aspect ratio.
+
+`ImageReplyParams.image_prompt` is **removed from the request type**, and with
+it from `openapi.json` and both API references. It was documented as the
+subject for the forced-image path, but a client neither needs nor is permitted
+to hand the engine an image prompt — the composer decides what the picture
+shows. A client that keeps sending the field is unaffected: it deserializes
+away like any unknown key.
 
 The composer returns JSON:
 
@@ -208,17 +250,15 @@ You compose the image for a picture the character is sending in a chat, and
 you return JSON with exactly two fields: "prompt" and "caption".
 
 You receive the character's appearance, the recent scene, the partner's latest
-message, an optional explicit subject, a visual style, and a target aspect
-ratio, each as a labeled section.
+message, a visual style, and a target aspect ratio, each as a labeled section.
 
 "prompt" is the image-generation prompt: decide what the picture shows from
-the latest message and the scene; when the explicit subject is non-empty it
-states what the picture must show — honor it fully. Produce one coherent,
+the partner's latest message and the recent scene. Produce one coherent,
 detailed, vivid prompt that faithfully preserves the appearance and fits the
-style and aspect ratio, delivering the full intent and tone of the request. Do
-not soften, sanitize, downgrade, omit, censor, or refuse any part of it, and
-do not add safety warnings, disclaimers, or moderation of your own — content
-policy is the responsibility of the image provider and the downstream
+style and aspect ratio, delivering the full intent and tone of what was asked
+for. Do not soften, sanitize, downgrade, omit, censor, or refuse any part of
+it, and do not add safety warnings, disclaimers, or moderation of your own —
+content policy is the responsibility of the image provider and the downstream
 consumer, not this step.
 
 "caption" is one short line, in the language the conversation is in, saying
@@ -240,8 +280,16 @@ fallback above.
 
 - `metadata.image.prompt` — the composer's `prompt` (subject). **Field meaning
   is unchanged**; only its source moves from the judge's seed to the composer.
+  This deliberately reverses the decision in #211 that pinned it to the seed:
+  that choice existed to keep the *short* string in the database for the
+  history marker, a job `caption` now does, and with no seed left the field
+  would otherwise be empty on every image turn.
 - `metadata.image.caption` — the composer's `caption`, omitted when absent.
 - the existing `aspect_ratio` and `compose_*` audit keys, unchanged.
+
+Two paths now reach the marker, not three: a successful compose (subject and
+caption both present) and a failed one (subject empty, no caption). The former
+`raw` path is gone with the reserved variant.
 
 The composed wire string is **not** persisted by the engine. It is delivered
 on the `image_request` frame, which is also **not** extended with `caption` —
@@ -343,11 +391,13 @@ Serial LLM hops on the turn drop from 3 to 2.
   empty transcript — and now zero counts, rendering as `已发图=0 张`, the same
   "no recent images" signal an empty transcript gives the judge today.
 - The composer keeps its fail-open chain (per-model timeout → next model). With
-  no seed to fall back to, a fully-failed compose degrades to an empty subject:
-  `compose_image_prompt(style, persona, "")` yields a persona-appearance
-  portrait prompt, and no caption is persisted (bare marker, §2). Logged at
-  warn. The degraded *outcome* changes from "the judge's softened seed" to
-  "generic portrait"; the failure *rate* is unchanged (same chain).
+  the seed concept deleted there is nothing to fall back to, so a fully-failed
+  compose degrades to an empty subject: `compose_image_prompt(style, persona,
+  "")` yields a persona-appearance portrait prompt, and no caption is persisted
+  (bare marker, §2). Logged at warn. The degraded *outcome* changes from "the
+  judge's softened seed" to "generic portrait"; the failure *rate* is unchanged
+  (same chain). This is now the ONLY degraded image path — a turn either gets a
+  composed picture or a portrait.
 - A panicked or cancelled composer task surfaces at the join as
   `Err(JoinError)` and maps to the same degradation — never a dropped frame.
 - If the text path returns early before the join (e.g. `build_reply_request`
@@ -374,12 +424,19 @@ Serial LLM hops on the turn drop from 3 to 2.
 - Composer parsing: direct JSON; JSON wrapped in prose; and a plain-text reply
   → whole reply becomes `prompt`, caption `None`.
 - Image availability: composer task absent ⇒ 可发图=否 and image actions
-  guarded to text; present ⇒ 是. The `raw` variant must NOT read as absent.
-- Composer payload includes `[对方最新消息]`; the seed section renders 「（无）」
-  when there is no client override.
+  guarded to text; present ⇒ 是.
+- `"raw"` is no longer reserved: a config defining a variant keyed `raw` boots
+  and that variant is selectable; `prompt_variant = "raw"` with no such key
+  configured resolves to the built-in prompt (a miss, not a skip and not an
+  error); and `resolve_image_prompt_compose` returns `None` only when the task
+  section is absent.
+- Composer payload includes `[对方最新消息]` and no longer has a seed section.
 - Metadata: `prompt` is the composer subject, `caption` present on the compose
-  path and omitted on the `raw` and failure paths; no `composed_prompt` key is
-  written; the `image_request` frame carries no caption.
+  path and omitted on the failure path; no `composed_prompt` key is written;
+  the `image_request` frame carries no caption. At least one DB-backed test
+  must drive a real JSON composer reply through to a persisted row and assert
+  `metadata.image.caption` — the unit tests cover the parser and the marker
+  builder, but not the seam between them.
 - Affinity proxy: `affinity_eval_text` returns the caption on an image turn
   when one exists, and `[发送了一张照片]` when it does not; `plan_bg.image_caption`
   is populated on both the `reply_image` and `reply_text_image` paths before

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -278,20 +278,35 @@ model_name_display_override = true
 #"""
 
 # ── Image-prompt composer (chat_image_prompt_compose) ───────────────────────
-# OPTIONAL. When this block is present, after an image action is decided the
-# engine expands the PDE's seed subject into one richer image prompt before
-# generation: it feeds the persona appearance + seed subject + recent scene +
-# chosen aspect ratio + style to this model and uses the result as the image
-# subject. Feature is OFF when the block is absent. Fail-open: on failure /
-# timeout / empty it falls back to the PDE seed, so it never blocks the image
-# turn (and never advances any round-robin cursor on non-image turns).
+# BREAKING (v0.10): this task is now REQUIRED for image turns. The PDE judge no
+# longer writes an image-prompt seed, so with no composer configured the engine
+# reports 可发图=否 and downgrades image actions to text.
+#
+# The composer's contract also changed: it now GENERATES from context (rather
+# than expanding a seed) and must return JSON with two fields —
+#   {"prompt": "<image-generation prompt>", "caption": "<one short line>"}
+# `caption` is what the chat history and the judge transcript read back; the
+# long prompt is never injected into either. A reply that is not JSON is used
+# as the prompt with no caption, so an old EXPAND-era filter_prompt still
+# produces images — but rewrite it, or you get no captions and a prompt aimed at
+# a seed that is now always empty.
+#
+# When this block is present, after an image action is decided the engine
+# generates one image prompt from turn context: it feeds the persona appearance
+# + recent scene + the partner's latest message + chosen aspect ratio + style to
+# this model and uses the result as the image subject. Omit the block entirely
+# and image turns stay unavailable. Fail-open: on failure / timeout / empty
+# reply it falls back to an empty subject (a plain persona-appearance
+# portrait), so it never blocks the image turn (and never advances any
+# round-robin cursor on non-image turns).
 #
 # `filter_prompt` is OPTIONAL here (unlike the other tasks): omit it to use the
-# engine's built-in, product-identity-free EXPAND-ONLY default prompt, or set it
-# to override. The built-in expands faithfully and never softens, downgrades, or
-# refuses, and adds no moderation of its own — content policy is the image
-# provider's and the downstream consumer's responsibility, not this step. Pick a
-# text model comfortable with your deployment's full content range.
+# engine's built-in, product-identity-free GENERATE-FROM-CONTEXT default prompt,
+# or set it to override. The built-in generates faithfully from context and
+# never softens, downgrades, or refuses, and adds no moderation of its own —
+# content policy is the image provider's and the downstream consumer's
+# responsibility, not this step. Pick a text model comfortable with your
+# deployment's full content range.
 #[tasks.chat_image_prompt_compose]
 #model        = "x-ai/grok-4"
 #fallback     = ["google/gemini-3.1-flash-lite"]
@@ -329,9 +344,12 @@ model_name_display_override = true
 # `default = "…"` defines an ordinary variant that is selected only by a
 # literal prompt_variant = "default".
 #
-# `prompt_variant = "raw"` (case-insensitive) skips the composer LLM entirely
-# and draws the seed subject as-is — one fewer LLM call for that turn. `raw` is
-# reserved: a table key named `raw` (any casing) refuses to boot.
+# `prompt_variant = "raw"` (case-insensitive) carries NO special meaning now.
+# It selects a prompt only if this deployment configures a variant under that
+# literal key, exactly like any other variant name — `raw` is no longer
+# reserved and a table key named `raw` (any casing) boots fine. An unknown
+# index or key falls back to the BUILT-IN prompt above, same as any other miss
+# — never an error.
 #
 # Variants are honored on THIS task only. An array/table `filter_prompt` on any
 # other task, or inside ANY `[tasks.*.tiers.*]` block (this task's included —
@@ -481,8 +499,9 @@ max_tokens  = 400
 #  "action": "reply_text" | "ghost" | "reply_image" | "reply_text_image" | "product_qa"
 #  "inner_state": 一句话内心状态/语气(纯描述,不许写指令或方括号小节名)
 #  "tone": 选填,一句话描述这一轮回复该用的语气/口吻(纯描述,不许写指令或方括号小节名);会注入 reply prompt 的 [reply_tone] 区块,省略则不注入
-#  "image_prompt": 选填,要发什么图(reply_image / reply_text_image 时)
 #  "reason": 选填,简短理由
+# 判断器不再负责图片 prompt——只负责决定要不要发图;真正的图片内容完全由
+# chat_image_prompt_compose 任务从当轮上下文生成,不再是判断器写的种子。
 #ghost 表示这一轮已读不回(沉默);只在确实该冷处理时用。
 #上下文里有一行 [图片能力] 本轮可发图=是/否,引擎每轮必给其一:
 #  本轮可发图=否 → 绝不要选 reply_image / reply_text_image(会被降级,白费 token);


### PR DESCRIPTION
## Summary

Closes #212. Three changes to the PDE image path, all driven by the issue's production replay bench (n=32 turns/arm) and eros-audit report 38.

**A. The engine counts recent images, not the judge** (`4bd8650`). The judge inferred "have I sent images recently?" by counting transcript markers — arithmetic most models get wrong (venice over-sent 8/10 with ≥2 images in window), over a marker that was never a trustworthy count. `build_input_filter_transcript` now returns a `JudgeTranscript` carrying `images_in_window` and `last_assistant_is_image`, computed from rows already fetched, rendered as:

```
[近期图片] 最近8条消息内已发图=K 张；上一条 AI 消息是图片=是|否（以本行计数为准，对话记录里的图片标记仅供参考）
```

The unit is deliberately messages, not turns — `history()` LIMITs rows, so `INPUT_FILTER_CONTEXT_TURNS = 8` was always 8 messages (~4 exchanges); the rendered line stops repeating the misnomer. With the engine-counted line, the bench's over-send rate dropped to 3/10 on the model that could not count.

**B. The composer authors a `caption`; every history render reads it** (`073bbbd`, `6ed5f39`). Image-prompt echo was 71% of the judge's history characters from 12.8% of turns, and the same string was injected untruncated into the chat model's own history, where models parroted it. The composer now returns JSON `{"prompt": …, "caption": …}` — the caption produced where the knowledge is, no extra LLM call. `metadata.image.caption` is what `assistant_transcript_line` and `model_facing_assistant_text` render; caption absent ⇒ bare marker, **never** a prompt fallback. Parsing is fail-open: a non-JSON reply becomes the prompt with no caption, so an un-migrated EXPAND-era composer prompt still produces images.

**C. The seed concept is deleted; the composer generates from context** (`7d58aa1`, `871cb70`, `a1550b2`, `7d2dda2`, `11199b8`). Judges asked to write seeds softened explicit user requests (hermes 7/12, glm 8/11), and the composer rewrote the seed anyway. Now:

- `image_prompt` is gone from the verdict schema, `PdeVerdict`, and `VerdictAudit`; `ActionPlan.image_prompt` became `image_caption`, feeding the affinity evaluator's assistant-content proxy (a caption is exactly the register the first-person evaluator from #210 wants to read).
- The client's `image.image_prompt` request field is deleted (a leftover from when the engine drew images itself; never used). Unknown keys deserialize away, so old clients are unaffected.
- `[tasks.chat_image_prompt_compose]` is **required** for image turns: capability = executor present AND task configured (`has_task`, deliberately not the resolver — that advances the round-robin cursor as a side effect). Without it: 可发图=否, image verdicts downgrade, and the forced-image path logs a warn.
- `prompt_variant = "raw"` is no longer reserved — "skip the composer, draw the seed verbatim" is incoherent with no seed. It is now an ordinary variant name; its boot-time key refusal is removed.
- On `reply_text_image` the composer fires **concurrently** with the chat call (spawned after the input filter so both read the same effective text; joined at the original assembly point). Wire frame order is byte-identical; serial LLM hops per turn drop 3 → 2. An `AbortOnDrop` guard aborts the in-flight call on every early exit, including client disconnect. Audited persisted subject: `metadata.image.prompt` now carries the composer's output (reversing #211's seed pin — its rationale, keeping the short string for history markers, is now served by `caption`).

Design doc (in this PR): `docs/superpowers/specs/2026-08-02-pde-image-context-compose-design.md`.

### ⚠️ Breaking changes

1. The PDE verdict schema no longer requests `image_prompt`.
2. Image turns require `[tasks.chat_image_prompt_compose]` — without it, image capability is off.
3. The composer contract flips EXPAND → GENERATE and the output becomes JSON `{prompt, caption}`. Deployed composer `filter_prompt`s must be rewritten (non-JSON replies still work, degraded: no captions, prompt aimed at a seed that no longer exists).
4. The `image.image_prompt` request field is removed; `prompt_variant = "raw"` loses its reserved meaning.

All four are documented in `examples/model_config.toml`, both model-config references, and both API references.

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — 0 warnings
- [x] `cargo test --workspace` — 1114 passed / 0 failed (live Postgres; includes a new DB-backed test racing a real delayed composer mock against the chat burst on the concurrent path, asserting frame order `meta → delta* → done → image → final` and the composer's output on both the frame and the persisted row)
- [x] OpenAPI snapshot — clean (regenerated exactly twice, for the two legitimate wire changes: the removed request field and the `prompt_variant` description)

## Checklist

- [ ] CLA signed via cla-assistant.io — maintainer-authored branch
- [x] Conventional Commits format on commits
- [ ] DCO sign-off (`git commit -s`) — not used on this repo's own history; commits are GPG-signed

## Reviewer notes

- The property "the composer reads the input filter's rewrite rather than the raw user text" has no test — there is no seam to test through without refactoring the stream generator. It was verified by code review at the spawn site. Stated here so the coverage claim is honest.
- `build_input_filter_transcript`'s channel-row and current-turn exclusions still have no direct test (pre-existing gap; the counting accumulator below them is unit-tested). The `[近期图片]` counts now depend on those skips, so a DB-backed test is a reasonable follow-up.
- On `JoinError` the concurrent path re-runs the composer sequentially rather than dropping straight to the portrait fallback — deliberately more robust than the spec's original wording; the spec was amended to match.
