### PR TITLE
refactor(server): dedupe LLM-reply JSON parsing, single usage to_value per arm

### DIFF
--- a/crates/eros-engine-server/src/pipeline/mod.rs
+++ b/crates/eros-engine-server/src/pipeline/mod.rs
@@ -94,6 +94,15 @@ pub(super) fn find_json_block(raw: &str) -> Option<&str> {
     None
 }
 
+/// Parse an LLM reply expected to contain a JSON object of type `T`: try the
+/// whole text first, then fall back to the balanced `{…}` block (via
+/// `find_json_block`) for replies that fence or prose-wrap their JSON.
+pub(super) fn parse_llm_json<T: serde::de::DeserializeOwned>(raw: &str) -> Option<T> {
+    serde_json::from_str::<T>(raw)
+        .ok()
+        .or_else(|| find_json_block(raw).and_then(|b| serde_json::from_str::<T>(b).ok()))
+}
+
 pub async fn compute_signals_for_session(
     pool: &sqlx::PgPool,
     session_id: Uuid,
@@ -339,5 +348,48 @@ mod tests {
         let v: serde_json::Value = serde_json::from_str(block).unwrap();
         assert_eq!(v["a"], "b}c");
         assert_eq!(v["d"]["e"], 1);
+    }
+
+    #[derive(serde::Deserialize, Debug, PartialEq)]
+    struct ParseProbe {
+        verdict: String,
+        score: i32,
+    }
+
+    #[test]
+    fn parse_llm_json_accepts_pure_json() {
+        let raw = r#"{"verdict":"pass","score":3}"#;
+        let parsed: ParseProbe = super::parse_llm_json(raw).unwrap();
+        assert_eq!(
+            parsed,
+            ParseProbe {
+                verdict: "pass".into(),
+                score: 3
+            }
+        );
+    }
+
+    #[test]
+    fn parse_llm_json_falls_back_to_embedded_block() {
+        let raw = "Sure! Here is the result:\n```json\n{\"verdict\":\"fail\",\"score\":-2}\n```\nHope that helps.";
+        let parsed: ParseProbe = super::parse_llm_json(raw).unwrap();
+        assert_eq!(
+            parsed,
+            ParseProbe {
+                verdict: "fail".into(),
+                score: -2
+            }
+        );
+    }
+
+    #[test]
+    fn parse_llm_json_none_when_no_json() {
+        assert!(super::parse_llm_json::<ParseProbe>("no json here").is_none());
+    }
+
+    #[test]
+    fn parse_llm_json_none_when_shape_mismatch() {
+        // Valid JSON block, wrong shape: the fallback must also fail typed.
+        assert!(super::parse_llm_json::<ParseProbe>(r#"prose {"other": 1} prose"#).is_none());
     }
 }

--- a/crates/eros-engine-server/src/pipeline/post_process.rs
+++ b/crates/eros-engine-server/src/pipeline/post_process.rs
@@ -454,9 +454,7 @@ fn parse_affinity_eval(
     String,
 ) {
     use eros_engine_core::affinity::AffinityDeltas;
-    let parsed: Option<LlmAffinityEval> = serde_json::from_str(raw)
-        .ok()
-        .or_else(|| super::find_json_block(raw).and_then(|b| serde_json::from_str(b).ok()));
+    let parsed: Option<LlmAffinityEval> = super::parse_llm_json(raw);
     let Some(e) = parsed else {
         return (AffinityDeltas::default(), None, String::new());
     };
@@ -920,9 +918,7 @@ async fn extract_facts(
     };
 
     // Parse once; distinguish parse_error (no JSON at all) from empty/ok.
-    let parsed = serde_json::from_str::<serde_json::Value>(&raw)
-        .ok()
-        .or_else(|| super::find_json_block(&raw).and_then(|b| serde_json::from_str(b).ok()));
+    let parsed = super::parse_llm_json::<serde_json::Value>(&raw);
     match parsed {
         Some(v) => {
             let facts = extract_facts_array(&v);

--- a/crates/eros-engine-server/src/pipeline/story.rs
+++ b/crates/eros-engine-server/src/pipeline/story.rs
@@ -185,9 +185,7 @@ fn story_response_format() -> serde_json::Value {
 /// Warns (once per round) on unknown insight keys — the fixed field list is
 /// the contract; unknown keys are dropped by the typed deserialize.
 fn parse_story_output(raw: &str) -> Option<StoryOutput> {
-    let value: serde_json::Value = serde_json::from_str(raw)
-        .ok()
-        .or_else(|| super::find_json_block(raw).and_then(|b| serde_json::from_str(b).ok()))?;
+    let value: serde_json::Value = super::parse_llm_json(raw)?;
     if let Some(obj) = value.get("insight").and_then(|v| v.as_object()) {
         let unknown: Vec<&str> = obj
             .keys()

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -578,6 +578,7 @@ fn drive_chat_burst(
                 };
                 let effective_ghost = is_ghost_fallback || regex_ghost;
 
+                let usage_full = last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok());
                 // Persist BEFORE yielding Done (spec §2.3 risk R7).
                 let row = eros_engine_store::chat::AssistantInsert {
                     id: msg_uuid,
@@ -586,7 +587,7 @@ fn drive_chat_burst(
                     continues_from_message_id: continues_from.map(Into::into),
                     truncated,
                     model: Some(model_id.clone()),
-                    usage: last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok()),
+                    usage: usage_full.clone(),
                     generation_id: last_gen_id.clone(),
                     filter_audit,
                     metadata: if is_ghost_fallback {
@@ -612,7 +613,7 @@ fn drive_chat_burst(
                 // Strip OPENROUTER_USAGE_HIDDEN_KEYS from the wire usage. The DB
                 // row above persists the full unfiltered usage; only the frame is
                 // filtered (mirrors the sync send_message path).
-                let mut wire_usage = last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok());
+                let mut wire_usage = usage_full;
                 filter_usage_keys(&mut wire_usage, &state.config.openrouter_usage_hidden_keys);
                 yield ProtocolFrame::Done {
                     message_id: ulid_string(msg_ulid),
@@ -873,6 +874,8 @@ fn drive_chat_burst(
                     // "empty_completion" so ops can tell the two apart.
                     let msg_ulid = Ulid::new();
                     let msg_uuid: Uuid = msg_ulid.into();
+                    let usage_full =
+                        last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok());
                     let row = eros_engine_store::chat::AssistantInsert {
                         id: msg_uuid,
                         content: String::new(),
@@ -880,7 +883,7 @@ fn drive_chat_burst(
                         continues_from_message_id: None,
                         truncated: false,
                         model: Some(model_id.clone()),
-                        usage: last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok()),
+                        usage: usage_full.clone(),
                         generation_id: last_gen_id.clone(),
                         filter_audit: None,
                         metadata: ghost_fallback_metadata(build_metadata(None), "empty_completion"),
@@ -923,8 +926,7 @@ fn drive_chat_burst(
                     // on an otherwise-empty completion) — same wire contract as the
                     // other served Done frames; the DB row above already persisted
                     // the full unfiltered usage.
-                    let mut wire_usage =
-                        last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok());
+                    let mut wire_usage = usage_full;
                     filter_usage_keys(&mut wire_usage, &state.config.openrouter_usage_hidden_keys);
                     yield ProtocolFrame::Done {
                         message_id: ulid_string(msg_ulid),
@@ -1128,6 +1130,7 @@ fn drive_chat_burst(
                 };
             }
 
+            let usage_full = last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok());
             let row = eros_engine_store::chat::AssistantInsert {
                 id: msg_uuid,
                 content: visible.clone(),
@@ -1135,7 +1138,7 @@ fn drive_chat_burst(
                 continues_from_message_id: None,
                 truncated: false,
                 model: Some(model_id.clone()),
-                usage: last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok()),
+                usage: usage_full.clone(),
                 generation_id: last_gen_id.clone(),
                 filter_audit,
                 metadata: if is_ghost {
@@ -1157,7 +1160,7 @@ fn drive_chat_burst(
                 action: plan_action,
             });
 
-            let mut wire_usage = last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok());
+            let mut wire_usage = usage_full;
             filter_usage_keys(&mut wire_usage, &state.config.openrouter_usage_hidden_keys);
             if is_ghost {
                 outcome.lock().unwrap().ghost_fallback = true;
@@ -1483,12 +1486,7 @@ struct InputFilterVerdict {
 /// Parse the filter reply into a verdict: direct JSON first, then a balanced
 /// JSON block embedded in prose (mirrors post_process extraction parsing).
 fn parse_input_filter_verdict(text: &str) -> Option<InputFilterVerdict> {
-    serde_json::from_str::<InputFilterVerdict>(text)
-        .ok()
-        .or_else(|| {
-            super::find_json_block(text)
-                .and_then(|b| serde_json::from_str::<InputFilterVerdict>(b).ok())
-        })
+    super::parse_llm_json(text)
 }
 
 // ── PDE judge primitives ──────────────────────────────────────────────────────
@@ -1540,9 +1538,7 @@ pub(crate) struct PdeVerdict {
 /// Parse the judge reply: direct JSON first, then a balanced JSON block in prose
 /// (mirrors `parse_input_filter_verdict`).
 fn parse_pde_verdict(text: &str) -> Option<PdeVerdict> {
-    serde_json::from_str::<PdeVerdict>(text).ok().or_else(|| {
-        super::find_json_block(text).and_then(|b| serde_json::from_str::<PdeVerdict>(b).ok())
-    })
+    super::parse_llm_json(text)
 }
 
 const INNER_STATE_MAX_CHARS: usize = 200;
@@ -2033,9 +2029,7 @@ struct ImageVision {
 /// Parse the describe reply: direct JSON first, then a balanced JSON block
 /// embedded in prose (mirrors `parse_input_filter_verdict`).
 fn parse_image_vision(text: &str) -> Option<ImageVision> {
-    serde_json::from_str::<ImageVision>(text).ok().or_else(|| {
-        super::find_json_block(text).and_then(|b| serde_json::from_str::<ImageVision>(b).ok())
-    })
+    super::parse_llm_json(text)
 }
 
 /// Validity gate for a parsed describe. Reject a `content_filter` finish reason,
@@ -2418,9 +2412,7 @@ struct ComposeReply {
 ///
 /// A blank caption is normalised to `None`; callers must not persist `""`.
 pub(crate) fn parse_compose_reply(raw: &str) -> (String, Option<String>) {
-    let parsed = serde_json::from_str::<ComposeReply>(raw).ok().or_else(|| {
-        super::find_json_block(raw).and_then(|b| serde_json::from_str::<ComposeReply>(b).ok())
-    });
+    let parsed = super::parse_llm_json::<ComposeReply>(raw);
     match parsed {
         Some(r) => {
             let caption = r


### PR DESCRIPTION
## Summary

Two small chat-pipeline JSON hygiene cleanups spotted during the sonic-rs migration evaluation (evaluation concluded: not migrating — the swappable hot sites total ~1–2 ms per turn vs. seconds-level LLM-dominated turns).

1. **`parse_llm_json<T>` helper** (`pipeline/mod.rs`): extracts the repeated direct-parse → `find_json_block` fallback ladder, replacing the seven exact-pattern call sites (input filter, PDE verdict, image vision, compose reply, affinity eval, fact extraction, story output). Deliberately untouched: the insight-extraction site (its per-arm `is_object` filter salvages an array-wrapped object; an outer filter would change behavior) and the block-first strict parsers (world, world_town, dreaming).
2. **Single `usage_full` per arm** (`pipeline/stream.rs`): each of the three `drive_chat_burst` arms serialized the same `last_usage` twice (full DB copy + filtered wire copy); hoist one `to_value` per arm, matching the existing product_qa pattern.

No behavior change intended.

## Verification

- `cargo fmt --check` clean
- `cargo clippy -p eros-engine-server --all-targets` no warnings
- `cargo test -p eros-engine-server`: 526 passed, 0 failed (522 existing assertions unchanged + 4 new `parse_llm_json` unit tests, written red-first)
- OpenAPI snapshot: no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)