### PR TITLE
fix(voice): resolve affinity via user×instance — relationship line was dead on voice-channel sessions

### DIFF
--- a/crates/eros-engine-server/src/pipeline/voice.rs
+++ b/crates/eros-engine-server/src/pipeline/voice.rs
@@ -92,6 +92,7 @@ fn relationship_line(affinity: &Affinity, scope: RelationshipScope) -> Option<St
 pub struct VoiceTurn {
     pub session_id: Uuid,
     pub instance_id: Uuid,
+    pub user_id: Uuid,
     pub user_message_id: Uuid,
     pub relationship_scope: RelationshipScope,
 }
@@ -128,8 +129,16 @@ pub fn run_voice_turn(
             }
         };
 
-        // Read-only affinity load (never creates a row on the voice path).
-        let affinity = affinity_repo.load(turn.session_id).await.unwrap_or(None);
+        // Resolve affinity by user × persona-instance, not by session:
+        // `companion_affinity` is populated only by the text pipeline, so a
+        // voice-channel session's own `session_id` never has a row — this
+        // read-only lookup takes the freshest row across every session for
+        // the same pair (e.g. a prior text session) instead. Never creates a
+        // row on the voice path.
+        let affinity = affinity_repo
+            .load_latest_for_pair(turn.user_id, turn.instance_id)
+            .await
+            .unwrap_or(None);
 
         // Chronological history, includes the just-persisted user turn.
         let history = match chat_repo
@@ -564,6 +573,7 @@ data: [DONE]\n\n";
             VoiceTurn {
                 session_id,
                 instance_id,
+                user_id,
                 user_message_id: umid,
                 relationship_scope: RelationshipScope::default(),
             },
@@ -608,6 +618,144 @@ data: [DONE]\n\n";
         .await
         .unwrap();
         assert_eq!(scope_meta.as_deref(), Some("both"));
