### PR TITLE
chore(dev): reopen 1.0.4-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,7 +511,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "eros-engine-core"
-version = "1.0.3"
+version = "1.0.4-dev"
 dependencies = [
  "chrono",
  "serde",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-llm"
-version = "1.0.3"
+version = "1.0.4-dev"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-server"
-version = "1.0.3"
+version = "1.0.4-dev"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-store"
-version = "1.0.3"
+version = "1.0.4-dev"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "1.0.3"
+version = "1.0.4-dev"
 edition = "2021"
 license = "AGPL-3.0-only"
 repository = "https://github.com/etherfunlab/eros-engine"

--- a/crates/eros-engine-llm/Cargo.toml
+++ b/crates/eros-engine-llm/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "openrouter", "voyage", "embeddings", "llm"]
 categories = ["api-bindings"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "1.0.3" }
+eros-engine-core = { path = "../eros-engine-core", version = "1.0.4-dev" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/eros-engine-server/Cargo.toml
+++ b/crates/eros-engine-server/Cargo.toml
@@ -13,9 +13,9 @@ name = "eros-engine"
 path = "src/main.rs"
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "1.0.3" }
-eros-engine-llm  = { path = "../eros-engine-llm", version = "1.0.3" }
-eros-engine-store = { path = "../eros-engine-store", version = "1.0.3" }
+eros-engine-core = { path = "../eros-engine-core", version = "1.0.4-dev" }
+eros-engine-llm  = { path = "../eros-engine-llm", version = "1.0.4-dev" }
+eros-engine-store = { path = "../eros-engine-store", version = "1.0.4-dev" }
 axum = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0-only",
       "identifier": "AGPL-3.0-only"
     },
-    "version": "1.0.3"
+    "version": "1.0.4-dev"
   },
   "servers": [
     {

--- a/crates/eros-engine-store/Cargo.toml
+++ b/crates/eros-engine-store/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "memory", "pgvector", "postgres", "sqlx"]
 categories = ["database"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "1.0.3" }
+eros-engine-core = { path = "../eros-engine-core", version = "1.0.4-dev" }
 sqlx = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
## Summary

Reopens `dev` for development after the v1.0.3 release. Bumps the workspace version and the five path-dep pins from `1.0.3` to `1.0.4-dev`, and regenerates `Cargo.lock` and the OpenAPI snapshot (`info.version` follows `CARGO_PKG_VERSION`).

The README docker-pull examples deliberately stay at `:1.0.3` — they point at the last published image, not the in-development version.

No back-merge PR accompanies this one: v1.0.3 was promoted to `main` by fast-forward (`6015ee5..9743ad3`), so `main` and `dev` were the same commit and there is no ancestry gap to close.

## Test plan

- [x] `cargo check --workspace` — Cargo.lock regenerated
- [x] OpenAPI snapshot regenerated, `info.version = 1.0.4-dev`
- [x] All 6 version strings bumped (workspace + 3 server pins + llm pin + store pin)
- [x] README docker-pull left at `:1.0.3` (intentional)
- [x] Commit GPG-signed