### PR TITLE
chore(release): v1.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,7 +511,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "eros-engine-core"
-version = "1.0.2-dev"
+version = "1.0.2"
 dependencies = [
  "chrono",
  "serde",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-llm"
-version = "1.0.2-dev"
+version = "1.0.2"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-server"
-version = "1.0.2-dev"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-store"
-version = "1.0.2-dev"
+version = "1.0.2"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "1.0.2-dev"
+version = "1.0.2"
 edition = "2021"
 license = "AGPL-3.0-only"
 repository = "https://github.com/etherfunlab/eros-engine"

--- a/README.ja.md
+++ b/README.ja.md
@@ -67,14 +67,14 @@ eros-engine-llm   = "1.0"   # optional: model and embedding clients
 各 `v*` タグについて、複数アーキテクチャ対応のイメージを GitHub Container Registry へ公開しています。
 
 ```bash
-docker pull ghcr.io/etherfunlab/eros-engine:1.0.1
+docker pull ghcr.io/etherfunlab/eros-engine:1.0.2
 # Or follow the latest tagged release
 docker pull ghcr.io/etherfunlab/eros-engine:latest
 ```
 
 ```bash
 docker run --rm -p 8080:8080 --env-file .env \
-  ghcr.io/etherfunlab/eros-engine:1.0.1 serve
+  ghcr.io/etherfunlab/eros-engine:1.0.2 serve
 ```
 
 Postgres と `.env` は利用者側で用意してください。同じ `docker/Dockerfile` を任意のコンテナ環境へ配備できます。詳細は [Deploying](docs/deploying.md) を参照してください。

--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ eros-engine-llm   = "1.0"   # optional: model and embedding clients
 Multi-architecture images are published to GitHub Container Registry for every `v*` tag:
 
 ```bash
-docker pull ghcr.io/etherfunlab/eros-engine:1.0.1
+docker pull ghcr.io/etherfunlab/eros-engine:1.0.2
 # Or follow the latest tagged release
 docker pull ghcr.io/etherfunlab/eros-engine:latest
 ```
 
 ```bash
 docker run --rm -p 8080:8080 --env-file .env \
-  ghcr.io/etherfunlab/eros-engine:1.0.1 serve
+  ghcr.io/etherfunlab/eros-engine:1.0.2 serve
 ```
 
 Bring your own Postgres and `.env`; the same `docker/Dockerfile` can be deployed to any container host. See [Deploying](docs/deploying.md).

--- a/README.zh.md
+++ b/README.zh.md
@@ -67,14 +67,14 @@ eros-engine-llm   = "1.0"   # optional: model and embedding clients
 每个 `v*` tag 都会向 GitHub Container Registry 发布多架构镜像：
 
 ```bash
-docker pull ghcr.io/etherfunlab/eros-engine:1.0.1
+docker pull ghcr.io/etherfunlab/eros-engine:1.0.2
 # Or follow the latest tagged release
 docker pull ghcr.io/etherfunlab/eros-engine:latest
 ```
 
 ```bash
 docker run --rm -p 8080:8080 --env-file .env \
-  ghcr.io/etherfunlab/eros-engine:1.0.1 serve
+  ghcr.io/etherfunlab/eros-engine:1.0.2 serve
 ```
 
 你需要自行提供 Postgres 和 `.env`；同一个 `docker/Dockerfile` 可部署到任意容器托管平台。详见[部署](docs/deploying.zh.md)。

--- a/crates/eros-engine-llm/Cargo.toml
+++ b/crates/eros-engine-llm/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "openrouter", "voyage", "embeddings", "llm"]
 categories = ["api-bindings"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "1.0.2-dev" }
+eros-engine-core = { path = "../eros-engine-core", version = "1.0.2" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/eros-engine-server/Cargo.toml
+++ b/crates/eros-engine-server/Cargo.toml
@@ -13,9 +13,9 @@ name = "eros-engine"
 path = "src/main.rs"
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "1.0.2-dev" }
-eros-engine-llm  = { path = "../eros-engine-llm", version = "1.0.2-dev" }
-eros-engine-store = { path = "../eros-engine-store", version = "1.0.2-dev" }
+eros-engine-core = { path = "../eros-engine-core", version = "1.0.2" }
+eros-engine-llm  = { path = "../eros-engine-llm", version = "1.0.2" }
+eros-engine-store = { path = "../eros-engine-store", version = "1.0.2" }
 axum = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0-only",
       "identifier": "AGPL-3.0-only"
     },
-    "version": "1.0.2-dev"
+    "version": "1.0.2"
   },
   "servers": [
     {

--- a/crates/eros-engine-store/Cargo.toml
+++ b/crates/eros-engine-store/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "memory", "pgvector", "postgres", "sqlx"]
 categories = ["database"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "1.0.2-dev" }
+eros-engine-core = { path = "../eros-engine-core", version = "1.0.2" }
 sqlx = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
Version bump for the v1.0.2 stable cut. Merges into `dev`, then `dev` → `main` promotes.

Bumps the 6 version strings (workspace + 3 server path-dep pins + llm + store), regenerates `Cargo.lock` and `openapi.json` (`info.version` tracks `CARGO_PKG_VERSION`), and updates the docker-pull refs in all three READMEs. No functional change.

## Release delta — PRs merged into `dev` since v1.0.1

- #224 — fix(store)!: add missing persona_instances FKs on the three original tables
- #222 — docs(readme): simplify abstract, rename Why-this-exists to Highlights (en/zh/ja)
- #221 — refactor(server): dedupe LLM-reply JSON parsing, single usage to_value per arm

(#222 already reached `main` separately via #223; it is listed here for completeness of the `dev` delta.)

## Local verification

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — 1153 passed, 0 failed (69 + 372 + 526 + 186)
- `openapi.json` regenerated; diff is the version line only

🤖 Generated with [Claude Code](https://claude.com/claude-code)