### PR TITLE
fix(core): correct the ghost threshold comment and lock the non-decay

### DIFF
--- a/crates/eros-engine-core/src/ghost.rs
+++ b/crates/eros-engine-core/src/ghost.rs
@@ -41,7 +41,10 @@ pub fn ghost_permitted(a: &Affinity, s: GhostSignals) -> bool {
 }
 
 /// Decide whether to ghost: hard-safety protections (via `ghost_permitted`),
-/// then the score threshold (rises to 0.85 after a recent ghost, else 0.65).
+/// then the score threshold — 0.85 once this session has ghosted at all, else
+/// 0.65. The raised bar does NOT decay: the branch only asks whether
+/// `hours_since_last_ghost` is `Some`, and `last_ghost_at` is set-only (never
+/// cleared), so one ghost raises the bar for the rest of that session.
 pub fn decide(a: &Affinity, s: GhostSignals) -> GhostDecision {
     if !ghost_permitted(a, s) {
         return GhostDecision::Reply;
@@ -130,7 +133,7 @@ mod tests {
     }
 
     #[test]
-    fn raised_threshold_after_recent_ghost_blocks_mid_score() {
+    fn raised_threshold_after_prior_ghost_blocks_mid_score() {
         // ghost_score = (1-0.5)*0.4 + (1-0.5)*0.4 + 0.0*0.2 = 0.4
         // base 0.65 → would NOT ghost; post-ghost 0.85 → would NOT ghost
         let a = aff(0.5, 0.5, 0.0, 1);
@@ -151,6 +154,31 @@ mod tests {
             hours_since_last_ghost: Some(2.0),
         };
         assert_eq!(decide(&a, s), GhostDecision::Reply);
+    }
+
+    #[test]
+    fn raised_threshold_never_decays_with_time() {
+        // Same affinity as `ghost_when_score_above_threshold_post_protection`
+        // (score 0.82, ghosts at the 0.65 base threshold), but this session has
+        // ghosted before — a month ago. 0.82 < 0.85, so it still must not ghost.
+        //
+        // Pins the property the docs state: the branch tests only
+        // `hours_since_last_ghost.is_some()`, with no upper cutoff, and
+        // `last_ghost_at` is never cleared — so the bar stays raised for the
+        // life of the session. A decay window added here would silently make
+        // ghost-mechanics.md wrong.
+        let a = aff(0.1, 0.1, 0.5, 0);
+        for hours in [2.0, 24.0, 720.0] {
+            let s = GhostSignals {
+                message_count: 50,
+                hours_since_last_ghost: Some(hours),
+            };
+            assert_eq!(
+                decide(&a, s),
+                GhostDecision::Reply,
+                "score 0.82 must stay below the raised 0.85 bar at {hours}h"
+            );
+        }
     }
 
     #[test]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -119,7 +119,7 @@ fully visible on the live stream, replay, and client history.
 
 Two reasons:
 
-1. **Reasoning load.** Affinity math, ghost decisions, and PDE rules are the load-bearing logic. Keeping them I/O-free means a 0-dep cargo test runs in 0ms and never flakes on network. The 68 tests in `core` are the safety net for everything above. (The opt-in LLM judge layer lives in `server`, not `core`, so `core` stays zero-I/O.)
+1. **Reasoning load.** Affinity math, ghost decisions, and PDE rules are the load-bearing logic. Keeping them I/O-free means a 0-dep cargo test runs in 0ms and never flakes on network. The 69 tests in `core` are the safety net for everything above. (The opt-in LLM judge layer lives in `server`, not `core`, so `core` stays zero-I/O.)
 2. **Embeddability.** Anyone wanting to build a different product on top — journaling agent, language tutor, coaching companion — can pull in `core` without inheriting the HTTP shape, the Postgres schema, or the JWT auth. The 6-dim affinity model is the part most worth lifting; we made that easy.
 
 ## File structure

--- a/docs/architecture.zh.md
+++ b/docs/architecture.zh.md
@@ -115,7 +115,7 @@ post-process spawn 返回 `()` 是 fire-and-forget 設計——用戶面前的�
 
 兩個原因：
 
-1. **思考負擔。** 好感度數學、ghost 決策、PDE 規則——這些是承重邏輯。把它們做成無 I/O 的，意味著 0 依賴的 cargo test 0ms 跑完，不會因為網絡抖動而 flake。`core` 的 68 個測試是上層所有東西的安全網。（可选 LLM 判断器层在 `server` 里，不在 `core` 里，所以 `core` 保持零 I/O。）
+1. **思考負擔。** 好感度數學、ghost 決策、PDE 規則——這些是承重邏輯。把它們做成無 I/O 的，意味著 0 依賴的 cargo test 0ms 跑完，不會因為網絡抖動而 flake。`core` 的 69 個測試是上層所有東西的安全網。（可选 LLM 判断器层在 `server` 里，不在 `core` 里，所以 `core` 保持零 I/O。）
 2. **可嵌入性。** 任何想在這個基礎上做別的產品的人——日記式 agent、語言教練、教練類陪伴——可以只拉 `core` 進來，不用繼承 HTTP 的形狀、Postgres schema、JWT auth。六維好感度模型才是別人最想拿走的部份；我們把這件事做成輕巧的。
 
 ## 文件結構


### PR DESCRIPTION
Follow-up to #218, which corrected this claim in the docs but not in the code.

## The wrong claim

`decide`'s doc comment read:

> then the score threshold (rises to 0.85 after a recent ghost, else 0.65)

"after a recent ghost" implies the bar falls back to 0.65 once the ghost stops
being recent. It never does — the branch is:

```rust
let threshold = if s.hours_since_last_ghost.is_some() { 0.85 } else { 0.65 };
```

No upper cutoff, and `last_ghost_at` is only ever set, never cleared. Since
`companion_affinity` is 1:1 with a chat session, one ghost raises the bar for
the rest of that session.

The same wording had leaked into a test name, renamed
`raised_threshold_after_recent_ghost_...` → `..._after_prior_ghost_...`.

## The missing regression lock

Nothing pinned the property. Both existing threshold tests pass
`hours_since_last_ghost: Some(2.0)` — two hours out — so someone could add a
decay window tomorrow, watch every test stay green, and silently make
`ghost-mechanics.md` (and its Chinese counterpart) wrong.

`raised_threshold_never_decays_with_time` covers 2h / 24h / 720h with a score
of 0.82: above the 0.65 base, below the 0.85 raised bar, so it must stay
`Reply` at every distance.

**This is a characterization test, not a red-green cycle** — the behaviour
already holds, so it passed on first run. To confirm it actually has teeth I
temporarily changed the branch to `Some(h) if h < 24.0` and re-ran:

```
test ghost::tests::raised_threshold_never_decays_with_time ... FAILED
assertion `left == right` failed: score 0.82 must stay below the raised 0.85 bar at 24h
```

Then reverted.

## Also

Core test count 68 → 69 in `docs/architecture.md` / `.zh.md`, which state it —
drift I introduced by adding the test.

## Verification

`cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, and
`cargo test --workspace --all-features` (1127 passed, 0 failed) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)