### PR TITLE
chore(release): v1.0.2 — persona_instances FKs + LLM-reply parse helper

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,11 @@ The CLA grants etherfunlab the right to relicense your contribution. This is req
 ```bash
 git clone https://github.com/etherfunlab/eros-engine
 cd eros-engine
-docker compose -f docker/docker-compose.yml up -d postgres
+docker run -d --name eros-pg -p 5432:5432 \
+  -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=eros_engine_test \
+  pgvector/pgvector:pg16
+export DATABASE_URL=postgres://postgres:postgres@localhost:5432/eros_engine_test
+cargo run -p eros-engine-server -- migrate
 cargo test --workspace
 ```
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,7 +511,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "eros-engine-core"
-version = "1.0.2-dev"
+version = "1.0.2"
 dependencies = [
  "chrono",
  "serde",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-llm"
-version = "1.0.2-dev"
+version = "1.0.2"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-server"
-version = "1.0.2-dev"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-store"
-version = "1.0.2-dev"
+version = "1.0.2"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,7 +511,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "eros-engine-core"
-version = "1.0.1"
+version = "1.0.2-dev"
 dependencies = [
  "chrono",
  "serde",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-llm"
-version = "1.0.1"
+version = "1.0.2-dev"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-server"
-version = "1.0.1"
+version = "1.0.2-dev"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-store"
-version = "1.0.1"
+version = "1.0.2-dev"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "1.0.1"
+version = "1.0.2-dev"
 edition = "2021"
 license = "AGPL-3.0-only"
 repository = "https://github.com/etherfunlab/eros-engine"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "1.0.2-dev"
+version = "1.0.2"
 edition = "2021"
 license = "AGPL-3.0-only"
 repository = "https://github.com/etherfunlab/eros-engine"

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,8 +1,6 @@
 # eros-engine
 
-> **本物の人間のように感じられる AI コンパニオンのための、オープンソース Rust エンジン。永続記憶、進展する関係モデル、そして数千ターンにわたってペルソナを一貫させる意思決定エンジンを備えています。**
->
-> `eros-engine` は、[Eros Chat](https://chat.etherfun.xyz) のコンパニオンチャット中核を独立したサービスとして切り出したものです。会話を、構造化されたユーザープロフィール、2 層の長期記憶、6 次元の親密度モデルという永続的な状態へ変換します。これにより、ユーザーが戻るたびに、ペルソナはいつも同じ人物として振る舞います。
+**本物の人間のように感じられる AI コンパニオンのための、オープンソース Rust エンジン。永続記憶、進展する関係モデル、そして数千ターンにわたってペルソナを一貫させる意思決定エンジンを備えています。**
 
 [![CI](https://github.com/etherfunlab/eros-engine/actions/workflows/ci.yml/badge.svg)](https://github.com/etherfunlab/eros-engine/actions/workflows/ci.yml)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
@@ -13,19 +11,19 @@
 
 [English](README.md) · [中文](README.zh.md) · **日本語**
 
-## このエンジンが存在する理由
+## ハイライト
 
-多くの AI キャラクターアプリでは、記憶をプロンプトに追加するテキストとして扱い、関係性を一段落の指示で表現しています。デモでは機能しても、長いセッションでは振る舞いが徐々にずれ、キャラクター性が崩れ、デバッグも困難になります。`eros-engine` はこれらを明示的で検査可能な状態へ移すことで、コンパニオンを**本物の人間のように**感じさせます。コンパニオンはあなたを覚え、現在の関係性に応じて反応します。また、振る舞いは即興ではなく*決定*されるため、何ターン重ねても**キャラクター性を維持**します。
+多くの AI キャラクターアプリは、やがてあなたを忘れます。関係性はプロンプトに収まる文章へ戻り、会話が長くなるほど人物像もぶれていきます。`eros-engine` は、そこを持続する状態にします。コンパニオンはセッションをまたいであなたを覚え、交流とともに関係が変わり、汎用アシスタントの即興ではなく、その人物らしい判断から返信します。
 
-これを支えるのが、次の 5 つの柱です。
+土台となるのは次の 5 つです。
 
-- 🧠 **2 層の記憶** — プロフィール記憶（安定したユーザー情報）と関係記憶（共有した出来事、過去の話題への言及、未完了の話題）を Postgres + pgvector に保存し、セッションやペルソナをまたいでコンパニオンがあなたを記憶できるようにします。→ [Memory layers](docs/memory-layers.md)
-- 💞 **6 軸の親密度 + ghost mechanics** — 数値化された関係ベクトル（warmth、trust、intimacy、intrigue、patience、tension）を EMA による平滑化とリアルタイム減衰で更新します。時間とともに口調、会話の深さ、振る舞いを変化させ、*返信しない*という判断さえ可能にします。→ [Affinity model](docs/affinity-model.md) · [Ghost mechanics](docs/ghost-mechanics.md)
-- 🎭 **Persona Decision Engine (PDE)** — 各ターンの行動（返信、ghost、写真送信）と内的状態を選択します。デフォルトではルールベースで、任意に LLM judge を有効化できます。汎用アシスタントのような口調ではなく、人間らしくキャラクターに沿った返信を維持する仕組みです。judge の呼び出しは `companion_decision_events` に監査記録されます。→ [Model config](docs/model-config.md)
-- 🧩 **構造化されたユーザーインサイト** — 都市、職業、興味、MBTI signals、感情的ニーズ、生活リズム、マッチング設定を JSONB プロフィールとして保持し、重み付きの `training_level` を付与します。下流プロダクトからクエリし、マッチメイキング、オンボーディング、分析、gating に利用できます。→ [API reference](docs/api-reference.md)
-- ⚡ **流暢なコンパニオンチャットのための設計** — トークン単位の SSE ストリーミング、画像理解（ユーザーからの写真送信）、コンパニオンによる画像生成（`reply_image` / `reply_text_image`）、リクエスト単位の `prompt_traits` と tier、OpenRouter ベースのルーティングを備えています。タスクごとのモデル選択（固定 / ラウンドロビン / 加重とフォールバックチェーン）と、すべての呼び出しに対する監査にも対応します。→ [API reference](docs/api-reference.md) · [Model config](docs/model-config.md)
+- 🧠 **2 層の記憶** — 安定したユーザー情報と、共有した出来事、過去への言及、続きのある話題をそれぞれ保持します。→ [Memory layers](docs/memory-layers.md)
+- 💞 **変化する親密度** — 6 つの関係軸が滑らかに変化し、時間とともに減衰します。口調や会話の深さ、返信するかどうかにも影響します。→ [Affinity model](docs/affinity-model.md) · [Ghost mechanics](docs/ghost-mechanics.md)
+- 🎭 **Persona Decision Engine（PDE）** — 生成前に、そのターンの行動と内面状態を選びます。標準はルールベースで、LLM judge も任意で使えます。→ [Model config](docs/model-config.md)
+- 🧩 **構造化されたユーザー理解** — 検索可能なプロフィールを育て、導入体験、パーソナライズ、分析などに活用できます。→ [API reference](docs/api-reference.md)
+- ⚡ **一通りそろったチャット経路** — SSE ストリーミング、画像理解と生成要求、`prompt_traits`、タスク別モデル選択、フォールバック、呼び出し監査を備えます。OpenRouter が標準ですが、`[providers]` から OpenAI 互換のチャット・embedding 提供元を追加できます。→ [API reference](docs/api-reference.md) · [Model config](docs/model-config.md)
 
-これは汎用エージェントフレームワークではありません。同じペルソナが同じユーザーと複数のセッションにわたって会話するプロダクトに特化したエンジンです。AI コンパニオン、ジャーナリングコンパニオン、コーチングエージェント、語学チューター、キャラクターチャットなどに適しています。
+汎用エージェントフレームワークではありません。同じ人物が同じユーザーを時間をかけて知っていくプロダクトのための、状態を持つ中核です。AI コンパニオン、日記、コーチ、語学チューター、キャラクターチャットに向いています。
 
 ## アーキテクチャ
 
@@ -45,18 +43,9 @@
 └─────────────────────────────────────────────────────────┘
 ```
 
-ワークスペースは 4 つの crate に分かれています。
+4 つの crate が、ドメインロジック、モデル接続、永続化、HTTP サービスを分担します。`eros-engine-server` を API として動かすことも、`core + llm + store` を独自の Rust サービスへ組み込むこともできます。境界とデータフローは [Architecture](docs/architecture.md) を参照してください。
 
-| Crate | 役割 |
-|---|---|
-| `eros-engine-core` | 純粋なドメインロジック：親密度の計算、ghost の判定、PDE、ペルソナ型。I/O はありません。 |
-| `eros-engine-llm` | OpenRouter チャットクライアント、Voyage embedding クライアント、TOML モデル設定ローダー。 |
-| `eros-engine-store` | Postgres + pgvector による永続化。すべてのテーブルは `engine` schema 配下に置かれます。 |
-| `eros-engine-server` | Axum HTTP サービス、Supabase JWT ミドルウェア、OpenAPI ドキュメント、pipeline の接続処理。 |
-
-`eros-engine-server` を HTTP API として実行することも、`core + llm + store` を独自の Rust サービスへ直接組み込むこともできます。crate の境界、pipeline の各フェーズ、データフローについては、[Architecture](docs/architecture.md) を参照してください。
-
-## ライブラリとして使う
+## ライブラリ利用
 
 3 つのライブラリ crate は crates.io で公開されています（[core](https://crates.io/crates/eros-engine-core) · [store](https://crates.io/crates/eros-engine-store) · [llm](https://crates.io/crates/eros-engine-llm)）。
 
@@ -67,106 +56,88 @@ cargo add eros-engine-core eros-engine-store eros-engine-llm
 ```toml
 [dependencies]
 eros-engine-core  = "1.0"
-eros-engine-store = "1.0"   # only if you want the Postgres + pgvector layer
-eros-engine-llm   = "1.0"   # only if you want the OpenRouter + Voyage clients
+eros-engine-store = "1.0"   # optional: Postgres + pgvector persistence
+eros-engine-llm   = "1.0"   # optional: model and embedding clients
 ```
 
-`eros-engine-server` は意図的に crates.io では公開していません。Docker イメージとして実行してください（下記参照）。
+`eros-engine-server` は crates.io では公開していません。Docker イメージで実行してください。
 
-## Docker イメージとして実行する
+## Docker イメージ
 
-`eros-engine-server` のマルチアーキテクチャイメージ（`linux/amd64` + `linux/arm64`）は、`v*` タグごとに GitHub Container Registry へ公開されます。
+各 `v*` タグについて、複数アーキテクチャ対応のイメージを GitHub Container Registry へ公開しています。
 
 ```bash
 docker pull ghcr.io/etherfunlab/eros-engine:1.0.1
-# or track the latest tagged release
+# Or follow the latest tagged release
 docker pull ghcr.io/etherfunlab/eros-engine:latest
 ```
-
-最小構成での実行例です（Postgres と独自の `.env` が必要です）。
 
 ```bash
 docker run --rm -p 8080:8080 --env-file .env \
   ghcr.io/etherfunlab/eros-engine:1.0.1 serve
 ```
 
-このイメージのビルドには、同じ `docker/Dockerfile` が使われています。任意のコンテナホストにデプロイできます。詳細は [Deploying](docs/deploying.md) を参照してください。
+Postgres と `.env` は利用者側で用意してください。同じ `docker/Dockerfile` を任意のコンテナ環境へ配備できます。詳細は [Deploying](docs/deploying.md) を参照してください。
 
 ## ドキュメント
 
-- [Architecture](docs/architecture.md) — crate の境界、pipeline の各フェーズ、データフロー。
-- [Affinity model](docs/affinity-model.md) — 6 つの次元、EMA、時間減衰、関係ラベル。
-- [Ghost mechanics](docs/ghost-mechanics.md) — スコア式、保護ルール、例。
-- [Memory layers](docs/memory-layers.md) — プロフィール記憶と関係記憶、Voyage、pgvector による検索。
-- [World system](docs/world-system.md) — 実験的なオーナー単位のペルソナワールド：World Memories のシミュレーションとリコール注入、World Town のソーシャルフィード。
-- [Model config](docs/model-config.md) — `model_config.toml` schema、すべてのタスク（chat、vision、image generation、PDE、filters、extraction）、モデル選択、マルチプロバイダールーティング（`[providers]`）、0.x の安定性に関する方針。
-- [Prompt traits](docs/prompt-traits.md) — リクエスト単位の system prompt 注入と tier の許可リスト。
-- [LLM / OpenRouter audit](docs/llm-audit.md) — ユーザー単位 / セッション単位の attribution の受け渡し。
-- [Deploying](docs/deploying.md) — Docker、独自の Postgres / IdP、運用向け環境変数。
-- [API reference](docs/api-reference.md) — すべての `/comp/*` endpoint、リクエストフィールド、SSE frame layout。
+- [Architecture](docs/architecture.md) — crate の境界、処理段階、データフロー。
+- [Affinity model](docs/affinity-model.md) — 関係軸、平滑化、減衰、関係ラベル。
+- [Ghost mechanics](docs/ghost-mechanics.md) — コンパニオンが沈黙する条件と理由。
+- [Memory layers](docs/memory-layers.md) — プロフィール記憶と関係記憶、embedding、検索。
+- [World system](docs/world-system.md) — 実験的な World Memories、World Town、World Stories のシミュレーション。
+- [Model config](docs/model-config.md) — タスク、モデル選択、フォールバック、`[providers]` による複数提供元へのルーティング。
+- [Prompt traits](docs/prompt-traits.md) — リクエストごとのプロンプト調整と tier の許可リスト。
+- [LLM / OpenRouter audit](docs/llm-audit.md) — ユーザー・セッション単位の帰属情報。
+- [Deploying](docs/deploying.md) — Docker、Postgres、認証、運用。
+- [API reference](docs/api-reference.md) — ルート、リクエスト schema、SSE frame。
 
 ## クイックスタート
 
-前提条件：Rust ツールチェーン（`rust-toolchain.toml`）、`pgvector` を導入した Postgres 16+、OpenRouter API key、Voyage API key、そして認証元を 1 つ（Supabase JWKS（`SUPABASE_URL`）または旧来の `SUPABASE_JWT_SECRET`）、あるいは独自の `AuthValidator`。
+Rust、`pgvector` を導入した Postgres 16+、OpenRouter API キー、認証元が 1 つ必要です。標準の embedding 経路は Voyage を使います。embedding は別の提供元にも振り分けられ、読み取りと書き込みの両方を Voyage から外した場合に限り `VOYAGE_API_KEY` は不要です。
 
 ```bash
 git clone https://github.com/etherfunlab/eros-engine
 cd eros-engine
-cp .env.example .env   # fill in DATABASE_URL, OPENROUTER_API_KEY, VOYAGE_API_KEY, and one auth source
+cp .env.example .env   # Set DATABASE_URL, OPENROUTER_API_KEY, VOYAGE_API_KEY, and one auth source
 
 cargo run -p eros-engine-server -- migrate
 cargo run -p eros-engine-server -- seed-personas examples/personas
 cargo run -p eros-engine-server -- serve
 ```
 
-サーバーはデフォルトで `0.0.0.0:8080` で待ち受けます。Scalar API ドキュメントは `/docs` にあります。生の OpenAPI JSON は `print-openapi` サブコマンドで出力してください。公式の Eros Chat Web クライアントはクローズドソースです。独自の UI を用意するか、crate を別のサービスへ組み込んでください。
+サーバーは標準で `0.0.0.0:8080` を使用し、Scalar API ドキュメントは `/docs` にあります。公式 Eros Chat Web クライアントは非公開です。独自の UI を用意するか、crate を別のサービスへ組み込んでください。
 
 ## API 概要
 
-デフォルトでは、すべての `/comp/*` ルートに `Authorization: Bearer <Supabase JWT>` が必要です（他の identity provider には、差し替え可能な `AuthValidator` trait で対応できます）。主な endpoint は次のとおりです。
-
-- `POST /comp/chat/start` — ペルソナとのチャットセッションを開始します。
-- `POST /comp/chat/{session_id}/message/stream` — **中心となる**チャットターンの endpoint です。トークン単位の Server-Sent Events を返します。ターンごとの任意フィールドには、`tier`、`prompt_traits`、`audit`、`tips_amount_usd`（コンパニオンへの tip）、`image_url`（コンパニオンへ写真を送信）、`image`（コンパニオンによる画像生成を要求。style / aspect ratio を指定）があります。画像ターンではエンジンがプロンプトを組み立てて `image_request` frame を送出し、チャットストリーム自体は描画しません。
-- `GET /comp/chat/{session_id}/history` · `GET /comp/chat/{user_id}/sessions` · `GET /comp/user/{user_id}/profile` — 履歴、セッション一覧、構造化されたインサイトプロフィールを取得します。
-- `GET /comp/affinity/{session_id}` — debug 専用のリアルタイム親密度ベクトル（`EXPOSE_AFFINITY_DEBUG=true`）。
-
-完全なリクエスト schema、SSE frame layout（チャットストリーム上の `delta`、`image_request`、ghost、error frame を含む）、各フィールドの意味については、[API reference](docs/api-reference.md) を参照してください。
+基本の流れは、ペルソナとのセッションを作り、SSE ストリーミングのエンドポイントへ会話を送るだけです。履歴、セッション、プロフィール、任意の親密度デバッグ用ルートもあります。標準認証は Supabase JWT で、`AuthValidator` により差し替えられます。パス、ペイロード、ストリームの各 frame は [API reference](docs/api-reference.md) を参照してください。
 
 ## 設定
 
-必須の環境変数は `DATABASE_URL`、`OPENROUTER_API_KEY`、`VOYAGE_API_KEY` と、**いずれか 1 つ**の認証元です。`SUPABASE_URL` / `SUPABASE_JWKS_URL`（JWKS、2025 年以降の Supabase のデフォルト）、**または** `SUPABASE_JWT_SECRET`（旧来の HS256）を設定してください。認証元が未設定の場合、サーバーは起動しません。
+最低限、`DATABASE_URL`、認証元を 1 つ、そして `OPENROUTER_API_KEY` を設定します。OpenRouter は組み込みの標準提供元で、その API キーは起動時に必ず必要です。`[providers]` では OpenAI 互換のチャット・embedding エンドポイントをそれぞれのキーで追加できます。標準の Voyage embedding 構成には `VOYAGE_API_KEY` が必要ですが、`[tasks.embedding]` で読み取りと書き込みを両方とも別の提供元へ振り分けた場合は不要です。
 
-その他の項目には適切なデフォルト値があります。モデルルーティング（`MODEL_CONFIG_PATH` → `model_config.toml`、または `MODEL_CONFIG_DIR` で分割設定ディレクトリ）、OpenRouter attribution headers、dreaming-lite / snapshot sweepers、関係性の難易度を調整する `EMA_INERTIA`、debug toggles などです。全項目の一覧は [`.env.example`](.env.example)、運用ガイドは [Deploying](docs/deploying.md)、モデルルーティングは [Model config](docs/model-config.md) を参照してください。
+環境変数の全一覧は [`.env.example`](.env.example)、運用情報は [Deploying](docs/deploying.md)、ルーティングの詳細は [Model config](docs/model-config.md) にあります。
 
-## Roadmap
+## ロードマップ
 
-現時点ではエンジンに含まれていませんが、今後の候補となっている項目です。
+- [ ] **複数ペルソナの実験環境** — 同じセッションで複数の AI ペルソナが互いに、またユーザーと会話する仕組み。
+- [ ] **音声メッセージ**と**ネイティブ音声 I/O** — 低遅延の音声ターン API は提供済みで、STT/TTS は現在呼び出し側の担当です。
+- [ ] **動画生成** — コンパニオンから短い動画を送信。
 
-- [ ] **Agents playground** — 複数の AI ペルソナが 1 つのセッションで互いに、そしてユーザーと対話します。
-- [ ] **Voice messages** — コンパニオンとユーザーの双方が送信できる音声ターン。
-- [ ] **Real-time voice conversation** — 低レイテンシーの音声によるリアルタイムなやり取り。
-- [ ] **Video generation** — image executor を拡張し、コンパニオンが短い動画クリップを送信します。
+## スコープ外
 
-## 意図的に対象外としているもの
-
-このリポジトリは、会話、記憶、関係状態の中核です。次の機能は含まれません。
-
-- **Matchmaking** — 多段階 filtering、soft scoring、agent-to-agent matching simulation は、引き続きクローズドソースのプロダクトに含まれます。
-- **完全な social UX** — onboarding、video、voice、billing、photos、moderation UI、mobile clients。
-- **ペルソナの provenance / marketplace logic** — 商用プロダクトのコードであり、このエンジンには含まれません。
-
-別のプロダクトを構築する場合、再利用できるのは親密度 + 記憶 + インサイトの pipeline です。
+このリポジトリが扱うのは、会話、記憶、関係状態の中核です。マッチング、ソーシャルプロダクト全体の体験、ペルソナの流通・来歴管理は対象外です。再利用の中心となるのは、親密度、記憶、ユーザー理解の処理系です。
 
 ## コンテンツに関する注意
 
-`examples/personas/` のサンプルペルソナは、成人向けキャラクターチャットの例として記述されています。関係状態がその段階に達すると、相手を誘惑したり欲求を表現したりする一方で、敬意を欠く行為や境界を越える行為は拒否します。プロダクトで SFW をデフォルトにする必要がある場合は、デプロイ前にこれらのペルソナファイルを置き換えてください。
+`examples/personas/` のサンプルは成人向けキャラクターチャットです。関係が深まれば誘惑や欲求を表すことがありますが、敬意を欠く行為や境界を越える行為は拒否します。SFW を標準にする場合は、配備前にこれらのペルソナを置き換えてください。
 
-リクエストごとの振る舞いは、メッセージ route の [`prompt_traits`](docs/prompt-traits.md) フィールドでさらに調整できます。エンジンは渡されたテキストを不透明なデータとして扱うため、`prompt_traits` がどのようなポリシーを表すかは、frontend / middleware 側で完全に定義します。
+リクエストごとの振る舞いは [`prompt_traits`](docs/prompt-traits.md) でも調整できます。エンジンはその文字列を解釈しないため、方針はフロントエンドまたはミドルウェア側で定義します。
 
 ## コントリビューション
 
-[`CONTRIBUTING.md`](CONTRIBUTING.md) をお読みください。すべての contributor は、最初の PR で cla-assistant.io を通じて [`CLA`](CLA.md) に同意する必要があります。
+[`CONTRIBUTING.md`](CONTRIBUTING.md) をお読みください。初回 PR では cla-assistant.io を通じて [`CLA`](CLA.md) への同意が必要です。
 
 ## ライセンス
 
-`eros-engine` は AGPL-3.0-only でライセンスされています。AGPL が配布モデルに適さない場合は、商用ライセンスをご利用いただけます：`henrylin@etherfun.xyz`。
+`eros-engine` は AGPL-3.0-only です。商用ライセンスについては `henrylin@etherfun.xyz` までお問い合わせください。

--- a/README.ja.md
+++ b/README.ja.md
@@ -67,14 +67,14 @@ eros-engine-llm   = "1.0"   # optional: model and embedding clients
 各 `v*` タグについて、複数アーキテクチャ対応のイメージを GitHub Container Registry へ公開しています。
 
 ```bash
-docker pull ghcr.io/etherfunlab/eros-engine:1.0.1
+docker pull ghcr.io/etherfunlab/eros-engine:1.0.2
 # Or follow the latest tagged release
 docker pull ghcr.io/etherfunlab/eros-engine:latest
 ```
 
 ```bash
 docker run --rm -p 8080:8080 --env-file .env \
-  ghcr.io/etherfunlab/eros-engine:1.0.1 serve
+  ghcr.io/etherfunlab/eros-engine:1.0.2 serve
 ```
 
 Postgres と `.env` は利用者側で用意してください。同じ `docker/Dockerfile` を任意のコンテナ環境へ配備できます。詳細は [Deploying](docs/deploying.md) を参照してください。

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # eros-engine
 
-> **An open-source Rust engine for AI companions that feel real: persistent memory, an evolving relationship model, and a decision engine that keeps a persona in character across thousands of turns.**
->
-> `eros-engine` is the companion-chat core behind [Eros Chat](https://chat.etherfun.xyz), extracted into a standalone service. It turns conversation into durable state — a structured user profile, two-layer long-term memory, and a six-dimensional affinity model — so a persona behaves like the same person each time a user comes back.
+**An open-source Rust engine for AI companions that feel real: persistent memory, an evolving relationship model, and a decision engine that keeps a persona in character across thousands of turns.**
 
 [![CI](https://github.com/etherfunlab/eros-engine/actions/workflows/ci.yml/badge.svg)](https://github.com/etherfunlab/eros-engine/actions/workflows/ci.yml)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
@@ -13,19 +11,19 @@
 
 **English** · [中文](README.zh.md) · [日本語](README.ja.md)
 
-## Why this exists
+## Highlights
 
-Most AI character apps treat memory as text appended to a prompt and relationship as a paragraph of instructions. That can work in a demo, but behavior drifts over long sessions, breaks character, and becomes hard to debug. `eros-engine` moves those concerns into explicit, inspectable state, so a companion feels like **a real person** — remembering you and responding to the state of the relationship — and **stays in character** turn after turn, because behavior is *decided*, not improvised.
+Most AI character apps eventually forget who you are. Their relationships reset to whatever fits in a prompt, and their personalities drift as the conversation grows. `eros-engine` makes those parts durable: a companion remembers you across sessions, the relationship changes through interaction, and each reply is chosen in character rather than improvised by a generic assistant.
 
-Five pillars support this:
+The engine has five foundations:
 
-- 🧠 **Two-layer memory** — profile memory (stable user facts) and relationship memory (shared moments, callbacks, open threads) in Postgres + pgvector, so the companion remembers you across sessions and personas. → [Memory layers](docs/memory-layers.md)
-- 💞 **Six-axis affinity + ghost mechanics** — a numeric relationship vector (warmth, trust, intimacy, intrigue, patience, tension) updated with EMA smoothing and real-time decay; it reshapes tone, depth, and behavior over time, and can even decide *not* to reply. → [Affinity model](docs/affinity-model.md) · [Ghost mechanics](docs/ghost-mechanics.md)
-- 🎭 **Persona Decision Engine (PDE)** — selects each turn's action (reply, ghost, or send a photo) and inner state — rules-based by default, with an opt-in LLM judge. This keeps replies human and in character instead of sounding like a generic assistant; judge calls are audited to `companion_decision_events`. → [Model config](docs/model-config.md)
-- 🧩 **Structured user insight** — a JSONB profile (city, occupation, interests, MBTI signals, emotional needs, life rhythm, matching preferences) with a weighted `training_level`, queryable by downstream products for matchmaking, onboarding, analytics, or gating. → [API reference](docs/api-reference.md)
-- ⚡ **Built for fluent companion chat** — token-by-token SSE streaming; image understanding (the user can send a photo) and companion-sent image generation (`reply_image` / `reply_text_image`); per-request prompt traits and tiers; OpenRouter-backed routing with per-task model selection (fixed / round-robin / weighted, plus a fallback chain) and full call auditing. → [API reference](docs/api-reference.md) · [Model config](docs/model-config.md)
+- 🧠 **Two-layer memory** — stable facts about the user live alongside shared moments, callbacks, and unfinished threads. → [Memory layers](docs/memory-layers.md)
+- 💞 **Evolving affinity** — six relationship dimensions change smoothly and decay with time, shaping tone, depth, and even whether the companion replies. → [Affinity model](docs/affinity-model.md) · [Ghost mechanics](docs/ghost-mechanics.md)
+- 🎭 **Persona Decision Engine (PDE)** — before generation, the engine chooses an action and inner state. Rules work out of the box; an LLM judge is optional. → [Model config](docs/model-config.md)
+- 🧩 **Structured user insight** — the engine builds a queryable profile that downstream products can use for onboarding, personalization, and analysis. → [API reference](docs/api-reference.md)
+- ⚡ **A complete chat path** — SSE streaming, image understanding and generation requests, prompt traits, per-task model selection, fallbacks, and call auditing. OpenRouter is the default; additional OpenAI-compatible chat and embedding providers can be configured through `[providers]`. → [API reference](docs/api-reference.md) · [Model config](docs/model-config.md)
 
-This is not a generic agent framework. It is a focused engine for products where one persona talks to the same user across many sessions: AI companions, journaling companions, coaching agents, language tutors, and character chat.
+This is not a generic agent framework. It is the stateful core for products where one persona gets to know the same person over time: companions, journals, coaches, tutors, and character chat.
 
 ## Architecture
 
@@ -45,18 +43,9 @@ This is not a generic agent framework. It is a focused engine for products where
 └─────────────────────────────────────────────────────────┘
 ```
 
-The workspace is split into four crates:
+Four crates keep domain logic, model access, persistence, and the HTTP service separate. Run `eros-engine-server` as an API, or embed `core + llm + store` in your own Rust service. See [Architecture](docs/architecture.md) for the boundaries and data flow.
 
-| Crate | Role |
-|---|---|
-| `eros-engine-core` | Pure domain logic: affinity math, ghost decision, PDE, persona types. Zero I/O. |
-| `eros-engine-llm` | OpenRouter chat client, Voyage embedding client, TOML model-config loader. |
-| `eros-engine-store` | Postgres + pgvector persistence, with all tables under the `engine` schema. |
-| `eros-engine-server` | Axum HTTP service, Supabase JWT middleware, OpenAPI docs, and pipeline wiring. |
-
-You can run `eros-engine-server` as an HTTP API, or embed `core + llm + store` directly in your own Rust service. See [Architecture](docs/architecture.md) for crate boundaries, pipeline phases, and data flow.
-
-## Use as a library
+## Library use
 
 The three library crates are on crates.io ([core](https://crates.io/crates/eros-engine-core) · [store](https://crates.io/crates/eros-engine-store) · [llm](https://crates.io/crates/eros-engine-llm)):
 
@@ -67,106 +56,88 @@ cargo add eros-engine-core eros-engine-store eros-engine-llm
 ```toml
 [dependencies]
 eros-engine-core  = "1.0"
-eros-engine-store = "1.0"   # only if you want the Postgres + pgvector layer
-eros-engine-llm   = "1.0"   # only if you want the OpenRouter + Voyage clients
+eros-engine-store = "1.0"   # optional: Postgres + pgvector persistence
+eros-engine-llm   = "1.0"   # optional: model and embedding clients
 ```
 
-`eros-engine-server` is intentionally not published to crates.io — run it as a Docker image (below).
+`eros-engine-server` is not published to crates.io; run it as a Docker image instead.
 
-## Run as a Docker image
+## Docker image
 
-Multi-arch (`linux/amd64` + `linux/arm64`) images for `eros-engine-server` are published to GitHub Container Registry for every `v*` tag:
+Multi-architecture images are published to GitHub Container Registry for every `v*` tag:
 
 ```bash
 docker pull ghcr.io/etherfunlab/eros-engine:1.0.1
-# or track the latest tagged release
+# Or follow the latest tagged release
 docker pull ghcr.io/etherfunlab/eros-engine:latest
 ```
-
-Minimal run (you bring Postgres + your own `.env`):
 
 ```bash
 docker run --rm -p 8080:8080 --env-file .env \
   ghcr.io/etherfunlab/eros-engine:1.0.1 serve
 ```
 
-The `docker/Dockerfile` is the same artifact used to build this image. Deploy it on any container host. See [Deploying](docs/deploying.md).
+Bring your own Postgres and `.env`; the same `docker/Dockerfile` can be deployed to any container host. See [Deploying](docs/deploying.md).
 
 ## Documentation
 
-- [Architecture](docs/architecture.md) — crate boundaries, pipeline phases, data flow.
-- [Affinity model](docs/affinity-model.md) — six dimensions, EMA, time decay, relationship labels.
-- [Ghost mechanics](docs/ghost-mechanics.md) — score formula, protection rules, examples.
-- [Memory layers](docs/memory-layers.md) — profile vs relationship memory, Voyage, pgvector retrieval.
-- [World system](docs/world-system.md) — experimental per-owner persona worlds: World Memories (relationship simulation + recall injection), World Town (social feed), and World Stories (per-instance persona life simulation feeding both).
-- [Model config](docs/model-config.md) — `model_config.toml` schema, every task (chat, vision, image generation, PDE, filters, extraction), model selection, multi-provider routing (`[providers]`), 0.x stability commitments.
-- [Prompt traits](docs/prompt-traits.md) — per-request system-prompt injection and tier allow-lists.
-- [LLM / OpenRouter audit](docs/llm-audit.md) — per-user / per-session attribution passthrough.
-- [Deploying](docs/deploying.md) — Docker, bring-your-own Postgres / IdP, operational env vars.
-- [API reference](docs/api-reference.md) — every `/comp/*` endpoint, request fields, and SSE frame layout.
+- [Architecture](docs/architecture.md) — crate boundaries, pipeline phases, and data flow.
+- [Affinity model](docs/affinity-model.md) — relationship dimensions, smoothing, decay, and labels.
+- [Ghost mechanics](docs/ghost-mechanics.md) — when and why a companion may stay silent.
+- [Memory layers](docs/memory-layers.md) — profile and relationship memory, embeddings, and retrieval.
+- [World system](docs/world-system.md) — experimental World Memories, World Town, and World Stories simulations.
+- [Model config](docs/model-config.md) — tasks, selection, fallbacks, and multi-provider routing through `[providers]`.
+- [Prompt traits](docs/prompt-traits.md) — per-request prompt behavior and tier allow-lists.
+- [LLM / OpenRouter audit](docs/llm-audit.md) — user and session attribution.
+- [Deploying](docs/deploying.md) — Docker, Postgres, identity, and operations.
+- [API reference](docs/api-reference.md) — routes, request schemas, and SSE frames.
 
 ## Quickstart
 
-Prerequisites: a Rust toolchain (`rust-toolchain.toml`), Postgres 16+ with `pgvector`, an OpenRouter API key, a Voyage API key, and one auth source — Supabase JWKS (`SUPABASE_URL`) or a legacy `SUPABASE_JWT_SECRET` (or your own `AuthValidator`).
+You need Rust, Postgres 16+ with `pgvector`, an OpenRouter API key, and one auth source. Voyage powers the default embedding route; embeddings can be routed to other providers instead, and once both embedding reads and writes leave Voyage, `VOYAGE_API_KEY` is no longer needed.
 
 ```bash
 git clone https://github.com/etherfunlab/eros-engine
 cd eros-engine
-cp .env.example .env   # fill in DATABASE_URL, OPENROUTER_API_KEY, VOYAGE_API_KEY, and one auth source
+cp .env.example .env   # Set DATABASE_URL, OPENROUTER_API_KEY, VOYAGE_API_KEY, and one auth source
 
 cargo run -p eros-engine-server -- migrate
 cargo run -p eros-engine-server -- seed-personas examples/personas
 cargo run -p eros-engine-server -- serve
 ```
 
-The server listens on `0.0.0.0:8080` by default. Scalar API docs are available at `/docs`; dump the raw OpenAPI JSON with the `print-openapi` subcommand. The official Eros Chat web client is closed-source — bring your own UI or embed the crates in another service.
+The server listens on `0.0.0.0:8080` by default, with Scalar API docs at `/docs`. The official Eros Chat web client is closed-source, so bring your own UI or embed the crates in another service.
 
 ## API surface
 
-All `/comp/*` routes require `Authorization: Bearer <Supabase JWT>` by default (the `AuthValidator` trait is pluggable for other identity providers). Key endpoints:
-
-- `POST /comp/chat/start` — open a chat session against a persona.
-- `POST /comp/chat/{session_id}/message/stream` — **the** chat turn endpoint: token-by-token Server-Sent Events. Optional per-turn fields include `tier`, `prompt_traits`, `audit`, `tips_amount_usd` (tip the companion), `image_url` (send the companion a photo), and `image` (request a companion-generated image — style / aspect ratio). For an image turn the engine composes the prompt and emits an `image_request` frame; it does not draw on the chat stream.
-- `GET /comp/chat/{session_id}/history` · `GET /comp/chat/{user_id}/sessions` · `GET /comp/user/{user_id}/profile` — history, session list, and the structured insight profile.
-- `GET /comp/affinity/{session_id}` — debug-only live affinity vector (`EXPOSE_AFFINITY_DEBUG=true`).
-
-For the full request schema, SSE frame layout (including `delta`, `image_request`, ghost, and error frames on the chat stream), and per-field semantics, see the [API reference](docs/api-reference.md).
+The main flow is simple: start a persona session, then send turns to the SSE streaming endpoint. The engine also exposes history, session, profile, and optional affinity-debug routes. Authentication uses Supabase JWTs by default and can be replaced through `AuthValidator`. See the [API reference](docs/api-reference.md) for paths, payloads, and stream frames.
 
 ## Configuration
 
-Required env vars: `DATABASE_URL`, `OPENROUTER_API_KEY`, `VOYAGE_API_KEY`, and **one** auth source — `SUPABASE_URL` / `SUPABASE_JWKS_URL` (JWKS, the post-2025 Supabase default) **or** `SUPABASE_JWT_SECRET` (legacy HS256). The server refuses to boot if no auth source is set.
+At minimum, configure `DATABASE_URL`, one authentication source, and `OPENROUTER_API_KEY` — OpenRouter is the built-in default and its key is always required at boot. `[providers]` adds OpenAI-compatible endpoints for chat and embeddings, each with its own key; the default Voyage embedding setup requires `VOYAGE_API_KEY`, unless `[tasks.embedding]` routes both reads and writes elsewhere.
 
-Everything else has sane defaults: model routing (`MODEL_CONFIG_PATH` → `model_config.toml`, or a split config directory via `MODEL_CONFIG_DIR`), OpenRouter attribution headers, the dreaming-lite / snapshot sweepers, the `EMA_INERTIA` relationship-difficulty dial, and debug toggles. The full variable list lives in [`.env.example`](.env.example); operational guidance is in [Deploying](docs/deploying.md), and model routing in [Model config](docs/model-config.md).
+The complete environment list is in [`.env.example`](.env.example), operational guidance in [Deploying](docs/deploying.md), and routing details in [Model config](docs/model-config.md).
 
 ## Roadmap
 
-Not part of the engine today, but on the radar:
+- [ ] **Agents playground** — multiple personas sharing a session with each other and the user.
+- [ ] **Voice messages** and **native audio I/O** — the low-latency voice-turn API already ships; STT/TTS currently stay on the caller's side.
+- [ ] **Video generation** for companion-sent clips.
 
-- [ ] **Agents playground** — multiple AI personas interacting with each other (and the user) in one session.
-- [ ] **Voice messages** — companion-sent and user-sent audio turns.
-- [ ] **Real-time voice conversation** — low-latency spoken back-and-forth.
-- [ ] **Video generation** — short companion-sent video clips, extending the image executor.
+## Non-goals
 
-## What is deliberately out of scope
-
-This repository is the conversation, memory, and relationship-state core. It does not include:
-
-- **Matchmaking** — multi-stage filtering, soft scoring, and agent-to-agent matching simulation remain in the closed-source product.
-- **Full social UX** — onboarding, video, voice, billing, photos, moderation UI, and mobile clients.
-- **Persona provenance / marketplace logic** — commercial product code, not part of the engine.
-
-If you are building a different product, the reusable part is the affinity + memory + insight pipeline.
+This repository is the conversation, memory, and relationship-state core. Matchmaking, the full social product experience, and persona marketplace or provenance logic remain outside the engine. The reusable center is the affinity, memory, and insight pipeline.
 
 ## Content note
 
-The example personas under `examples/personas/` are written as adult character-chat examples. They can flirt and express desire when the relationship state reaches that point, while still refusing disrespectful or boundary-crossing behavior. If your product needs a SFW default, replace those persona files before deploying.
+The personas in `examples/personas/` are adult character-chat examples. They may flirt or express desire as a relationship develops, while refusing disrespectful or boundary-crossing behavior. Replace them before deployment if your product needs a SFW default.
 
-Per-request behavior can be further adjusted via the [`prompt_traits`](docs/prompt-traits.md) field on the message routes — the engine treats the supplied text as opaque, so the policy defining what those traits encode lives entirely in your frontend / middleware.
+Per-request behavior can also be adjusted through [`prompt_traits`](docs/prompt-traits.md). The engine treats this text as opaque; your frontend or middleware owns its policy.
 
 ## Contributing
 
-Read [`CONTRIBUTING.md`](CONTRIBUTING.md). All contributors must accept the [`CLA`](CLA.md) through cla-assistant.io on their first PR.
+Read [`CONTRIBUTING.md`](CONTRIBUTING.md). Contributors accept the [`CLA`](CLA.md) through cla-assistant.io on their first PR.
 
 ## License
 
-`eros-engine` is licensed under AGPL-3.0-only. If AGPL does not fit your distribution model, commercial licensing is available: `henrylin@etherfun.xyz`.
+`eros-engine` is licensed under AGPL-3.0-only. For commercial licensing, contact `henrylin@etherfun.xyz`.

--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ eros-engine-llm   = "1.0"   # optional: model and embedding clients
 Multi-architecture images are published to GitHub Container Registry for every `v*` tag:
 
 ```bash
-docker pull ghcr.io/etherfunlab/eros-engine:1.0.1
+docker pull ghcr.io/etherfunlab/eros-engine:1.0.2
 # Or follow the latest tagged release
 docker pull ghcr.io/etherfunlab/eros-engine:latest
 ```
 
 ```bash
 docker run --rm -p 8080:8080 --env-file .env \
-  ghcr.io/etherfunlab/eros-engine:1.0.1 serve
+  ghcr.io/etherfunlab/eros-engine:1.0.2 serve
 ```
 
 Bring your own Postgres and `.env`; the same `docker/Dockerfile` can be deployed to any container host. See [Deploying](docs/deploying.md).

--- a/README.zh.md
+++ b/README.zh.md
@@ -67,14 +67,14 @@ eros-engine-llm   = "1.0"   # optional: model and embedding clients
 每个 `v*` tag 都会向 GitHub Container Registry 发布多架构镜像：
 
 ```bash
-docker pull ghcr.io/etherfunlab/eros-engine:1.0.1
+docker pull ghcr.io/etherfunlab/eros-engine:1.0.2
 # Or follow the latest tagged release
 docker pull ghcr.io/etherfunlab/eros-engine:latest
 ```
 
 ```bash
 docker run --rm -p 8080:8080 --env-file .env \
-  ghcr.io/etherfunlab/eros-engine:1.0.1 serve
+  ghcr.io/etherfunlab/eros-engine:1.0.2 serve
 ```
 
 你需要自行提供 Postgres 和 `.env`；同一个 `docker/Dockerfile` 可部署到任意容器托管平台。详见[部署](docs/deploying.zh.md)。

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,8 +1,6 @@
 # eros-engine
 
-> **一个让 AI 伴侣如真人般鲜活的开源 Rust 引擎：具备持久记忆、持续演变的关系模型，以及让人设历经数千轮对话仍保持一致的决策引擎。**
->
-> `eros-engine` 是 [Eros Chat](https://chat.etherfun.xyz) 背后的伴侣对话核心，现已抽离为独立服务。它将对话转化为持久状态——结构化用户画像、双层长期记忆和六维亲密度模型——让用户每次回来时，角色都像始终如一的同一个人。
+**一个让 AI 伴侣如真人般鲜活的开源 Rust 引擎：具备持久记忆、持续演变的关系模型，以及让人设历经数千轮对话仍保持一致的决策引擎。**
 
 [![CI](https://github.com/etherfunlab/eros-engine/actions/workflows/ci.yml/badge.svg)](https://github.com/etherfunlab/eros-engine/actions/workflows/ci.yml)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
@@ -13,19 +11,19 @@
 
 [English](README.md) · **中文** · [日本語](README.ja.md)
 
-## 为什么做这个
+## 亮点
 
-大多数 AI 角色应用只是将记忆作为文本附加到 prompt 中，并用一段指令描述关系。这种做法或许足以演示，但在长会话中，行为会逐渐漂移、偏离人设，而且难以调试。`eros-engine` 将这些要素转化为明确、可检查的状态，使伴侣**如真人一般**——记得你，也会根据当前的关系状态作出反应——并在一轮又一轮对话中**始终符合人设**，因为行为是经过*决策*的，而非临场发挥。
+大多数 AI 角色应用用不了多久就会忘记你。关系被压缩成 prompt 里的一段文字，聊得越久，人设越容易漂移。`eros-engine` 把这些真正重要的部分变成持久状态：伴侣能跨会话记住你，关系会随着相处而变化，每次回复也会依照人设作出决定，而不是让一个通用助手临场发挥。
 
-这建立在五大支柱之上：
+引擎建立在五项基础能力之上：
 
-- 🧠 **双层记忆**——画像记忆（稳定的用户事实）与关系记忆（共同经历、前情呼应、未完话题）均存储在 Postgres + pgvector 中，让伴侣能够跨会话、跨人设记住你。→ [记忆分层](docs/memory-layers.zh.md)
-- 💞 **六维亲密度 + ghost 机制**——以数值关系向量（warmth、trust、intimacy、intrigue、patience、tension）结合 EMA 平滑与实时衰减；它会逐渐改变语气、深度和行为，甚至可以决定*不回复*。→ [亲密度模型](docs/affinity-model.zh.md) · [ghost 机制](docs/ghost-mechanics.zh.md)
-- 🎭 **人设决策引擎（PDE）**——为每轮对话选择行为（回复、ghost 或发送照片）与内在状态——默认基于规则，也可选择启用 LLM judge。它让回复自然、符合人设，而非流于通用助手的腔调；judge 调用会审计到 `companion_decision_events`。→ [模型配置](docs/model-config.zh.md)
-- 🧩 **结构化用户洞察**——以 JSONB 画像记录城市、职业、兴趣、MBTI 信号、情感需求、生活节奏和匹配偏好，并附带加权的 `training_level`；下游产品可查询这些数据，用于匹配、用户引导、分析或 gating。→ [API 参考](docs/api-reference.zh.md)
-- ⚡ **专为流畅的伴侣对话打造**——逐 token 的 SSE 流式输出；图像理解（用户可发送照片）和伴侣端图像生成（`reply_image` / `reply_text_image`）；按请求指定 `prompt_traits` 与 tier；基于 OpenRouter 的路由，支持按任务选择模型（固定 / 轮询 / 加权，并配有 fallback chain）和完整的调用审计。→ [API 参考](docs/api-reference.zh.md) · [模型配置](docs/model-config.zh.md)
+- 🧠 **双层记忆**——稳定的用户事实与共同经历、前情呼应、未完话题各有其位。→ [记忆分层](docs/memory-layers.zh.md)
+- 💞 **演变的亲密度**——六个关系维度平滑变化，也会随时间衰减，逐渐影响语气、深度，甚至是否回复。→ [亲密度模型](docs/affinity-model.zh.md) · [ghost 机制](docs/ghost-mechanics.zh.md)
+- 🎭 **人设决策引擎（PDE）**——生成回复前，先选择行为与内在状态。默认规则即可运行，也可启用 LLM 评判。→ [模型配置](docs/model-config.zh.md)
+- 🧩 **结构化用户洞察**——持续形成可查询的用户画像，供下游产品用于引导、个性化和分析。→ [API 参考](docs/api-reference.zh.md)
+- ⚡ **完整的聊天链路**——SSE 流式输出、图像理解与生成请求、prompt traits、按任务选模型、故障回退及调用审计。OpenRouter 是默认提供方，也可通过 `[providers]` 接入其他兼容 OpenAI 的聊天和 embedding 服务。→ [API 参考](docs/api-reference.zh.md) · [模型配置](docs/model-config.zh.md)
 
-这不是通用 agent 框架，而是一个专注于同一人设跨多个会话与同一用户持续交流的引擎，适用于 AI 伴侣、日记伴侣、教练 agent、语言导师和角色聊天。
+它不是通用 agent 框架，而是为同一人设与同一用户长期相处而做的有状态核心，适合 AI 伴侣、日记伙伴、教练、语言导师和角色聊天。
 
 ## 架构
 
@@ -45,20 +43,11 @@
 └─────────────────────────────────────────────────────────┘
 ```
 
-工作区分为四个 crate：
+四个 crate 分别承载领域逻辑、模型访问、持久化和 HTTP 服务。你可以将 `eros-engine-server` 作为 API 运行，也可以把 `core + llm + store` 嵌入自己的 Rust 服务。边界与数据流详见[架构](docs/architecture.zh.md)。
 
-| Crate | 职责 |
-|---|---|
-| `eros-engine-core` | 纯领域逻辑：亲密度计算、ghost 决策、PDE、人设类型。无 I/O。 |
-| `eros-engine-llm` | OpenRouter 聊天客户端、Voyage embedding 客户端、TOML 模型配置加载器。 |
-| `eros-engine-store` | Postgres + pgvector 持久化，所有表均位于 `engine` schema 下。 |
-| `eros-engine-server` | Axum HTTP 服务、Supabase JWT 中间件、OpenAPI 文档和 pipeline 连接。 |
+## 库集成
 
-你可以将 `eros-engine-server` 作为 HTTP API 运行，也可以把 `core + llm + store` 直接嵌入自己的 Rust 服务。有关 crate 边界、pipeline 阶段和数据流，请参阅[架构](docs/architecture.zh.md)。
-
-## 作为库使用
-
-三个库 crate 已发布到 crates.io（[core](https://crates.io/crates/eros-engine-core) · [store](https://crates.io/crates/eros-engine-store) · [llm](https://crates.io/crates/eros-engine-llm)）：
+三个库 crate 均已发布到 crates.io（[core](https://crates.io/crates/eros-engine-core) · [store](https://crates.io/crates/eros-engine-store) · [llm](https://crates.io/crates/eros-engine-llm)）：
 
 ```bash
 cargo add eros-engine-core eros-engine-store eros-engine-llm
@@ -67,106 +56,88 @@ cargo add eros-engine-core eros-engine-store eros-engine-llm
 ```toml
 [dependencies]
 eros-engine-core  = "1.0"
-eros-engine-store = "1.0"   # only if you want the Postgres + pgvector layer
-eros-engine-llm   = "1.0"   # only if you want the OpenRouter + Voyage clients
+eros-engine-store = "1.0"   # optional: Postgres + pgvector persistence
+eros-engine-llm   = "1.0"   # optional: model and embedding clients
 ```
 
-`eros-engine-server` 有意不发布到 crates.io——请使用 Docker 镜像运行（见下文）。
+`eros-engine-server` 不发布到 crates.io，请使用 Docker 镜像运行。
 
-## 作为 Docker 镜像运行
+## Docker 镜像
 
-每个 `v*` tag 都会将 `eros-engine-server` 的多架构镜像（`linux/amd64` + `linux/arm64`）发布到 GitHub Container Registry：
+每个 `v*` tag 都会向 GitHub Container Registry 发布多架构镜像：
 
 ```bash
 docker pull ghcr.io/etherfunlab/eros-engine:1.0.1
-# or track the latest tagged release
+# Or follow the latest tagged release
 docker pull ghcr.io/etherfunlab/eros-engine:latest
 ```
-
-最简运行方式（需自行提供 Postgres 和 `.env`）：
 
 ```bash
 docker run --rm -p 8080:8080 --env-file .env \
   ghcr.io/etherfunlab/eros-engine:1.0.1 serve
 ```
 
-构建此镜像使用的正是 `docker/Dockerfile`，可将其部署到任意容器托管平台。请参阅[部署](docs/deploying.zh.md)。
+你需要自行提供 Postgres 和 `.env`；同一个 `docker/Dockerfile` 可部署到任意容器托管平台。详见[部署](docs/deploying.zh.md)。
 
 ## 文档
 
-- [架构](docs/architecture.zh.md)——crate 边界、pipeline 阶段、数据流。
-- [亲密度模型](docs/affinity-model.zh.md)——六个维度、EMA、时间衰减、关系标签。
-- [ghost 机制](docs/ghost-mechanics.zh.md)——评分公式、保护规则、示例。
-- [记忆分层](docs/memory-layers.zh.md)——画像记忆 vs 关系记忆、Voyage、pgvector 检索。
-- [世界系统](docs/world-system.zh.md)——实验性的按 owner 角色世界：World Memories 模拟 + 召回注入，以及 World Town 社交动态流。
-- [模型配置](docs/model-config.zh.md)——`model_config.toml` schema、各任务（chat、vision、图像生成、PDE、过滤器、抽取）、选模型规则、多 provider 路由（`[providers]`）、0.x 稳定性承诺。
-- [Prompt traits](docs/prompt-traits.zh.md)——按请求注入系统 prompt 与 tier 白名单。
-- [LLM / OpenRouter 审计](docs/llm-audit.zh.md)——按用户 / 按会话的归因透传。
-- [部署](docs/deploying.zh.md)——Docker、自带 Postgres / IdP、运行期环境变量。
-- [API 参考](docs/api-reference.zh.md)——每个 `/comp/*` 端点、请求字段、SSE 帧布局。
+- [架构](docs/architecture.zh.md)——crate 边界、pipeline 阶段和数据流。
+- [亲密度模型](docs/affinity-model.zh.md)——关系维度、平滑、衰减和标签。
+- [ghost 机制](docs/ghost-mechanics.zh.md)——伴侣何时以及为何保持沉默。
+- [记忆分层](docs/memory-layers.zh.md)——画像与关系记忆、embedding 和检索。
+- [世界系统](docs/world-system.zh.md)——实验性的 World Memories、World Town 与 World Stories 模拟。
+- [模型配置](docs/model-config.zh.md)——任务、模型选择、故障回退及通过 `[providers]` 实现的多提供方路由。
+- [Prompt traits](docs/prompt-traits.zh.md)——按请求调整 prompt 行为及 tier 白名单。
+- [LLM / OpenRouter 审计](docs/llm-audit.zh.md)——用户与会话归因。
+- [部署](docs/deploying.zh.md)——Docker、Postgres、身份认证和运维。
+- [API 参考](docs/api-reference.zh.md)——路由、请求结构和 SSE 帧。
 
 ## 快速开始
 
-前置：`rust-toolchain.toml` 指定的 Rust 工具链、带 `pgvector` 的 Postgres 16+、一个 OpenRouter API key、一个 Voyage API key，以及一个鉴权来源——Supabase JWKS（`SUPABASE_URL`）或旧版 `SUPABASE_JWT_SECRET`（或你自己的 `AuthValidator`）。
+你需要 Rust、带 `pgvector` 的 Postgres 16+、一个 OpenRouter API key，以及一个鉴权来源。默认 embedding 路由使用 Voyage；embedding 也可路由到其他提供方，只有在读取和写入均不再使用 Voyage 时，才无需 `VOYAGE_API_KEY`。
 
 ```bash
 git clone https://github.com/etherfunlab/eros-engine
 cd eros-engine
-cp .env.example .env   # fill in DATABASE_URL, OPENROUTER_API_KEY, VOYAGE_API_KEY, and one auth source
+cp .env.example .env   # Set DATABASE_URL, OPENROUTER_API_KEY, VOYAGE_API_KEY, and one auth source
 
 cargo run -p eros-engine-server -- migrate
 cargo run -p eros-engine-server -- seed-personas examples/personas
 cargo run -p eros-engine-server -- serve
 ```
 
-服务默认监听 `0.0.0.0:8080`。Scalar API 文档位于 `/docs`；原始 OpenAPI JSON 用 `print-openapi` 子命令导出。官方 Eros Chat Web 客户端并未开源——请自行提供 UI，或将这些 crate 嵌入其他服务。
+服务默认监听 `0.0.0.0:8080`，Scalar API 文档位于 `/docs`。官方 Eros Chat Web 客户端并未开源，请自行提供 UI，或将这些 crate 嵌入其他服务。
 
 ## API 一览
 
-默认所有 `/comp/*` 路由都需要 `Authorization: Bearer <Supabase JWT>`（`AuthValidator` trait 可替换成其他身份提供方）。核心端点：
-
-- `POST /comp/chat/start`——与指定人设开启聊天会话。
-- `POST /comp/chat/{session_id}/message/stream`——**核心**对话端点：逐 token 的 Server-Sent Events。每轮可选字段：`tier`、`prompt_traits`、`audit`、`tips_amount_usd`（给角色打赏）、`image_url`（给角色发一张照片）、`image`（请求角色生成一张图片——风格 / 画幅）。图片轮次由引擎组合提示词并发出 `image_request` 帧，聊天流本身不绘图。
-- `GET /comp/chat/{session_id}/history` · `GET /comp/chat/{user_id}/sessions` · `GET /comp/user/{user_id}/profile`——历史、会话列表、结构化画像。
-- `GET /comp/affinity/{session_id}`——仅调试用的实时亲密度向量（`EXPOSE_AFFINITY_DEBUG=true`）。
-
-有关完整的请求 schema、SSE 帧布局（包括聊天流上的 `delta`、`image_request`、ghost 和 error 帧）以及各字段语义，请参阅 [API 参考](docs/api-reference.zh.md)。
+核心流程很简单：创建人设会话，然后向 SSE 流式端点发送对话。引擎还提供历史记录、会话、画像及可选的亲密度调试路由。默认使用 Supabase JWT 鉴权，也可通过 `AuthValidator` 替换。具体路径、payload 与流式帧详见 [API 参考](docs/api-reference.zh.md)。
 
 ## 配置
 
-必填环境变量：`DATABASE_URL`、`OPENROUTER_API_KEY`、`VOYAGE_API_KEY`，以及**一个**身份验证来源——`SUPABASE_URL` / `SUPABASE_JWKS_URL`（JWKS，Supabase 在 2025 年之后的默认方式）**或** `SUPABASE_JWT_SECRET`（旧版 HS256）。若未设置身份验证来源，服务将拒绝启动。
+至少需要设置 `DATABASE_URL`、一个身份验证来源，以及 `OPENROUTER_API_KEY`——OpenRouter 是内置默认提供方，启动时始终需要它的 key。`[providers]` 可加入兼容 OpenAI 的聊天和 embedding 端点，各用各的 key；默认 Voyage embedding 配置需要 `VOYAGE_API_KEY`，除非 `[tasks.embedding]` 将读取和写入都路由到其他提供方。
 
-其余配置均有合理的默认值：模型路由（`MODEL_CONFIG_PATH` → `model_config.toml`，或通过 `MODEL_CONFIG_DIR` 使用拆分的配置目录）、OpenRouter 归因标头、dreaming-lite / snapshot sweepers、用于调整关系难度的 `EMA_INERTIA`，以及调试开关。完整变量清单见 [`.env.example`](.env.example)；操作指南见[部署](docs/deploying.zh.md)，模型路由见[模型配置](docs/model-config.zh.md)。
+完整环境变量见 [`.env.example`](.env.example)，运维说明见[部署](docs/deploying.zh.md)，路由细节见[模型配置](docs/model-config.zh.md)。
 
-## Roadmap
+## 路线图
 
-目前不在引擎里，但在计划中：
+- [ ] **多角色实验场**——多个 AI 人设在同一会话中彼此互动，也与用户互动。
+- [ ] **语音消息**与**原生音频 I/O**——低延迟的语音回合 API 已经就位，STT/TTS 目前由调用方负责。
+- [ ] **视频生成**——由伴侣发送短视频片段。
 
-- [ ] **Agents playground**——多个 AI 人设在同一会话里互相（以及与用户）互动。
-- [ ] **语音消息**——角色发出与用户发出的音频轮次。
-- [ ] **实时语音对话**——低延迟的语音来回。
-- [ ] **视频生成**——角色主动发送的短视频片段，延续图像执行器。
+## 非目标
 
-## 明确不在范围内
-
-本仓库提供对话、记忆和关系状态的核心能力，不包含：
-
-- **匹配**——多阶段过滤、软打分、agent 对 agent 的匹配模拟，仍在闭源产品里。
-- **完整社交 UX**——引导、视频、语音、计费、相册、审核 UI、移动端。
-- **人设来源 / 市场逻辑**——属于商业产品代码，不是引擎的一部分。
-
-如果你在构建其他类型的产品，可复用的部分是亲密度 + 记忆 + 洞察 pipeline。
+本仓库只提供对话、记忆和关系状态的核心。匹配、完整的社交产品体验，以及人设市场或来源逻辑不属于本引擎。可复用的中心是亲密度、记忆与洞察 pipeline。
 
 ## 内容提示
 
-`examples/personas/` 下的示例人设是面向成人的角色聊天示例。当关系状态到位时，它们可以调情、表达欲望，同时仍会拒绝不尊重或越界的行为。如果你的产品需要默认 SFW，请在部署前替换这些人设文件。
+`examples/personas/` 下是面向成人的角色聊天示例。关系发展到相应阶段时，它们可能调情或表达欲望，同时会拒绝不尊重或越界的行为。如果产品需要默认 SFW，请在部署前替换这些人设。
 
-还可通过消息路由中的 [`prompt_traits`](docs/prompt-traits.zh.md) 字段进一步调整每次请求的行为——引擎将传入文本视为不透明内容，因此 `prompt_traits` 所编码的策略完全由前端 / 中间件定义。
+也可通过 [`prompt_traits`](docs/prompt-traits.zh.md) 调整每次请求的行为。引擎将其文本视为不透明内容，具体策略由你的前端或中间件负责。
 
 ## 贡献
 
-阅读 [`CONTRIBUTING.md`](CONTRIBUTING.md)。所有贡献者在首次 PR 时须通过 cla-assistant.io 接受 [`CLA`](CLA.md)。
+请阅读 [`CONTRIBUTING.md`](CONTRIBUTING.md)。贡献者须在首次 PR 时通过 cla-assistant.io 接受 [`CLA`](CLA.md)。
 
 ## 许可
 
-`eros-engine` 以 AGPL-3.0-only 授权。如果 AGPL 不适合你的分发模式，可提供商业授权：`henrylin@etherfun.xyz`。
+`eros-engine` 以 AGPL-3.0-only 授权。如需商业授权，请联系 `henrylin@etherfun.xyz`。

--- a/crates/eros-engine-llm/Cargo.toml
+++ b/crates/eros-engine-llm/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "openrouter", "voyage", "embeddings", "llm"]
 categories = ["api-bindings"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "1.0.2-dev" }
+eros-engine-core = { path = "../eros-engine-core", version = "1.0.2" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/eros-engine-llm/Cargo.toml
+++ b/crates/eros-engine-llm/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "openrouter", "voyage", "embeddings", "llm"]
 categories = ["api-bindings"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "1.0.1" }
+eros-engine-core = { path = "../eros-engine-core", version = "1.0.2-dev" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/eros-engine-server/Cargo.toml
+++ b/crates/eros-engine-server/Cargo.toml
@@ -13,9 +13,9 @@ name = "eros-engine"
 path = "src/main.rs"
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "1.0.1" }
-eros-engine-llm  = { path = "../eros-engine-llm", version = "1.0.1" }
-eros-engine-store = { path = "../eros-engine-store", version = "1.0.1" }
+eros-engine-core = { path = "../eros-engine-core", version = "1.0.2-dev" }
+eros-engine-llm  = { path = "../eros-engine-llm", version = "1.0.2-dev" }
+eros-engine-store = { path = "../eros-engine-store", version = "1.0.2-dev" }
 axum = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/eros-engine-server/Cargo.toml
+++ b/crates/eros-engine-server/Cargo.toml
@@ -13,9 +13,9 @@ name = "eros-engine"
 path = "src/main.rs"
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "1.0.2-dev" }
-eros-engine-llm  = { path = "../eros-engine-llm", version = "1.0.2-dev" }
-eros-engine-store = { path = "../eros-engine-store", version = "1.0.2-dev" }
+eros-engine-core = { path = "../eros-engine-core", version = "1.0.2" }
+eros-engine-llm  = { path = "../eros-engine-llm", version = "1.0.2" }
+eros-engine-store = { path = "../eros-engine-store", version = "1.0.2" }
 axum = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0-only",
       "identifier": "AGPL-3.0-only"
     },
-    "version": "1.0.1"
+    "version": "1.0.2-dev"
   },
   "servers": [
     {

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0-only",
       "identifier": "AGPL-3.0-only"
     },
-    "version": "1.0.2-dev"
+    "version": "1.0.2"
   },
   "servers": [
     {

--- a/crates/eros-engine-server/src/pipeline/dreaming.rs
+++ b/crates/eros-engine-server/src/pipeline/dreaming.rs
@@ -320,6 +320,7 @@ fn normalise_category(raw: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::routes::companion::testutil::seed_persona_instance;
 
     #[test]
     fn parse_memory_candidates_handles_clean_json() {
@@ -454,7 +455,7 @@ mod tests {
         );
 
         let user_id = uuid::Uuid::new_v4();
-        let instance_id = uuid::Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id: uuid::Uuid = sqlx::query_scalar(
             "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
         )

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -1009,6 +1009,7 @@ mod tests {
     // either need a live Voyage key or a trait-mock indirection that
     // doesn't justify its weight for a single thin function.
 
+    use crate::routes::companion::testutil::seed_persona_instance;
     use eros_engine_store::human_insight::HumanInsightRepo;
     use eros_engine_store::memory::{MemoryLayer, MemoryRepo};
     use sqlx::PgPool;
@@ -1055,7 +1056,7 @@ mod tests {
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
     async fn recall_memory_with_embedding_isolates_layers(pool: PgPool) {
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, Some(instance_id)).await;
         let repo = MemoryRepo { pool: &pool };
 
@@ -1107,7 +1108,7 @@ mod tests {
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
     async fn recall_memory_with_embedding_groups_categorised_rows(pool: PgPool) {
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, Some(instance_id)).await;
         let repo = MemoryRepo { pool: &pool };
 
@@ -1180,7 +1181,7 @@ mod tests {
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
     async fn recall_memory_with_embedding_respects_top_k(pool: PgPool) {
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, Some(instance_id)).await;
         let repo = MemoryRepo { pool: &pool };
 
@@ -1236,7 +1237,7 @@ mod tests {
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
     async fn recall_memory_with_embedding_picks_nearest_per_layer(pool: PgPool) {
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, Some(instance_id)).await;
         let repo = MemoryRepo { pool: &pool };
 
@@ -1332,7 +1333,7 @@ mod tests {
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
     async fn recall_gating_skips_layers_per_flags(pool: PgPool) {
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, Some(instance_id)).await;
         let repo = MemoryRepo { pool: &pool };
         repo.upsert(
@@ -2038,7 +2039,7 @@ mod tests {
 
         let chat_repo = ChatRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session = chat_repo
             .create_session(user_id, instance_id)
             .await

--- a/crates/eros-engine-server/src/pipeline/mod.rs
+++ b/crates/eros-engine-server/src/pipeline/mod.rs
@@ -94,6 +94,15 @@ pub(super) fn find_json_block(raw: &str) -> Option<&str> {
     None
 }
 
+/// Parse an LLM reply expected to contain a JSON object of type `T`: try the
+/// whole text first, then fall back to the balanced `{…}` block (via
+/// `find_json_block`) for replies that fence or prose-wrap their JSON.
+pub(super) fn parse_llm_json<T: serde::de::DeserializeOwned>(raw: &str) -> Option<T> {
+    serde_json::from_str::<T>(raw)
+        .ok()
+        .or_else(|| find_json_block(raw).and_then(|b| serde_json::from_str::<T>(b).ok()))
+}
+
 pub async fn compute_signals_for_session(
     pool: &sqlx::PgPool,
     session_id: Uuid,
@@ -339,5 +348,48 @@ mod tests {
         let v: serde_json::Value = serde_json::from_str(block).unwrap();
         assert_eq!(v["a"], "b}c");
         assert_eq!(v["d"]["e"], 1);
+    }
+
+    #[derive(serde::Deserialize, Debug, PartialEq)]
+    struct ParseProbe {
+        verdict: String,
+        score: i32,
+    }
+
+    #[test]
+    fn parse_llm_json_accepts_pure_json() {
+        let raw = r#"{"verdict":"pass","score":3}"#;
+        let parsed: ParseProbe = super::parse_llm_json(raw).unwrap();
+        assert_eq!(
+            parsed,
+            ParseProbe {
+                verdict: "pass".into(),
+                score: 3
+            }
+        );
+    }
+
+    #[test]
+    fn parse_llm_json_falls_back_to_embedded_block() {
+        let raw = "Sure! Here is the result:\n```json\n{\"verdict\":\"fail\",\"score\":-2}\n```\nHope that helps.";
+        let parsed: ParseProbe = super::parse_llm_json(raw).unwrap();
+        assert_eq!(
+            parsed,
+            ParseProbe {
+                verdict: "fail".into(),
+                score: -2
+            }
+        );
+    }
+
+    #[test]
+    fn parse_llm_json_none_when_no_json() {
+        assert!(super::parse_llm_json::<ParseProbe>("no json here").is_none());
+    }
+
+    #[test]
+    fn parse_llm_json_none_when_shape_mismatch() {
+        // Valid JSON block, wrong shape: the fallback must also fail typed.
+        assert!(super::parse_llm_json::<ParseProbe>(r#"prose {"other": 1} prose"#).is_none());
     }
 }

--- a/crates/eros-engine-server/src/pipeline/post_process.rs
+++ b/crates/eros-engine-server/src/pipeline/post_process.rs
@@ -454,9 +454,7 @@ fn parse_affinity_eval(
     String,
 ) {
     use eros_engine_core::affinity::AffinityDeltas;
-    let parsed: Option<LlmAffinityEval> = serde_json::from_str(raw)
-        .ok()
-        .or_else(|| super::find_json_block(raw).and_then(|b| serde_json::from_str(b).ok()));
+    let parsed: Option<LlmAffinityEval> = super::parse_llm_json(raw);
     let Some(e) = parsed else {
         return (AffinityDeltas::default(), None, String::new());
     };
@@ -920,9 +918,7 @@ async fn extract_facts(
     };
 
     // Parse once; distinguish parse_error (no JSON at all) from empty/ok.
-    let parsed = serde_json::from_str::<serde_json::Value>(&raw)
-        .ok()
-        .or_else(|| super::find_json_block(&raw).and_then(|b| serde_json::from_str(b).ok()));
+    let parsed = super::parse_llm_json::<serde_json::Value>(&raw);
     match parsed {
         Some(v) => {
             let facts = extract_facts_array(&v);

--- a/crates/eros-engine-server/src/pipeline/post_process.rs
+++ b/crates/eros-engine-server/src/pipeline/post_process.rs
@@ -1065,6 +1065,7 @@ async fn refresh_lead_score(state: &AppState, session_id: Uuid, user_id: Uuid) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::routes::companion::testutil::seed_persona_instance;
     use uuid::Uuid;
 
     #[test]
@@ -1836,7 +1837,7 @@ mod tests {
         let state = crate::routes::companion::test_state(pool.clone());
 
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = sqlx::query_scalar::<_, Uuid>(
             "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
         )
@@ -1951,7 +1952,7 @@ mod tests {
         use eros_engine_store::affinity::AffinityRepo;
 
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = sqlx::query_scalar::<_, Uuid>(
             "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
         )

--- a/crates/eros-engine-server/src/pipeline/story.rs
+++ b/crates/eros-engine-server/src/pipeline/story.rs
@@ -185,9 +185,7 @@ fn story_response_format() -> serde_json::Value {
 /// Warns (once per round) on unknown insight keys — the fixed field list is
 /// the contract; unknown keys are dropped by the typed deserialize.
 fn parse_story_output(raw: &str) -> Option<StoryOutput> {
-    let value: serde_json::Value = serde_json::from_str(raw)
-        .ok()
-        .or_else(|| super::find_json_block(raw).and_then(|b| serde_json::from_str(b).ok()))?;
+    let value: serde_json::Value = super::parse_llm_json(raw)?;
     if let Some(obj) = value.get("insight").and_then(|v| v.as_object()) {
         let unknown: Vec<&str> = obj
             .keys()

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -578,6 +578,7 @@ fn drive_chat_burst(
                 };
                 let effective_ghost = is_ghost_fallback || regex_ghost;
 
+                let usage_full = last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok());
                 // Persist BEFORE yielding Done (spec §2.3 risk R7).
                 let row = eros_engine_store::chat::AssistantInsert {
                     id: msg_uuid,
@@ -586,7 +587,7 @@ fn drive_chat_burst(
                     continues_from_message_id: continues_from.map(Into::into),
                     truncated,
                     model: Some(model_id.clone()),
-                    usage: last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok()),
+                    usage: usage_full.clone(),
                     generation_id: last_gen_id.clone(),
                     filter_audit,
                     metadata: if is_ghost_fallback {
@@ -612,7 +613,7 @@ fn drive_chat_burst(
                 // Strip OPENROUTER_USAGE_HIDDEN_KEYS from the wire usage. The DB
                 // row above persists the full unfiltered usage; only the frame is
                 // filtered (mirrors the sync send_message path).
-                let mut wire_usage = last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok());
+                let mut wire_usage = usage_full;
                 filter_usage_keys(&mut wire_usage, &state.config.openrouter_usage_hidden_keys);
                 yield ProtocolFrame::Done {
                     message_id: ulid_string(msg_ulid),
@@ -873,6 +874,8 @@ fn drive_chat_burst(
                     // "empty_completion" so ops can tell the two apart.
                     let msg_ulid = Ulid::new();
                     let msg_uuid: Uuid = msg_ulid.into();
+                    let usage_full =
+                        last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok());
                     let row = eros_engine_store::chat::AssistantInsert {
                         id: msg_uuid,
                         content: String::new(),
@@ -880,7 +883,7 @@ fn drive_chat_burst(
                         continues_from_message_id: None,
                         truncated: false,
                         model: Some(model_id.clone()),
-                        usage: last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok()),
+                        usage: usage_full.clone(),
                         generation_id: last_gen_id.clone(),
                         filter_audit: None,
                         metadata: ghost_fallback_metadata(build_metadata(None), "empty_completion"),
@@ -923,8 +926,7 @@ fn drive_chat_burst(
                     // on an otherwise-empty completion) — same wire contract as the
                     // other served Done frames; the DB row above already persisted
                     // the full unfiltered usage.
-                    let mut wire_usage =
-                        last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok());
+                    let mut wire_usage = usage_full;
                     filter_usage_keys(&mut wire_usage, &state.config.openrouter_usage_hidden_keys);
                     yield ProtocolFrame::Done {
                         message_id: ulid_string(msg_ulid),
@@ -1128,6 +1130,7 @@ fn drive_chat_burst(
                 };
             }
 
+            let usage_full = last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok());
             let row = eros_engine_store::chat::AssistantInsert {
                 id: msg_uuid,
                 content: visible.clone(),
@@ -1135,7 +1138,7 @@ fn drive_chat_burst(
                 continues_from_message_id: None,
                 truncated: false,
                 model: Some(model_id.clone()),
-                usage: last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok()),
+                usage: usage_full.clone(),
                 generation_id: last_gen_id.clone(),
                 filter_audit,
                 metadata: if is_ghost {
@@ -1157,7 +1160,7 @@ fn drive_chat_burst(
                 action: plan_action,
             });
 
-            let mut wire_usage = last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok());
+            let mut wire_usage = usage_full;
             filter_usage_keys(&mut wire_usage, &state.config.openrouter_usage_hidden_keys);
             if is_ghost {
                 outcome.lock().unwrap().ghost_fallback = true;
@@ -1483,12 +1486,7 @@ struct InputFilterVerdict {
 /// Parse the filter reply into a verdict: direct JSON first, then a balanced
 /// JSON block embedded in prose (mirrors post_process extraction parsing).
 fn parse_input_filter_verdict(text: &str) -> Option<InputFilterVerdict> {
-    serde_json::from_str::<InputFilterVerdict>(text)
-        .ok()
-        .or_else(|| {
-            super::find_json_block(text)
-                .and_then(|b| serde_json::from_str::<InputFilterVerdict>(b).ok())
-        })
+    super::parse_llm_json(text)
 }
 
 // ── PDE judge primitives ──────────────────────────────────────────────────────
@@ -1540,9 +1538,7 @@ pub(crate) struct PdeVerdict {
 /// Parse the judge reply: direct JSON first, then a balanced JSON block in prose
 /// (mirrors `parse_input_filter_verdict`).
 fn parse_pde_verdict(text: &str) -> Option<PdeVerdict> {
-    serde_json::from_str::<PdeVerdict>(text).ok().or_else(|| {
-        super::find_json_block(text).and_then(|b| serde_json::from_str::<PdeVerdict>(b).ok())
-    })
+    super::parse_llm_json(text)
 }
 
 const INNER_STATE_MAX_CHARS: usize = 200;
@@ -2033,9 +2029,7 @@ struct ImageVision {
 /// Parse the describe reply: direct JSON first, then a balanced JSON block
 /// embedded in prose (mirrors `parse_input_filter_verdict`).
 fn parse_image_vision(text: &str) -> Option<ImageVision> {
-    serde_json::from_str::<ImageVision>(text).ok().or_else(|| {
-        super::find_json_block(text).and_then(|b| serde_json::from_str::<ImageVision>(b).ok())
-    })
+    super::parse_llm_json(text)
 }
 
 /// Validity gate for a parsed describe. Reject a `content_filter` finish reason,
@@ -2418,9 +2412,7 @@ struct ComposeReply {
 ///
 /// A blank caption is normalised to `None`; callers must not persist `""`.
 pub(crate) fn parse_compose_reply(raw: &str) -> (String, Option<String>) {
-    let parsed = serde_json::from_str::<ComposeReply>(raw).ok().or_else(|| {
-        super::find_json_block(raw).and_then(|b| serde_json::from_str::<ComposeReply>(b).ok())
-    });
+    let parsed = super::parse_llm_json::<ComposeReply>(raw);
     match parsed {
         Some(r) => {
             let caption = r

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -830,6 +830,16 @@ pub(crate) mod testutil {
         .await
         .unwrap()
     }
+
+    /// Genome + active instance in one step, returning the instance id.
+    /// Since 0040 `chat_sessions.instance_id` carries a real FK, so tests that
+    /// only need "some valid instance" must persist one instead of fabricating
+    /// a bare `Uuid::new_v4()`. The genome name is randomised so repeat calls
+    /// never collide on `persona_instances UNIQUE(genome_id, owner_uid)`.
+    pub(crate) async fn seed_persona_instance(pool: &PgPool, owner: Uuid) -> Uuid {
+        let genome_id = seed_genome(pool, &format!("seed-{}", Uuid::new_v4())).await;
+        seed_instance(pool, genome_id, owner).await
+    }
 }
 
 #[cfg(test)]

--- a/crates/eros-engine-server/src/routes/companion_stream.rs
+++ b/crates/eros-engine-server/src/routes/companion_stream.rs
@@ -597,6 +597,7 @@ pub fn router() -> OpenApiRouter<AppState> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::routes::companion::testutil::seed_persona_instance;
     use axum::body::{to_bytes, Body};
     use axum::http::{header, Request};
     use axum::Router;
@@ -974,8 +975,9 @@ mod tests {
         let persisted = serde_json::Value::Object(meta_map);
 
         let chat_repo = ChatRepo { pool: &pool };
+        let user_id = uuid::Uuid::new_v4();
         let session = chat_repo
-            .create_session(uuid::Uuid::new_v4(), uuid::Uuid::new_v4())
+            .create_session(user_id, seed_persona_instance(&pool, user_id).await)
             .await
             .unwrap();
         chat_repo
@@ -1086,8 +1088,9 @@ mod tests {
     async fn user_row_omits_scope_raw_keys_when_request_fields_are_none(pool: sqlx::PgPool) {
         use eros_engine_store::chat::ChatRepo;
         let chat_repo = ChatRepo { pool: &pool };
+        let user_id = uuid::Uuid::new_v4();
         let session = chat_repo
-            .create_session(uuid::Uuid::new_v4(), uuid::Uuid::new_v4())
+            .create_session(user_id, seed_persona_instance(&pool, user_id).await)
             .await
             .unwrap();
         // None of the three optional fields present, no tip, no tier → meta_map

--- a/crates/eros-engine-server/src/routes/voice.rs
+++ b/crates/eros-engine-server/src/routes/voice.rs
@@ -239,6 +239,7 @@ pub fn router() -> OpenApiRouter<AppState> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::routes::companion::testutil::seed_persona_instance;
     use axum::body::Body;
     use axum::http::{header, Request};
     use axum::Router;
@@ -448,22 +449,31 @@ mod tests {
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
-    async fn voice_404_when_persona_instance_missing(pool: PgPool) {
-        // A session whose persona instance is missing/inactive must be rejected
-        // pre-stream (404) WITHOUT persisting a user row. chat_sessions.instance_id
-        // has no FK, so a dangling instance_id is possible; load_companion also
-        // filters status='active', so an archived instance takes the same path.
+    async fn voice_404_when_persona_instance_inactive(pool: PgPool) {
+        // A session whose persona instance is not active must be rejected
+        // pre-stream (404) WITHOUT persisting a user row. Archival is the only
+        // way to reach this state — 0040 gave chat_sessions.instance_id a real
+        // FK, so a dangling id can no longer be written and a deleted instance
+        // takes its sessions with it (ON DELETE CASCADE). That matches
+        // production: the engine only ever flips status to 'archived', it never
+        // DELETEs an instance. load_companion filters status = 'active', so
+        // this lands on the same 404 branch the dangling case used to take.
         let user_id = Uuid::new_v4();
-        let missing_instance = Uuid::new_v4(); // no matching persona_instances row
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id: Uuid = sqlx::query_scalar(
             "INSERT INTO engine.chat_sessions (user_id, instance_id, channel) \
              VALUES ($1, $2, 'voice') RETURNING id",
         )
         .bind(user_id)
-        .bind(missing_instance)
+        .bind(instance_id)
         .fetch_one(&pool)
         .await
         .unwrap();
+        sqlx::query("UPDATE engine.persona_instances SET status = 'archived' WHERE id = $1")
+            .bind(instance_id)
+            .execute(&pool)
+            .await
+            .unwrap();
 
         let mut app = build_router(with_voice(crate::routes::companion::test_state(
             pool.clone(),

--- a/crates/eros-engine-store/Cargo.toml
+++ b/crates/eros-engine-store/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "memory", "pgvector", "postgres", "sqlx"]
 categories = ["database"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "1.0.2-dev" }
+eros-engine-core = { path = "../eros-engine-core", version = "1.0.2" }
 sqlx = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/eros-engine-store/Cargo.toml
+++ b/crates/eros-engine-store/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "memory", "pgvector", "postgres", "sqlx"]
 categories = ["database"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "1.0.1" }
+eros-engine-core = { path = "../eros-engine-core", version = "1.0.2-dev" }
 sqlx = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/eros-engine-store/migrations/0040_persona_instance_fks.sql
+++ b/crates/eros-engine-store/migrations/0040_persona_instance_fks.sql
@@ -1,0 +1,42 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+--
+-- The three original instance-scoped tables — chat_sessions (0001),
+-- companion_affinity (0002) and companion_memories (0003) — reference
+-- engine.persona_instances(id) by convention only. They predate the
+-- world/story tables (0035-0039), which all declare a real foreign key, so
+-- nothing at the DB level stopped a bogus instance_id from being written and
+-- no cascade fired when an instance row was removed out of band.
+--
+-- The practical cost beyond integrity: without a declared FK the Supabase
+-- table editor renders instance_id as a plain UUID column, so there is no way
+-- to navigate from a session to its persona instance — you copy the UUID out
+-- and search the other table by hand, which is easy to get wrong when a row
+-- carries two similar-looking UUIDs (its own id and its instance_id).
+--
+-- ON DELETE CASCADE matches all six existing FKs into persona_instances. The
+-- engine itself never DELETEs an instance — it flips status to 'archived' and
+-- PersonaStore::ensure_active_instance reactivates it — so this only governs
+-- deliberate out-of-band deletion, where wiping the instance's data is the
+-- point. chat_messages already cascades from chat_sessions, so dropping an
+-- instance now takes its whole conversation history with it in one step.
+--
+-- companion_memories.instance_id stays nullable (NULL = profile layer, see
+-- 0003); a foreign key ignores NULL, so profile-layer rows are unaffected.
+--
+-- All three columns were verified orphan-free beforehand and the tables are
+-- small, so the constraints go in validated rather than NOT VALID + VALIDATE.
+
+ALTER TABLE engine.chat_sessions
+    ADD CONSTRAINT chat_sessions_instance_id_fkey
+    FOREIGN KEY (instance_id) REFERENCES engine.persona_instances(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE engine.companion_affinity
+    ADD CONSTRAINT companion_affinity_instance_id_fkey
+    FOREIGN KEY (instance_id) REFERENCES engine.persona_instances(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE engine.companion_memories
+    ADD CONSTRAINT companion_memories_instance_id_fkey
+    FOREIGN KEY (instance_id) REFERENCES engine.persona_instances(id)
+    ON DELETE CASCADE;

--- a/crates/eros-engine-store/src/affinity.rs
+++ b/crates/eros-engine-store/src/affinity.rs
@@ -387,6 +387,7 @@ impl<'a> AffinityRepo<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::testutil::seed_persona_instance;
 
     async fn make_session(pool: &PgPool, user_id: Uuid, instance_id: Uuid) -> Uuid {
         sqlx::query_scalar::<_, Uuid>(
@@ -404,7 +405,7 @@ mod tests {
     async fn load_or_create_idempotent(pool: PgPool) {
         let repo = AffinityRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, instance_id).await;
 
         let a1 = repo
@@ -425,7 +426,7 @@ mod tests {
     async fn persist_with_event_updates_vector_and_logs(pool: PgPool) {
         let repo = AffinityRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, instance_id).await;
 
         let mut a = repo
@@ -476,7 +477,7 @@ mod tests {
     async fn record_ghost_increments_counters(pool: PgPool) {
         let repo = AffinityRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, instance_id).await;
 
         let mut a = repo
@@ -499,7 +500,7 @@ mod tests {
     async fn persist_with_event_records_post_ema_effective(pool: PgPool) {
         let repo = AffinityRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, instance_id).await;
         let mut a = repo
             .load_or_create(session_id, user_id, instance_id)
@@ -546,7 +547,7 @@ mod tests {
     async fn persist_with_event_effective_reflects_clamping(pool: PgPool) {
         let repo = AffinityRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, instance_id).await;
         let mut a = repo
             .load_or_create(session_id, user_id, instance_id)
@@ -585,7 +586,7 @@ mod tests {
     async fn record_ghost_writes_zero_effective_deltas(pool: PgPool) {
         let repo = AffinityRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, instance_id).await;
         let mut a = repo
             .load_or_create(session_id, user_id, instance_id)
@@ -613,7 +614,7 @@ mod tests {
     async fn concurrent_persist_with_event_does_not_lose_updates(pool: PgPool) {
         let repo = AffinityRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, instance_id).await;
         let base = repo
             .load_or_create(session_id, user_id, instance_id)
@@ -686,7 +687,7 @@ mod tests {
     async fn persist_with_event_flips_label_when_axes_cross_thresholds(pool: PgPool) {
         let repo = AffinityRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, instance_id).await;
         let mut a = repo
             .load_or_create(session_id, user_id, instance_id)
@@ -744,7 +745,7 @@ mod tests {
     async fn list_events_newest_first_with_filter(pool: PgPool) {
         let repo = AffinityRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, instance_id).await;
         let a = repo
             .load_or_create(session_id, user_id, instance_id)
@@ -776,7 +777,7 @@ mod tests {
     async fn latest_turn_event_includes_ghost_skips_time_decay(pool: PgPool) {
         let repo = AffinityRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, instance_id).await;
         let a = repo
             .load_or_create(session_id, user_id, instance_id)
@@ -804,7 +805,7 @@ mod tests {
     async fn latest_turn_event_none_when_only_time_decay(pool: PgPool) {
         let repo = AffinityRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, instance_id).await;
         let a = repo
             .load_or_create(session_id, user_id, instance_id)
@@ -819,7 +820,7 @@ mod tests {
     async fn latest_turn_event_none_for_session_without_events(pool: PgPool) {
         let repo = AffinityRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, instance_id).await;
         repo.load_or_create(session_id, user_id, instance_id)
             .await
@@ -865,7 +866,7 @@ mod tests {
     async fn recent_emotional_reasons_newest_first_skips_empty_and_scoped(pool: PgPool) {
         let repo = AffinityRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, instance_id).await;
         let a = repo
             .load_or_create(session_id, user_id, instance_id)
@@ -902,9 +903,11 @@ mod tests {
         .await; // wrong type → skip
 
         // Another session must not leak in.
-        let other_session = make_session(&pool, Uuid::new_v4(), Uuid::new_v4()).await;
+        let other_user = Uuid::new_v4();
+        let other_instance = seed_persona_instance(&pool, other_user).await;
+        let other_session = make_session(&pool, other_user, other_instance).await;
         let b = repo
-            .load_or_create(other_session, Uuid::new_v4(), Uuid::new_v4())
+            .load_or_create(other_session, other_user, other_instance)
             .await
             .unwrap();
         seed_event_ctx(
@@ -934,7 +937,7 @@ mod tests {
     async fn recent_emotional_reasons_excludes_events_after_cutoff(pool: PgPool) {
         let repo = AffinityRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, instance_id).await;
         let a = repo
             .load_or_create(session_id, user_id, instance_id)
@@ -978,7 +981,7 @@ mod tests {
     async fn generated_bond_chemistry_match_core(pool: PgPool) {
         let repo = AffinityRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, instance_id).await;
         let mut a = repo
             .load_or_create(session_id, user_id, instance_id)
@@ -1017,7 +1020,7 @@ mod tests {
     async fn persist_writes_new_legacy_label(pool: PgPool) {
         let repo = AffinityRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, instance_id).await;
         let mut a = repo
             .load_or_create(session_id, user_id, instance_id)
@@ -1051,7 +1054,7 @@ mod tests {
     async fn persist_with_event_patience_target_sets_directly_bypassing_ema(pool: PgPool) {
         let repo = AffinityRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, instance_id).await;
         let mut a = repo
             .load_or_create(session_id, user_id, instance_id)
@@ -1107,7 +1110,7 @@ mod tests {
     async fn persist_with_event_patience_none_keeps_ema_path(pool: PgPool) {
         let repo = AffinityRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, instance_id).await;
         let mut a = repo
             .load_or_create(session_id, user_id, instance_id)
@@ -1143,7 +1146,7 @@ mod tests {
     async fn label_changes_recorded_on_tier_crossing_and_null_otherwise(pool: PgPool) {
         let repo = AffinityRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, instance_id).await;
         let mut a = repo
             .load_or_create(session_id, user_id, instance_id)
@@ -1199,7 +1202,7 @@ mod tests {
     async fn effective_line_deltas_are_floored_exact(pool: PgPool) {
         let repo = AffinityRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, instance_id).await;
         let mut a = repo
             .load_or_create(session_id, user_id, instance_id)
@@ -1243,7 +1246,7 @@ mod tests {
     async fn persist_with_event_stores_openrouter_audit_trio(pool: PgPool) {
         let repo = AffinityRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, instance_id).await;
         let mut a = repo
             .load_or_create(session_id, user_id, instance_id)

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -1051,12 +1051,25 @@ impl<'a> ChatRepo<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::testutil::seed_persona_instance;
+
+    /// A session on a freshly seeded persona instance, for the many tests that
+    /// just need "some session" and never look at the ids. Since 0040 the FK on
+    /// `chat_sessions.instance_id` rejects a fabricated `Uuid::new_v4()`.
+    async fn throwaway_session(pool: &PgPool) -> ChatSession {
+        let owner = Uuid::new_v4();
+        let instance_id = seed_persona_instance(pool, owner).await;
+        ChatRepo { pool }
+            .create_session(owner, instance_id)
+            .await
+            .unwrap()
+    }
 
     #[sqlx::test(migrations = "./migrations")]
     async fn create_then_retrieve_session(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let s = repo.create_session(user_id, instance_id).await.unwrap();
         let loaded = repo.get_session(s.id).await.unwrap().unwrap();
         assert_eq!(loaded.user_id, user_id);
@@ -1069,7 +1082,7 @@ mod tests {
     async fn append_message_and_history_roundtrip(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let s = repo.create_session(user_id, instance_id).await.unwrap();
 
         repo.append_message(s.id, "user", "hello").await.unwrap();
@@ -1093,7 +1106,7 @@ mod tests {
     async fn history_slim_returns_role_content_sent_at_in_order(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let s = repo.create_session(user_id, instance_id).await.unwrap();
 
         repo.append_message(s.id, "user", "alpha").await.unwrap();
@@ -1117,7 +1130,7 @@ mod tests {
     async fn history_slim_respects_limit_and_offset(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let s = repo.create_session(user_id, instance_id).await.unwrap();
         for n in 0..5 {
             repo.append_message(s.id, "user", &format!("m{n}"))
@@ -1144,7 +1157,7 @@ mod tests {
     async fn history_slim_exposes_channel(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let s = repo.create_session(user_id, instance_id).await.unwrap();
 
         repo.append_message(s.id, "user", "normal turn")
@@ -1175,9 +1188,9 @@ mod tests {
         let user_id = Uuid::new_v4();
         let other_user = Uuid::new_v4();
 
-        let i1 = Uuid::new_v4();
-        let i2 = Uuid::new_v4();
-        let i3 = Uuid::new_v4();
+        let i1 = seed_persona_instance(&pool, user_id).await;
+        let i2 = seed_persona_instance(&pool, user_id).await;
+        let i3 = seed_persona_instance(&pool, other_user).await;
 
         repo.create_session(user_id, i1).await.unwrap();
         repo.create_session_with_metadata(user_id, i2, serde_json::json!({}), "voice")
@@ -1204,7 +1217,7 @@ mod tests {
     async fn create_or_resume_returns_existing(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let first = repo.create_session(user_id, instance_id).await.unwrap();
         let resumed = repo.create_or_resume(user_id, instance_id).await.unwrap();
         assert_eq!(first.id, resumed.id);
@@ -1214,7 +1227,7 @@ mod tests {
     async fn upsert_user_message_idempotent_first_insert(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let s = repo.create_session(user_id, instance_id).await.unwrap();
 
         let outcome = repo
@@ -1239,7 +1252,7 @@ mod tests {
     async fn upsert_user_message_idempotent_replay_after_done(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let s = repo.create_session(user_id, instance_id).await.unwrap();
 
         let first = match repo
@@ -1307,7 +1320,7 @@ mod tests {
     async fn upsert_user_message_idempotent_409_when_no_assistant_and_not_ghost(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let s = repo.create_session(user_id, instance_id).await.unwrap();
 
         let first = match repo
@@ -1347,7 +1360,7 @@ mod tests {
     async fn upsert_user_message_idempotent_replay_when_ghost(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let s = repo.create_session(user_id, instance_id).await.unwrap();
 
         let first = match repo
@@ -1393,7 +1406,7 @@ mod tests {
     async fn resume_latest_session_returns_latest_and_bumps(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
 
         // no session yet → None
         assert!(repo
@@ -1444,10 +1457,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn upsert_user_message_writes_role_user_and_no_metadata(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
         let outcome = repo
             .upsert_user_message_idempotent(s.id, "hi", "01J0000000000000000000000A", "user", None)
             .await
@@ -1472,10 +1482,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn upsert_user_message_writes_gift_user_role_and_tip_metadata(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
         let meta = serde_json::json!({ "tips_amount_usd": 20.0, "tier": "gold" });
         repo.upsert_user_message_idempotent(
             s.id,
@@ -1500,10 +1507,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn upsert_user_message_replay_finds_gift_user_row(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
         let meta = serde_json::json!({ "tips_amount_usd": 5.0 });
         repo.upsert_user_message_idempotent(
             s.id,
@@ -1537,10 +1541,7 @@ mod tests {
     #[allow(clippy::type_complexity)] // sqlx tuple query — type alias would add noise
     async fn assistant_batch_round_trips_filter_audit(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
         let user_msg_id = match repo
             .upsert_user_message_idempotent(s.id, "hi", "01J0000000000000000000001A", "user", None)
             .await
@@ -1604,10 +1605,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn assistant_batch_filter_audit_columns_default_null(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
         let user_msg_id = match repo
             .upsert_user_message_idempotent(s.id, "hi", "01J0000000000000000000002A", "user", None)
             .await
@@ -1680,10 +1678,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn assistant_batch_filter_audit_with_none_generation_id_writes_null(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
         let user_msg_id = match repo
             .upsert_user_message_idempotent(s.id, "hi", "01J0000000000000000000003A", "user", None)
             .await
@@ -1732,10 +1727,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn assistant_batch_filter_triggers_json_null_persists_as_sql_null(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
         let user_msg_id = match repo
             .upsert_user_message_idempotent(s.id, "hi", "01J0000000000000000000004A", "user", None)
             .await
@@ -1788,10 +1780,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn assistant_batch_persists_metadata_with_prompt_traits(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
         let user_msg_id = match repo
             .upsert_user_message_idempotent(s.id, "hi", "01J0000000000000000000004A", "user", None)
             .await
@@ -1830,10 +1819,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn assistant_batch_metadata_default_null(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
         let user_msg_id = match repo
             .upsert_user_message_idempotent(s.id, "hi", "01J0000000000000000000005A", "user", None)
             .await
@@ -1871,10 +1857,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn assistant_batch_persists_metadata_with_tier(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
         let user_msg_id = match repo
             .upsert_user_message_idempotent(s.id, "hi", "01J0000000000000000000006A", "user", None)
             .await
@@ -1916,10 +1899,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn recent_turn_pairs_empty_session_returns_empty(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
         let cutoff = Utc::now() + chrono::Duration::seconds(60);
         let pairs = repo.recent_turn_pairs(s.id, cutoff, 3).await.unwrap();
         assert!(pairs.is_empty());
@@ -1928,10 +1908,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn recent_turn_pairs_single_pair_returned(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
         let user_msg_id = match repo
             .upsert_user_message_idempotent(s.id, "hi", "01J0000000000000000010001A", "user", None)
             .await
@@ -1964,10 +1941,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn recent_turn_pairs_skips_truncated_assistant(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
 
         let u1 = match repo
             .upsert_user_message_idempotent(s.id, "u1", "01J0000000000000000020001A", "user", None)
@@ -2033,10 +2007,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn recent_turn_pairs_returns_latest_three_when_more_exist(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
         // Insert 5 complete pairs.
         for n in 0..5u8 {
             // ULIDs must be unique and monotonic. Use n in the suffix:
@@ -2084,10 +2055,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn recent_turn_pairs_cutoff_excludes_current_turn(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
         let u1 = match repo
             .upsert_user_message_idempotent(s.id, "u1", "01J0000000000000000040001A", "user", None)
             .await
@@ -2136,10 +2104,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn recent_turn_pairs_drops_orphan_user_at_end(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
         let u1 = match repo
             .upsert_user_message_idempotent(s.id, "u1", "01J0000000000000000050001A", "user", None)
             .await
@@ -2179,10 +2144,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn recent_turn_pairs_includes_gift_user_pair(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
         let meta = serde_json::json!({"tips_amount_usd": 20.0});
         let u1 = match repo
             .upsert_user_message_idempotent(
@@ -2228,10 +2190,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn set_user_input_rewrite_stamps_audit_keeps_content(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let session = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let session = throwaway_session(&pool).await;
         let umid = match repo
             .upsert_user_message_idempotent(
                 session.id,
@@ -2285,10 +2244,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn set_user_input_rewrite_blank_reason_leaves_triggers_null(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let session = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let session = throwaway_session(&pool).await;
         let umid = match repo
             .upsert_user_message_idempotent(
                 session.id,
@@ -2321,10 +2277,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn recent_turn_pairs_before_message_uses_msg_sent_at_not_now(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(uuid::Uuid::new_v4(), uuid::Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
 
         // Insert 1 prior complete pair.
         let u1 = match repo
@@ -2398,7 +2351,7 @@ mod tests {
     async fn history_row_exposes_metadata_column(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let s = repo.create_session(user_id, instance_id).await.unwrap();
 
         let meta = serde_json::json!({ "image_url": "https://x/y.png" });
@@ -2424,7 +2377,7 @@ mod tests {
     async fn set_user_image_vision_merges_and_preserves(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let s = repo.create_session(user_id, instance_id).await.unwrap();
 
         let seed = serde_json::json!({ "image_url": "https://x/y.png" });
@@ -2470,7 +2423,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn migration_0027_drops_legacy_non_tip_gift_user_rows(pool: PgPool) {
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id: Uuid = sqlx::query_scalar(
             "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
         )
@@ -2535,7 +2488,7 @@ mod tests {
         let repo = ChatRepo { pool: &pool };
         // minimal session + user row + assistant row
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let s = repo.create_session(user_id, instance_id).await.unwrap();
         let u = match repo
             .upsert_user_message_idempotent(
@@ -2591,7 +2544,7 @@ mod tests {
         // scope via the test module's `use super::*;`.
         let chat_repo = ChatRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session = chat_repo
             .create_session(user_id, instance_id)
             .await
@@ -2677,14 +2630,8 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn message_sent_at_in_session_scopes_by_session(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
-        let other = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
+        let other = throwaway_session(&pool).await;
         let base = chrono::Utc::now();
         let m = insert_at(&pool, s.id, "user", "hi", base).await;
         let n = insert_at(&pool, other.id, "user", "yo", base).await;
@@ -2711,10 +2658,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn history_anchored_rewind_drops_between_and_keeps_m_and_u(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
         let base = chrono::Utc::now();
         // A B M C D E U with strictly increasing sent_at.
         let labels = ["A", "B", "M", "C", "D", "E", "U"];
@@ -2755,10 +2699,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn history_anchored_drop_history_returns_only_current(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
         let base = chrono::Utc::now();
         insert_at(&pool, s.id, "user", "old1", base).await;
         insert_at(
@@ -2790,10 +2731,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn history_anchored_rewind_counts_current_toward_limit(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
         let base = chrono::Utc::now();
         // A B M C D E U with strictly increasing sent_at.
         let labels = ["A", "B", "M", "C", "D", "E", "U"];
@@ -2834,10 +2772,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn merge_assistant_metadata_key_writes_under_named_key(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let s = repo
-            .create_session(Uuid::new_v4(), Uuid::new_v4())
-            .await
-            .unwrap();
+        let s = throwaway_session(&pool).await;
         let user_msg_id = match repo
             .upsert_user_message_idempotent(s.id, "hi", "01J0000000000000000000002A", "user", None)
             .await
@@ -2900,14 +2835,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn channel_column_accepts_voice_and_null_rejects_other(pool: PgPool) {
         // Minimal session to satisfy FKs.
-        let session_id: Uuid = sqlx::query_scalar(
-            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
-        )
-        .bind(Uuid::new_v4())
-        .bind(Uuid::new_v4())
-        .fetch_one(&pool)
-        .await
-        .unwrap();
+        let session_id = throwaway_session(&pool).await.id;
 
         // NULL channel (default) — ok.
         sqlx::query(
@@ -2942,14 +2870,7 @@ mod tests {
 
     #[sqlx::test(migrations = "./migrations")]
     async fn voice_inserts_are_marked_and_idempotent(pool: PgPool) {
-        let session_id: Uuid = sqlx::query_scalar(
-            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
-        )
-        .bind(Uuid::new_v4())
-        .bind(Uuid::new_v4())
-        .fetch_one(&pool)
-        .await
-        .unwrap();
+        let session_id = throwaway_session(&pool).await.id;
         let repo = ChatRepo { pool: &pool };
 
         // User insert: idempotent on client_msg_id.
@@ -3025,14 +2946,7 @@ mod tests {
         // (`gift_user`) row must be classified as Duplicate (→ 409), not error
         // out with RowNotFound (→ 500). The unique index is role-agnostic, so
         // the conflict-recovery SELECT must not filter by role.
-        let session_id: Uuid = sqlx::query_scalar(
-            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
-        )
-        .bind(Uuid::new_v4())
-        .bind(Uuid::new_v4())
-        .fetch_one(&pool)
-        .await
-        .unwrap();
+        let session_id = throwaway_session(&pool).await.id;
         let cmid = "01J9000000000000000000GIFT1";
         sqlx::query(
             "INSERT INTO engine.chat_messages (session_id, role, content, client_msg_id) \
@@ -3059,14 +2973,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn channel_check_accepts_product_qa_and_rejects_unknown(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let session_id: Uuid = sqlx::query_scalar(
-            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
-        )
-        .bind(Uuid::new_v4())
-        .bind(Uuid::new_v4())
-        .fetch_one(&pool)
-        .await
-        .unwrap();
+        let session_id = throwaway_session(&pool).await.id;
 
         // product_qa accepted
         sqlx::query(
@@ -3098,7 +3005,8 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn sessions_are_channel_scoped(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let (user_id, instance_id) = (Uuid::new_v4(), Uuid::new_v4());
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
 
         let text = repo.create_session(user_id, instance_id).await.unwrap();
 
@@ -3134,14 +3042,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn mark_user_message_product_qa_stamps_channel_idempotently(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let session_id: Uuid = sqlx::query_scalar(
-            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
-        )
-        .bind(Uuid::new_v4())
-        .bind(Uuid::new_v4())
-        .fetch_one(&pool)
-        .await
-        .unwrap();
+        let session_id = throwaway_session(&pool).await.id;
         let user_id: Uuid = sqlx::query_scalar(
             "INSERT INTO engine.chat_messages (session_id, role, content) \
              VALUES ($1, 'user', '介绍下这个产品') RETURNING id",
@@ -3166,14 +3067,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn insert_product_qa_assistant_message_round_trips(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let session_id: Uuid = sqlx::query_scalar(
-            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
-        )
-        .bind(Uuid::new_v4())
-        .bind(Uuid::new_v4())
-        .fetch_one(&pool)
-        .await
-        .unwrap();
+        let session_id = throwaway_session(&pool).await.id;
         let user_id: Uuid = sqlx::query_scalar(
             "INSERT INTO engine.chat_messages (session_id, role, content) \
              VALUES ($1, 'user', 'q') RETURNING id",
@@ -3212,14 +3106,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn recent_product_qa_pairs_returns_only_marked_pairs_before_cutoff(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let session_id: Uuid = sqlx::query_scalar(
-            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
-        )
-        .bind(Uuid::new_v4())
-        .bind(Uuid::new_v4())
-        .fetch_one(&pool)
-        .await
-        .unwrap();
+        let session_id = throwaway_session(&pool).await.id;
         // normal pair (must NOT appear)
         for (role, content) in [("user", "嗨"), ("assistant", "嗨呀")] {
             sqlx::query(
@@ -3268,14 +3155,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn context_readers_exclude_channel_marked_rows(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
-        let session_id: Uuid = sqlx::query_scalar(
-            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
-        )
-        .bind(Uuid::new_v4())
-        .bind(Uuid::new_v4())
-        .fetch_one(&pool)
-        .await
-        .unwrap();
+        let session_id = throwaway_session(&pool).await.id;
         // one normal pair, one product_qa pair, then cutoff row
         for (role, content, channel) in [
             ("user", "嗨", None::<&str>),

--- a/crates/eros-engine-store/src/lib.rs
+++ b/crates/eros-engine-store/src/lib.rs
@@ -26,6 +26,39 @@ pub struct OpenRouterCallMeta {
     pub usage: Option<serde_json::Value>,
 }
 
+/// Test helpers shared across this crate's `#[cfg(test)]` modules.
+#[cfg(test)]
+pub(crate) mod testutil {
+    use sqlx::PgPool;
+    use uuid::Uuid;
+
+    /// Persist a genome + active instance and return the instance id.
+    /// Since 0040 `chat_sessions.instance_id`, `companion_affinity.instance_id`
+    /// and `companion_memories.instance_id` carry real FKs, so a test that just
+    /// needs "some valid instance" has to own one rather than fabricate a bare
+    /// `Uuid::new_v4()`. The genome name is randomised so repeat calls never
+    /// collide on `persona_instances UNIQUE(genome_id, owner_uid)`.
+    pub(crate) async fn seed_persona_instance(pool: &PgPool, owner: Uuid) -> Uuid {
+        let genome_id = sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata) \
+             VALUES ($1, 'you are a companion', '{}'::jsonb) RETURNING id",
+        )
+        .bind(format!("seed-{}", Uuid::new_v4()))
+        .fetch_one(pool)
+        .await
+        .unwrap();
+        sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO engine.persona_instances (genome_id, owner_uid) \
+             VALUES ($1, $2) RETURNING id",
+        )
+        .bind(genome_id)
+        .bind(owner)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+    }
+}
+
 #[cfg(test)]
 mod migration_tests {
     use sqlx::PgPool;
@@ -52,6 +85,36 @@ mod migration_tests {
         .await
         .expect("query relrowsecurity for _sqlx_migrations");
         assert!(enabled, "RLS must be enabled on public._sqlx_migrations");
+    }
+
+    /// 0040 closed the gap where the three original instance-scoped tables
+    /// referenced `persona_instances` by convention only. Pins both the
+    /// existence of each FK and its ON DELETE action — a plain `REFERENCES`
+    /// (confdeltype 'a' = NO ACTION) would silently block instance deletion
+    /// instead of wiping the instance's data, which is not what 0040 chose.
+    #[sqlx::test(migrations = "./migrations")]
+    async fn migration_0040_instance_fks_exist_with_cascade(pool: PgPool) {
+        for table in ["chat_sessions", "companion_affinity", "companion_memories"] {
+            let deltype: Option<i8> = sqlx::query_scalar(
+                "SELECT c.confdeltype::text::\"char\" FROM pg_constraint c \
+                 JOIN unnest(c.conkey) k(attnum) ON true \
+                 JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = k.attnum \
+                 WHERE c.contype = 'f' \
+                   AND c.conrelid = ('engine.' || $1)::regclass \
+                   AND c.confrelid = 'engine.persona_instances'::regclass \
+                   AND a.attname = 'instance_id'",
+            )
+            .bind(table)
+            .fetch_optional(&pool)
+            .await
+            .expect("query instance_id foreign key")
+            .flatten();
+            assert_eq!(
+                deltype,
+                Some(b'c' as i8),
+                "engine.{table}.instance_id must carry an ON DELETE CASCADE FK to persona_instances"
+            );
+        }
     }
 
     #[sqlx::test(migrations = "./migrations")]

--- a/crates/eros-engine-store/src/memory.rs
+++ b/crates/eros-engine-store/src/memory.rs
@@ -188,6 +188,7 @@ impl<'a> MemoryRepo<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::testutil::seed_persona_instance;
 
     fn unit_embedding(seed: usize) -> Vec<f32> {
         // Generate a deterministic 512-dim vector with a single hot index.
@@ -212,7 +213,7 @@ mod tests {
     async fn upsert_then_retrieve(pool: PgPool) {
         let repo = MemoryRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, Some(instance_id)).await;
 
         let emb = unit_embedding(7);
@@ -244,7 +245,7 @@ mod tests {
     async fn cosine_search_picks_nearest_neighbour(pool: PgPool) {
         let repo = MemoryRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, Some(instance_id)).await;
 
         let target_id = repo
@@ -297,7 +298,7 @@ mod tests {
     async fn relationship_search_excludes_legacy_transcript_rows(pool: PgPool) {
         let repo = MemoryRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, Some(instance_id)).await;
 
         // Legacy verbatim turn (contains "\nAI："). It is the NEAREST neighbour
@@ -422,7 +423,7 @@ mod tests {
     async fn category_roundtrips_through_search(pool: PgPool) {
         let repo = MemoryRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, Some(instance_id)).await;
 
         repo.upsert(
@@ -466,7 +467,7 @@ mod tests {
     async fn profile_layer_isolates_from_relationship(pool: PgPool) {
         let repo = MemoryRepo { pool: &pool };
         let user_id = Uuid::new_v4();
-        let instance_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
         let session_id = make_session(&pool, user_id, Some(instance_id)).await;
 
         // Profile-layer write has instance_id forced to NULL.


### PR DESCRIPTION
Promotes `dev` to `main` for the **v1.0.2** stable release. Squash-merge, then the signed `v1.0.2` tag goes on the resulting `main` commit.

## Release delta — PRs merged into `dev` since v1.0.1

- #224 — `fix(store)!`: add missing `persona_instances` FKs on the three original tables ⚠️ **breaking**
- #222 — `docs(readme)`: simplify abstract, rename "Why this exists" to "Highlights" (en/zh/ja)
- #221 — `refactor(server)`: dedupe LLM-reply JSON parsing, single usage `to_value` per arm
- #226 — `chore(release)`: v1.0.2 version bump

#222 already reached `main` separately via #223, so its content is a no-op here; it is listed for completeness of the `dev` delta.

## Breaking change

#224 adds real foreign keys (`0040_persona_instance_fks.sql`) on `chat_sessions.instance_id`, `companion_affinity.instance_id` and `companion_memories.instance_id`, all `ON DELETE CASCADE`. A direct DB writer inserting an unknown `instance_id` now gets `23503`, and deleting an instance now cascades to its chat history. The engine never `DELETE`s an instance (it archives), so the cascade only governs deliberate out-of-band deletion.

## Verification

Local, on the release commit:

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — 1153 passed, 0 failed (69 + 372 + 526 + 186)
- `openapi.json` regenerated; diff is the `info.version` line only

## Post-merge sequence

1. Signed `v1.0.2` tag on the squashed `main` commit → triggers `release-docker.yml` → GHCR `:1.0.2` + `:latest`
2. `gh release create v1.0.2` — full release, not prerelease
3. `cargo publish` — core → store → llm (server is never published)
4. Back-merge `main` → `dev` (merge-commit), then reopen `dev` at `1.0.3-dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