+    }
+
+    /// Task 0 (affinity dead-row fix): `companion_affinity` is session-keyed
+    /// and populated only by the text pipeline, so a voice-channel session's
+    /// own `session_id` never has a row. The turn here runs on a voice
+    /// session that has none of its own, while an earlier TEXT session for
+    /// the same user × instance pair does — proving the relationship line
+    /// resolves via the pair, not the (affinity-less) voice session_id.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn run_voice_turn_renders_relationship_line_from_text_session_affinity(
+        pool: sqlx::PgPool,
+    ) {
+        use eros_engine_llm::model_config::ModelConfig;
+        use futures_util::StreamExt;
+        use wiremock::matchers::path as wm_path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        let body = "\
+data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n\
+data: {\"choices\":[{\"delta\":{\"content\":\" there\"}}],\"id\":\"gen-v\",\"model\":\"primary\"}\n\n\
+data: [DONE]\n\n";
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+
+        // Seed persona + instance.
+        let user_id = Uuid::new_v4();
+        let genome_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata) \
+             VALUES ('V', 'You are V.', '{}'::jsonb) RETURNING id",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let instance_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_instances (genome_id, owner_uid) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(genome_id).bind(user_id).fetch_one(&pool).await.unwrap();
+
+        // A prior TEXT session for this pair, with its own affinity row —
+        // fresh-seed defaults land on Acquaintance/Spark (bond ≈ chemistry ≈
+        // 0.033, same tiers `fresh_affinity_gets_acquaintance_and_spark_line`
+        // asserts on for those exact phrases).
+        let text_session_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_sessions (user_id, instance_id, channel) \
+             VALUES ($1, $2, 'text') RETURNING id",
+        )
+        .bind(user_id)
+        .bind(instance_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        AffinityRepo { pool: &pool }
+            .load_or_create(text_session_id, user_id, instance_id)
+            .await
+            .unwrap();
+
+        // The voice session this turn actually runs on — no affinity row of
+        // its own.
+        let voice_session_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_sessions (user_id, instance_id, channel) \
+             VALUES ($1, $2, 'voice') RETURNING id",
+        )
+        .bind(user_id)
+        .bind(instance_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        // Persist the user turn as the route would.
+        let repo = ChatRepo { pool: &pool };
+        let umid = match repo
+            .insert_voice_user_message(voice_session_id, "hello", "01J9000000000000000000VOIC7")
+            .await
+            .unwrap()
+        {
+            eros_engine_store::chat::VoiceUserInsert::Inserted(id) => id,
+            other => panic!("expected Inserted, got {other:?}"),
+        };
+
+        // State with a chat_voice task + mock OpenRouter.
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = Arc::new(
+            ModelConfig::from_toml_str(
+                "[tasks.chat_voice]\nmodel = \"primary\"\nmax_tokens = 100\n",
+            )
+            .unwrap(),
+        );
+        state.openrouter = Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+
+        let resolved = state.model_config.resolve_voice().unwrap();
+        let frames: Vec<ProtocolFrame> = run_voice_turn(
+            Arc::new(state),
+            VoiceTurn {
+                session_id: voice_session_id,
+                instance_id,
+                user_id,
+                user_message_id: umid,
+                relationship_scope: RelationshipScope::default(),
+            },
+            resolved,
+        )
+        .collect()
+        .await;
+
+        assert!(matches!(frames.last(), Some(ProtocolFrame::Done { .. })));
+        assert!(!frames
+            .iter()
+            .any(|f| matches!(f, ProtocolFrame::Error { .. })));
+
+        // The outbound system prompt must carry the relationship line
+        // derived from the TEXT session's affinity row — proof the voice
+        // path resolved it by pair, not by its own (nonexistent) row.
+        let received = mock
+            .received_requests()
+            .await
+            .expect("recording enabled by default");
+        assert_eq!(received.len(), 1);
+        let req_body = String::from_utf8_lossy(&received[0].body);
+        assert!(
+            req_body.contains("still getting to know each other"),
+            "expected the bond relationship line in the outbound request; body={req_body}"
+        );
+        assert!(
+            req_body.contains("faint, unspoken spark"),
+            "expected the chemistry relationship line in the outbound request; body={req_body}"
+        );
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
@@ -686,6 +834,7 @@ data: [DONE]\n\n";
             VoiceTurn {
                 session_id,
                 instance_id,
+                user_id,
                 user_message_id: umid,
                 relationship_scope: RelationshipScope::default(),
             },
@@ -817,6 +966,7 @@ data: [DONE]\n\n";
             VoiceTurn {
                 session_id,
                 instance_id,
+                user_id,
                 user_message_id: umid,
                 relationship_scope: RelationshipScope::default(),
             },
@@ -948,6 +1098,7 @@ data: [DONE]\n\n";
             VoiceTurn {
                 session_id,
                 instance_id,
+                user_id,
                 user_message_id: umid,
                 relationship_scope: RelationshipScope::default(),
             },
@@ -1072,6 +1223,7 @@ data: [DONE]\n\n";
             VoiceTurn {
                 session_id,
                 instance_id,
+                user_id,
                 user_message_id: umid,
                 relationship_scope: RelationshipScope::default(),
             },
@@ -1187,6 +1339,7 @@ data: [DONE]\n\n";
             VoiceTurn {
                 session_id,
                 instance_id,
+                user_id,
                 user_message_id: umid,
                 relationship_scope: RelationshipScope::default(),
             },
@@ -1308,6 +1461,7 @@ data: [DONE]\n\n";
             VoiceTurn {
                 session_id,
                 instance_id,
+                user_id,
                 user_message_id: umid,
                 relationship_scope: RelationshipScope::default(),
             },

--- a/crates/eros-engine-server/src/routes/voice.rs
+++ b/crates/eros-engine-server/src/routes/voice.rs
@@ -205,6 +205,7 @@ pub async fn voice_turn_stream(
     let turn = VoiceTurn {
         session_id,
         instance_id,
+        user_id,
         user_message_id,
         relationship_scope: req.relationship_scope.unwrap_or_default(),
     };

--- a/crates/eros-engine-store/src/affinity.rs
+++ b/crates/eros-engine-store/src/affinity.rs
@@ -109,6 +109,31 @@ impl<'a> AffinityRepo<'a> {
         Ok(row.map(AffinityRow::into_domain))
     }
 
+    /// Load the freshest affinity row for a user × persona-instance pair,
+    /// across all sessions. `companion_affinity` is session-keyed
+    /// (`session_id UNIQUE`) and rows are created only by the text
+    /// pipeline, so a voice-channel session never has one of its own — the
+    /// voice path resolves affinity by pair instead, taking whichever
+    /// session's row was updated most recently (latest state wins). Never
+    /// creates a row. `idx_affinity_user` covers the `user_id` filter;
+    /// per-user row counts are small enough that this scan is cheap.
+    pub async fn load_latest_for_pair(
+        &self,
+        user_id: Uuid,
+        instance_id: Uuid,
+    ) -> Result<Option<Affinity>, sqlx::Error> {
+        let row = sqlx::query_as::<_, AffinityRow>(
+            "SELECT * FROM engine.companion_affinity \
+             WHERE user_id = $1 AND instance_id = $2 \
+             ORDER BY updated_at DESC LIMIT 1",
+        )
+        .bind(user_id)
+        .bind(instance_id)
+        .fetch_optional(self.pool)
+        .await?;
+        Ok(row.map(AffinityRow::into_domain))
+    }
+
     /// Load existing or insert a fresh row with default values.
     pub async fn load_or_create(
         &self,
@@ -420,6 +445,79 @@ mod tests {
         // Lowered seed (stranger start) from migration 0029.
         assert!((a1.warmth - 0.1).abs() < 1e-9);
         assert!((a1.intrigue).abs() < 1e-9);
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn load_latest_for_pair_returns_freshest_row(pool: PgPool) {
+        let repo = AffinityRepo { pool: &pool };
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
+
+        // Two sessions for the same user × instance pair (e.g. a text
+        // session and a later voice session) each get their own affinity
+        // row — companion_affinity.session_id is UNIQUE.
+        let older_session = make_session(&pool, user_id, instance_id).await;
+        let newer_session = make_session(&pool, user_id, instance_id).await;
+        let older = repo
+            .load_or_create(older_session, user_id, instance_id)
+            .await
+            .unwrap();
+        let newer = repo
+            .load_or_create(newer_session, user_id, instance_id)
+            .await
+            .unwrap();
+
+        // Force a deterministic updated_at ordering instead of relying on
+        // real-time gaps between the two load_or_create calls above.
+        sqlx::query("UPDATE engine.companion_affinity SET updated_at = now() - interval '1 hour' WHERE id = $1")
+            .bind(older.id)
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("UPDATE engine.companion_affinity SET updated_at = now() WHERE id = $1")
+            .bind(newer.id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let latest = repo
+            .load_latest_for_pair(user_id, instance_id)
+            .await
+            .unwrap()
+            .expect("a row exists for this pair");
+        assert_eq!(
+            latest.id, newer.id,
+            "the most recently updated session's row wins, not the oldest"
+        );
+
+        // A different pair (different user) must not leak in.
+        let other_user = Uuid::new_v4();
+        let other_instance = seed_persona_instance(&pool, other_user).await;
+        let other_session = make_session(&pool, other_user, other_instance).await;
+        repo.load_or_create(other_session, other_user, other_instance)
+            .await
+            .unwrap();
+        let scoped = repo
+            .load_latest_for_pair(user_id, instance_id)
+            .await
+            .unwrap()
+            .expect("still the original pair's row");
+        assert_eq!(scoped.id, newer.id);
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn load_latest_for_pair_none_when_pair_has_none(pool: PgPool) {
+        let repo = AffinityRepo { pool: &pool };
+        // A brand-new user × instance pair with zero sessions and zero
+        // affinity rows — the state of every voice-channel session before
+        // any text session for the same pair has ever run.
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
+        assert!(repo
+            .load_latest_for_pair(user_id, instance_id)
+            .await
+            .unwrap()
+            .is_none());
     }
 
     #[sqlx::test(migrations = "./migrations")]


### PR DESCRIPTION
## Problem

`companion_affinity` is keyed one row per session (`session_id UNIQUE`, `0002_affinity.sql`), and rows are only ever created by the text pipeline's per-turn eval — both `load_or_create` production call sites key on the **text** session. A `channel='voice'` session therefore never acquires an affinity row, `AffinityRepo::load(session_id)` on the voice path is always `None`, and the bond/chemistry relationship line (#209) **never renders in production**. The voice prompt has effectively been persona + directive only.

## Fix

- New `AffinityRepo::load_latest_for_pair(user_id, instance_id)` — `ORDER BY updated_at DESC LIMIT 1`, read-only. `load(session_id)` untouched (other routes still use it).
- Voice pipeline resolves affinity via user × persona-instance instead of by session; `VoiceTurn` gains `user_id` (populated from the authenticated user, after the ownership check).
- No migration: query filters by `user_id` first and rides `idx_affinity_user`; per-pair cardinality is small.
- Read-only semantics preserved — the voice path still never creates affinity rows.

This resolution is deliberately compatible with per-call voice sessions (upcoming voice-memory branch).

## Tests

- Store: pair-scoped load returns the freshest row (explicit `updated_at` backdating, no clock races); pair isolation (another user's row doesn't leak); `None`-safe when the pair has no rows.
- E2E (wiremock): affinity seeded on a *different* (text) session for the same user×instance, voice turn run on a voice session with no row of its own — asserts the relationship line now reaches the outbound wire prompt. This reproduces the exact production bug shape; reverting the pipeline change makes it fail.
- 25 store affinity + 26 server voice tests green; fmt/clippy `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)