### PR TITLE
chore(release): v1.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,7 +511,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "eros-engine-core"
-version = "1.0.3-dev"
+version = "1.0.3"
 dependencies = [
  "chrono",
  "serde",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-llm"
-version = "1.0.3-dev"
+version = "1.0.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-server"
-version = "1.0.3-dev"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-store"
-version = "1.0.3-dev"
+version = "1.0.3"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "1.0.3-dev"
+version = "1.0.3"
 edition = "2021"
 license = "AGPL-3.0-only"
 repository = "https://github.com/etherfunlab/eros-engine"

--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ eros-engine-llm   = "1.0"   # optional: model and embedding clients
 Multi-architecture images are published to GitHub Container Registry for every `v*` tag:
 
 ```bash
-docker pull ghcr.io/etherfunlab/eros-engine:1.0.2
+docker pull ghcr.io/etherfunlab/eros-engine:1.0.3
 # Or follow the latest tagged release
 docker pull ghcr.io/etherfunlab/eros-engine:latest
 ```
 
 ```bash
 docker run --rm -p 8080:8080 --env-file .env \
-  ghcr.io/etherfunlab/eros-engine:1.0.2 serve
+  ghcr.io/etherfunlab/eros-engine:1.0.3 serve
 ```
 
 Bring your own Postgres and `.env`; the same `docker/Dockerfile` can be deployed to any container host. See [Deploying](docs/deploying.md).

--- a/crates/eros-engine-llm/Cargo.toml
+++ b/crates/eros-engine-llm/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "openrouter", "voyage", "embeddings", "llm"]
 categories = ["api-bindings"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "1.0.3-dev" }
+eros-engine-core = { path = "../eros-engine-core", version = "1.0.3" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/eros-engine-server/Cargo.toml
+++ b/crates/eros-engine-server/Cargo.toml
@@ -13,9 +13,9 @@ name = "eros-engine"
 path = "src/main.rs"
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "1.0.3-dev" }
-eros-engine-llm  = { path = "../eros-engine-llm", version = "1.0.3-dev" }
-eros-engine-store = { path = "../eros-engine-store", version = "1.0.3-dev" }
+eros-engine-core = { path = "../eros-engine-core", version = "1.0.3" }
+eros-engine-llm  = { path = "../eros-engine-llm", version = "1.0.3" }
+eros-engine-store = { path = "../eros-engine-store", version = "1.0.3" }
 axum = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0-only",
       "identifier": "AGPL-3.0-only"
     },
-    "version": "1.0.3-dev"
+    "version": "1.0.3"
   },
   "servers": [
     {

--- a/crates/eros-engine-store/Cargo.toml
+++ b/crates/eros-engine-store/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "memory", "pgvector", "postgres", "sqlx"]
 categories = ["database"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "1.0.3-dev" }
+eros-engine-core = { path = "../eros-engine-core", version = "1.0.3" }
 sqlx = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
## Summary

Cuts **v1.0.3**. Bumps the workspace version and the five path-dep pins from `1.0.3-dev` to `1.0.3`, regenerates `Cargo.lock` and the OpenAPI snapshot (`info.version` follows `CARGO_PKG_VERSION`), and updates the README docker-pull examples to `:1.0.3`. The `:latest` line is unchanged.

## Release delta since v1.0.2

v1.0.2 was published `2026-08-05T12:33:43Z`. Exactly one PR has merged into `dev` since:

**Features**
- #230 — `feat(prompt)`: iron rule ⑫ — no bracket action blocks in chat replies

(#229 back-merged v1.0.2 and reopened `1.0.3-dev`; #228 and #226 predate the v1.0.2 publish and shipped in that release.)

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 1154 passed, 0 failed
- [x] `cargo check --workspace` — Cargo.lock regenerated
- [x] OpenAPI snapshot regenerated, `info.version = 1.0.3`

## Checklist

- [x] All 6 version strings bumped (workspace + 3 server pins + llm pin + store pin)
- [x] `Cargo.lock` regenerated
- [x] `openapi.json` regenerated
- [x] README docker-pull version bumped (2 occurrences; `:latest` untouched)
- [x] Commit GPG-signed
- [x] `main` is an ancestor of `dev` — `git merge-tree` against `origin/*` reports no conflicting paths
