### PR TITLE
fix(store)!: add missing persona_instances FKs on the three original tables

### DIFF
--- a/crates/eros-engine-server/src/pipeline/dreaming.rs
+++ b/crates/eros-engine-server/src/pipeline/dreaming.rs
@@ -320,6 +320,7 @@ fn normalise_category(raw: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::routes::companion::testutil::seed_persona_instance;
 
     #[test]
     fn parse_memory_candidates_handles_clean_json() {
@@ -454,7 +455,7 @@ mod tests {
         );
 
         let user_id = uuid::Uuid::new_v4();
-        let instance_id = uuid::Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id: uuid::Uuid = sqlx::query_scalar(
             "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
         )

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -1009,6 +1009,7 @@ mod tests {
     // either need a live Voyage key or a trait-mock indirection that
     // doesn't justify its weight for a single thin function.
 
+    use crate::routes::companion::testutil::seed_persona_instance;
     use eros_engine_store::human_insight::HumanInsightRepo;
     use eros_engine_store::memory::{MemoryLayer, MemoryRepo};
     use sqlx::PgPool;
@@ -1055,7 +1056,7 @@ mod tests {
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
     async fn recall_memory_with_embedding_isolates_layers(pool: PgPool) {
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, Some(instance_id)).await;
         let repo = MemoryRepo { pool: &pool };
 
@@ -1107,7 +1108,7 @@ mod tests {
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
     async fn recall_memory_with_embedding_groups_categorised_rows(pool: PgPool) {
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, Some(instance_id)).await;
         let repo = MemoryRepo { pool: &pool };
 
@@ -1180,7 +1181,7 @@ mod tests {
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
     async fn recall_memory_with_embedding_respects_top_k(pool: PgPool) {
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, Some(instance_id)).await;
         let repo = MemoryRepo { pool: &pool };
 
@@ -1236,7 +1237,7 @@ mod tests {
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
     async fn recall_memory_with_embedding_picks_nearest_per_layer(pool: PgPool) {
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, Some(instance_id)).await;
         let repo = MemoryRepo { pool: &pool };
 
@@ -1332,7 +1333,7 @@ mod tests {
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
     async fn recall_gating_skips_layers_per_flags(pool: PgPool) {
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, Some(instance_id)).await;
         let repo = MemoryRepo { pool: &pool };
         repo.upsert(
@@ -2038,7 +2039,7 @@ mod tests {
 
         let chat_repo = ChatRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session = chat_repo
             .create_session(user_id, instance_id)
             .await

--- a/crates/eros-engine-server/src/pipeline/post_process.rs
+++ b/crates/eros-engine-server/src/pipeline/post_process.rs
@@ -1065,6 +1065,7 @@ async fn refresh_lead_score(state: &AppState, session_id: Uuid, user_id: Uuid) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::routes::companion::testutil::seed_persona_instance;
     use uuid::Uuid;
 
     #[test]
@@ -1836,7 +1837,7 @@ mod tests {
         let state = crate::routes::companion::test_state(pool.clone());
 
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = sqlx::query_scalar::<_, Uuid>(
             "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
         )
@@ -1951,7 +1952,7 @@ mod tests {
         use eros_engine_store::affinity::AffinityRepo;
 
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = sqlx::query_scalar::<_, Uuid>(
             "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
         )

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -830,6 +830,16 @@ pub(crate) mod testutil {
         .await
         .unwrap()
     }
+
+    /// Genome + active instance in one step, returning the instance id.
+    /// Since 0040 `chat_sessions.instance_id` carries a real FK, so tests that
+    /// only need "some valid instance" must persist one instead of fabricating
+    /// a bare `Uuid::new_v4()`. The genome name is randomised so repeat calls
+    /// never collide on `persona_instances UNIQUE(genome_id, owner_uid)`.
+    pub(crate) async fn seed_persona_instance(pool: &PgPool, owner: Uuid) -> Uuid {
+        let genome_id = seed_genome(pool, &format!("seed-{}", Uuid::new_v4())).await;
+        seed_instance(pool, genome_id, owner).await
+    }
 }
 
 #[cfg(test)]

--- a/crates/eros-engine-server/src/routes/companion_stream.rs
+++ b/crates/eros-engine-server/src/routes/companion_stream.rs
@@ -597,6 +597,7 @@ pub fn router() -> OpenApiRouter<AppState> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::routes::companion::testutil::seed_persona_instance;
     use axum::body::{to_bytes, Body};
     use axum::http::{header, Request};
     use axum::Router;
@@ -974,8 +975,9 @@ mod tests {
         let persisted = serde_json::Value::Object(meta_map);
 
         let chat_repo = ChatRepo { pool: &pool };
+        let user_id = uuid::Uuid::new_v4();
         let session = chat_repo
-            .create_session(uuid::Uuid::new_v4(), uuid::Uuid::new_v4())
+            .create_session(user_id, seed_persona_instance(&pool, user_id).await)
             .await
             .unwrap();
         chat_repo
@@ -1086,8 +1088,9 @@ mod tests {
     async fn user_row_omits_scope_raw_keys_when_request_fields_are_none(pool: sqlx::PgPool) {
         use eros_engine_store::chat::ChatRepo;
         let chat_repo = ChatRepo { pool: &pool };
+        let user_id = uuid::Uuid::new_v4();
         let session = chat_repo
-            .create_session(uuid::Uuid::new_v4(), uuid::Uuid::new_v4())
+            .create_session(user_id, seed_persona_instance(&pool, user_id).await)
             .await
             .unwrap();
         // None of the three optional fields present, no tip, no tier → meta_map

--- a/crates/eros-engine-server/src/routes/voice.rs
+++ b/crates/eros-engine-server/src/routes/voice.rs
@@ -239,6 +239,7 @@ pub fn router() -> OpenApiRouter<AppState> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::routes::companion::testutil::seed_persona_instance;
     use axum::body::Body;
     use axum::http::{header, Request};
     use axum::Router;
@@ -448,22 +449,31 @@ mod tests {
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
-    async fn voice_404_when_persona_instance_missing(pool: PgPool) {
-        // A session whose persona instance is missing/inactive must be rejected
-        // pre-stream (404) WITHOUT persisting a user row. chat_sessions.instance_id
-        // has no FK, so a dangling instance_id is possible; load_companion also
-        // filters status='active', so an archived instance takes the same path.
+    async fn voice_404_when_persona_instance_inactive(pool: PgPool) {
+        // A session whose persona instance is not active must be rejected
+        // pre-stream (404) WITHOUT persisting a user row. Archival is the only
+        // way to reach this state — 0040 gave chat_sessions.instance_id a real
+        // FK, so a dangling id can no longer be written and a deleted instance
+        // takes its sessions with it (ON DELETE CASCADE). That matches
+        // production: the engine only ever flips status to 'archived', it never
+        // DELETEs an instance. load_companion filters status = 'active', so
+        // this lands on the same 404 branch the dangling case used to take.
         let user_id = Uuid::new_v4();
-        let missing_instance = Uuid::new_v4(); // no matching persona_instances row
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id: Uuid = sqlx::query_scalar(
             "INSERT INTO engine.chat_sessions (user_id, instance_id, channel) \
              VALUES ($1, $2, 'voice') RETURNING id",
         )
         .bind(user_id)
-        .bind(missing_instance)
+        .bind(instance_id)
         .fetch_one(&pool)
         .await
         .unwrap();
+        sqlx::query("UPDATE engine.persona_instances SET status = 'archived' WHERE id = $1")
+            .bind(instance_id)
+            .execute(&pool)
+            .await
+            .unwrap();
 
         let mut app = build_router(with_voice(crate::routes::companion::test_state(
             pool.clone(),

--- a/crates/eros-engine-store/migrations/0040_persona_instance_fks.sql
+++ b/crates/eros-engine-store/migrations/0040_persona_instance_fks.sql
@@ -1,0 +1,42 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+--
+-- The three original instance-scoped tables — chat_sessions (0001),
+-- companion_affinity (0002) and companion_memories (0003) — reference
+-- engine.persona_instances(id) by convention only. They predate the
+-- world/story tables (0035-0039), which all declare a real foreign key, so
+-- nothing at the DB level stopped a bogus instance_id from being written and
+-- no cascade fired when an instance row was removed out of band.
+--
+-- The practical cost beyond integrity: without a declared FK the Supabase
+-- table editor renders instance_id as a plain UUID column, so there is no way
+-- to navigate from a session to its persona instance — you copy the UUID out
+-- and search the other table by hand, which is easy to get wrong when a row
+-- carries two similar-looking UUIDs (its own id and its instance_id).
+--
+-- ON DELETE CASCADE matches all six existing FKs into persona_instances. The
+-- engine itself never DELETEs an instance — it flips status to 'archived' and
+-- PersonaStore::ensure_active_instance reactivates it — so this only governs
+-- deliberate out-of-band deletion, where wiping the instance's data is the
+-- point. chat_messages already cascades from chat_sessions, so dropping an
+-- instance now takes its whole conversation history with it in one step.
+--
+-- companion_memories.instance_id stays nullable (NULL = profile layer, see
+-- 0003); a foreign key ignores NULL, so profile-layer rows are unaffected.
+--
+-- All three columns were verified orphan-free beforehand and the tables are
+-- small, so the constraints go in validated rather than NOT VALID + VALIDATE.
+
+ALTER TABLE engine.chat_sessions
+    ADD CONSTRAINT chat_sessions_instance_id_fkey
+    FOREIGN KEY (instance_id) REFERENCES engine.persona_instances(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE engine.companion_affinity
+    ADD CONSTRAINT companion_affinity_instance_id_fkey
+    FOREIGN KEY (instance_id) REFERENCES engine.persona_instances(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE engine.companion_memories
+    ADD CONSTRAINT companion_memories_instance_id_fkey
+    FOREIGN KEY (instance_id) REFERENCES engine.persona_instances(id)
+    ON DELETE CASCADE;

--- a/crates/eros-engine-store/src/affinity.rs
+++ b/crates/eros-engine-store/src/affinity.rs
@@ -387,6 +387,7 @@ impl<'a> AffinityRepo<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::testutil::seed_persona_instance;
 
     async fn make_session(pool: &PgPool, user_id: Uuid, instance_id: Uuid) -> Uuid {
         sqlx::query_scalar::<_, Uuid>(
@@ -404,7 +405,7 @@ mod tests {
     async fn load_or_create_idempotent(pool: PgPool) {
         let repo = AffinityRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, instance_id).await;
 
         let a1 = repo
@@ -425,7 +426,7 @@ mod tests {
     async fn persist_with_event_updates_vector_and_logs(pool: PgPool) {
         let repo = AffinityRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, instance_id).await;
 
         let mut a = repo
@@ -476,7 +477,7 @@ mod tests {
     async fn record_ghost_increments_counters(pool: PgPool) {
         let repo = AffinityRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, instance_id).await;
 
         let mut a = repo
@@ -499,7 +500,7 @@ mod tests {
     async fn persist_with_event_records_post_ema_effective(pool: PgPool) {
         let repo = AffinityRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, instance_id).await;
         let mut a = repo
             .load_or_create(session_id, user_id, instance_id)
@@ -546,7 +547,7 @@ mod tests {
     async fn persist_with_event_effective_reflects_clamping(pool: PgPool) {
         let repo = AffinityRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, instance_id).await;
         let mut a = repo
             .load_or_create(session_id, user_id, instance_id)
@@ -585,7 +586,7 @@ mod tests {
     async fn record_ghost_writes_zero_effective_deltas(pool: PgPool) {
         let repo = AffinityRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, instance_id).await;
         let mut a = repo
             .load_or_create(session_id, user_id, instance_id)
@@ -613,7 +614,7 @@ mod tests {
     async fn concurrent_persist_with_event_does_not_lose_updates(pool: PgPool) {
         let repo = AffinityRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, instance_id).await;
         let base = repo
             .load_or_create(session_id, user_id, instance_id)
@@ -686,7 +687,7 @@ mod tests {
     async fn persist_with_event_flips_label_when_axes_cross_thresholds(pool: PgPool) {
         let repo = AffinityRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, instance_id).await;
         let mut a = repo
             .load_or_create(session_id, user_id, instance_id)
@@ -744,7 +745,7 @@ mod tests {
     async fn list_events_newest_first_with_filter(pool: PgPool) {
         let repo = AffinityRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, instance_id).await;
         let a = repo
             .load_or_create(session_id, user_id, instance_id)
@@ -776,7 +777,7 @@ mod tests {
     async fn latest_turn_event_includes_ghost_skips_time_decay(pool: PgPool) {
         let repo = AffinityRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, instance_id).await;
         let a = repo
             .load_or_create(session_id, user_id, instance_id)
@@ -804,7 +805,7 @@ mod tests {
     async fn latest_turn_event_none_when_only_time_decay(pool: PgPool) {
         let repo = AffinityRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, instance_id).await;
         let a = repo
             .load_or_create(session_id, user_id, instance_id)
@@ -819,7 +820,7 @@ mod tests {
     async fn latest_turn_event_none_for_session_without_events(pool: PgPool) {
         let repo = AffinityRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, instance_id).await;
         repo.load_or_create(session_id, user_id, instance_id)
             .await
@@ -865,7 +866,7 @@ mod tests {
     async fn recent_emotional_reasons_newest_first_skips_empty_and_scoped(pool: PgPool) {
         let repo = AffinityRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, instance_id).await;
         let a = repo
             .load_or_create(session_id, user_id, instance_id)
@@ -902,9 +903,11 @@ mod tests {
         .await; // wrong type → skip
 
         // Another session must not leak in.
-        let other_session = make_session(&pool, Uuid::new_v4(), Uuid::new_v4()).await;
+        let other_user = Uuid::new_v4();
+        let other_instance = seed_persona_instance(&pool, other_user).await;
+        let other_session = make_session(&pool, other_user, other_instance).await;
         let b = repo
-            .load_or_create(other_session, Uuid::new_v4(), Uuid::new_v4())
+            .load_or_create(other_session, other_user, other_instance)
             .await
             .unwrap();
         seed_event_ctx(
@@ -934,7 +937,7 @@ mod tests {
     async fn recent_emotional_reasons_excludes_events_after_cutoff(pool: PgPool) {
         let repo = AffinityRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, instance_id).await;
         let a = repo
             .load_or_create(session_id, user_id, instance_id)
@@ -978,7 +981,7 @@ mod tests {
     async fn generated_bond_chemistry_match_core(pool: PgPool) {
         let repo = AffinityRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, instance_id).await;
         let mut a = repo
             .load_or_create(session_id, user_id, instance_id)
@@ -1017,7 +1020,7 @@ mod tests {
     async fn persist_writes_new_legacy_label(pool: PgPool) {
         let repo = AffinityRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, instance_id).await;
         let mut a = repo
             .load_or_create(session_id, user_id, instance_id)
@@ -1051,7 +1054,7 @@ mod tests {
     async fn persist_with_event_patience_target_sets_directly_bypassing_ema(pool: PgPool) {
         let repo = AffinityRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, instance_id).await;
         let mut a = repo
             .load_or_create(session_id, user_id, instance_id)
@@ -1107,7 +1110,7 @@ mod tests {
     async fn persist_with_event_patience_none_keeps_ema_path(pool: PgPool) {
         let repo = AffinityRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, instance_id).await;
         let mut a = repo
             .load_or_create(session_id, user_id, instance_id)
@@ -1143,7 +1146,7 @@ mod tests {
     async fn label_changes_recorded_on_tier_crossing_and_null_otherwise(pool: PgPool) {
         let repo = AffinityRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, instance_id).await;
         let mut a = repo
             .load_or_create(session_id, user_id, instance_id)
@@ -1199,7 +1202,7 @@ mod tests {
     async fn effective_line_deltas_are_floored_exact(pool: PgPool) {
         let repo = AffinityRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, instance_id).await;
         let mut a = repo
             .load_or_create(session_id, user_id, instance_id)
@@ -1243,7 +1246,7 @@ mod tests {
     async fn persist_with_event_stores_openrouter_audit_trio(pool: PgPool) {
         let repo = AffinityRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, instance_id).await;
         let mut a = repo
             .load_or_create(session_id, user_id, instance_id)

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -1051,12 +1051,25 @@ impl<'a> ChatRepo<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::testutil::seed_persona_instance;
+
+    /// A session on a freshly seeded persona instance, for the many tests that
+    /// just need "some session" and never look at the ids. Since 0040 the FK on
+    /// `chat_sessions.instance_id` rejects a fabricated `Uuid::new_v4()`.
+    async fn throwaway_session(pool: &PgPool) -> ChatSession {
+        let owner = Uuid::new_v4();
+        let instance_id = seed_persona_instance(pool, owner).await;
+        ChatRepo { pool }
+            .create_session(owner, instance_id)
+            .await
+            .unwrap()
+    }
 
     #[sqlx::test(migrations = "./migrations")]
     async fn create_then_retrieve_session(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let s = repo.create_session(user_id, instance_id).await.unwrap();
         let loaded = repo.get_session(s.id).await.unwrap().unwrap();
         assert_eq!(loaded.user_id, user_id);
@@ -1069,7 +1082,7 @@ mod tests {
     async fn append_message_and_history_roundtrip(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let s = repo.create_session(user_id, instance_id).await.unwrap();
 
         repo.append_message(s.id, "user", "hello").await.unwrap();
@@ -1093,7 +1106,7 @@ mod tests {
     async fn history_slim_returns_role_content_sent_at_in_order(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let s = repo.create_session(user_id, instance_id).await.unwrap();
 
         repo.append_message(s.id, "user", "alpha").await.unwrap();
@@ -1117,7 +1130,7 @@ mod tests {
     async fn history_slim_respects_limit_and_offset(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let s = repo.create_session(user_id, instance_id).await.unwrap();
         for n in 0..5 {
             repo.append_message(s.id, "user", &format!("m{n}"))
@@ -1144,7 +1157,7 @@ mod tests {
     async fn history_slim_exposes_channel(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let s = repo.create_session(user_id, instance_id).await.unwrap();
 
         repo.append_message(s.id, "user", "normal turn")
@@ -1175,9 +1188,9 @@ mod tests {
         let user_id = Uuid::new_v4();
         let other_user = Uuid::new_v4();
 
-        let i1 = Uuid::new_v4();
-        let i2 = Uuid::new_v4();
-        let i3 = Uuid::new_v4();
+        let i1 = seed_persona_instance(&pool, user_id).await;
+        let i2 = seed_persona_instance(&pool, user_id).await;
+        let i3 = seed_persona_instance(&pool, other_user).await;
 
         repo.create_session(user_id, i1).await.unwrap();
         repo.create_session_with_metadata(user_id, i2, serde_json::json!({}), "voice")
@@ -1204,7 +1217,7 @@ mod tests {
     async fn create_or_resume_returns_existing(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let first = repo.create_session(user_id, instance_id).await.unwrap();
         let resumed = repo.create_or_resume(user_id, instance_id).await.unwrap();
         assert_eq!(first.id, resumed.id);
@@ -1214,7 +1227,7 @@ mod tests {
     async fn upsert_user_message_idempotent_first_insert(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let s = repo.create_session(user_id, instance_id).await.unwrap();
 
         let outcome = repo
@@ -1239,7 +1252,7 @@ mod tests {
     async fn upsert_user_message_idempotent_replay_after_done(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let s = repo.create_session(user_id, instance_id).await.unwrap();
 
         let first = match repo
@@ -1307,7 +1320,7 @@ mod tests {
     async fn upsert_user_message_idempotent_409_when_no_assistant_and_not_ghost(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let s = repo.create_session(user_id, instance_id).await.unwrap();
 
         let first = match repo
@@ -1347,7 +1360,7 @@ mod tests {
     async fn upsert_user_message_idempotent_replay_when_ghost(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let s = repo.create_session(user_id, instance_id).await.unwrap();
 
         let first = match repo
@@ -1393,7 +1406,7 @@ mod tests {
     async fn resume_latest_session_returns_latest_and_bumps(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
 
         // no session yet → None
         assert!(repo
@@ -1444,10 +1457,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn upsert_user_message_writes_role_user_and_no_metadata(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
         let outcome = repo
             .upsert_user_message_idempotent(s.id, "hi", "01J0000000000000000000000A", "user", None)
             .await
@@ -1472,10 +1482,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn upsert_user_message_writes_gift_user_role_and_tip_metadata(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
         let meta = serde_json::json!({ "tips_amount_usd": 20.0, "tier": "gold" });
         repo.upsert_user_message_idempotent(
             s.id,
@@ -1500,10 +1507,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn upsert_user_message_replay_finds_gift_user_row(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
         let meta = serde_json::json!({ "tips_amount_usd": 5.0 });
         repo.upsert_user_message_idempotent(
             s.id,
@@ -1537,10 +1541,7 @@ mod tests {
     #[allow(clippy::type_complexity)] // sqlx tuple query — type alias would add noise
     async fn assistant_batch_round_trips_filter_audit(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
         let user_msg_id = match repo
             .upsert_user_message_idempotent(s.id, "hi", "01J0000000000000000000001A", "user", None)
             .await
@@ -1604,10 +1605,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn assistant_batch_filter_audit_columns_default_null(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
         let user_msg_id = match repo
             .upsert_user_message_idempotent(s.id, "hi", "01J0000000000000000000002A", "user", None)
             .await
@@ -1680,10 +1678,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn assistant_batch_filter_audit_with_none_generation_id_writes_null(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
         let user_msg_id = match repo
             .upsert_user_message_idempotent(s.id, "hi", "01J0000000000000000000003A", "user", None)
             .await
@@ -1732,10 +1727,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn assistant_batch_filter_triggers_json_null_persists_as_sql_null(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
         let user_msg_id = match repo
             .upsert_user_message_idempotent(s.id, "hi", "01J0000000000000000000004A", "user", None)
             .await
@@ -1788,10 +1780,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn assistant_batch_persists_metadata_with_prompt_traits(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
         let user_msg_id = match repo
             .upsert_user_message_idempotent(s.id, "hi", "01J0000000000000000000004A", "user", None)
             .await
@@ -1830,10 +1819,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn assistant_batch_metadata_default_null(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
         let user_msg_id = match repo
             .upsert_user_message_idempotent(s.id, "hi", "01J0000000000000000000005A", "user", None)
             .await
@@ -1871,10 +1857,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn assistant_batch_persists_metadata_with_tier(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
         let user_msg_id = match repo
             .upsert_user_message_idempotent(s.id, "hi", "01J0000000000000000000006A", "user", None)
             .await
@@ -1916,10 +1899,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn recent_turn_pairs_empty_session_returns_empty(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
         let cutoff = Utc::now() + chrono::Duration::seconds(60);
         let pairs = repo.recent_turn_pairs(s.id, cutoff, 3).await.unwrap();
         assert!(pairs.is_empty());
@@ -1928,10 +1908,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn recent_turn_pairs_single_pair_returned(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
         let user_msg_id = match repo
             .upsert_user_message_idempotent(s.id, "hi", "01J0000000000000000010001A", "user", None)
             .await
@@ -1964,10 +1941,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn recent_turn_pairs_skips_truncated_assistant(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
 
         let u1 = match repo
             .upsert_user_message_idempotent(s.id, "u1", "01J0000000000000000020001A", "user", None)
@@ -2033,10 +2007,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn recent_turn_pairs_returns_latest_three_when_more_exist(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
         // Insert 5 complete pairs.
         for n in 0..5u8 {
             // ULIDs must be unique and monotonic. Use n in the suffix:
@@ -2084,10 +2055,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn recent_turn_pairs_cutoff_excludes_current_turn(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
         let u1 = match repo
             .upsert_user_message_idempotent(s.id, "u1", "01J0000000000000000040001A", "user", None)
             .await
@@ -2136,10 +2104,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn recent_turn_pairs_drops_orphan_user_at_end(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
         let u1 = match repo
             .upsert_user_message_idempotent(s.id, "u1", "01J0000000000000000050001A", "user", None)
             .await
@@ -2179,10 +2144,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn recent_turn_pairs_includes_gift_user_pair(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
         let meta = serde_json::json!({"tips_amount_usd": 20.0});
         let u1 = match repo
             .upsert_user_message_idempotent(
@@ -2228,10 +2190,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn set_user_input_rewrite_stamps_audit_keeps_content(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let session = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let session = throwaway_session(&pool).await;
         let umid = match repo
             .upsert_user_message_idempotent(
                 session.id,
@@ -2285,10 +2244,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn set_user_input_rewrite_blank_reason_leaves_triggers_null(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let session = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let session = throwaway_session(&pool).await;
         let umid = match repo
             .upsert_user_message_idempotent(
                 session.id,
@@ -2321,10 +2277,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn recent_turn_pairs_before_message_uses_msg_sent_at_not_now(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(uuid::Uuid::new_v4(), uuid::Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
 
         // Insert 1 prior complete pair.
         let u1 = match repo
@@ -2398,7 +2351,7 @@ mod tests {
     async fn history_row_exposes_metadata_column(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let s = repo.create_session(user_id, instance_id).await.unwrap();
 
         let meta = serde_json::json!({ "image_url": "https://x/y.png" });
@@ -2424,7 +2377,7 @@ mod tests {
     async fn set_user_image_vision_merges_and_preserves(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let s = repo.create_session(user_id, instance_id).await.unwrap();
 
         let seed = serde_json::json!({ "image_url": "https://x/y.png" });
@@ -2470,7 +2423,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn migration_0027_drops_legacy_non_tip_gift_user_rows(pool: PgPool) {
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id: Uuid = sqlx::query_scalar(
             "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
         )
@@ -2535,7 +2488,7 @@ mod tests {
         let repo = ChatRepo { pool: &pool };
         // minimal session + user row + assistant row
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let s = repo.create_session(user_id, instance_id).await.unwrap();
         let u = match repo
             .upsert_user_message_idempotent(
@@ -2591,7 +2544,7 @@ mod tests {
         // scope via the test module's `use super::*;`.
         let chat_repo = ChatRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session = chat_repo
             .create_session(user_id, instance_id)
             .await
@@ -2677,14 +2630,8 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn message_sent_at_in_session_scopes_by_session(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
-        let other = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
+        let other = throwaway_session(&pool).await;
         let base = chrono::Utc::now();
         let m = insert_at(&pool, s.id, "user", "hi", base).await;
         let n = insert_at(&pool, other.id, "user", "yo", base).await;
@@ -2711,10 +2658,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn history_anchored_rewind_drops_between_and_keeps_m_and_u(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
         let base = chrono::Utc::now();
         // A B M C D E U with strictly increasing sent_at.
         let labels = ["A", "B", "M", "C", "D", "E", "U"];
@@ -2755,10 +2699,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn history_anchored_drop_history_returns_only_current(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
         let base = chrono::Utc::now();
         insert_at(&pool, s.id, "user", "old1", base).await;
         insert_at(
@@ -2790,10 +2731,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn history_anchored_rewind_counts_current_toward_limit(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
         let base = chrono::Utc::now();
         // A B M C D E U with strictly increasing sent_at.
         let labels = ["A", "B", "M", "C", "D", "E", "U"];
@@ -2834,10 +2772,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn merge_assistant_metadata_key_writes_under_named_key(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
         let user_msg_id = match repo
             .upsert_user_message_idempotent(s.id, "hi", "01J0000000000000000000002A", "user", None)
             .await
@@ -2900,14 +2835,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn channel_column_accepts_voice_and_null_rejects_other(pool: PgPool) {
         // Minimal session to satisfy FKs.
-        let session_id: Uuid = sqlx::query_scalar(
-            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
-        )
-        .bind(Uuid::new_v4())
-        .bind(Uuid::new_v4())
-        .fetch_one(&pool)
-        .await
-        .unwrap();
+        let session_id = throwaway_session(&pool).await.id;
 
         // NULL channel (default) — ok.
         sqlx::query(
@@ -2942,14 +2870,7 @@ mod tests {
 
     #[sqlx::test(migrations = "./migrations")]
     async fn voice_inserts_are_marked_and_idempotent(pool: PgPool) {
-        let session_id: Uuid = sqlx::query_scalar(
-            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
-        )
-        .bind(Uuid::new_v4())
-        .bind(Uuid::new_v4())
-        .fetch_one(&pool)
-        .await
-        .unwrap();
+        let session_id = throwaway_session(&pool).await.id;
         let repo = ChatRepo { pool: &pool };
 
         // User insert: idempotent on client_msg_id.
@@ -3025,14 +2946,7 @@ mod tests {
         // (`gift_user`) row must be classified as Duplicate (→ 409), not error
         // out with RowNotFound (→ 500). The unique index is role-agnostic, so
         // the conflict-recovery SELECT must not filter by role.
-        let session_id: Uuid = sqlx::query_scalar(
-            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
-        )
-        .bind(Uuid::new_v4())
-        .bind(Uuid::new_v4())
-        .fetch_one(&pool)
-        .await
-        .unwrap();
+        let session_id = throwaway_session(&pool).await.id;
         let cmid = "01J9000000000000000000GIFT1";
         sqlx::query(
             "INSERT INTO engine.chat_messages (session_id, role, content, client_msg_id) \
@@ -3059,14 +2973,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn channel_check_accepts_product_qa_and_rejects_unknown(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let session_id: Uuid = sqlx::query_scalar(
-            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
-        )
-        .bind(Uuid::new_v4())
-        .bind(Uuid::new_v4())
-        .fetch_one(&pool)
-        .await
-        .unwrap();
+        let session_id = throwaway_session(&pool).await.id;
 
         // product_qa accepted
         sqlx::query(
@@ -3098,7 +3005,8 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn sessions_are_channel_scoped(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let (user_id, instance_id) = (Uuid::new_v4(), Uuid::new_v4());
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
 
         let text = repo.create_session(user_id, instance_id).await.unwrap();
 
@@ -3134,14 +3042,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn mark_user_message_product_qa_stamps_channel_idempotently(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let session_id: Uuid = sqlx::query_scalar(
-            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
-        )
-        .bind(Uuid::new_v4())
-        .bind(Uuid::new_v4())
-        .fetch_one(&pool)
-        .await
-        .unwrap();
+        let session_id = throwaway_session(&pool).await.id;
         let user_id: Uuid = sqlx::query_scalar(
             "INSERT INTO engine.chat_messages (session_id, role, content) \
              VALUES ($1, 'user', '介绍下这个产品') RETURNING id",
@@ -3166,14 +3067,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn insert_product_qa_assistant_message_round_trips(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let session_id: Uuid = sqlx::query_scalar(
-            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
-        )
-        .bind(Uuid::new_v4())
-        .bind(Uuid::new_v4())
-        .fetch_one(&pool)
-        .await
-        .unwrap();
+        let session_id = throwaway_session(&pool).await.id;
         let user_id: Uuid = sqlx::query_scalar(
             "INSERT INTO engine.chat_messages (session_id, role, content) \
              VALUES ($1, 'user', 'q') RETURNING id",
@@ -3212,14 +3106,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn recent_product_qa_pairs_returns_only_marked_pairs_before_cutoff(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let session_id: Uuid = sqlx::query_scalar(
-            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
-        )
-        .bind(Uuid::new_v4())
-        .bind(Uuid::new_v4())
-        .fetch_one(&pool)
-        .await
-        .unwrap();
+        let session_id = throwaway_session(&pool).await.id;
         // normal pair (must NOT appear)
         for (role, content) in [("user", "嗨"), ("assistant", "嗨呀")] {
             sqlx::query(
@@ -3268,14 +3155,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn context_readers_exclude_channel_marked_rows(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let session_id: Uuid = sqlx::query_scalar(
-            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
-        )
-        .bind(Uuid::new_v4())
-        .bind(Uuid::new_v4())
-        .fetch_one(&pool)
-        .await
-        .unwrap();
+        let session_id = throwaway_session(&pool).await.id;
         // one normal pair, one product_qa pair, then cutoff row
         for (role, content, channel) in [
             ("user", "嗨", None::<&str>),

--- a/crates/eros-engine-store/src/lib.rs
+++ b/crates/eros-engine-store/src/lib.rs
@@ -26,6 +26,39 @@ pub struct OpenRouterCallMeta {
     pub usage: Option<serde_json::Value>,
 }
 
+/// Test helpers shared across this crate's `#[cfg(test)]` modules.
+#[cfg(test)]
+pub(crate) mod testutil {
+    use sqlx::PgPool;
+    use uuid::Uuid;
+
+    /// Persist a genome + active instance and return the instance id.
+    /// Since 0040 `chat_sessions.instance_id`, `companion_affinity.instance_id`
+    /// and `companion_memories.instance_id` carry real FKs, so a test that just
+    /// needs "some valid instance" has to own one rather than fabricate a bare
+    /// `Uuid::new_v4()`. The genome name is randomised so repeat calls never
+    /// collide on `persona_instances UNIQUE(genome_id, owner_uid)`.
+    pub(crate) async fn seed_persona_instance(pool: &PgPool, owner: Uuid) -> Uuid {
+        let genome_id = sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata) \
+             VALUES ($1, 'you are a companion', '{}'::jsonb) RETURNING id",
+        )
+        .bind(format!("seed-{}", Uuid::new_v4()))
+        .fetch_one(pool)
+        .await
+        .unwrap();
+        sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO engine.persona_instances (genome_id, owner_uid) \
+             VALUES ($1, $2) RETURNING id",
+        )
+        .bind(genome_id)
+        .bind(owner)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+    }
+}
+
 #[cfg(test)]
 mod migration_tests {
     use sqlx::PgPool;
@@ -52,6 +85,36 @@ mod migration_tests {
         .await
         .expect("query relrowsecurity for _sqlx_migrations");
         assert!(enabled, "RLS must be enabled on public._sqlx_migrations");
+    }
+
+    /// 0040 closed the gap where the three original instance-scoped tables
+    /// referenced `persona_instances` by convention only. Pins both the
+    /// existence of each FK and its ON DELETE action — a plain `REFERENCES`
+    /// (confdeltype 'a' = NO ACTION) would silently block instance deletion
+    /// instead of wiping the instance's data, which is not what 0040 chose.
+    #[sqlx::test(migrations = "./migrations")]
+    async fn migration_0040_instance_fks_exist_with_cascade(pool: PgPool) {
+        for table in ["chat_sessions", "companion_affinity", "companion_memories"] {
+            let deltype: Option<i8> = sqlx::query_scalar(
+                "SELECT c.confdeltype::text::\"char\" FROM pg_constraint c \
+                 JOIN unnest(c.conkey) k(attnum) ON true \
+                 JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = k.attnum \
+                 WHERE c.contype = 'f' \
+                   AND c.conrelid = ('engine.' || $1)::regclass \
+                   AND c.confrelid = 'engine.persona_instances'::regclass \
+                   AND a.attname = 'instance_id'",
+            )
+            .bind(table)
+            .fetch_optional(&pool)
+            .await
+            .expect("query instance_id foreign key")
+            .flatten();
+            assert_eq!(
+                deltype,
+                Some(b'c' as i8),
+                "engine.{table}.instance_id must carry an ON DELETE CASCADE FK to persona_instances"
+            );
+        }
     }
 
     #[sqlx::test(migrations = "./migrations")]

--- a/crates/eros-engine-store/src/memory.rs
+++ b/crates/eros-engine-store/src/memory.rs
@@ -188,6 +188,7 @@ impl<'a> MemoryRepo<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::testutil::seed_persona_instance;
 
     fn unit_embedding(seed: usize) -> Vec<f32> {
         // Generate a deterministic 512-dim vector with a single hot index.
@@ -212,7 +213,7 @@ mod tests {
     async fn upsert_then_retrieve(pool: PgPool) {
         let repo = MemoryRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, Some(instance_id)).await;
 
         let emb = unit_embedding(7);
@@ -244,7 +245,7 @@ mod tests {
     async fn cosine_search_picks_nearest_neighbour(pool: PgPool) {
         let repo = MemoryRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, Some(instance_id)).await;
 
         let target_id = repo
@@ -297,7 +298,7 @@ mod tests {
     async fn relationship_search_excludes_legacy_transcript_rows(pool: PgPool) {
         let repo = MemoryRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, Some(instance_id)).await;
 
         // Legacy verbatim turn (contains "\nAI："). It is the NEAREST neighbour
@@ -422,7 +423,7 @@ mod tests {
     async fn category_roundtrips_through_search(pool: PgPool) {
         let repo = MemoryRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, Some(instance_id)).await;
 
         repo.upsert(
@@ -466,7 +467,7 @@ mod tests {
     async fn profile_layer_isolates_from_relationship(pool: PgPool) {
         let repo = MemoryRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, Some(instance_id)).await;
 
         // Profile-layer write has instance_id forced to NULL.


### PR DESCRIPTION
## What

`chat_sessions.instance_id`, `companion_affinity.instance_id` and `companion_memories.instance_id` referenced `engine.persona_instances(id)` by convention only. They predate the world/story tables (0035–0039), which all declare a real foreign key — so nothing at the DB level stopped a bogus `instance_id` from being written, and no cascade fired when an instance was removed out of band.

Migration `0040_persona_instance_fks.sql` adds the three FKs, all `ON DELETE CASCADE`.

## Why it surfaced

Beyond integrity, the missing FK cost navigability: the Supabase table editor renders `instance_id` as a plain UUID column, so there's no way to click from a session through to its persona instance — you copy the UUID out and search the other table by hand. That's easy to get wrong on a row carrying two similar-looking UUIDs (its own `id` and its `instance_id`), which is exactly how this got noticed.

## Design decisions

- **`ON DELETE CASCADE`** matches all six existing FKs into `persona_instances`. The engine never `DELETE`s an instance — it flips `status` to `'archived'` (`PersonaStore::ensure_active_instance` reactivates) — so this only governs deliberate out-of-band deletion, where wiping the instance's data is the point. `chat_messages` already cascades from `chat_sessions`, so dropping an instance now takes its conversation history with it.
- **`companion_memories.instance_id` stays nullable** (NULL = profile layer, see 0003). A FK ignores NULL, so profile-layer rows are unaffected.
- **Validated, not `NOT VALID`**: all three columns verified orphan-free against prod beforehand, and the tables are small (206 / 184 / 3250 rows).
- **`chat_sessions.instance_id` left nullable** — tightening to `NOT NULL` is a separate decision, deliberately not bundled here.

## Breaking

A direct DB writer that inserts an unknown `instance_id` now gets `23503`, and deleting a `persona_instances` row now removes its chat history. The engine itself is unaffected — prod has 0 orphans and 0 NULLs across all three columns.

## Test fallout

89 tests (12 server + 77 store) fabricated an `instance_id` with `Uuid::new_v4()` and now violate the FK. Added `seed_persona_instance` helpers (`store::testutil`, `routes::companion::testutil`) and pointed those tests at a real instance. Setup-only changes — no assertion weakened.

One semantic change worth review attention: `voice_404_when_persona_instance_missing` → `voice_404_when_persona_instance_inactive`. It constructed a session pointing at a non-existent instance, which the FK now makes unrepresentable. It seeds a real instance and archives it instead — the path production actually takes, hitting the same `load_companion` `status = 'active'` 404 branch. Assertions unchanged.

## Verification

| Gate | Result |
|---|---|
| `cargo test --workspace` | 1153 passed, 0 failed |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `cargo fmt --all --check` | clean |
| openapi snapshot | no drift |

New guard test `migration_0040_instance_fks_exist_with_cascade` pins both FK existence and `confdeltype = 'c'`. Sanity-checked against prod (which does not have 0040 applied) with the same SQL — returns 0 rows, confirming the test fails without the migration rather than passing vacuously.

Not applied to any live database; that's a separate deploy step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)