### PR TITLE
feat(voice): memory — first-turn bootstrap snapshot + per-turn vector recall

### DIFF
--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -884,6 +884,11 @@ pub struct TaskConfig {
     /// docs/superpowers/specs/2026-07-11-voice-tts-audio-tags-design.md.
     #[serde(default)]
     pub tts_audio_tags: Option<bool>,
+    /// chat_voice-only: per-turn vector recall on the voice path. Omitted ⇒
+    /// enabled. Set `recall = false` to keep the voice prompt recall-free.
+    /// Read only by `resolve_voice`.
+    #[serde(default)]
+    pub recall: Option<bool>,
     /// world_director-only: hours between per-owner director rounds. Read only
     /// on `[tasks.world_director]` (like `ghosting` on pde_decision). Default 24.
     #[serde(default)]
@@ -1140,6 +1145,7 @@ pub struct ResolvedVoice {
     pub max_tokens: u32,
     pub reasoning: Option<ReasoningConfig>,
     pub directive: String,
+    pub recall: bool,
 }
 
 /// Generic, product-identity-free default prompt for the image-prompt composer.
@@ -1753,6 +1759,7 @@ impl ModelConfig {
         const VOICE_TASK: &str = "chat_voice";
         let task_cfg = self.tasks.get(VOICE_TASK)?;
         let audio_tags = task_cfg.tts_audio_tags.unwrap_or(false);
+        let recall = task_cfg.recall.unwrap_or(true);
         let custom = task_cfg
             .filter_prompt
             .as_ref()
@@ -1773,6 +1780,7 @@ impl ModelConfig {
             max_tokens: m.max_tokens,
             reasoning: m.reasoning,
             directive,
+            recall,
         })
     }
 
@@ -4584,6 +4592,21 @@ retry_depth = 0
         let v = cfg.resolve_voice().expect("voice enabled");
         assert_eq!(v.directive, "Speak like a pirate.");
         assert!(!v.directive.contains("[laughs]"));
+    }
+
+    #[test]
+    fn resolve_voice_recall_defaults_true() {
+        let cfg = ModelConfig::from_toml_str("[tasks.chat_voice]\nmodel = \"m\"\n").unwrap();
+        let resolved = cfg.resolve_voice().expect("voice enabled");
+        assert!(resolved.recall);
+    }
+
+    #[test]
+    fn resolve_voice_recall_false_when_configured_off() {
+        let cfg = ModelConfig::from_toml_str("[tasks.chat_voice]\nmodel = \"m\"\nrecall = false\n")
+            .unwrap();
+        let resolved = cfg.resolve_voice().expect("voice enabled");
+        assert!(!resolved.recall);
     }
 
     #[test]

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -2135,6 +2135,13 @@
           "content": {
             "type": "string"
           },
+          "memory_scope": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "How much long-term memory this turn may use — same field name, enum,\nwire values, and default (`neutral_and_relationship`) as the chat\nstream. On the session's FIRST turn the resolved insight tier is frozen\ninto the bootstrap snapshot and never changes for the rest of the call."
+          },
           "relationship_scope": {
             "type": [
               "string",

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -1388,6 +1388,13 @@
             ],
             "description": "Conversation channel ('text' default, or 'voice'). Passed through to\nthe canonical start; see `StartChatRequest::channel`."
           },
+          "force_new": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "Skip resume and always create a fresh session. Passed through to the\ncanonical start; see `StartChatRequest::force_new`."
+          },
           "genome_id": {
             "type": [
               "string",
@@ -1918,6 +1925,13 @@
               "null"
             ],
             "description": "Conversation channel for the session: `\"text\"` (default) or `\"voice\"`.\nStart/resume is channel-scoped — a voice-channel start never resumes a\ntext session and vice versa, so the two conversations stay isolated."
+          },
+          "force_new": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "When `true`, skip resume entirely and always create a fresh session\n(returns `is_new: true`), even if a resumable one exists for this\nuser × instance × channel. Default `false`/omitted keeps the normal\nresume-or-create behavior. Intended for callers (e.g. voice calls)\nthat want one session per call rather than a continued conversation."
           },
           "genome_id": {
             "type": [

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -2140,7 +2140,7 @@
               "string",
               "null"
             ],
-            "description": "How much long-term memory this turn may use — same field name, enum,\nwire values, and default (`neutral_and_relationship`) as the chat\nstream. On the session's FIRST turn the resolved insight tier is frozen\ninto the bootstrap snapshot and never changes for the rest of the call."
+            "description": "How much long-term memory this turn may use — same field name, enum,\nwire values, and default (`neutral_and_relationship`) as the chat\nstream. The first successfully-assembling turn's resolved insight\ntier is frozen into the bootstrap snapshot and never changes for the\nrest of the call."
           },
           "relationship_scope": {
             "type": [

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -33,6 +33,26 @@ const RELATIONSHIP_RECALL_K: i32 = 3;
 /// Five categories × 2 = at most 10 lines of grouped profile context;
 /// kept small so the prompt doesn't bloat once classification fills in.
 const K_PER_CATEGORY: i32 = 2;
+
+/// Recall fan-out sizes for one call site of `recall_memory` /
+/// `recall_memory_with_embedding`. Parameterised so callers other than the
+/// text-chat path (e.g. voice) can reuse the same search + grouping logic
+/// with a smaller tier without touching the constants below.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RecallTier {
+    pub grouped_k: i32,
+    pub raw_k: i32,
+    pub relationship_k: i32,
+}
+
+/// Text-chat recall tier — same values as the historical unparameterised
+/// constants, now passed explicitly.
+pub(crate) const TEXT_RECALL_TIER: RecallTier = RecallTier {
+    grouped_k: K_PER_CATEGORY,
+    raw_k: PROFILE_RECALL_K,
+    relationship_k: RELATIONSHIP_RECALL_K,
+};
+
 /// World-memories fragment recall size (spec §3.2).
 const WORLD_RECALL_K: i32 = 3;
 /// World-stories episode recall size (stories spec §5.3).
@@ -309,13 +329,14 @@ pub(crate) fn compose_image_prompt(
 /// element is the computed query embedding (`Some` only on success), reused
 /// by `fetch_world_context` so world-fragment recall doesn't pay a second
 /// Voyage call.
-async fn recall_memory(
+pub(crate) async fn recall_memory(
     state: &AppState,
     user_id: Uuid,
     instance_id: Uuid,
     query_text: &str,
     x_on: bool,
     y_on: bool,
+    tier: RecallTier,
 ) -> (Vec<(String, Vec<String>)>, Vec<String>, Option<Vec<f32>>) {
     if (!x_on && !y_on) || query_text.trim().is_empty() {
         return (vec![], vec![], None);
@@ -335,9 +356,16 @@ async fn recall_memory(
         y_on,
         "recall_memory: embedded query, dispatching pgvector search"
     );
-    let (profile_groups, relationship) =
-        recall_memory_with_embedding(&state.pool, user_id, instance_id, &embedding, x_on, y_on)
-            .await;
+    let (profile_groups, relationship) = recall_memory_with_embedding(
+        &state.pool,
+        user_id,
+        instance_id,
+        &embedding,
+        x_on,
+        y_on,
+        tier,
+    )
+    .await;
     (profile_groups, relationship, Some(embedding))
 }
 
@@ -354,22 +382,23 @@ async fn recall_memory(
 /// Hot path (`x_on` ⇒ `y_on`): the three profile + relationship searches run
 /// in parallel via `tokio::join!`. Relationship-only (`!x_on && y_on`): only
 /// the relationship search runs. Both off: no DB round-trip.
-async fn recall_memory_with_embedding(
+pub(crate) async fn recall_memory_with_embedding(
     pool: &PgPool,
     user_id: Uuid,
     instance_id: Uuid,
     embedding: &[f32],
     x_on: bool,
     y_on: bool,
+    tier: RecallTier,
 ) -> (Vec<(String, Vec<String>)>, Vec<String>) {
     let repo = MemoryRepo { pool };
 
     let (profile_groups, relationship): (Vec<(String, Vec<String>)>, Vec<String>) = if x_on {
         // X on ⇒ Y on: original three-way parallel recall (hot path).
         let (grouped_res, raw_res, rel_res) = tokio::join!(
-            repo.search_profile_grouped(user_id, embedding, K_PER_CATEGORY),
-            repo.search(user_id, None, embedding, PROFILE_RECALL_K),
-            repo.search(user_id, Some(instance_id), embedding, RELATIONSHIP_RECALL_K),
+            repo.search_profile_grouped(user_id, embedding, tier.grouped_k),
+            repo.search(user_id, None, embedding, tier.raw_k),
+            repo.search(user_id, Some(instance_id), embedding, tier.relationship_k),
         );
         let grouped_rows = grouped_res.unwrap_or_else(|e| {
             tracing::warn!("profile-layer grouped search failed: {e}");
@@ -390,7 +419,7 @@ async fn recall_memory_with_embedding(
     } else if y_on {
         // relationship_only: skip both profile-layer searches.
         let rel = match repo
-            .search(user_id, Some(instance_id), embedding, RELATIONSHIP_RECALL_K)
+            .search(user_id, Some(instance_id), embedding, tier.relationship_k)
             .await
         {
             Ok(rows) => rows.into_iter().map(|r| r.content).collect(),
@@ -538,7 +567,7 @@ fn insights_to_bullets(insights: &Value) -> Vec<String> {
 /// emotional_needs / family / finance_status).
 /// Matching-only columns (preferred_gender / age / deal_breakers) are never
 /// rendered. `Off` → empty (defensive; loaders gate it before calling).
-fn human_insights_to_bullets(row: &HumanInsightsRow, mode: InsightMode) -> Vec<String> {
+pub(crate) fn human_insights_to_bullets(row: &HumanInsightsRow, mode: InsightMode) -> Vec<String> {
     if matches!(mode, InsightMode::Off) {
         return vec![];
     }
@@ -756,8 +785,16 @@ pub(super) async fn build_reply_request(
         );
     }
 
-    let (mut profile_groups, relationship_facts, query_embedding) =
-        recall_memory(state, user_id, instance_id, &query_text, x_on, y_on).await;
+    let (mut profile_groups, relationship_facts, query_embedding) = recall_memory(
+        state,
+        user_id,
+        instance_id,
+        &query_text,
+        x_on,
+        y_on,
+        TEXT_RECALL_TIER,
+    )
+    .await;
 
     let insight_bullets = load_human_insight_bullets(&state.pool, user_id, mem_mode).await;
     if !insight_bullets.is_empty() {
@@ -1047,6 +1084,7 @@ mod tests {
             &unit_embedding(7),
             true,
             true,
+            TEXT_RECALL_TIER,
         )
         .await;
         assert!(profile.is_empty());
@@ -1096,6 +1134,7 @@ mod tests {
             &unit_embedding(11),
             true,
             true,
+            TEXT_RECALL_TIER,
         )
         .await;
         assert_eq!(
@@ -1159,6 +1198,7 @@ mod tests {
             &unit_embedding(7),
             true,
             true,
+            TEXT_RECALL_TIER,
         )
         .await;
 
@@ -1223,6 +1263,7 @@ mod tests {
             &unit_embedding(100),
             true,
             true,
+            TEXT_RECALL_TIER,
         )
         .await;
 
@@ -1305,6 +1346,7 @@ mod tests {
             &unit_embedding(42),
             true,
             true,
+            TEXT_RECALL_TIER,
         )
         .await;
         assert_eq!(profile_groups.len(), 1);
@@ -1322,6 +1364,7 @@ mod tests {
             &unit_embedding(99),
             true,
             true,
+            TEXT_RECALL_TIER,
         )
         .await;
         assert_eq!(
@@ -1369,6 +1412,7 @@ mod tests {
             &unit_embedding(11),
             false,
             true,
+            TEXT_RECALL_TIER,
         )
         .await;
         assert!(prof.is_empty(), "profile groups must be empty when X off");
@@ -1382,6 +1426,7 @@ mod tests {
             &unit_embedding(11),
             false,
             false,
+            TEXT_RECALL_TIER,
         )
         .await;
         assert!(prof2.is_empty() && rel2.is_empty());
@@ -1394,6 +1439,7 @@ mod tests {
             &unit_embedding(11),
             true,
             true,
+            TEXT_RECALL_TIER,
         )
         .await;
         assert!(
@@ -1401,6 +1447,154 @@ mod tests {
             "profile groups should be present when X on"
         );
         assert!(!rel3.is_empty(), "relationship should be present when Y on");
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn recall_memory_with_embedding_voice_tier_respects_k(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
+        let session_id = make_session(&pool, user_id, Some(instance_id)).await;
+        let repo = MemoryRepo { pool: &pool };
+
+        // Two categorised profile rows in each of two categories — more than
+        // the voice tier's grouped_k=1, so the cap must actually bite.
+        for (i, content) in ["lives in shanghai", "works remote"].iter().enumerate() {
+            repo.upsert(
+                MemoryLayer::Profile,
+                session_id,
+                user_id,
+                None,
+                content,
+                &unit_embedding(500 + i),
+                Some("fact"),
+                None,
+            )
+            .await
+            .unwrap();
+        }
+        for (i, content) in ["loves coffee", "loves tea"].iter().enumerate() {
+            repo.upsert(
+                MemoryLayer::Profile,
+                session_id,
+                user_id,
+                None,
+                content,
+                &unit_embedding(510 + i),
+                Some("preference"),
+                None,
+            )
+            .await
+            .unwrap();
+        }
+
+        // Three relationship rows — more than the voice tier's
+        // relationship_k=2, so the cap must actually bite.
+        for i in 0..3 {
+            repo.upsert(
+                MemoryLayer::Relationship,
+                session_id,
+                user_id,
+                Some(instance_id),
+                &format!("relationship-{i}"),
+                &unit_embedding(600 + i),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        }
+
+        let voice_tier = RecallTier {
+            grouped_k: 1,
+            raw_k: 2,
+            relationship_k: 2,
+        };
+
+        let (profile_groups, relationship) = recall_memory_with_embedding(
+            &pool,
+            user_id,
+            instance_id,
+            &unit_embedding(500),
+            true,
+            true,
+            voice_tier,
+        )
+        .await;
+
+        // grouped_k=1 ⇒ each of the two categories is capped to a single
+        // bullet even though 2 rows exist per category.
+        assert_eq!(profile_groups.len(), 2, "both categories present");
+        for (label, items) in &profile_groups {
+            assert_eq!(
+                items.len(),
+                1,
+                "grouped_k=1 must cap category {label:?} to 1 row"
+            );
+        }
+
+        // relationship_k=2 ⇒ capped below the 3 rows seeded.
+        assert_eq!(relationship.len(), 2);
+    }
+
+    /// `recall_memory_with_embedding_voice_tier_respects_k` above seeds only
+    /// categorised profile rows, so `build_profile_groups` always takes the
+    /// grouped branch and the raw-fallback `raw_res` — though computed with
+    /// `tier.raw_k` — is discarded unread. That test alone never observes
+    /// whether `raw_k` is actually threaded through. Grouped and raw are
+    /// mutually-exclusive fallback paths (`build_profile_groups` returns the
+    /// grouped rows whenever any exist), so a single seeded scenario can't
+    /// exercise both; this sibling test seeds *only* uncategorised rows to
+    /// force the raw-fallback branch and assert its cap directly.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn recall_memory_with_embedding_voice_tier_raw_fallback_cap(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
+        let session_id = make_session(&pool, user_id, Some(instance_id)).await;
+        let repo = MemoryRepo { pool: &pool };
+
+        // Three uncategorised profile rows, zero categorised — forces the
+        // "近况" raw-fallback branch, more than the voice tier's raw_k=2.
+        for i in 0..3 {
+            repo.upsert(
+                MemoryLayer::Profile,
+                session_id,
+                user_id,
+                None,
+                &format!("raw-fact-{i}"),
+                &unit_embedding(700 + i),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        }
+
+        let voice_tier = RecallTier {
+            grouped_k: 1,
+            raw_k: 2,
+            relationship_k: 2,
+        };
+
+        let (profile_groups, _relationship) = recall_memory_with_embedding(
+            &pool,
+            user_id,
+            instance_id,
+            &unit_embedding(700),
+            true,
+            true,
+            voice_tier,
+        )
+        .await;
+
+        // No categorised rows exist ⇒ raw fallback fires under "近况",
+        // capped to raw_k=2 even though 3 rows were seeded.
+        assert_eq!(profile_groups.len(), 1);
+        assert_eq!(profile_groups[0].0, "近况");
+        assert_eq!(
+            profile_groups[0].1.len(),
+            2,
+            "raw_k=2 must cap the 近况 fallback group to 2 rows"
+        );
     }
 
     // ─── human_insights_to_bullets ──────────────────────────────────────

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -1504,11 +1504,7 @@ mod tests {
             .unwrap();
         }
 
-        let voice_tier = RecallTier {
-            grouped_k: 1,
-            raw_k: 2,
-            relationship_k: 2,
-        };
+        let voice_tier = crate::pipeline::voice::VOICE_RECALL_TIER;
 
         let (profile_groups, relationship) = recall_memory_with_embedding(
             &pool,
@@ -1569,11 +1565,7 @@ mod tests {
             .unwrap();
         }
 
-        let voice_tier = RecallTier {
-            grouped_k: 1,
-            raw_k: 2,
-            relationship_k: 2,
-        };
+        let voice_tier = crate::pipeline::voice::VOICE_RECALL_TIER;
 
         let (profile_groups, _relationship) = recall_memory_with_embedding(
             &pool,

--- a/crates/eros-engine-server/src/pipeline/voice.rs
+++ b/crates/eros-engine-server/src/pipeline/voice.rs
@@ -7,6 +7,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
 use std::sync::Arc;
+use std::time::Duration;
 use ulid::Ulid;
 use uuid::Uuid;
 
@@ -20,32 +21,94 @@ use eros_engine_store::chat::{ChatMessageSlim, ChatRepo};
 use eros_engine_store::human_insight::HumanInsightRepo;
 use eros_engine_store::persona::PersonaRepo;
 
-use crate::pipeline::handlers::human_insights_to_bullets;
+use crate::memory_hygiene::prune_recalled;
+use crate::pipeline::handlers::{human_insights_to_bullets, recall_memory, RecallTier};
 use crate::pipeline::stream::{
     ulid_string, ProtocolFrame, StreamErrorCode, STREAM_OPEN_TIMEOUT, STREAM_TOTAL_TIMEOUT,
 };
+use crate::prompt::render_recall_sections;
 use crate::state::AppState;
 
 /// `chat_sessions.metadata` key holding a voice session's frozen bootstrap
 /// snapshot (write-once — see `ChatRepo::set_voice_bootstrap`).
 const VOICE_BOOTSTRAP_KEY: &str = "voice_bootstrap";
 
+/// Backchannel floor for per-turn recall: an utterance carrying fewer than
+/// this many alphanumeric characters (see `recall_query_chars` — whitespace
+/// and punctuation, ASCII *and* CJK, don't count) skips recall entirely, with
+/// no embedding round trip and no query. Calls are full of 嗯 / 好啊 / 哈哈;
+/// embedding them buys nothing but latency and garbage nearest neighbours.
+/// The bootstrap snapshot and the in-session history still carry the turn.
+const VOICE_RECALL_MIN_QUERY_CHARS: usize = 4;
+
+/// Wall-clock budget for the WHOLE per-turn recall leg (embed round trip +
+/// pgvector searches). Blowing it degrades to "no recall block" with a warn —
+/// a memory problem must never delay or fail a voice reply. It wraps only the
+/// recall future; persona / affinity / history / bootstrap keep their own
+/// behaviour.
+const VOICE_RECALL_BUDGET: Duration = Duration::from_millis(300);
+
+/// Voice K tier — deliberately far below the text path's (2 / 4 / 3): a spoken
+/// turn can absorb a couple of recalled lines, not a wall of them, and every
+/// row is prompt latency. Spec §5.
+const VOICE_RECALL_TIER: RecallTier = RecallTier {
+    grouped_k: 1,
+    raw_k: 2,
+    relationship_k: 2,
+};
+
+/// Characters that make an utterance worth embedding: alphanumerics only.
+/// `char::is_alphanumeric` keeps CJK ideographs, kana, letters and digits, and
+/// drops every kind of whitespace plus ASCII (`!?.,;:()"'`) *and* CJK
+/// (`，。！？～…、；：「」『』（）`) punctuation — the CJK half is the point:
+/// counting raw `chars()` would let 嗯嗯，好～ sail past the threshold.
+fn recall_query_chars(content: &str) -> usize {
+    content.chars().filter(|c| c.is_alphanumeric()).count()
+}
+
+/// Turn one turn's recall results into the trailing prompt block: prune →
+/// render → label. A section that rendered empty is OMITTED — the text path's
+/// Chinese placeholders (`（刚认识，还不了解他）` / `（还没有专属记忆，慢慢来）`)
+/// never appear on voice, and a turn that recalled nothing costs the prompt
+/// nothing (`None` ⇒ byte-identical to a no-recall turn).
+fn render_recall_block(
+    profile_groups: Vec<(String, Vec<String>)>,
+    relationship_facts: Vec<String>,
+) -> Option<String> {
+    let (profile_groups, relationship_facts) = prune_recalled(profile_groups, relationship_facts);
+    let (profile_sec, rel_sec) = render_recall_sections(&profile_groups, &relationship_facts);
+    let mut parts: Vec<String> = Vec::with_capacity(2);
+    if let Some(p) = profile_sec {
+        parts.push(format!("[user_profile]\n{p}"));
+    }
+    if let Some(r) = rel_sec {
+        parts.push(format!("[shared_memories]\n{r}"));
+    }
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join("\n\n"))
+    }
+}
+
 /// Assemble the thin voice system prompt: persona + voice directive +
 /// the (already rendered) bootstrap block + one optional relationship line
-/// (bond/chemistry-derived, gated by `relationship_scope`). Deliberately
-/// excludes memories, traits, scopes, and every heavy block the text path's
-/// `build_prompt` composes.
+/// (bond/chemistry-derived, gated by `relationship_scope`) + this turn's
+/// (already rendered) recall block. Deliberately excludes traits, scopes, and
+/// every heavy block the text path's `build_prompt` composes.
 ///
-/// Order matters: persona → directive → bootstrap → relationship line. The
-/// bootstrap block is frozen for the whole call, so everything up to (and
-/// including) it is byte-stable across the call's turns — provider-side
-/// prefix caching keeps working.
+/// Order matters: persona → directive → bootstrap → relationship line →
+/// recall. The bootstrap block is frozen for the whole call, so everything up
+/// to (and including) it is byte-stable across the call's turns — provider-side
+/// prefix caching keeps working, and the one genuinely per-turn block sits
+/// last where it disturbs the least.
 pub fn build_voice_prompt(
     genome: &PersonaGenome,
     directive: &str,
     bootstrap: Option<&str>,
     affinity: Option<&Affinity>,
     relationship_scope: RelationshipScope,
+    recall: Option<&str>,
 ) -> String {
     let mut s = String::with_capacity(genome.system_prompt.len() + directive.len() + 384);
     s.push_str(&genome.system_prompt);
@@ -58,6 +121,10 @@ pub fn build_voice_prompt(
     if let Some(line) = affinity.and_then(|a| relationship_line(a, relationship_scope)) {
         s.push_str("\n\n");
         s.push_str(&line);
+    }
+    if let Some(block) = recall {
+        s.push_str("\n\n");
+        s.push_str(block);
     }
     s
 }
@@ -302,13 +369,17 @@ fn relationship_line(affinity: &Affinity, scope: RelationshipScope) -> Option<St
 }
 
 /// Inputs for one voice turn. The user utterance is already persisted (by the
-/// route) as the latest history row, so the generator reads it from history —
-/// it is not passed again here.
+/// route) as the latest history row, so the wire messages come from history —
+/// `content` is carried separately only because the per-turn recall needs it
+/// as the embedding query BEFORE the history read has returned.
 pub struct VoiceTurn {
     pub session_id: Uuid,
     pub instance_id: Uuid,
     pub user_id: Uuid,
     pub user_message_id: Uuid,
+    /// This turn's utterance verbatim — the per-turn recall query text (voice
+    /// has no input-filter rewrite).
+    pub content: String,
     pub relationship_scope: RelationshipScope,
     /// This turn's memory scope. On the FIRST turn its resolved `InsightMode`
     /// picks the bootstrap snapshot's insight tier — frozen for the whole call
@@ -355,12 +426,22 @@ pub fn run_voice_turn(
         }
         let assemble_bootstrap_now = matches!(plan, BootstrapPlan::Assemble);
         // The FIRST turn's scope decides the snapshot's insight tier; later
-        // turns can't change it (the snapshot is frozen).
-        let insight_mode = turn.memory_scope.resolve().0;
+        // turns can't change it (the snapshot is frozen). `x_on`/`y_on` are
+        // per-turn and drive the recall gate below.
+        let (insight_mode, x_on, y_on) = turn.memory_scope.resolve();
+
+        // Recall gate — settled BEFORE any embedding work, in this order:
+        //   1. the deployment kill-switch beats any per-request scope;
+        //   2. both memory layers off ⇒ nothing to search;
+        //   3. a backchannel utterance isn't worth a round trip.
+        // A skipped turn constructs no recall future at all.
+        let recall_on = resolved.recall
+            && (x_on || y_on)
+            && recall_query_chars(&turn.content) >= VOICE_RECALL_MIN_QUERY_CHARS;
 
         // All independent reads in one round trip's worth of wall clock. The
-        // bootstrap future is inert unless this is the first turn.
-        let (persona_res, affinity_res, history_res, assembled) = tokio::join!(
+        // bootstrap and recall futures are inert unless their gate opened.
+        let (persona_res, affinity_res, history_res, assembled, recalled) = tokio::join!(
             persona_repo.load_companion(turn.instance_id),
             // Resolve affinity by user × persona-instance, not by session:
             // `companion_affinity` is populated only by the text pipeline, so a
@@ -379,6 +460,26 @@ pub fn run_voice_turn(
                         turn.instance_id,
                         turn.session_id,
                         insight_mode,
+                    ).await)
+                } else {
+                    None
+                }
+            },
+            // Per-turn vector recall: READ-ONLY (no embed_document, no memory
+            // insert, no post-process). The budget wraps this arm alone.
+            async {
+                if recall_on {
+                    Some(tokio::time::timeout(
+                        VOICE_RECALL_BUDGET,
+                        recall_memory(
+                            &state,
+                            turn.user_id,
+                            turn.instance_id,
+                            &turn.content,
+                            x_on,
+                            y_on,
+                            VOICE_RECALL_TIER,
+                        ),
                     ).await)
                 } else {
                     None
@@ -446,12 +547,34 @@ pub fn run_voice_turn(
         };
         let bootstrap_block = bootstrap.as_ref().and_then(render_bootstrap);
 
+        // Recall degrades silently in every direction: the gate closed, the
+        // budget blew, or `recall_memory` swallowed an embed/search failure
+        // into empty results. None of them is worth an `error` frame — the
+        // persona just sounds slightly less "with it" for this turn.
+        let recall_block = match recalled {
+            None => None,
+            Some(Err(_elapsed)) => {
+                tracing::warn!(
+                    session_id = %turn.session_id,
+                    budget_ms = VOICE_RECALL_BUDGET.as_millis(),
+                    "voice: per-turn recall exceeded its budget — no recall block this turn",
+                );
+                None
+            }
+            // The query embedding is deliberately DISCARDED: the voice path has
+            // no world-fragment recall to reuse it for.
+            Some(Ok((profile_groups, relationship_facts, _embedding))) => {
+                render_recall_block(profile_groups, relationship_facts)
+            }
+        };
+
         let system_prompt = build_voice_prompt(
             &persona.genome,
             &resolved.directive,
             bootstrap_block.as_deref(),
             affinity.as_ref(),
             turn.relationship_scope,
+            recall_block.as_deref(),
         );
 
         let mut messages = Vec::with_capacity(history.len() + 1);
@@ -722,6 +845,7 @@ mod tests {
             None,
             None,
             RelationshipScope::default(),
+            None,
         );
         assert_eq!(p, "You are Mia.\n\nDIRECTIVE");
     }
@@ -742,6 +866,7 @@ mod tests {
             render_bootstrap(&s).as_deref(),
             None,
             RelationshipScope::None,
+            None,
         );
         assert_eq!(
             p,
@@ -762,6 +887,7 @@ mod tests {
             render_bootstrap(&s).as_deref(),
             Some(&a),
             RelationshipScope::default(),
+            None,
         );
         let directive = p.find("DIRECTIVE").expect("directive present");
         let about = p.find("[关于他]").expect("insights sub-block present");
@@ -784,6 +910,7 @@ mod tests {
             render_bootstrap(&s).as_deref(),
             None,
             RelationshipScope::None,
+            None,
         );
         assert_eq!(p, "You are Mia.\n\nDIRECTIVE\n\n[上次通话]\n用户：你好");
         assert!(!p.contains("[关于他]"));
@@ -798,6 +925,7 @@ mod tests {
             render_bootstrap(&s).as_deref(),
             None,
             RelationshipScope::None,
+            None,
         );
         assert_eq!(p, "You are Mia.\n\nDIRECTIVE\n\n[关于他]\n- 城市：上海");
         assert!(!p.contains("[上次通话]"));
@@ -815,11 +943,196 @@ mod tests {
             render_bootstrap(&empty).as_deref(),
             None,
             RelationshipScope::None,
+            None,
         );
         assert_eq!(p, "You are Mia.\n\nDIRECTIVE");
         // A whitespace-only prev_call is empty too.
         let blank = snapshot(&["  "], Some("   \n "));
         assert!(render_bootstrap(&blank).is_none());
+    }
+
+    // ─── per-turn recall block ──────────────────────────────────────────
+
+    /// The backchannel counter keeps only alphanumerics (CJK ideographs
+    /// included) — ASCII *and* CJK punctuation and every kind of whitespace
+    /// are stripped before the threshold is applied.
+    #[test]
+    fn recall_query_chars_counts_only_alphanumerics() {
+        for (content, expected) in [
+            ("嗯", 1usize),
+            ("好啊", 2),
+            ("哈哈", 2),
+            ("哈哈哈哈", 4),
+            ("ok", 2),
+            ("嗯嗯，好～", 3),
+            ("带我去东京吧", 6),
+            ("想你", 2),
+            ("", 0),
+        ] {
+            assert_eq!(
+                recall_query_chars(content),
+                expected,
+                "recall_query_chars({content:?})"
+            );
+        }
+    }
+
+    /// Only the table's ≥ 4 entries may pass the gate.
+    #[test]
+    fn recall_backchannel_threshold_skips_short_utterances() {
+        for skipped in ["嗯", "好啊", "哈哈", "ok", "嗯嗯，好～", "想你", ""] {
+            assert!(
+                recall_query_chars(skipped) < VOICE_RECALL_MIN_QUERY_CHARS,
+                "{skipped:?} must be treated as a backchannel"
+            );
+        }
+        for kept in ["哈哈哈哈", "带我去东京吧"] {
+            assert!(
+                recall_query_chars(kept) >= VOICE_RECALL_MIN_QUERY_CHARS,
+                "{kept:?} must NOT be treated as a backchannel"
+            );
+        }
+    }
+
+    #[test]
+    fn recall_block_rendering_is_pinned() {
+        let block = render_recall_block(
+            vec![("客观事实".to_string(), vec!["住在上海".to_string()])],
+            vec!["一起看过电影".to_string()],
+        )
+        .expect("both sections present");
+        assert_eq!(
+            block,
+            "[user_profile]\n[客观事实]\n- 住在上海\n\n[shared_memories]\n- 一起看过电影"
+        );
+    }
+
+    /// Dynamic content last: the recall block sits AFTER the relationship
+    /// line, which itself sits after the frozen bootstrap.
+    #[test]
+    fn recall_block_is_the_last_prompt_segment() {
+        let a = affinity_at(0.0, 0.0, 0.0, 0.0, 0.0);
+        let s = snapshot(&["城市：上海"], Some("用户：你好"));
+        let block = render_recall_block(
+            vec![("偏好".to_string(), vec!["喜欢猫".to_string()])],
+            vec!["聊到深夜".to_string()],
+        );
+        let p = build_voice_prompt(
+            &genome(),
+            "DIRECTIVE",
+            render_bootstrap(&s).as_deref(),
+            Some(&a),
+            RelationshipScope::default(),
+            block.as_deref(),
+        );
+        assert_eq!(
+            p,
+            "You are Mia.\n\nDIRECTIVE\n\n\
+             [关于他]\n- 城市：上海\n\n[上次通话]\n用户：你好\n\n\
+             You two are still getting to know each other; keep it light and natural. \
+             A faint, unspoken spark exists between you. Keep it subtle — light teasing \
+             is allowed, but do not lean into romance or seduction yet.\n\n\
+             [user_profile]\n[偏好]\n- 喜欢猫\n\n[shared_memories]\n- 聊到深夜"
+        );
+        assert!(
+            p.ends_with("[shared_memories]\n- 聊到深夜"),
+            "the recall block must be the final segment: {p}"
+        );
+    }
+
+    /// One empty section is omitted entirely — never a placeholder, never a
+    /// dangling label.
+    #[test]
+    fn recall_block_omits_the_empty_section() {
+        let only_profile = render_recall_block(
+            vec![("偏好".to_string(), vec!["喜欢猫".to_string()])],
+            vec![],
+        )
+        .expect("profile only");
+        assert_eq!(only_profile, "[user_profile]\n[偏好]\n- 喜欢猫");
+        let only_rel = render_recall_block(vec![], vec!["聊到深夜".to_string()]).expect("rel only");
+        assert_eq!(only_rel, "[shared_memories]\n- 聊到深夜");
+    }
+
+    /// Both sections empty ⇒ no block at all, and the prompt is BYTE-identical
+    /// to the same turn without recall.
+    #[test]
+    fn recall_both_sections_empty_emits_no_block() {
+        assert!(render_recall_block(vec![], vec![]).is_none());
+        // A group whose items all pruned away is empty too.
+        assert!(
+            render_recall_block(vec![("偏好".to_string(), vec!["   ".to_string()])], vec![])
+                .is_none()
+        );
+        let a = affinity_at(0.0, 0.0, 0.0, 0.0, 0.0);
+        let with_none = build_voice_prompt(
+            &genome(),
+            "DIRECTIVE",
+            None,
+            Some(&a),
+            RelationshipScope::Bond,
+            None,
+        );
+        let with_empty = build_voice_prompt(
+            &genome(),
+            "DIRECTIVE",
+            None,
+            Some(&a),
+            RelationshipScope::Bond,
+            render_recall_block(vec![], vec![]).as_deref(),
+        );
+        assert_eq!(with_none, with_empty);
+        assert_eq!(
+            with_none,
+            "You are Mia.\n\nDIRECTIVE\n\n\
+             You two are still getting to know each other; keep it light and natural."
+        );
+    }
+
+    /// The text path substitutes Chinese placeholders for empty recall
+    /// sections. The voice prompt must NEVER carry them — a call that recalled
+    /// nothing simply says nothing about it.
+    #[test]
+    fn voice_prompt_never_renders_the_text_path_placeholders() {
+        const PLACEHOLDERS: [&str; 2] = ["（刚认识，还不了解他）", "（还没有专属记忆，慢慢来）"];
+        let a = affinity_at(0.9, 0.2, 0.2, 0.9, 0.9);
+        let s = snapshot(&["城市：上海"], Some("用户：你好"));
+        for groups in [
+            vec![],
+            vec![("偏好".to_string(), vec!["喜欢猫".to_string()])],
+        ] {
+            for facts in [vec![], vec!["聊到深夜".to_string()]] {
+                let p = build_voice_prompt(
+                    &genome(),
+                    "DIRECTIVE",
+                    render_bootstrap(&s).as_deref(),
+                    Some(&a),
+                    RelationshipScope::default(),
+                    render_recall_block(groups.clone(), facts.clone()).as_deref(),
+                );
+                for ph in PLACEHOLDERS {
+                    assert!(
+                        !p.contains(ph),
+                        "placeholder {ph} leaked into a voice prompt: {p}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Deduplication runs before rendering: a fact present in both layers is
+    /// kept in the profile section and dropped from `[shared_memories]`.
+    #[test]
+    fn recall_block_prunes_cross_layer_duplicates() {
+        let block = render_recall_block(
+            vec![("偏好".to_string(), vec!["喜欢猫".to_string()])],
+            vec!["喜欢猫".to_string(), "聊到深夜".to_string()],
+        )
+        .expect("a block");
+        assert_eq!(
+            block,
+            "[user_profile]\n[偏好]\n- 喜欢猫\n\n[shared_memories]\n- 聊到深夜"
+        );
     }
 
     // ─── prev-call transcript rendering ─────────────────────────────────
@@ -900,6 +1213,7 @@ mod tests {
             None,
             Some(&a),
             RelationshipScope::default(),
+            None,
         );
         assert!(p.contains("still getting to know each other"));
         assert!(p.contains("faint, unspoken spark"));
@@ -916,6 +1230,7 @@ mod tests {
             None,
             Some(&a),
             RelationshipScope::default(),
+            None,
         );
         assert!(p.contains("know each other inside out"));
         assert!(p.contains("do not lean into romance or seduction yet"));
@@ -935,6 +1250,7 @@ mod tests {
             None,
             Some(&a),
             RelationshipScope::default(),
+            None,
         );
         assert!(p.contains("close friends"));
         assert!(p.contains("deeply in love"));
@@ -950,6 +1266,7 @@ mod tests {
             None,
             Some(&low),
             RelationshipScope::default(),
+            None,
         );
         assert!(p_low.contains("faint, unspoken spark"));
         assert!(!p_low.contains("growing attraction"));
@@ -961,6 +1278,7 @@ mod tests {
             None,
             Some(&high),
             RelationshipScope::default(),
+            None,
         );
         assert!(p_high.contains("growing attraction"));
         assert!(!p_high.contains("faint, unspoken spark"));
@@ -975,6 +1293,7 @@ mod tests {
             None,
             Some(&a),
             RelationshipScope::None,
+            None,
         );
         assert_eq!(p, "You are Mia.\n\nDIRECTIVE");
     }
@@ -988,6 +1307,7 @@ mod tests {
             None,
             Some(&a),
             RelationshipScope::Bond,
+            None,
         );
         assert!(p.contains("close friends"));
         assert!(!p.contains("deeply in love"));
@@ -1002,6 +1322,7 @@ mod tests {
             None,
             Some(&a),
             RelationshipScope::Chemistry,
+            None,
         );
         assert!(!p.contains("close friends"));
         assert!(p.contains("deeply in love"));
@@ -1065,7 +1386,7 @@ data: [DONE]\n\n";
         let mut state = crate::routes::companion::test_state(pool.clone());
         state.model_config = Arc::new(
             ModelConfig::from_toml_str(
-                "[tasks.chat_voice]\nmodel = \"primary\"\nmax_tokens = 100\n",
+                "[tasks.chat_voice]\nmodel = \"primary\"\nmax_tokens = 100\nrecall = false\n",
             )
             .unwrap(),
         );
@@ -1084,6 +1405,7 @@ data: [DONE]\n\n";
                 instance_id,
                 user_id,
                 user_message_id: umid,
+                content: "hello".into(),
                 relationship_scope: RelationshipScope::default(),
                 memory_scope: MemoryScope::default(),
                 session_metadata: serde_json::json!({}),
@@ -1219,7 +1541,7 @@ data: [DONE]\n\n";
         let mut state = crate::routes::companion::test_state(pool.clone());
         state.model_config = Arc::new(
             ModelConfig::from_toml_str(
-                "[tasks.chat_voice]\nmodel = \"primary\"\nmax_tokens = 100\n",
+                "[tasks.chat_voice]\nmodel = \"primary\"\nmax_tokens = 100\nrecall = false\n",
             )
             .unwrap(),
         );
@@ -1238,6 +1560,7 @@ data: [DONE]\n\n";
                 instance_id,
                 user_id,
                 user_message_id: umid,
+                content: "hello".into(),
                 relationship_scope: RelationshipScope::default(),
                 memory_scope: MemoryScope::default(),
                 session_metadata: serde_json::json!({}),
@@ -1330,7 +1653,7 @@ data: [DONE]\n\n";
         let mut state = crate::routes::companion::test_state(pool.clone());
         state.model_config = Arc::new(
             ModelConfig::from_toml_str(
-                "[tasks.chat_voice]\nmodel = \"primary\"\nmax_tokens = 100\n",
+                "[tasks.chat_voice]\nmodel = \"primary\"\nmax_tokens = 100\nrecall = false\n",
             )
             .unwrap(),
         );
@@ -1349,6 +1672,7 @@ data: [DONE]\n\n";
                 instance_id,
                 user_id,
                 user_message_id: umid,
+                content: "hello".into(),
                 relationship_scope: RelationshipScope::default(),
                 memory_scope: MemoryScope::default(),
                 session_metadata: serde_json::json!({}),
@@ -1463,7 +1787,7 @@ data: [DONE]\n\n";
         let mut state = crate::routes::companion::test_state(pool.clone());
         state.model_config = Arc::new(
             ModelConfig::from_toml_str(
-                "[tasks.chat_voice]\nmodel = \"primary\"\nfallback = [\"backup\"]\nmax_tokens = 100\n",
+                "[tasks.chat_voice]\nmodel = \"primary\"\nfallback = [\"backup\"]\nmax_tokens = 100\nrecall = false\n",
             )
             .unwrap(),
         );
@@ -1483,6 +1807,7 @@ data: [DONE]\n\n";
                 instance_id,
                 user_id,
                 user_message_id: umid,
+                content: "hello".into(),
                 relationship_scope: RelationshipScope::default(),
                 memory_scope: MemoryScope::default(),
                 session_metadata: serde_json::json!({}),
@@ -1598,7 +1923,7 @@ data: [DONE]\n\n";
         let mut state = crate::routes::companion::test_state(pool.clone());
         state.model_config = Arc::new(
             ModelConfig::from_toml_str(
-                "[tasks.chat_voice]\nmodel = \"primary\"\nmax_tokens = 100\n",
+                "[tasks.chat_voice]\nmodel = \"primary\"\nmax_tokens = 100\nrecall = false\n",
             )
             .unwrap(),
         );
@@ -1617,6 +1942,7 @@ data: [DONE]\n\n";
                 instance_id,
                 user_id,
                 user_message_id: umid,
+                content: "hello".into(),
                 relationship_scope: RelationshipScope::default(),
                 memory_scope: MemoryScope::default(),
                 session_metadata: serde_json::json!({}),
@@ -1723,7 +2049,7 @@ data: [DONE]\n\n";
         let mut state = crate::routes::companion::test_state(pool.clone());
         state.model_config = Arc::new(
             ModelConfig::from_toml_str(
-                "[tasks.chat_voice]\nmodel = \"primary\"\nmax_tokens = 100\n",
+                "[tasks.chat_voice]\nmodel = \"primary\"\nmax_tokens = 100\nrecall = false\n",
             )
             .unwrap(),
         );
@@ -1744,6 +2070,7 @@ data: [DONE]\n\n";
                 instance_id,
                 user_id,
                 user_message_id: umid,
+                content: "hello".into(),
                 relationship_scope: RelationshipScope::default(),
                 memory_scope: MemoryScope::default(),
                 session_metadata: serde_json::json!({}),
@@ -1843,7 +2170,7 @@ data: [DONE]\n\n";
         let mut state = crate::routes::companion::test_state(pool.clone());
         state.model_config = Arc::new(
             ModelConfig::from_toml_str(
-                "[tasks.chat_voice]\nmodel = \"primary\"\nmax_tokens = 100\n",
+                "[tasks.chat_voice]\nmodel = \"primary\"\nmax_tokens = 100\nrecall = false\n",
             )
             .unwrap(),
         );
@@ -1862,6 +2189,7 @@ data: [DONE]\n\n";
                 instance_id,
                 user_id,
                 user_message_id: umid,
+                content: "hello".into(),
                 relationship_scope: RelationshipScope::default(),
                 memory_scope: MemoryScope::default(),
                 session_metadata: serde_json::json!({}),
@@ -1966,7 +2294,7 @@ data: [DONE]\n\n";
         let mut state = crate::routes::companion::test_state(pool.clone());
         state.model_config = Arc::new(
             ModelConfig::from_toml_str(
-                "[tasks.chat_voice]\nmodel = \"primary\"\nfallback = [\"backup\"]\nmax_tokens = 100\n",
+                "[tasks.chat_voice]\nmodel = \"primary\"\nfallback = [\"backup\"]\nmax_tokens = 100\nrecall = false\n",
             )
             .unwrap(),
         );
@@ -1986,6 +2314,7 @@ data: [DONE]\n\n";
                 instance_id,
                 user_id,
                 user_message_id: umid,
+                content: "hello".into(),
                 relationship_scope: RelationshipScope::default(),
                 memory_scope: MemoryScope::default(),
                 session_metadata: serde_json::json!({}),
@@ -2190,7 +2519,7 @@ data: [DONE]\n\n";
         let mut state = crate::routes::companion::test_state(pool.clone());
         state.model_config = Arc::new(
             ModelConfig::from_toml_str(
-                "[tasks.chat_voice]\nmodel = \"primary\"\nmax_tokens = 100\n",
+                "[tasks.chat_voice]\nmodel = \"primary\"\nmax_tokens = 100\nrecall = false\n",
             )
             .unwrap(),
         );
@@ -2208,6 +2537,7 @@ data: [DONE]\n\n";
                 instance_id,
                 user_id,
                 user_message_id: umid,
+                content: "hello".into(),
                 relationship_scope: RelationshipScope::None,
                 memory_scope,
                 session_metadata: session.metadata,
@@ -2651,5 +2981,447 @@ data: [DONE]\n\n";
         assert_eq!(marker["insights"], serde_json::json!(["城市：上海"]));
         let sys = system_prompt_of(&last_request_body(&mock).await);
         assert!(sys.contains("[关于他]\n- 城市：上海"), "{sys}");
+    }
+
+    // ─── per-turn recall, end to end ────────────────────────────────────
+    //
+    // The embedding leg is mocked by pointing `[tasks.embedding]` at a custom
+    // `[providers.<name>]` OpenAI-compatible endpoint served by a SECOND
+    // wiremock server — exactly how a deployment wires a self-hosted embedding
+    // provider, and the same wire `EmbedHttpClient` speaks in production.
+    // Every test below installs that router, so nothing here can reach the
+    // real Voyage endpoint; a "zero embedding calls" assertion is then a
+    // genuine request count on a live mock, not an absence of configuration.
+    //
+    // The pre-existing voice e2e tests above stay network-free a different
+    // way: their `[tasks.chat_voice]` config carries `recall = false`, so the
+    // gate closes before `state.embed` (a Voyage router) is ever touched.
+
+    /// 512-dim unit vector — a query embedded at the same seed is the exact
+    /// nearest neighbour of a row stored at it.
+    fn unit_embedding(seed: usize) -> Vec<f32> {
+        let mut v = vec![0.0_f32; 512];
+        v[seed % 512] = 1.0;
+        v
+    }
+
+    /// A wiremock server standing in for the embeddings provider.
+    async fn embed_mock(status: u16, delay: Option<Duration>) -> wiremock::MockServer {
+        use wiremock::matchers::path as wm_path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let mut tpl = ResponseTemplate::new(status);
+        if status == 200 {
+            tpl = tpl.set_body_json(
+                serde_json::json!({ "data": [ { "embedding": unit_embedding(1) } ] }),
+            );
+        }
+        if let Some(d) = delay {
+            tpl = tpl.set_delay(d);
+        }
+        Mock::given(wm_path("/v1/embeddings"))
+            .respond_with(tpl)
+            .mount(&server)
+            .await;
+        server
+    }
+
+    /// An `EmbeddingRouter` whose read backend is `embed_mock`, built through
+    /// the production `from_config_with` path (custom provider + its
+    /// `<NAME>_API_KEY`).
+    fn embed_router(uri: &str) -> eros_engine_llm::embedding::EmbeddingRouter {
+        let cfg = eros_engine_llm::model_config::ModelConfig::from_toml_str(&format!(
+            "[providers.mockembed]\nembeddings = \"{uri}/v1/embeddings\"\n\
+             [tasks.embedding]\nmodel = \"mock-embed@mockembed\"\n"
+        ))
+        .expect("embedding provider config parses");
+        eros_engine_llm::embedding::EmbeddingRouter::from_config_with(&cfg, |k| {
+            (k == "MOCKEMBED_API_KEY").then(|| "test-key".to_string())
+        })
+        .expect("mock embedding router builds")
+    }
+
+    async fn embed_hits(embed: &wiremock::MockServer) -> usize {
+        embed
+            .received_requests()
+            .await
+            .expect("recording enabled by default")
+            .len()
+    }
+
+    /// One categorised profile row + one relationship row, both stored at
+    /// `unit_embedding(1)` — the vector `embed_mock` hands back.
+    async fn seed_recallable_memories(
+        pool: &sqlx::PgPool,
+        session_id: Uuid,
+        user_id: Uuid,
+        instance_id: Uuid,
+    ) {
+        use eros_engine_store::memory::{MemoryLayer, MemoryRepo};
+        let repo = MemoryRepo { pool };
+        repo.upsert(
+            MemoryLayer::Profile,
+            session_id,
+            user_id,
+            None,
+            "喜欢在东京散步",
+            &unit_embedding(1),
+            Some("preference"),
+            None,
+        )
+        .await
+        .unwrap();
+        repo.upsert(
+            MemoryLayer::Relationship,
+            session_id,
+            user_id,
+            Some(instance_id),
+            "上次约好一起去东京",
+            &unit_embedding(1),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    }
+
+    /// Knobs for one recall e2e turn.
+    struct RecallTurnOpts<'a> {
+        client_msg_id: &'a str,
+        /// The utterance — also the recall query text.
+        content: &'a str,
+        memory_scope: MemoryScope,
+        relationship_scope: RelationshipScope,
+        /// `[tasks.chat_voice] recall = …`
+        recall: bool,
+    }
+
+    impl Default for RecallTurnOpts<'_> {
+        fn default() -> Self {
+            Self {
+                client_msg_id: "01J9RECALL000000000000001",
+                // 6 alphanumeric chars — comfortably past the backchannel floor.
+                content: "带我去东京吧",
+                memory_scope: MemoryScope::default(),
+                relationship_scope: RelationshipScope::None,
+                recall: true,
+            }
+        }
+    }
+
+    /// One voice turn, driven the way the route drives it, with BOTH the chat
+    /// and the embedding provider mocked.
+    async fn run_recall_turn(
+        pool: &sqlx::PgPool,
+        mock: &wiremock::MockServer,
+        embed: &wiremock::MockServer,
+        session_id: Uuid,
+        instance_id: Uuid,
+        user_id: Uuid,
+        opts: RecallTurnOpts<'_>,
+    ) -> Vec<ProtocolFrame> {
+        use eros_engine_llm::model_config::ModelConfig;
+        use futures_util::StreamExt;
+
+        let repo = ChatRepo { pool };
+        let session = repo
+            .get_session(session_id)
+            .await
+            .unwrap()
+            .expect("session exists");
+        let umid = match repo
+            .insert_voice_user_message(session_id, opts.content, opts.client_msg_id)
+            .await
+            .unwrap()
+        {
+            eros_engine_store::chat::VoiceUserInsert::Inserted(id) => id,
+            other => panic!("expected Inserted, got {other:?}"),
+        };
+
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = Arc::new(
+            ModelConfig::from_toml_str(&format!(
+                "[tasks.chat_voice]\nmodel = \"primary\"\nmax_tokens = 100\nrecall = {}\n",
+                opts.recall
+            ))
+            .unwrap(),
+        );
+        state.openrouter = Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+        state.embed = Arc::new(embed_router(&embed.uri()));
+
+        let resolved = state.model_config.resolve_voice().unwrap();
+        run_voice_turn(
+            Arc::new(state),
+            VoiceTurn {
+                session_id,
+                instance_id,
+                user_id,
+                user_message_id: umid,
+                content: opts.content.to_string(),
+                relationship_scope: opts.relationship_scope,
+                memory_scope: opts.memory_scope,
+                session_metadata: session.metadata,
+            },
+            resolved,
+        )
+        .collect()
+        .await
+    }
+
+    fn assert_streamed_hi(frames: &[ProtocolFrame]) {
+        let text: String = frames
+            .iter()
+            .filter_map(|f| match f {
+                ProtocolFrame::Delta { content, .. } => Some(content.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(text, "hi", "the reply must still stream; got {frames:?}");
+        assert!(matches!(frames.last(), Some(ProtocolFrame::Done { .. })));
+        assert_no_error_frame(frames);
+    }
+
+    fn assert_no_recall_block(sys: &str) {
+        assert!(
+            !sys.contains("[user_profile]"),
+            "recall block present: {sys}"
+        );
+        assert!(
+            !sys.contains("[shared_memories]"),
+            "recall block present: {sys}"
+        );
+        // …and never the text path's placeholders in its place.
+        assert!(!sys.contains("（刚认识，还不了解他）"), "{sys}");
+        assert!(!sys.contains("（还没有专属记忆，慢慢来）"), "{sys}");
+    }
+
+    /// The happy path: this turn's utterance is embedded, the pgvector hits are
+    /// rendered under `[user_profile]` / `[shared_memories]`, and the block is
+    /// the LAST thing in the system prompt — after the relationship line.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn run_voice_turn_recall_snippets_appear_in_wire_prompt(pool: sqlx::PgPool) {
+        let mock = bootstrap_mock().await;
+        let embed = embed_mock(200, None).await;
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_instance(&pool, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id, "voice").await;
+        seed_recallable_memories(&pool, session_id, user_id, instance_id).await;
+
+        // An affinity row for the pair, so a relationship line exists for the
+        // recall block to sit after (fresh seed ⇒ Acquaintance / Spark).
+        let text_session = seed_session(&pool, user_id, instance_id, "text").await;
+        AffinityRepo { pool: &pool }
+            .load_or_create(text_session, user_id, instance_id)
+            .await
+            .unwrap();
+
+        let frames = run_recall_turn(
+            &pool,
+            &mock,
+            &embed,
+            session_id,
+            instance_id,
+            user_id,
+            RecallTurnOpts {
+                relationship_scope: RelationshipScope::default(),
+                ..Default::default()
+            },
+        )
+        .await;
+        assert_streamed_hi(&frames);
+        assert_eq!(embed_hits(&embed).await, 1, "exactly one embedding call");
+
+        let sys = system_prompt_of(&last_request_body(&mock).await);
+        assert!(
+            sys.contains("[user_profile]\n[偏好]\n- 喜欢在东京散步"),
+            "profile section missing: {sys}"
+        );
+        assert!(
+            sys.contains("[shared_memories]\n- 上次约好一起去东京"),
+            "relationship section missing: {sys}"
+        );
+        // Dynamic content last: after the relationship line, and at the very
+        // end of the prompt.
+        let line = sys
+            .find("still getting to know each other")
+            .expect("relationship line present");
+        let block = sys.find("[user_profile]").expect("recall block present");
+        assert!(
+            line < block,
+            "the recall block must follow the relationship line: {sys}"
+        );
+        assert!(
+            sys.ends_with("[shared_memories]\n- 上次约好一起去东京"),
+            "the recall block must be the final segment: {sys}"
+        );
+    }
+
+    /// The embedding provider fails: the reply still streams, no recall block,
+    /// and no `error` frame — the failure is swallowed inside `recall_memory`.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn run_voice_turn_embed_failure_degrades_to_no_block(pool: sqlx::PgPool) {
+        let mock = bootstrap_mock().await;
+        let embed = embed_mock(500, None).await;
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_instance(&pool, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id, "voice").await;
+        seed_recallable_memories(&pool, session_id, user_id, instance_id).await;
+
+        let frames = run_recall_turn(
+            &pool,
+            &mock,
+            &embed,
+            session_id,
+            instance_id,
+            user_id,
+            RecallTurnOpts::default(),
+        )
+        .await;
+        assert_streamed_hi(&frames);
+        assert_eq!(
+            embed_hits(&embed).await,
+            1,
+            "the embedding WAS attempted — it just failed"
+        );
+        assert_no_recall_block(&system_prompt_of(&last_request_body(&mock).await));
+    }
+
+    /// The embedding provider hangs past `VOICE_RECALL_BUDGET`: the turn stops
+    /// waiting, streams its reply with no recall block, and emits no `error`
+    /// frame. The wall-clock bound is deliberately loose — it only has to prove
+    /// the turn did NOT sit out the provider's full delay.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn run_voice_turn_embed_timeout_degrades_to_no_block(pool: sqlx::PgPool) {
+        let mock = bootstrap_mock().await;
+        let embed = embed_mock(200, Some(Duration::from_secs(3))).await;
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_instance(&pool, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id, "voice").await;
+        seed_recallable_memories(&pool, session_id, user_id, instance_id).await;
+
+        let started = std::time::Instant::now();
+        let frames = run_recall_turn(
+            &pool,
+            &mock,
+            &embed,
+            session_id,
+            instance_id,
+            user_id,
+            RecallTurnOpts::default(),
+        )
+        .await;
+        let elapsed = started.elapsed();
+        assert_streamed_hi(&frames);
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "the turn must not wait out the provider's 3s delay; took {elapsed:?}"
+        );
+        assert_no_recall_block(&system_prompt_of(&last_request_body(&mock).await));
+    }
+
+    /// `memory_scope: "none"` resolves both layers off ⇒ the gate closes before
+    /// any embedding work: zero calls on the embedding mock.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn run_voice_turn_memory_scope_none_issues_no_embedding_call(pool: sqlx::PgPool) {
+        let mock = bootstrap_mock().await;
+        let embed = embed_mock(200, None).await;
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_instance(&pool, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id, "voice").await;
+        seed_recallable_memories(&pool, session_id, user_id, instance_id).await;
+
+        let frames = run_recall_turn(
+            &pool,
+            &mock,
+            &embed,
+            session_id,
+            instance_id,
+            user_id,
+            RecallTurnOpts {
+                memory_scope: MemoryScope::None,
+                ..Default::default()
+            },
+        )
+        .await;
+        assert_streamed_hi(&frames);
+        assert_eq!(
+            embed_hits(&embed).await,
+            0,
+            "both layers off ⇒ no embedding round trip"
+        );
+        assert_no_recall_block(&system_prompt_of(&last_request_body(&mock).await));
+    }
+
+    /// The deployment kill-switch wins over the request: `recall = false` with
+    /// the most permissive `memory_scope` still issues no embedding call.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn run_voice_turn_config_recall_false_beats_request(pool: sqlx::PgPool) {
+        let mock = bootstrap_mock().await;
+        let embed = embed_mock(200, None).await;
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_instance(&pool, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id, "voice").await;
+        seed_recallable_memories(&pool, session_id, user_id, instance_id).await;
+
+        let frames = run_recall_turn(
+            &pool,
+            &mock,
+            &embed,
+            session_id,
+            instance_id,
+            user_id,
+            RecallTurnOpts {
+                recall: false,
+                memory_scope: MemoryScope::Full,
+                ..Default::default()
+            },
+        )
+        .await;
+        assert_streamed_hi(&frames);
+        assert_eq!(
+            embed_hits(&embed).await,
+            0,
+            "config recall = false must beat memory_scope: full"
+        );
+        assert_no_recall_block(&system_prompt_of(&last_request_body(&mock).await));
+    }
+
+    /// A backchannel turn (嗯嗯 — 2 alphanumerics after punctuation stripping)
+    /// skips recall entirely: no embedding call, reply unaffected.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn run_voice_turn_backchannel_turn_skips_embedding_call(pool: sqlx::PgPool) {
+        let mock = bootstrap_mock().await;
+        let embed = embed_mock(200, None).await;
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_instance(&pool, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id, "voice").await;
+        seed_recallable_memories(&pool, session_id, user_id, instance_id).await;
+
+        let frames = run_recall_turn(
+            &pool,
+            &mock,
+            &embed,
+            session_id,
+            instance_id,
+            user_id,
+            RecallTurnOpts {
+                content: "嗯嗯",
+                ..Default::default()
+            },
+        )
+        .await;
+        assert_streamed_hi(&frames);
+        assert_eq!(
+            embed_hits(&embed).await,
+            0,
+            "a backchannel utterance must not cost an embedding round trip"
+        );
+        assert_no_recall_block(&system_prompt_of(&last_request_body(&mock).await));
     }
 }

--- a/crates/eros-engine-server/src/pipeline/voice.rs
+++ b/crates/eros-engine-server/src/pipeline/voice.rs
@@ -3,31 +3,47 @@
 //!
 //! Spec: docs/superpowers/specs/2026-07-07-voice-call-parts-design.md
 
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
 use std::sync::Arc;
 use ulid::Ulid;
 use uuid::Uuid;
 
 use eros_engine_core::affinity::{Affinity, BondLabel, ChemistryLabel};
 use eros_engine_core::persona::PersonaGenome;
-use eros_engine_core::scope::RelationshipScope;
+use eros_engine_core::scope::{InsightMode, MemoryScope, RelationshipScope};
 use eros_engine_llm::model_config::ResolvedVoice;
 use eros_engine_llm::openrouter::{ChatMessage as WireMessage, ChatRequest, UsageBlock};
 use eros_engine_store::affinity::AffinityRepo;
-use eros_engine_store::chat::ChatRepo;
+use eros_engine_store::chat::{ChatMessageSlim, ChatRepo};
+use eros_engine_store::human_insight::HumanInsightRepo;
 use eros_engine_store::persona::PersonaRepo;
 
+use crate::pipeline::handlers::human_insights_to_bullets;
 use crate::pipeline::stream::{
     ulid_string, ProtocolFrame, StreamErrorCode, STREAM_OPEN_TIMEOUT, STREAM_TOTAL_TIMEOUT,
 };
 use crate::state::AppState;
 
-/// Assemble the thin voice system prompt: persona + voice directive + one
-/// optional relationship line (bond/chemistry-derived, gated by
-/// `relationship_scope`). Deliberately excludes recall, memories, traits,
-/// scopes, and every heavy block the text path's `build_prompt` composes.
+/// `chat_sessions.metadata` key holding a voice session's frozen bootstrap
+/// snapshot (write-once — see `ChatRepo::set_voice_bootstrap`).
+const VOICE_BOOTSTRAP_KEY: &str = "voice_bootstrap";
+
+/// Assemble the thin voice system prompt: persona + voice directive +
+/// the (already rendered) bootstrap block + one optional relationship line
+/// (bond/chemistry-derived, gated by `relationship_scope`). Deliberately
+/// excludes memories, traits, scopes, and every heavy block the text path's
+/// `build_prompt` composes.
+///
+/// Order matters: persona → directive → bootstrap → relationship line. The
+/// bootstrap block is frozen for the whole call, so everything up to (and
+/// including) it is byte-stable across the call's turns — provider-side
+/// prefix caching keeps working.
 pub fn build_voice_prompt(
     genome: &PersonaGenome,
     directive: &str,
+    bootstrap: Option<&str>,
     affinity: Option<&Affinity>,
     relationship_scope: RelationshipScope,
 ) -> String {
@@ -35,11 +51,210 @@ pub fn build_voice_prompt(
     s.push_str(&genome.system_prompt);
     s.push_str("\n\n");
     s.push_str(directive);
+    if let Some(block) = bootstrap {
+        s.push_str("\n\n");
+        s.push_str(block);
+    }
     if let Some(line) = affinity.and_then(|a| relationship_line(a, relationship_scope)) {
         s.push_str("\n\n");
         s.push_str(&line);
     }
     s
+}
+
+/// A voice call's frozen bootstrap context, stored under
+/// `chat_sessions.metadata.voice_bootstrap` on the session's first turn and
+/// re-injected verbatim on every later turn (OpenRouter is stateless — there
+/// is no such thing as "injected once at session start").
+///
+/// Everything here is stored **rendered**: the bullets and the transcript are
+/// the exact strings that go into the prompt, never re-derived from live rows.
+/// That is what makes the prefix byte-stable for the whole call even as the
+/// underlying `human_insights` row changes.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct VoiceBootstrap {
+    /// 基础画像 bullets, rendered at first turn under that turn's `InsightMode`.
+    pub insights: Vec<String>,
+    /// Previous voice call's tail, rendered as a plain transcript.
+    #[serde(default)]
+    pub prev_call: Option<String>,
+    /// The sibling voice session the transcript came from (audit only).
+    #[serde(default)]
+    pub prev_session_id: Option<Uuid>,
+    pub created_at: DateTime<Utc>,
+}
+
+/// What this turn should do about the bootstrap snapshot, decided purely from
+/// the session `metadata` the route already loaded — no query.
+#[derive(Debug)]
+enum BootstrapPlan {
+    /// Marker present and well-formed: inject it, touch nothing.
+    Frozen(VoiceBootstrap),
+    /// Marker present but unreadable: inject nothing and NEVER rewrite — the
+    /// snapshot is write-once, and clobbering it would be worse than degrading.
+    Malformed,
+    /// Marker absent: assemble a snapshot this turn (the only path that reads).
+    Assemble,
+}
+
+fn plan_bootstrap(session_metadata: &serde_json::Value) -> BootstrapPlan {
+    match session_metadata.get(VOICE_BOOTSTRAP_KEY) {
+        None => BootstrapPlan::Assemble,
+        Some(v) => match serde_json::from_value::<VoiceBootstrap>(v.clone()) {
+            Ok(b) => BootstrapPlan::Frozen(b),
+            Err(_) => BootstrapPlan::Malformed,
+        },
+    }
+}
+
+/// Render the bootstrap block: `[关于他]` bullets then the `[上次通话]`
+/// transcript. Each sub-block is omitted when its part is empty; `None` when
+/// both are — the caller then emits no block at all (no stray blank lines).
+fn render_bootstrap(b: &VoiceBootstrap) -> Option<String> {
+    let bullets: Vec<&str> = b
+        .insights
+        .iter()
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .collect();
+    let prev = b
+        .prev_call
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    if bullets.is_empty() && prev.is_none() {
+        return None;
+    }
+    let mut s = String::new();
+    if !bullets.is_empty() {
+        s.push_str("[关于他]");
+        for b in bullets {
+            s.push_str("\n- ");
+            s.push_str(b);
+        }
+    }
+    if let Some(t) = prev {
+        if !s.is_empty() {
+            s.push_str("\n\n");
+        }
+        s.push_str("[上次通话]\n");
+        s.push_str(t);
+    }
+    Some(s)
+}
+
+/// Render a sibling voice session's tail as a plain transcript, one line per
+/// message. Empty-content rows are skipped (a caption-less image turn would
+/// otherwise render as a bare speaker prefix) and so is any role outside the
+/// user/assistant pair; `gift_user` speaks as the user.
+fn render_prev_call(rows: &[ChatMessageSlim]) -> Option<String> {
+    let mut lines: Vec<String> = Vec::with_capacity(rows.len());
+    for m in rows {
+        let content = m.content.trim();
+        if content.is_empty() {
+            continue;
+        }
+        let speaker = match m.role.as_str() {
+            "user" | "gift_user" => "用户",
+            "assistant" => "她",
+            _ => continue,
+        };
+        lines.push(format!("{speaker}：{content}"));
+    }
+    if lines.is_empty() {
+        None
+    } else {
+        Some(lines.join("\n"))
+    }
+}
+
+/// 基础画像 bullets for the snapshot. `Off` short-circuits without a query —
+/// an empty part, and still a SUCCESS (the marker may be written).
+async fn load_bootstrap_insights(
+    pool: &PgPool,
+    user_id: Uuid,
+    mode: InsightMode,
+) -> Result<Vec<String>, sqlx::Error> {
+    if matches!(mode, InsightMode::Off) {
+        return Ok(Vec::new());
+    }
+    // Deliberately NOT `load_human_insight_bullets`: it swallows Err into an
+    // empty vec, erasing the failed-vs-empty distinction this snapshot needs
+    // (an empty read freezes the marker; a failed read must not).
+    match (HumanInsightRepo { pool }).load(user_id).await {
+        Ok(Some(row)) => Ok(human_insights_to_bullets(&row, mode)),
+        Ok(None) => Ok(Vec::new()),
+        Err(e) => Err(e),
+    }
+}
+
+/// The previous call's tail: the latest sibling voice session for this
+/// user × instance (never this session, never a text session) and its last
+/// `VOICE_HISTORY_WINDOW` messages. No sibling ⇒ an empty part, still a
+/// success (first-ever call).
+async fn load_bootstrap_prev_call(
+    pool: &PgPool,
+    user_id: Uuid,
+    instance_id: Uuid,
+    session_id: Uuid,
+) -> Result<(Option<String>, Option<Uuid>), sqlx::Error> {
+    let repo = ChatRepo { pool };
+    let Some(sibling) = repo
+        .latest_sibling_voice_session(user_id, instance_id, session_id)
+        .await?
+    else {
+        return Ok((None, None));
+    };
+    // Same 8-message unit as the in-session window (spec §3). `history_slim`
+    // is the narrow, channel-blind projection — the sibling is already
+    // channel-scoped by the lookup.
+    let rows = repo
+        .history_slim(sibling.id, VOICE_HISTORY_WINDOW, 0)
+        .await?;
+    Ok((render_prev_call(&rows), Some(sibling.id)))
+}
+
+/// Assemble a first-turn snapshot. The two parts degrade independently; the
+/// returned flag is `true` only when BOTH succeeded — a partial snapshot is
+/// injected in memory for this turn but must not be frozen, so the next turn
+/// retries.
+async fn assemble_bootstrap(
+    pool: &PgPool,
+    user_id: Uuid,
+    instance_id: Uuid,
+    session_id: Uuid,
+    insight_mode: InsightMode,
+) -> (VoiceBootstrap, bool) {
+    let (insights_res, prev_res) = tokio::join!(
+        load_bootstrap_insights(pool, user_id, insight_mode),
+        load_bootstrap_prev_call(pool, user_id, instance_id, session_id),
+    );
+    let mut complete = true;
+    let insights = match insights_res {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(error = %e, "voice: bootstrap insights read failed");
+            complete = false;
+            Vec::new()
+        }
+    };
+    let (prev_call, prev_session_id) = match prev_res {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(error = %e, "voice: bootstrap prev-call read failed");
+            complete = false;
+            (None, None)
+        }
+    };
+    (
+        VoiceBootstrap {
+            insights,
+            prev_call,
+            prev_session_id,
+            created_at: Utc::now(),
+        },
+        complete,
+    )
 }
 
 /// One relationship-tone line, derived at read time from the affinity row's
@@ -95,17 +310,29 @@ pub struct VoiceTurn {
     pub user_id: Uuid,
     pub user_message_id: Uuid,
     pub relationship_scope: RelationshipScope,
+    /// This turn's memory scope. On the FIRST turn its resolved `InsightMode`
+    /// picks the bootstrap snapshot's insight tier — frozen for the whole call
+    /// from then on.
+    pub memory_scope: MemoryScope,
+    /// `chat_sessions.metadata` as the route already loaded it. Carries the
+    /// `voice_bootstrap` marker, so the common path (marker present) costs no
+    /// extra query at all.
+    pub session_metadata: serde_json::Value,
 }
 
-/// Recent turns fed to the model on a voice turn. Shorter than the text path to
-/// keep latency/tokens down.
-pub const VOICE_HISTORY_WINDOW: i64 = 12;
+/// Recent turns fed to the model on a voice turn — 8 messages (4 exchanges).
+/// Shorter than the text path to keep latency/tokens down; the bootstrap
+/// snapshot and per-turn recall carry the longer memory. Doubles as the tail
+/// length quoted from the previous call into the bootstrap snapshot.
+pub const VOICE_HISTORY_WINDOW: i64 = 8;
 
-/// Drive one voice turn: load persona + (optional) affinity + recent history,
-/// assemble the thin prompt, stream a single-model completion (walking the
-/// outage fallback chain ourselves, since `execute_stream` is single-model),
-/// emit `delta`* then `done`, and persist the assistant turn. `error` only when
-/// no candidate produced anything.
+/// Drive one voice turn: load persona + (optional) affinity + recent history
+/// (+ the bootstrap snapshot on a session's first turn), assemble the thin
+/// prompt, stream a single-model completion (walking the outage fallback chain
+/// ourselves, since `execute_stream` is single-model), emit `delta`* then
+/// `done`, and persist the assistant turn. `error` only when no candidate
+/// produced anything — never for a memory problem, which always degrades to a
+/// warn.
 pub fn run_voice_turn(
     state: Arc<AppState>,
     turn: VoiceTurn,
@@ -116,7 +343,50 @@ pub fn run_voice_turn(
         let persona_repo = PersonaRepo { pool: &state.pool };
         let affinity_repo = AffinityRepo { pool: &state.pool };
 
-        let persona = match persona_repo.load_companion(turn.instance_id).await {
+        // Decided from the session row the route already loaded: after the
+        // first turn this is `Frozen` and the whole bootstrap costs ZERO
+        // queries.
+        let plan = plan_bootstrap(&turn.session_metadata);
+        if matches!(plan, BootstrapPlan::Malformed) {
+            tracing::warn!(
+                session_id = %turn.session_id,
+                "voice: unreadable voice_bootstrap metadata — injecting nothing, never rewriting",
+            );
+        }
+        let assemble_bootstrap_now = matches!(plan, BootstrapPlan::Assemble);
+        // The FIRST turn's scope decides the snapshot's insight tier; later
+        // turns can't change it (the snapshot is frozen).
+        let insight_mode = turn.memory_scope.resolve().0;
+
+        // All independent reads in one round trip's worth of wall clock. The
+        // bootstrap future is inert unless this is the first turn.
+        let (persona_res, affinity_res, history_res, assembled) = tokio::join!(
+            persona_repo.load_companion(turn.instance_id),
+            // Resolve affinity by user × persona-instance, not by session:
+            // `companion_affinity` is populated only by the text pipeline, so a
+            // voice-channel session's own `session_id` never has a row — this
+            // read-only lookup takes the freshest row across every session for
+            // the same pair (e.g. a prior text session) instead. Never creates a
+            // row on the voice path.
+            affinity_repo.load_latest_for_pair(turn.user_id, turn.instance_id),
+            // Chronological history, includes the just-persisted user turn.
+            chat_repo.history(turn.session_id, VOICE_HISTORY_WINDOW, 0),
+            async {
+                if assemble_bootstrap_now {
+                    Some(assemble_bootstrap(
+                        &state.pool,
+                        turn.user_id,
+                        turn.instance_id,
+                        turn.session_id,
+                        insight_mode,
+                    ).await)
+                } else {
+                    None
+                }
+            },
+        );
+
+        let persona = match persona_res {
             Ok(Some(p)) => p,
             _ => {
                 yield ProtocolFrame::Error {
@@ -129,22 +399,9 @@ pub fn run_voice_turn(
             }
         };
 
-        // Resolve affinity by user × persona-instance, not by session:
-        // `companion_affinity` is populated only by the text pipeline, so a
-        // voice-channel session's own `session_id` never has a row — this
-        // read-only lookup takes the freshest row across every session for
-        // the same pair (e.g. a prior text session) instead. Never creates a
-        // row on the voice path.
-        let affinity = affinity_repo
-            .load_latest_for_pair(turn.user_id, turn.instance_id)
-            .await
-            .unwrap_or(None);
+        let affinity = affinity_res.unwrap_or(None);
 
-        // Chronological history, includes the just-persisted user turn.
-        let history = match chat_repo
-            .history(turn.session_id, VOICE_HISTORY_WINDOW, 0)
-            .await
-        {
+        let history = match history_res {
             Ok(h) => h,
             Err(e) => {
                 tracing::warn!(error = %e, "voice: history read failed");
@@ -158,9 +415,41 @@ pub fn run_voice_turn(
             }
         };
 
+        // Freeze the snapshot on the first turn, then inject it (this turn from
+        // the in-memory copy, later turns from `metadata`). Every failure here
+        // is a warn: a memory problem never costs the caller a reply.
+        let bootstrap = match plan {
+            BootstrapPlan::Frozen(b) => Some(b),
+            BootstrapPlan::Malformed => None,
+            BootstrapPlan::Assemble => match assembled {
+                Some((snapshot, complete)) => {
+                    if complete {
+                        match serde_json::to_value(&snapshot) {
+                            // rows_affected 0 = the key was already there (a
+                            // concurrent first turn won the race): normal, and
+                            // this turn just uses its own identical copy.
+                            Ok(v) => if let Err(e) = chat_repo.set_voice_bootstrap(turn.session_id, &v).await {
+                                tracing::warn!(error = %e, "voice: bootstrap snapshot write failed; using in-memory copy");
+                            },
+                            Err(e) => tracing::warn!(error = %e, "voice: bootstrap snapshot serialize failed"),
+                        }
+                    } else {
+                        tracing::warn!(
+                            session_id = %turn.session_id,
+                            "voice: bootstrap assembly incomplete — injecting what loaded, marker left unwritten (next turn retries)",
+                        );
+                    }
+                    Some(snapshot)
+                }
+                None => None,
+            },
+        };
+        let bootstrap_block = bootstrap.as_ref().and_then(render_bootstrap);
+
         let system_prompt = build_voice_prompt(
             &persona.genome,
             &resolved.directive,
+            bootstrap_block.as_deref(),
             affinity.as_ref(),
             turn.relationship_scope,
         );
@@ -403,10 +692,202 @@ mod tests {
         }
     }
 
+    /// A frozen snapshot with both parts populated.
+    fn snapshot(insights: &[&str], prev_call: Option<&str>) -> VoiceBootstrap {
+        VoiceBootstrap {
+            insights: insights.iter().map(|s| (*s).to_string()).collect(),
+            prev_call: prev_call.map(str::to_string),
+            prev_session_id: None,
+            created_at: Utc::now(),
+        }
+    }
+
+    fn slim(role: &str, content: &str) -> ChatMessageSlim {
+        ChatMessageSlim {
+            id: Uuid::new_v4(),
+            role: role.into(),
+            content: content.into(),
+            sent_at: Utc::now(),
+            client_msg_id: None,
+            tips_amount_usd: None,
+            channel: None,
+        }
+    }
+
     #[test]
     fn includes_persona_and_directive_without_affinity() {
-        let p = build_voice_prompt(&genome(), "DIRECTIVE", None, RelationshipScope::default());
+        let p = build_voice_prompt(
+            &genome(),
+            "DIRECTIVE",
+            None,
+            None,
+            RelationshipScope::default(),
+        );
         assert_eq!(p, "You are Mia.\n\nDIRECTIVE");
+    }
+
+    // ─── bootstrap block rendering ──────────────────────────────────────
+
+    /// The whole block, byte-pinned: label, bullet prefix, sub-block order,
+    /// and the `\n\n` joining discipline the prompt already uses.
+    #[test]
+    fn bootstrap_block_rendering_is_pinned() {
+        let s = snapshot(
+            &["城市：上海", "职业：设计师"],
+            Some("用户：你好\n她：嗨呀"),
+        );
+        let p = build_voice_prompt(
+            &genome(),
+            "DIRECTIVE",
+            render_bootstrap(&s).as_deref(),
+            None,
+            RelationshipScope::None,
+        );
+        assert_eq!(
+            p,
+            "You are Mia.\n\nDIRECTIVE\n\n\
+             [关于他]\n- 城市：上海\n- 职业：设计师\n\n\
+             [上次通话]\n用户：你好\n她：嗨呀"
+        );
+    }
+
+    /// Order: persona → directive → bootstrap → relationship line.
+    #[test]
+    fn bootstrap_block_sits_between_directive_and_relationship_line() {
+        let a = affinity_at(0.0, 0.0, 0.0, 0.0, 0.0);
+        let s = snapshot(&["城市：上海"], Some("用户：你好"));
+        let p = build_voice_prompt(
+            &genome(),
+            "DIRECTIVE",
+            render_bootstrap(&s).as_deref(),
+            Some(&a),
+            RelationshipScope::default(),
+        );
+        let directive = p.find("DIRECTIVE").expect("directive present");
+        let about = p.find("[关于他]").expect("insights sub-block present");
+        let prev = p.find("[上次通话]").expect("prev-call sub-block present");
+        let line = p
+            .find("still getting to know each other")
+            .expect("relationship line present");
+        assert!(
+            directive < about && about < prev && prev < line,
+            "expected persona → directive → bootstrap → relationship line; got {p}"
+        );
+    }
+
+    #[test]
+    fn bootstrap_empty_insights_omits_the_about_sub_block() {
+        let s = snapshot(&[], Some("用户：你好"));
+        let p = build_voice_prompt(
+            &genome(),
+            "DIRECTIVE",
+            render_bootstrap(&s).as_deref(),
+            None,
+            RelationshipScope::None,
+        );
+        assert_eq!(p, "You are Mia.\n\nDIRECTIVE\n\n[上次通话]\n用户：你好");
+        assert!(!p.contains("[关于他]"));
+    }
+
+    #[test]
+    fn bootstrap_missing_prev_call_omits_the_prev_call_sub_block() {
+        let s = snapshot(&["城市：上海"], None);
+        let p = build_voice_prompt(
+            &genome(),
+            "DIRECTIVE",
+            render_bootstrap(&s).as_deref(),
+            None,
+            RelationshipScope::None,
+        );
+        assert_eq!(p, "You are Mia.\n\nDIRECTIVE\n\n[关于他]\n- 城市：上海");
+        assert!(!p.contains("[上次通话]"));
+    }
+
+    /// Both parts empty ⇒ no block at all, and no stray blank lines: the
+    /// prompt must be byte-identical to the no-bootstrap prompt.
+    #[test]
+    fn bootstrap_both_parts_empty_emits_no_block() {
+        let empty = snapshot(&[], None);
+        assert!(render_bootstrap(&empty).is_none());
+        let p = build_voice_prompt(
+            &genome(),
+            "DIRECTIVE",
+            render_bootstrap(&empty).as_deref(),
+            None,
+            RelationshipScope::None,
+        );
+        assert_eq!(p, "You are Mia.\n\nDIRECTIVE");
+        // A whitespace-only prev_call is empty too.
+        let blank = snapshot(&["  "], Some("   \n "));
+        assert!(render_bootstrap(&blank).is_none());
+    }
+
+    // ─── prev-call transcript rendering ─────────────────────────────────
+
+    #[test]
+    fn prev_call_transcript_maps_roles_and_skips_noise() {
+        let rows = vec![
+            slim("user", "你好"),
+            slim("assistant", "嗨呀"),
+            slim("assistant", "   "), // empty-content row: skipped
+            slim("gift_user", "（打赏 $5）"),
+            slim("system", "ignored"), // unknown role: skipped
+            slim("user", "晚安"),
+        ];
+        assert_eq!(
+            render_prev_call(&rows).unwrap(),
+            "用户：你好\n她：嗨呀\n用户：（打赏 $5）\n用户：晚安"
+        );
+    }
+
+    #[test]
+    fn prev_call_transcript_none_when_nothing_renders() {
+        assert!(render_prev_call(&[]).is_none());
+        assert!(render_prev_call(&[slim("assistant", ""), slim("tool", "x")]).is_none());
+    }
+
+    // ─── bootstrap marker plan ──────────────────────────────────────────
+
+    #[test]
+    fn plan_is_assemble_when_marker_absent() {
+        assert!(matches!(
+            plan_bootstrap(&serde_json::json!({})),
+            BootstrapPlan::Assemble
+        ));
+        assert!(matches!(
+            plan_bootstrap(&serde_json::json!({ "is_demo": true })),
+            BootstrapPlan::Assemble
+        ));
+    }
+
+    #[test]
+    fn plan_is_frozen_when_marker_well_formed() {
+        let s = snapshot(&["城市：上海"], Some("用户：你好"));
+        let meta = serde_json::json!({ "voice_bootstrap": serde_json::to_value(&s).unwrap() });
+        match plan_bootstrap(&meta) {
+            BootstrapPlan::Frozen(b) => {
+                assert_eq!(b.insights, vec!["城市：上海".to_string()]);
+                assert_eq!(b.prev_call.as_deref(), Some("用户：你好"));
+            }
+            other => panic!("expected Frozen, got {other:?}"),
+        }
+    }
+
+    /// Malformed marker ⇒ inject nothing AND never rewrite (a distinct plan
+    /// from `Assemble`, which would write).
+    #[test]
+    fn plan_is_malformed_on_garbage_marker() {
+        for v in [
+            serde_json::json!({ "voice_bootstrap": "not-an-object" }),
+            serde_json::json!({ "voice_bootstrap": null }),
+            serde_json::json!({ "voice_bootstrap": { "insights": "not-a-list" } }),
+            serde_json::json!({ "voice_bootstrap": { "insights": [] } }), // no created_at
+        ] {
+            assert!(
+                matches!(plan_bootstrap(&v), BootstrapPlan::Malformed),
+                "expected Malformed for {v}"
+            );
+        }
     }
 
     #[test]
@@ -416,6 +897,7 @@ mod tests {
         let p = build_voice_prompt(
             &genome(),
             "DIRECTIVE",
+            None,
             Some(&a),
             RelationshipScope::default(),
         );
@@ -431,6 +913,7 @@ mod tests {
         let p = build_voice_prompt(
             &genome(),
             "DIRECTIVE",
+            None,
             Some(&a),
             RelationshipScope::default(),
         );
@@ -449,6 +932,7 @@ mod tests {
         let p = build_voice_prompt(
             &genome(),
             "DIRECTIVE",
+            None,
             Some(&a),
             RelationshipScope::default(),
         );
@@ -460,12 +944,24 @@ mod tests {
     fn chemistry_boundary_switches_clause_at_crush() {
         // (0+0.52+0.50)/3 ≈ 0.34 ⇒ tier 2: still the subtle clause.
         let low = affinity_at(0.0, 0.0, 0.0, 0.52, 0.50);
-        let p_low = build_voice_prompt(&genome(), "D", Some(&low), RelationshipScope::default());
+        let p_low = build_voice_prompt(
+            &genome(),
+            "D",
+            None,
+            Some(&low),
+            RelationshipScope::default(),
+        );
         assert!(p_low.contains("faint, unspoken spark"));
         assert!(!p_low.contains("growing attraction"));
         // (0+0.54+0.54)/3 = 0.36 ⇒ tier 3: switches to the Crush clause.
         let high = affinity_at(0.0, 0.0, 0.0, 0.54, 0.54);
-        let p_high = build_voice_prompt(&genome(), "D", Some(&high), RelationshipScope::default());
+        let p_high = build_voice_prompt(
+            &genome(),
+            "D",
+            None,
+            Some(&high),
+            RelationshipScope::default(),
+        );
         assert!(p_high.contains("growing attraction"));
         assert!(!p_high.contains("faint, unspoken spark"));
     }
@@ -473,14 +969,26 @@ mod tests {
     #[test]
     fn scope_none_suppresses_line() {
         let a = affinity_at(0.9, 0.2, 0.2, 0.9, 0.9);
-        let p = build_voice_prompt(&genome(), "DIRECTIVE", Some(&a), RelationshipScope::None);
+        let p = build_voice_prompt(
+            &genome(),
+            "DIRECTIVE",
+            None,
+            Some(&a),
+            RelationshipScope::None,
+        );
         assert_eq!(p, "You are Mia.\n\nDIRECTIVE");
     }
 
     #[test]
     fn scope_bond_emits_base_only() {
         let a = affinity_at(0.9, 0.2, 0.2, 0.9, 0.9); // CloseFriend / Beloved
-        let p = build_voice_prompt(&genome(), "DIRECTIVE", Some(&a), RelationshipScope::Bond);
+        let p = build_voice_prompt(
+            &genome(),
+            "DIRECTIVE",
+            None,
+            Some(&a),
+            RelationshipScope::Bond,
+        );
         assert!(p.contains("close friends"));
         assert!(!p.contains("deeply in love"));
     }
@@ -491,6 +999,7 @@ mod tests {
         let p = build_voice_prompt(
             &genome(),
             "DIRECTIVE",
+            None,
             Some(&a),
             RelationshipScope::Chemistry,
         );
@@ -576,6 +1085,8 @@ data: [DONE]\n\n";
                 user_id,
                 user_message_id: umid,
                 relationship_scope: RelationshipScope::default(),
+                memory_scope: MemoryScope::default(),
+                session_metadata: serde_json::json!({}),
             },
             resolved,
         )
@@ -728,6 +1239,8 @@ data: [DONE]\n\n";
                 user_id,
                 user_message_id: umid,
                 relationship_scope: RelationshipScope::default(),
+                memory_scope: MemoryScope::default(),
+                session_metadata: serde_json::json!({}),
             },
             resolved,
         )
@@ -837,6 +1350,8 @@ data: [DONE]\n\n";
                 user_id,
                 user_message_id: umid,
                 relationship_scope: RelationshipScope::default(),
+                memory_scope: MemoryScope::default(),
+                session_metadata: serde_json::json!({}),
             },
             resolved,
         )
@@ -969,6 +1484,8 @@ data: [DONE]\n\n";
                 user_id,
                 user_message_id: umid,
                 relationship_scope: RelationshipScope::default(),
+                memory_scope: MemoryScope::default(),
+                session_metadata: serde_json::json!({}),
             },
             resolved,
         )
@@ -1101,6 +1618,8 @@ data: [DONE]\n\n";
                 user_id,
                 user_message_id: umid,
                 relationship_scope: RelationshipScope::default(),
+                memory_scope: MemoryScope::default(),
+                session_metadata: serde_json::json!({}),
             },
             resolved,
         )
@@ -1226,6 +1745,8 @@ data: [DONE]\n\n";
                 user_id,
                 user_message_id: umid,
                 relationship_scope: RelationshipScope::default(),
+                memory_scope: MemoryScope::default(),
+                session_metadata: serde_json::json!({}),
             },
             resolved,
         )
@@ -1342,6 +1863,8 @@ data: [DONE]\n\n";
                 user_id,
                 user_message_id: umid,
                 relationship_scope: RelationshipScope::default(),
+                memory_scope: MemoryScope::default(),
+                session_metadata: serde_json::json!({}),
             },
             resolved,
         )
@@ -1464,6 +1987,8 @@ data: [DONE]\n\n";
                 user_id,
                 user_message_id: umid,
                 relationship_scope: RelationshipScope::default(),
+                memory_scope: MemoryScope::default(),
+                session_metadata: serde_json::json!({}),
             },
             resolved,
         )
@@ -1515,5 +2040,616 @@ data: [DONE]\n\n";
         .await
         .unwrap();
         assert_eq!(content, "recovered");
+    }
+
+    // ─── bootstrap snapshot, end to end ─────────────────────────────────
+    //
+    // Shared scaffolding for the bootstrap e2e tests: one always-succeeding
+    // mock, and a `run_bootstrap_turn` that mirrors the route (load the
+    // session row → persist the user turn → drive the pipeline with that
+    // row's metadata), so "the marker written by turn 1 is what turn 2 sees"
+    // is exercised the way production reaches it.
+
+    async fn bootstrap_mock() -> wiremock::MockServer {
+        use wiremock::matchers::path as wm_path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        let body = "\
+data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}],\"id\":\"gen-b\",\"model\":\"primary\"}\n\n\
+data: [DONE]\n\n";
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+        mock
+    }
+
+    async fn seed_instance(pool: &sqlx::PgPool, user_id: Uuid) -> Uuid {
+        let genome_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata) \
+             VALUES ('V', 'You are V.', '{}'::jsonb) RETURNING id",
+        )
+        .fetch_one(pool)
+        .await
+        .unwrap();
+        sqlx::query_scalar(
+            "INSERT INTO engine.persona_instances (genome_id, owner_uid) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(genome_id)
+        .bind(user_id)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+    }
+
+    async fn seed_session(pool: &sqlx::PgPool, user_id: Uuid, instance_id: Uuid, ch: &str) -> Uuid {
+        sqlx::query_scalar(
+            "INSERT INTO engine.chat_sessions (user_id, instance_id, channel) \
+             VALUES ($1, $2, $3) RETURNING id",
+        )
+        .bind(user_id)
+        .bind(instance_id)
+        .bind(ch)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+    }
+
+    /// A message `mins_ago` minutes old, so ordering is deterministic.
+    async fn seed_message(
+        pool: &sqlx::PgPool,
+        session_id: Uuid,
+        role: &str,
+        content: &str,
+        mins_ago: i32,
+    ) {
+        sqlx::query(
+            "INSERT INTO engine.chat_messages (session_id, role, content, channel, sent_at) \
+             VALUES ($1, $2, $3, 'voice', now() - make_interval(mins => $4))",
+        )
+        .bind(session_id)
+        .bind(role)
+        .bind(content)
+        .bind(mins_ago)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    async fn seed_insights(pool: &sqlx::PgPool, user_id: Uuid, insights: serde_json::Value) {
+        eros_engine_store::human_insight::HumanInsightRepo { pool }
+            .project_from_insights(user_id, &insights)
+            .await
+            .unwrap();
+    }
+
+    /// `metadata->'voice_bootstrap'`; `None` when the marker is absent.
+    async fn read_marker(pool: &sqlx::PgPool, session_id: Uuid) -> Option<serde_json::Value> {
+        sqlx::query_scalar(
+            "SELECT metadata->'voice_bootstrap' FROM engine.chat_sessions WHERE id = $1",
+        )
+        .bind(session_id)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+    }
+
+    async fn last_request_body(mock: &wiremock::MockServer) -> serde_json::Value {
+        let received = mock
+            .received_requests()
+            .await
+            .expect("recording enabled by default");
+        let last = received.last().expect("at least one upstream request");
+        serde_json::from_slice(&last.body).expect("JSON request body")
+    }
+
+    fn system_prompt_of(body: &serde_json::Value) -> String {
+        let m = &body["messages"][0];
+        assert_eq!(
+            m["role"], "system",
+            "first wire message must be the system prompt"
+        );
+        m["content"].as_str().expect("system content").to_string()
+    }
+
+    /// One turn, exactly as the route drives it.
+    async fn run_bootstrap_turn(
+        pool: &sqlx::PgPool,
+        mock: &wiremock::MockServer,
+        session_id: Uuid,
+        instance_id: Uuid,
+        user_id: Uuid,
+        client_msg_id: &str,
+        memory_scope: MemoryScope,
+    ) -> Vec<ProtocolFrame> {
+        use eros_engine_llm::model_config::ModelConfig;
+        use futures_util::StreamExt;
+
+        let repo = ChatRepo { pool };
+        // The route loads the full session row (metadata included) BEFORE the
+        // user insert and hands `metadata` to the pipeline — mirror that.
+        let session = repo
+            .get_session(session_id)
+            .await
+            .unwrap()
+            .expect("session exists");
+        let umid = match repo
+            .insert_voice_user_message(session_id, "hello", client_msg_id)
+            .await
+            .unwrap()
+        {
+            eros_engine_store::chat::VoiceUserInsert::Inserted(id) => id,
+            other => panic!("expected Inserted, got {other:?}"),
+        };
+
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = Arc::new(
+            ModelConfig::from_toml_str(
+                "[tasks.chat_voice]\nmodel = \"primary\"\nmax_tokens = 100\n",
+            )
+            .unwrap(),
+        );
+        state.openrouter = Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+        let resolved = state.model_config.resolve_voice().unwrap();
+        run_voice_turn(
+            Arc::new(state),
+            VoiceTurn {
+                session_id,
+                instance_id,
+                user_id,
+                user_message_id: umid,
+                relationship_scope: RelationshipScope::None,
+                memory_scope,
+                session_metadata: session.metadata,
+            },
+            resolved,
+        )
+        .collect()
+        .await
+    }
+
+    fn assert_no_error_frame(frames: &[ProtocolFrame]) {
+        assert!(
+            !frames
+                .iter()
+                .any(|f| matches!(f, ProtocolFrame::Error { .. })),
+            "a memory path must never emit an error frame; got {frames:?}"
+        );
+    }
+
+    /// First turn freezes the snapshot into `metadata.voice_bootstrap` and
+    /// injects it: insights at the default (Neutral) tier + the previous
+    /// call's tail.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn run_voice_turn_first_turn_freezes_and_injects_bootstrap(pool: sqlx::PgPool) {
+        let mock = bootstrap_mock().await;
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_instance(&pool, user_id).await;
+
+        seed_insights(
+            &pool,
+            user_id,
+            serde_json::json!({ "city": "上海", "occupation": "设计师", "love_values": "慢热" }),
+        )
+        .await;
+
+        // A previous call (sibling voice session) with a two-message tail.
+        let sibling = seed_session(&pool, user_id, instance_id, "voice").await;
+        seed_message(&pool, sibling, "user", "你好", 20).await;
+        seed_message(&pool, sibling, "assistant", "嗨呀", 19).await;
+
+        let session_id = seed_session(&pool, user_id, instance_id, "voice").await;
+        let frames = run_bootstrap_turn(
+            &pool,
+            &mock,
+            session_id,
+            instance_id,
+            user_id,
+            "01J9BOOT0000000000000001",
+            MemoryScope::default(),
+        )
+        .await;
+        assert_no_error_frame(&frames);
+
+        // Frozen in the session row, RENDERED.
+        let marker = read_marker(&pool, session_id)
+            .await
+            .expect("marker written");
+        assert_eq!(
+            marker["insights"],
+            serde_json::json!(["城市：上海", "职业：设计师"]),
+            "default scope ⇒ Neutral tier (no 感情观); got {marker}"
+        );
+        assert_eq!(
+            marker["prev_call"],
+            serde_json::json!("用户：你好\n她：嗨呀")
+        );
+        assert_eq!(marker["prev_session_id"], serde_json::json!(sibling));
+        assert!(
+            marker["created_at"].is_string(),
+            "created_at recorded: {marker}"
+        );
+
+        // …and injected into this very turn's system prompt.
+        let sys = system_prompt_of(&last_request_body(&mock).await);
+        assert!(
+            sys.contains("[关于他]\n- 城市：上海\n- 职业：设计师"),
+            "insights sub-block missing: {sys}"
+        );
+        assert!(
+            sys.contains("[上次通话]\n用户：你好\n她：嗨呀"),
+            "prev-call sub-block missing: {sys}"
+        );
+        assert!(
+            !sys.contains("感情观"),
+            "Neutral tier must not leak intimate fields: {sys}"
+        );
+    }
+
+    /// The snapshot is frozen: a later turn re-injects the stored strings and
+    /// never re-reads (or rewrites) live insight data.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn run_voice_turn_second_turn_reuses_frozen_snapshot(pool: sqlx::PgPool) {
+        let mock = bootstrap_mock().await;
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_instance(&pool, user_id).await;
+        seed_insights(&pool, user_id, serde_json::json!({ "city": "上海" })).await;
+        let session_id = seed_session(&pool, user_id, instance_id, "voice").await;
+
+        let frames = run_bootstrap_turn(
+            &pool,
+            &mock,
+            session_id,
+            instance_id,
+            user_id,
+            "01J9BOOT0000000000000001",
+            MemoryScope::default(),
+        )
+        .await;
+        assert_no_error_frame(&frames);
+        let first = read_marker(&pool, session_id)
+            .await
+            .expect("marker written");
+
+        // Live data moves on mid-call — and must NOT reach the prompt.
+        seed_insights(&pool, user_id, serde_json::json!({ "city": "北京" })).await;
+
+        let frames = run_bootstrap_turn(
+            &pool,
+            &mock,
+            session_id,
+            instance_id,
+            user_id,
+            "01J9BOOT0000000000000002",
+            MemoryScope::Full,
+        )
+        .await;
+        assert_no_error_frame(&frames);
+
+        let second = read_marker(&pool, session_id)
+            .await
+            .expect("marker still there");
+        assert_eq!(second, first, "the snapshot must never be rewritten");
+
+        let sys = system_prompt_of(&last_request_body(&mock).await);
+        assert!(sys.contains("城市：上海"), "frozen bullet missing: {sys}");
+        assert!(
+            !sys.contains("北京"),
+            "live insight data must not reach a later turn: {sys}"
+        );
+    }
+
+    /// No previous call ⇒ insights-only snapshot, no `[上次通话]` label.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn run_voice_turn_bootstrap_without_sibling_is_insights_only(pool: sqlx::PgPool) {
+        let mock = bootstrap_mock().await;
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_instance(&pool, user_id).await;
+        seed_insights(&pool, user_id, serde_json::json!({ "city": "上海" })).await;
+        let session_id = seed_session(&pool, user_id, instance_id, "voice").await;
+
+        let frames = run_bootstrap_turn(
+            &pool,
+            &mock,
+            session_id,
+            instance_id,
+            user_id,
+            "01J9BOOT0000000000000001",
+            MemoryScope::default(),
+        )
+        .await;
+        assert_no_error_frame(&frames);
+
+        let marker = read_marker(&pool, session_id)
+            .await
+            .expect("marker written");
+        assert_eq!(marker["insights"], serde_json::json!(["城市：上海"]));
+        assert_eq!(marker["prev_call"], serde_json::Value::Null);
+        assert_eq!(marker["prev_session_id"], serde_json::Value::Null);
+
+        let sys = system_prompt_of(&last_request_body(&mock).await);
+        assert!(sys.contains("[关于他]"));
+        assert!(!sys.contains("[上次通话]"), "no sibling ⇒ no tail: {sys}");
+    }
+
+    /// Sibling selection: never this session, never a text session.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn run_voice_turn_bootstrap_sibling_skips_current_and_text_sessions(pool: sqlx::PgPool) {
+        let mock = bootstrap_mock().await;
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_instance(&pool, user_id).await;
+
+        // The real previous call — oldest of the three, so "most recently
+        // active" alone would NOT pick it.
+        let voice_sibling = seed_session(&pool, user_id, instance_id, "voice").await;
+        seed_message(&pool, voice_sibling, "user", "语音上次内容", 30).await;
+
+        // A text session for the same pair, more recently active.
+        let text_session = seed_session(&pool, user_id, instance_id, "text").await;
+        sqlx::query(
+            "INSERT INTO engine.chat_messages (session_id, role, content, sent_at) \
+             VALUES ($1, 'user', '文字会话内容', now() - interval '5 minutes')",
+        )
+        .bind(text_session)
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query("UPDATE engine.chat_sessions SET last_active_at = now() WHERE id = $1")
+            .bind(text_session)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        // The session being bootstrapped, with prior content of its own.
+        let session_id = seed_session(&pool, user_id, instance_id, "voice").await;
+        seed_message(&pool, session_id, "user", "当前会话内容", 1).await;
+
+        let frames = run_bootstrap_turn(
+            &pool,
+            &mock,
+            session_id,
+            instance_id,
+            user_id,
+            "01J9BOOT0000000000000001",
+            MemoryScope::default(),
+        )
+        .await;
+        assert_no_error_frame(&frames);
+
+        let marker = read_marker(&pool, session_id)
+            .await
+            .expect("marker written");
+        assert_eq!(marker["prev_session_id"], serde_json::json!(voice_sibling));
+        let prev = marker["prev_call"].as_str().expect("a transcript");
+        assert_eq!(prev, "用户：语音上次内容");
+        assert!(
+            !prev.contains("文字会话内容"),
+            "text session leaked: {prev}"
+        );
+        assert!(!prev.contains("当前会话内容"), "self quoted: {prev}");
+    }
+
+    /// `memory_scope: "none"` on the FIRST turn ⇒ no insight part, frozen for
+    /// the whole call (a later turn asking for `full` still gets none).
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn run_voice_turn_memory_scope_none_freezes_snapshot_without_insights(
+        pool: sqlx::PgPool,
+    ) {
+        let mock = bootstrap_mock().await;
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_instance(&pool, user_id).await;
+        seed_insights(&pool, user_id, serde_json::json!({ "city": "上海" })).await;
+        let sibling = seed_session(&pool, user_id, instance_id, "voice").await;
+        seed_message(&pool, sibling, "user", "你好", 20).await;
+        let session_id = seed_session(&pool, user_id, instance_id, "voice").await;
+
+        let frames = run_bootstrap_turn(
+            &pool,
+            &mock,
+            session_id,
+            instance_id,
+            user_id,
+            "01J9BOOT0000000000000001",
+            MemoryScope::None,
+        )
+        .await;
+        assert_no_error_frame(&frames);
+
+        let marker = read_marker(&pool, session_id)
+            .await
+            .expect("marker written");
+        assert_eq!(
+            marker["insights"],
+            serde_json::json!([]),
+            "InsightMode::Off ⇒ empty part, still a written marker; got {marker}"
+        );
+        assert_eq!(marker["prev_call"], serde_json::json!("用户：你好"));
+        let sys = system_prompt_of(&last_request_body(&mock).await);
+        assert!(
+            !sys.contains("[关于他]"),
+            "scope none injected insights: {sys}"
+        );
+        assert!(
+            sys.contains("[上次通话]"),
+            "prev call still injected: {sys}"
+        );
+
+        // Turn 2 asks for Full — the frozen snapshot still wins.
+        let frames = run_bootstrap_turn(
+            &pool,
+            &mock,
+            session_id,
+            instance_id,
+            user_id,
+            "01J9BOOT0000000000000002",
+            MemoryScope::Full,
+        )
+        .await;
+        assert_no_error_frame(&frames);
+        let sys = system_prompt_of(&last_request_body(&mock).await);
+        assert!(
+            !sys.contains("城市：上海"),
+            "the first turn's scope decides the whole call: {sys}"
+        );
+    }
+
+    /// The in-session window is 8 messages — asserted on the wire request.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn run_voice_turn_history_window_is_eight(pool: sqlx::PgPool) {
+        let mock = bootstrap_mock().await;
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_instance(&pool, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id, "voice").await;
+
+        // 10 prior messages, oldest first; the turn's own user row makes 11.
+        for i in 0..10i32 {
+            let role = if i % 2 == 0 { "user" } else { "assistant" };
+            seed_message(&pool, session_id, role, &format!("m{i}"), 20 - i).await;
+        }
+
+        let frames = run_bootstrap_turn(
+            &pool,
+            &mock,
+            session_id,
+            instance_id,
+            user_id,
+            "01J9BOOT0000000000000001",
+            MemoryScope::default(),
+        )
+        .await;
+        assert_no_error_frame(&frames);
+
+        let body = last_request_body(&mock).await;
+        let msgs = body["messages"].as_array().expect("messages array");
+        assert_eq!(
+            msgs.len(),
+            9,
+            "system + VOICE_HISTORY_WINDOW(8) messages; got {}",
+            serde_json::to_string(&body["messages"]).unwrap()
+        );
+        assert_eq!(msgs[0]["role"], "system");
+        let wire: Vec<&str> = msgs[1..]
+            .iter()
+            .map(|m| m["content"].as_str().unwrap())
+            .collect();
+        assert_eq!(
+            wire,
+            vec!["m3", "m4", "m5", "m6", "m7", "m8", "m9", "hello"]
+        );
+    }
+
+    /// A marker that is present but unreadable: inject nothing, degrade with a
+    /// warn, and NEVER overwrite it.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn run_voice_turn_malformed_bootstrap_marker_is_never_rewritten(pool: sqlx::PgPool) {
+        let mock = bootstrap_mock().await;
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_instance(&pool, user_id).await;
+        seed_insights(&pool, user_id, serde_json::json!({ "city": "上海" })).await;
+        let sibling = seed_session(&pool, user_id, instance_id, "voice").await;
+        seed_message(&pool, sibling, "user", "你好", 20).await;
+        let session_id = seed_session(&pool, user_id, instance_id, "voice").await;
+        sqlx::query(
+            "UPDATE engine.chat_sessions \
+             SET metadata = '{\"voice_bootstrap\": \"garbage\"}'::jsonb WHERE id = $1",
+        )
+        .bind(session_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let frames = run_bootstrap_turn(
+            &pool,
+            &mock,
+            session_id,
+            instance_id,
+            user_id,
+            "01J9BOOT0000000000000001",
+            MemoryScope::default(),
+        )
+        .await;
+        assert_no_error_frame(&frames);
+
+        assert_eq!(
+            read_marker(&pool, session_id).await,
+            Some(serde_json::json!("garbage")),
+            "a write-once snapshot must never be clobbered, not even when unreadable"
+        );
+        let sys = system_prompt_of(&last_request_body(&mock).await);
+        assert!(!sys.contains("[关于他]"), "{sys}");
+        assert!(!sys.contains("[上次通话]"), "{sys}");
+    }
+
+    /// A failed part leaves the marker unwritten so the NEXT turn retries.
+    /// The insights read is broken by renaming its table out from under the
+    /// query (each `sqlx::test` gets its own database), then restored.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn run_voice_turn_failed_bootstrap_part_retries_next_turn(pool: sqlx::PgPool) {
+        let mock = bootstrap_mock().await;
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_instance(&pool, user_id).await;
+        seed_insights(&pool, user_id, serde_json::json!({ "city": "上海" })).await;
+        let sibling = seed_session(&pool, user_id, instance_id, "voice").await;
+        seed_message(&pool, sibling, "user", "你好", 20).await;
+        let session_id = seed_session(&pool, user_id, instance_id, "voice").await;
+
+        sqlx::query("ALTER TABLE engine.human_insights RENAME TO human_insights_broken")
+            .execute(&pool)
+            .await
+            .unwrap();
+        let frames = run_bootstrap_turn(
+            &pool,
+            &mock,
+            session_id,
+            instance_id,
+            user_id,
+            "01J9BOOT0000000000000001",
+            MemoryScope::default(),
+        )
+        .await;
+        assert_no_error_frame(&frames);
+
+        assert_eq!(
+            read_marker(&pool, session_id).await,
+            None,
+            "a partial assembly must not freeze the snapshot"
+        );
+        // The part that DID load is still injected this turn.
+        let sys = system_prompt_of(&last_request_body(&mock).await);
+        assert!(sys.contains("[上次通话]\n用户：你好"), "{sys}");
+        assert!(!sys.contains("[关于他]"), "{sys}");
+
+        sqlx::query("ALTER TABLE engine.human_insights_broken RENAME TO human_insights")
+            .execute(&pool)
+            .await
+            .unwrap();
+        let frames = run_bootstrap_turn(
+            &pool,
+            &mock,
+            session_id,
+            instance_id,
+            user_id,
+            "01J9BOOT0000000000000002",
+            MemoryScope::default(),
+        )
+        .await;
+        assert_no_error_frame(&frames);
+
+        let marker = read_marker(&pool, session_id)
+            .await
+            .expect("the retry wrote the marker");
+        assert_eq!(marker["insights"], serde_json::json!(["城市：上海"]));
+        let sys = system_prompt_of(&last_request_body(&mock).await);
+        assert!(sys.contains("[关于他]\n- 城市：上海"), "{sys}");
     }
 }

--- a/crates/eros-engine-server/src/pipeline/voice.rs
+++ b/crates/eros-engine-server/src/pipeline/voice.rs
@@ -51,7 +51,7 @@ const VOICE_RECALL_BUDGET: Duration = Duration::from_millis(300);
 /// Voice K tier — deliberately far below the text path's (2 / 4 / 3): a spoken
 /// turn can absorb a couple of recalled lines, not a wall of them, and every
 /// row is prompt latency. Spec §5.
-const VOICE_RECALL_TIER: RecallTier = RecallTier {
+pub(crate) const VOICE_RECALL_TIER: RecallTier = RecallTier {
     grouped_k: 1,
     raw_k: 2,
     relationship_k: 2,

--- a/crates/eros-engine-server/src/pipeline/voice.rs
+++ b/crates/eros-engine-server/src/pipeline/voice.rs
@@ -324,6 +324,54 @@ async fn assemble_bootstrap(
     )
 }
 
+/// Reload the winner's stored snapshot after THIS turn lost the
+/// `set_voice_bootstrap` write race (`rows_affected == 0`): re-read the
+/// session row and pull `metadata.voice_bootstrap` back out. `None` on ANY
+/// failure in that chain (query error, key missing — shouldn't happen right
+/// after a lost race, but the row could theoretically have moved again;
+/// malformed) — the caller then falls back to its own locally-assembled
+/// copy, which is always safe to inject, just possibly not what actually got
+/// frozen.
+async fn reload_bootstrap_winner(
+    chat_repo: &ChatRepo<'_>,
+    session_id: Uuid,
+) -> Option<VoiceBootstrap> {
+    let session = match chat_repo.get_session(session_id).await {
+        Ok(Some(s)) => s,
+        Ok(None) => {
+            tracing::warn!(
+                session_id = %session_id,
+                "voice: bootstrap race reload — session vanished; falling back to in-memory copy",
+            );
+            return None;
+        }
+        Err(e) => {
+            tracing::warn!(
+                session_id = %session_id, error = %e,
+                "voice: bootstrap race reload — session query failed; falling back to in-memory copy",
+            );
+            return None;
+        }
+    };
+    let Some(marker) = session.metadata.get(VOICE_BOOTSTRAP_KEY) else {
+        tracing::warn!(
+            session_id = %session_id,
+            "voice: bootstrap race reload — marker missing after a lost write race; falling back to in-memory copy",
+        );
+        return None;
+    };
+    match serde_json::from_value::<VoiceBootstrap>(marker.clone()) {
+        Ok(b) => Some(b),
+        Err(e) => {
+            tracing::warn!(
+                session_id = %session_id, error = %e,
+                "voice: bootstrap race reload — winner's stored snapshot unreadable; falling back to in-memory copy",
+            );
+            None
+        }
+    }
+}
+
 /// One relationship-tone line, derived at read time from the affinity row's
 /// bond/chemistry tiers — never from the cached `relationship_label`, which
 /// the voice path (no per-turn affinity eval) would leave stale forever.
@@ -523,14 +571,35 @@ pub fn run_voice_turn(
             BootstrapPlan::Frozen(b) => Some(b),
             BootstrapPlan::Malformed => None,
             BootstrapPlan::Assemble => match assembled {
-                Some((snapshot, complete)) => {
+                Some((mut snapshot, complete)) => {
                     if complete {
                         match serde_json::to_value(&snapshot) {
-                            // rows_affected 0 = the key was already there (a
-                            // concurrent first turn won the race): normal, and
-                            // this turn just uses its own identical copy.
-                            Ok(v) => if let Err(e) = chat_repo.set_voice_bootstrap(turn.session_id, &v).await {
-                                tracing::warn!(error = %e, "voice: bootstrap snapshot write failed; using in-memory copy");
+                            Ok(v) => match chat_repo.set_voice_bootstrap(turn.session_id, &v).await {
+                                // rows_affected 0 = the key was already there
+                                // — a concurrent first turn won the race.
+                                // That winner's stored snapshot can differ
+                                // from ours (e.g. a different `memory_scope`
+                                // on the two requests ⇒ different insight
+                                // tier), so injecting our own would violate
+                                // the frozen-single-snapshot-per-call
+                                // invariant for THIS turn. Reload and use the
+                                // winner's instead; any failure in that
+                                // reload falls back to our in-memory copy.
+                                Ok(0) => {
+                                    tracing::debug!(
+                                        session_id = %turn.session_id,
+                                        "voice: bootstrap write race lost — reloading winner's stored snapshot",
+                                    );
+                                    if let Some(winner) =
+                                        reload_bootstrap_winner(&chat_repo, turn.session_id).await
+                                    {
+                                        snapshot = winner;
+                                    }
+                                }
+                                // This turn's write won: the in-memory copy
+                                // IS the frozen one.
+                                Ok(_) => {}
+                                Err(e) => tracing::warn!(error = %e, "voice: bootstrap snapshot write failed; using in-memory copy"),
                             },
                             Err(e) => tracing::warn!(error = %e, "voice: bootstrap snapshot serialize failed"),
                         }
@@ -2676,6 +2745,111 @@ data: [DONE]\n\n";
         assert!(
             !sys.contains("北京"),
             "live insight data must not reach a later turn: {sys}"
+        );
+    }
+
+    /// The `rows_affected == 0` branch of `set_voice_bootstrap`: this turn
+    /// lost the write race to a concurrent first turn. Simulated
+    /// deterministically — the "winner's" snapshot is written directly
+    /// (distinguishable content) BEFORE the turn runs, and the turn is driven
+    /// with a STALE `session_metadata: {}` (exactly what a race loser
+    /// observed before the winner's write landed), so `plan_bootstrap` still
+    /// decides `Assemble` and this turn builds its OWN (different, from live
+    /// `human_insights`) snapshot before losing the write. The loser must
+    /// reload and inject the WINNER's stored snapshot, not its own.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn run_voice_turn_race_loser_injects_winners_stored_snapshot(pool: sqlx::PgPool) {
+        use eros_engine_llm::model_config::ModelConfig;
+        use futures_util::StreamExt;
+
+        let mock = bootstrap_mock().await;
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_instance(&pool, user_id).await;
+
+        // What this turn's OWN live assembly would produce, had it not lost
+        // the race — must NOT reach the wire prompt.
+        seed_insights(&pool, user_id, serde_json::json!({ "city": "上海" })).await;
+
+        let session_id = seed_session(&pool, user_id, instance_id, "voice").await;
+
+        // The concurrent winner's already-frozen snapshot, written directly.
+        let winner_snapshot = serde_json::json!({
+            "insights": ["来自DB胜者的画像"],
+            "prev_call": null,
+            "prev_session_id": null,
+            "created_at": Utc::now(),
+        });
+        let repo = ChatRepo { pool: &pool };
+        let rows = repo
+            .set_voice_bootstrap(session_id, &winner_snapshot)
+            .await
+            .unwrap();
+        assert_eq!(rows, 1, "the winner's own write must succeed");
+
+        let umid = match repo
+            .insert_voice_user_message(session_id, "hello", "01J9BOOTRACE0000000001")
+            .await
+            .unwrap()
+        {
+            eros_engine_store::chat::VoiceUserInsert::Inserted(id) => id,
+            other => panic!("expected Inserted, got {other:?}"),
+        };
+
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = Arc::new(
+            ModelConfig::from_toml_str(
+                "[tasks.chat_voice]\nmodel = \"primary\"\nmax_tokens = 100\nrecall = false\n",
+            )
+            .unwrap(),
+        );
+        state.openrouter = Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+        let resolved = state.model_config.resolve_voice().unwrap();
+        let frames: Vec<ProtocolFrame> = run_voice_turn(
+            Arc::new(state),
+            VoiceTurn {
+                session_id,
+                instance_id,
+                user_id,
+                user_message_id: umid,
+                content: "hello".into(),
+                relationship_scope: RelationshipScope::None,
+                memory_scope: MemoryScope::default(),
+                // The stale read a race loser actually saw: the marker isn't
+                // in it yet, even though the winner already wrote it to the
+                // DB by the time THIS turn's write races and loses.
+                session_metadata: serde_json::json!({}),
+            },
+            resolved,
+        )
+        .collect()
+        .await;
+        assert_no_error_frame(&frames);
+
+        // (a) wire prompt carries the DB winner's content, never the loser's
+        // own locally-assembled live-insights content.
+        let sys = system_prompt_of(&last_request_body(&mock).await);
+        assert!(
+            sys.contains("来自DB胜者的画像"),
+            "winner's stored snapshot missing from wire prompt: {sys}"
+        );
+        assert!(
+            !sys.contains("城市：上海"),
+            "loser's own locally-assembled snapshot leaked into the wire prompt: {sys}"
+        );
+
+        // (b) the DB marker is unchanged after the turn — the loser's write
+        // was a no-op, and the reload path never rewrites it either.
+        let marker = read_marker(&pool, session_id)
+            .await
+            .expect("marker present");
+        assert_eq!(
+            marker, winner_snapshot,
+            "the winner's snapshot must survive the loser's turn untouched"
         );
     }
 

--- a/crates/eros-engine-server/src/prompt.rs
+++ b/crates/eros-engine-server/src/prompt.rs
@@ -393,6 +393,54 @@ fn is_binary_gender(persona: &CompanionPersona) -> bool {
     matches!(meta_str(persona, "gender"), Some("male") | Some("female"))
 }
 
+/// Render the `[user_profile]` and `[shared_memories]` recall sections shared
+/// by every prompt builder. `None` means the respective input had no content
+/// to render (for `profile_groups`, no group with a non-empty item list);
+/// callers decide what an empty section becomes — `build_prompt` substitutes
+/// the placeholder text, a future voice builder can omit the section
+/// entirely. `Some` content is byte-identical to today's non-empty
+/// rendering: profile groups as `[label]\n- bullet` blocks joined by `\n\n`,
+/// relationship facts as `- fact` lines joined by `\n`.
+pub(crate) fn render_recall_sections(
+    profile_groups: &[(String, Vec<String>)],
+    relationship_facts: &[String],
+) -> (Option<String>, Option<String>) {
+    let non_empty_groups: Vec<&(String, Vec<String>)> = profile_groups
+        .iter()
+        .filter(|(_, items)| !items.is_empty())
+        .collect();
+    let profile_sec = if non_empty_groups.is_empty() {
+        None
+    } else {
+        Some(
+            non_empty_groups
+                .iter()
+                .map(|(label, items)| {
+                    let bullets = items
+                        .iter()
+                        .map(|f| format!("- {f}"))
+                        .collect::<Vec<_>>()
+                        .join("\n");
+                    format!("[{label}]\n{bullets}")
+                })
+                .collect::<Vec<_>>()
+                .join("\n\n"),
+        )
+    };
+    let rel_sec = if relationship_facts.is_empty() {
+        None
+    } else {
+        Some(
+            relationship_facts
+                .iter()
+                .map(|f| format!("- {f}"))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        )
+    };
+    (profile_sec, rel_sec)
+}
+
 /// Build the full companion system prompt (plain-text reply schema).
 ///
 /// `profile_groups` is a list of `(label, bullets)` pairs that get rendered
@@ -478,35 +526,9 @@ pub fn build_prompt(
         format!("\n\n[additional_guidance]\n{bullets}")
     };
 
-    let non_empty_groups: Vec<&(String, Vec<String>)> = profile_groups
-        .iter()
-        .filter(|(_, items)| !items.is_empty())
-        .collect();
-    let profile_str = if non_empty_groups.is_empty() {
-        "（刚认识，还不了解他）".to_string()
-    } else {
-        non_empty_groups
-            .iter()
-            .map(|(label, items)| {
-                let bullets = items
-                    .iter()
-                    .map(|f| format!("- {f}"))
-                    .collect::<Vec<_>>()
-                    .join("\n");
-                format!("[{label}]\n{bullets}")
-            })
-            .collect::<Vec<_>>()
-            .join("\n\n")
-    };
-    let rel_str = if relationship_facts.is_empty() {
-        "（还没有专属记忆，慢慢来）".to_string()
-    } else {
-        relationship_facts
-            .iter()
-            .map(|f| format!("- {f}"))
-            .collect::<Vec<_>>()
-            .join("\n")
-    };
+    let (profile_sec, rel_sec) = render_recall_sections(profile_groups, relationship_facts);
+    let profile_str = profile_sec.unwrap_or_else(|| "（刚认识，还不了解他）".to_string());
+    let rel_str = rel_sec.unwrap_or_else(|| "（还没有专属记忆，慢慢来）".to_string());
 
     let attitude = affinity
         .map(|a| affinity_to_attitude_prompt(a, affinity_scope))
@@ -835,6 +857,56 @@ mod tests {
                 status: "active".into(),
             },
         }
+    }
+
+    // render_recall_sections — unit tests for the extracted recall renderer.
+    // `build_prompt`'s [user_profile]/[shared_memories] sections must stay
+    // byte-identical to today's output; these tests pin the helper's exact
+    // formatting independent of that placeholder-substitution wiring.
+
+    #[test]
+    fn render_recall_sections_empty_inputs_returns_none_none() {
+        let (profile_sec, rel_sec) = render_recall_sections(&[], &[]);
+        assert_eq!(profile_sec, None);
+        assert_eq!(rel_sec, None);
+    }
+
+    #[test]
+    fn render_recall_sections_filters_only_empty_item_groups() {
+        let groups = vec![
+            ("空组".to_string(), vec![]),
+            ("基础画像".to_string(), vec!["住在上海".to_string()]),
+        ];
+        let (profile_sec, rel_sec) = render_recall_sections(&groups, &[]);
+        assert_eq!(
+            profile_sec,
+            Some("[基础画像]\n- 住在上海".to_string()),
+            "empty-item group is filtered out, mirroring non_empty_groups"
+        );
+        assert_eq!(rel_sec, None);
+    }
+
+    #[test]
+    fn render_recall_sections_renders_profile_groups_exact_format() {
+        let groups = vec![
+            ("基础画像".to_string(), vec!["住在上海".to_string()]),
+            (
+                "偏好".to_string(),
+                vec!["喜欢猫".to_string(), "怕黑".to_string()],
+            ),
+        ];
+        let (profile_sec, _) = render_recall_sections(&groups, &[]);
+        assert_eq!(
+            profile_sec,
+            Some("[基础画像]\n- 住在上海\n\n[偏好]\n- 喜欢猫\n- 怕黑".to_string())
+        );
+    }
+
+    #[test]
+    fn render_recall_sections_renders_relationship_facts_as_bullet_lines() {
+        let facts = vec!["聊到深夜".to_string(), "一起看过电影".to_string()];
+        let (_, rel_sec) = render_recall_sections(&[], &facts);
+        assert_eq!(rel_sec, Some("- 聊到深夜\n- 一起看过电影".to_string()));
     }
 
     #[test]

--- a/crates/eros-engine-server/src/routes/bff/companion.rs
+++ b/crates/eros-engine-server/src/routes/bff/companion.rs
@@ -73,6 +73,10 @@ pub struct BffStartRequest {
     /// the canonical start; see `StartChatRequest::channel`.
     #[serde(default)]
     pub channel: Option<String>,
+    /// Skip resume and always create a fresh session. Passed through to the
+    /// canonical start; see `StartChatRequest::force_new`.
+    #[serde(default)]
+    pub force_new: Option<bool>,
 }
 
 impl From<&BffStartRequest> for StartChatRequest {
@@ -82,6 +86,7 @@ impl From<&BffStartRequest> for StartChatRequest {
             genome_id: b.genome_id,
             is_demo: b.is_demo,
             channel: b.channel.clone(),
+            force_new: b.force_new,
         }
     }
 }
@@ -758,6 +763,40 @@ mod tests {
         .await;
         assert!(!text2["is_new"].as_bool().unwrap());
         assert_eq!(text2["session_id"], text1["session_id"]);
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn bff_start_force_new_creates_fresh_session(pool: PgPool) {
+        // Proves `force_new` survives the wire + the literal
+        // `From<&BffStartRequest> for StartChatRequest` impl — with
+        // `#[serde(default)]` on the field, a forgotten copy in that impl
+        // would silently drop it instead of failing loudly.
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let state = test_state(pool.clone());
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        let (status, first) = send_request(
+            &mut app,
+            bff_start_request(&token, json!({ "genome_id": genome_id })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "body={first}");
+        assert!(first["is_new"].as_bool().unwrap());
+        let first_id = first["session_id"].as_str().unwrap().to_string();
+
+        let (status, second) = send_request(
+            &mut app,
+            bff_start_request(&token, json!({ "genome_id": genome_id, "force_new": true })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "body={second}");
+        assert!(
+            second["is_new"].as_bool().unwrap(),
+            "force_new must produce is_new: true; got {second}"
+        );
+        assert_ne!(second["session_id"].as_str().unwrap(), first_id);
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -83,6 +83,13 @@ pub struct StartChatRequest {
     /// text session and vice versa, so the two conversations stay isolated.
     #[serde(default)]
     pub channel: Option<String>,
+    /// When `true`, skip resume entirely and always create a fresh session
+    /// (returns `is_new: true`), even if a resumable one exists for this
+    /// user × instance × channel. Default `false`/omitted keeps the normal
+    /// resume-or-create behavior. Intended for callers (e.g. voice calls)
+    /// that want one session per call rather than a continued conversation.
+    #[serde(default)]
+    pub force_new: Option<bool>,
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
@@ -471,11 +478,16 @@ pub(crate) async fn resolve_or_create_session(
     };
 
     // Resume the latest session (bumping last_active_at in one statement), or
-    // create a fresh one. Only `id` is consumed downstream.
-    let (session_id, is_new) = match chat_repo
-        .resume_latest_session(user_id, instance_id, channel)
-        .await?
-    {
+    // create a fresh one. Only `id` is consumed downstream. `force_new` skips
+    // the resume lookup entirely so the match below always falls to create.
+    let resumed = if req.force_new.unwrap_or(false) {
+        None
+    } else {
+        chat_repo
+            .resume_latest_session(user_id, instance_id, channel)
+            .await?
+    };
+    let (session_id, is_new) = match resumed {
         Some(s) => (s.id, false),
         None => {
             let metadata = if req.is_demo.unwrap_or(false) {
@@ -923,6 +935,119 @@ mod tests {
                 .await
                 .unwrap();
         assert_eq!(row_user_id, user_id);
+    }
+
+    // ─── Test 3b: force_new bypasses resume; default still resumes ──
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn start_force_new_creates_fresh_session_when_one_exists(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Echo").await;
+        let state = test_state(pool.clone());
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        // 1. Plain start creates the first session.
+        let body = serde_json::to_vec(&json!({ "genome_id": genome_id })).unwrap();
+        let req = Request::builder()
+            .method("POST")
+            .uri("/comp/chat/start")
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        let (status, first) = send_request(&mut app, req).await;
+        assert_eq!(status, StatusCode::OK, "body={first}");
+        assert_eq!(first["is_new"], true);
+        let first_id = first["session_id"].as_str().unwrap().to_string();
+
+        // 2. force_new: true must NOT resume — it always creates a fresh session.
+        let body =
+            serde_json::to_vec(&json!({ "genome_id": genome_id, "force_new": true })).unwrap();
+        let req = Request::builder()
+            .method("POST")
+            .uri("/comp/chat/start")
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        let (status, second) = send_request(&mut app, req).await;
+        assert_eq!(status, StatusCode::OK, "body={second}");
+        assert_eq!(second["is_new"], true);
+        let second_id = second["session_id"].as_str().unwrap().to_string();
+        assert_ne!(
+            second_id, first_id,
+            "force_new must create a session distinct from the resumable one"
+        );
+
+        // 3. A plain (non-force) start afterward resumes the LATEST session —
+        //    the one force_new just created, bumped ahead by last_active_at —
+        //    not a third fresh one.
+        let body = serde_json::to_vec(&json!({ "genome_id": genome_id })).unwrap();
+        let req = Request::builder()
+            .method("POST")
+            .uri("/comp/chat/start")
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        let (status, third) = send_request(&mut app, req).await;
+        assert_eq!(status, StatusCode::OK, "body={third}");
+        assert_eq!(third["is_new"], false);
+        assert_eq!(third["session_id"].as_str().unwrap(), second_id);
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn start_force_new_on_voice_channel(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Nyx").await;
+        let state = test_state(pool.clone());
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        // 1. Plain voice start creates the first voice session.
+        let body =
+            serde_json::to_vec(&json!({ "genome_id": genome_id, "channel": "voice" })).unwrap();
+        let req = Request::builder()
+            .method("POST")
+            .uri("/comp/chat/start")
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        let (status, first) = send_request(&mut app, req).await;
+        assert_eq!(status, StatusCode::OK, "body={first}");
+        assert_eq!(first["is_new"], true);
+        let first_id = first["session_id"].as_str().unwrap().to_string();
+
+        // 2. force_new on voice must create a fresh voice session, not resume.
+        let body = serde_json::to_vec(
+            &json!({ "genome_id": genome_id, "channel": "voice", "force_new": true }),
+        )
+        .unwrap();
+        let req = Request::builder()
+            .method("POST")
+            .uri("/comp/chat/start")
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        let (status, second) = send_request(&mut app, req).await;
+        assert_eq!(status, StatusCode::OK, "body={second}");
+        assert_eq!(second["is_new"], true);
+        let second_id_str = second["session_id"].as_str().unwrap();
+        assert_ne!(second_id_str, first_id);
+        let second_id = Uuid::parse_str(second_id_str).unwrap();
+
+        // The fresh session must land on the voice channel, not silently
+        // reset to text.
+        let channel: String =
+            sqlx::query_scalar("SELECT channel FROM engine.chat_sessions WHERE id = $1")
+                .bind(second_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(channel, "voice");
     }
 
     // ─── Test 4: cross-user GET /chat/{user_id}/sessions → 403 ──────
@@ -1417,6 +1542,7 @@ mod tests {
             genome_id: Some(genome_id),
             is_demo: None,
             channel: None,
+            force_new: None,
         };
         let resolved = resolve_or_create_session(&state, user_id, &req)
             .await
@@ -1453,6 +1579,7 @@ mod tests {
             genome_id: Some(genome_id),
             is_demo: None,
             channel: None,
+            force_new: None,
         };
         let resolved = resolve_or_create_session(&state, user_id, &req)
             .await
@@ -1484,6 +1611,7 @@ mod tests {
             genome_id: None,
             is_demo: None,
             channel: None,
+            force_new: None,
         };
         let err = resolve_or_create_session(&state, intruder, &req)
             .await
@@ -1513,6 +1641,7 @@ mod tests {
             genome_id: None,
             is_demo: None,
             channel: None,
+            force_new: None,
         };
         let err = resolve_or_create_session(&state, user_id, &req)
             .await

--- a/crates/eros-engine-server/src/routes/voice.rs
+++ b/crates/eros-engine-server/src/routes/voice.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 use utoipa_axum::{router::OpenApiRouter, routes};
 use uuid::Uuid;
 
-use eros_engine_core::scope::RelationshipScope;
+use eros_engine_core::scope::{MemoryScope, RelationshipScope};
 use eros_engine_store::chat::{ChatRepo, VoiceUserInsert};
 use eros_engine_store::persona::PersonaRepo;
 
@@ -40,6 +40,13 @@ pub struct VoiceTurnRequest {
     #[serde(default)]
     #[schema(value_type = Option<String>)]
     pub relationship_scope: Option<RelationshipScope>,
+    /// How much long-term memory this turn may use — same field name, enum,
+    /// wire values, and default (`neutral_and_relationship`) as the chat
+    /// stream. On the session's FIRST turn the resolved insight tier is frozen
+    /// into the bootstrap snapshot and never changes for the rest of the call.
+    #[serde(default)]
+    #[schema(value_type = Option<String>)]
+    pub memory_scope: Option<MemoryScope>,
 }
 
 fn pre(status: StatusCode, code: &'static str, message: &str, user_message: &str) -> AppError {
@@ -208,6 +215,10 @@ pub async fn voice_turn_stream(
         user_id,
         user_message_id,
         relationship_scope: req.relationship_scope.unwrap_or_default(),
+        memory_scope: req.memory_scope.unwrap_or_default(),
+        // Handed over from the row loaded above — the pipeline reads the
+        // `voice_bootstrap` marker from it instead of re-querying the session.
+        session_metadata: session.metadata,
     };
     let proto = run_voice_turn(Arc::new(state.clone()), turn, resolved);
 
@@ -347,6 +358,29 @@ mod tests {
                 "content": "hi",
                 "client_msg_id": "01J2222222222222222222222A",
                 "relationship_scope": "romance"
+            }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    /// `memory_scope` is a typed enum on the wire, exactly like
+    /// `relationship_scope`: an unknown value is a payload error, not a
+    /// silent fallback to the default.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn voice_422_when_memory_scope_invalid(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let session_id = seed(&pool, user_id).await;
+        let mut app = build_router(with_voice(crate::routes::companion::test_state(pool)));
+        let jwt = mint_jwt(user_id);
+        let resp = post_voice(
+            &mut app,
+            session_id,
+            &jwt,
+            json!({
+                "content": "hi",
+                "client_msg_id": "01J2222222222222222222222A",
+                "memory_scope": "everything"
             }),
         )
         .await;

--- a/crates/eros-engine-server/src/routes/voice.rs
+++ b/crates/eros-engine-server/src/routes/voice.rs
@@ -42,8 +42,9 @@ pub struct VoiceTurnRequest {
     pub relationship_scope: Option<RelationshipScope>,
     /// How much long-term memory this turn may use — same field name, enum,
     /// wire values, and default (`neutral_and_relationship`) as the chat
-    /// stream. On the session's FIRST turn the resolved insight tier is frozen
-    /// into the bootstrap snapshot and never changes for the rest of the call.
+    /// stream. The first successfully-assembling turn's resolved insight
+    /// tier is frozen into the bootstrap snapshot and never changes for the
+    /// rest of the call.
     #[serde(default)]
     #[schema(value_type = Option<String>)]
     pub memory_scope: Option<MemoryScope>,

--- a/crates/eros-engine-server/src/routes/voice.rs
+++ b/crates/eros-engine-server/src/routes/voice.rs
@@ -214,6 +214,10 @@ pub async fn voice_turn_stream(
         instance_id,
         user_id,
         user_message_id,
+        // Verbatim: the per-turn recall embeds it as the query text (voice has
+        // no input-filter rewrite). Already persisted above as the latest
+        // history row — the wire messages still come from there.
+        content: req.content,
         relationship_scope: req.relationship_scope.unwrap_or_default(),
         memory_scope: req.memory_scope.unwrap_or_default(),
         // Handed over from the row loaded above — the pipeline reads the

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -1065,6 +1065,59 @@ impl<'a> ChatRepo<'a> {
         .await?;
         Ok(())
     }
+
+    /// The user's most-recently-active OTHER voice session for this persona
+    /// instance — used to quote its tail into a new voice session's bootstrap
+    /// snapshot on that session's first turn. Same `(user_id, instance_id)`
+    /// pair, `channel = 'voice'`, and excludes `exclude_session_id` (the
+    /// session being bootstrapped) so a session never becomes its own
+    /// sibling. Read-only — unlike `resume_latest_session`, does NOT bump
+    /// `last_active_at`; this is a side lookup for a different session, not a
+    /// resume. Rides `idx_chat_sessions_user_instance_channel` (migration
+    /// 0031).
+    pub async fn latest_sibling_voice_session(
+        &self,
+        user_id: Uuid,
+        instance_id: Uuid,
+        exclude_session_id: Uuid,
+    ) -> Result<Option<ChatSession>, sqlx::Error> {
+        sqlx::query_as::<_, ChatSession>(
+            "SELECT * FROM engine.chat_sessions \
+             WHERE user_id = $1 AND instance_id = $2 AND channel = 'voice' AND id <> $3 \
+             ORDER BY last_active_at DESC LIMIT 1",
+        )
+        .bind(user_id)
+        .bind(instance_id)
+        .bind(exclude_session_id)
+        .fetch_optional(self.pool)
+        .await
+    }
+
+    /// Write-once snapshot of a voice session's bootstrap context into
+    /// `metadata.voice_bootstrap`. Guarded by `NOT (metadata ? 'voice_bootstrap')`
+    /// so a retried pipeline step, or two concurrent first-turn requests
+    /// racing each other, can never clobber the original snapshot — the
+    /// loser's write is a no-op, not a silent overwrite. No `COALESCE` needed:
+    /// `chat_sessions.metadata` is `NOT NULL DEFAULT '{}'` (migration 0001).
+    /// Returns `rows_affected`: 1 = this call wrote the snapshot; 0 = the key
+    /// was already present (race lost, or already written on a prior turn) —
+    /// callers treat 0 as a normal no-op, not an error.
+    pub async fn set_voice_bootstrap(
+        &self,
+        session_id: Uuid,
+        snapshot: &serde_json::Value,
+    ) -> Result<u64, sqlx::Error> {
+        let res = sqlx::query(
+            "UPDATE engine.chat_sessions \
+             SET metadata = metadata || jsonb_build_object('voice_bootstrap', $2::jsonb) \
+             WHERE id = $1 AND NOT (metadata ? 'voice_bootstrap')",
+        )
+        .bind(session_id)
+        .bind(snapshot)
+        .execute(self.pool)
+        .await?;
+        Ok(res.rows_affected())
+    }
 }
 
 #[cfg(test)]
@@ -3377,5 +3430,190 @@ mod tests {
             .unwrap();
         assert!(openings.iter().all(|c| c != "这是官方说明……"));
         assert!(openings.contains(&"嗨呀".to_string()));
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn latest_sibling_voice_session_excludes_current_and_text_channel(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
+
+        // The only session that should ever come back: an older voice
+        // session for the same user × instance.
+        let sibling = repo
+            .create_session_with_metadata(user_id, instance_id, serde_json::json!({}), "voice")
+            .await
+            .unwrap();
+        sqlx::query(
+            "UPDATE engine.chat_sessions SET last_active_at = now() - interval '2 hours' \
+             WHERE id = $1",
+        )
+        .bind(sibling.id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // Decoy: a text-channel session, more recently active than `sibling`.
+        // If the channel filter were missing, this would be picked instead.
+        let text_decoy = repo
+            .create_session_with_metadata(user_id, instance_id, serde_json::json!({}), "text")
+            .await
+            .unwrap();
+        sqlx::query(
+            "UPDATE engine.chat_sessions SET last_active_at = now() - interval '1 hour' \
+             WHERE id = $1",
+        )
+        .bind(text_decoy.id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // Current: the voice session we exclude by id. Left at its default
+        // `now()` last_active_at — the most recent of all three — so a
+        // missing `id <> $3` filter would wrongly return it instead of
+        // `sibling`.
+        let current = repo
+            .create_session_with_metadata(user_id, instance_id, serde_json::json!({}), "voice")
+            .await
+            .unwrap();
+
+        let found = repo
+            .latest_sibling_voice_session(user_id, instance_id, current.id)
+            .await
+            .unwrap();
+        assert_eq!(
+            found.map(|s| s.id),
+            Some(sibling.id),
+            "must exclude the current session and any text-channel session"
+        );
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn latest_sibling_voice_session_orders_by_last_active_at(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
+        let current = repo
+            .create_session_with_metadata(user_id, instance_id, serde_json::json!({}), "voice")
+            .await
+            .unwrap();
+
+        let older = repo
+            .create_session_with_metadata(user_id, instance_id, serde_json::json!({}), "voice")
+            .await
+            .unwrap();
+        sqlx::query(
+            "UPDATE engine.chat_sessions SET last_active_at = now() - interval '2 hours' \
+             WHERE id = $1",
+        )
+        .bind(older.id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let newer = repo
+            .create_session_with_metadata(user_id, instance_id, serde_json::json!({}), "voice")
+            .await
+            .unwrap();
+        sqlx::query(
+            "UPDATE engine.chat_sessions SET last_active_at = now() - interval '1 minute' \
+             WHERE id = $1",
+        )
+        .bind(newer.id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let found = repo
+            .latest_sibling_voice_session(user_id, instance_id, current.id)
+            .await
+            .unwrap()
+            .expect("a sibling voice session exists");
+        assert_eq!(
+            found.id, newer.id,
+            "must return the most-recently-active sibling"
+        );
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn latest_sibling_voice_session_none_when_no_sibling(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
+        let current = repo
+            .create_session_with_metadata(user_id, instance_id, serde_json::json!({}), "voice")
+            .await
+            .unwrap();
+
+        let found = repo
+            .latest_sibling_voice_session(user_id, instance_id, current.id)
+            .await
+            .unwrap();
+        assert!(
+            found.is_none(),
+            "no other voice session exists for this user × instance"
+        );
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn set_voice_bootstrap_writes_once_then_noops(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let s = throwaway_session(&pool).await;
+        let snapshot = serde_json::json!({
+            "tail": "上次聊到这里",
+            "prior_session_id": Uuid::new_v4().to_string(),
+        });
+
+        let rows = repo.set_voice_bootstrap(s.id, &snapshot).await.unwrap();
+        assert_eq!(rows, 1, "first write must succeed");
+
+        let loaded = repo.get_session(s.id).await.unwrap().unwrap();
+        assert_eq!(loaded.metadata["voice_bootstrap"], snapshot);
+
+        // Second call with a DIFFERENT snapshot must no-op — the key is
+        // already present.
+        let other_snapshot = serde_json::json!({"tail": "should never be written"});
+        let rows2 = repo
+            .set_voice_bootstrap(s.id, &other_snapshot)
+            .await
+            .unwrap();
+        assert_eq!(
+            rows2, 0,
+            "second write must be a no-op (key already present)"
+        );
+
+        let loaded2 = repo.get_session(s.id).await.unwrap().unwrap();
+        assert_eq!(
+            loaded2.metadata["voice_bootstrap"], snapshot,
+            "original snapshot must be preserved, not overwritten"
+        );
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn set_voice_bootstrap_preserves_other_metadata_keys(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
+        let s = repo
+            .create_session_with_metadata(
+                user_id,
+                instance_id,
+                serde_json::json!({"is_demo": true}),
+                "voice",
+            )
+            .await
+            .unwrap();
+
+        let snapshot = serde_json::json!({"tail": "接上次"});
+        let rows = repo.set_voice_bootstrap(s.id, &snapshot).await.unwrap();
+        assert_eq!(rows, 1);
+
+        let loaded = repo.get_session(s.id).await.unwrap().unwrap();
+        assert_eq!(
+            loaded.metadata["is_demo"],
+            serde_json::json!(true),
+            "pre-existing metadata keys must survive the merge"
+        );
+        assert_eq!(loaded.metadata["voice_bootstrap"], snapshot);
     }
 }

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -934,7 +934,10 @@ impl<'a> ChatRepo<'a> {
     /// `channel = 'voice'` and skips all replay/ghost machinery. Returns
     /// which case occurred — `Duplicate` when `client_msg_id` was already
     /// seen (existing row's id), `Inserted` (fresh row's id) otherwise — so
-    /// callers can refuse to regenerate a reply for a duplicate.
+    /// callers can refuse to regenerate a reply for a duplicate. Bumps
+    /// `last_active_at` only on the `Inserted` branch — a `Duplicate` replay
+    /// must not bump, or it would reorder sibling-session selection for a
+    /// later feature.
     pub async fn insert_voice_user_message(
         &self,
         session_id: Uuid,
@@ -946,6 +949,7 @@ impl<'a> ChatRepo<'a> {
         // migration 0012) — DO NOTHING and fall through to reading the existing id,
         // so concurrent duplicates are classified reliably (the loser gets
         // Duplicate, never a unique-violation 500).
+        let mut tx = self.pool.begin().await?;
         let inserted: Option<Uuid> = sqlx::query_scalar(
             "INSERT INTO engine.chat_messages (session_id, role, content, client_msg_id, channel) \
              VALUES ($1, 'user', $2, $3, 'voice') \
@@ -955,9 +959,16 @@ impl<'a> ChatRepo<'a> {
         .bind(session_id)
         .bind(content)
         .bind(client_msg_id)
-        .fetch_optional(self.pool)
+        .fetch_optional(&mut *tx)
         .await?;
         if let Some(id) = inserted {
+            // Bump only on a fresh insert. A `Duplicate` replay must NOT bump —
+            // it would reorder sibling-session selection for a later feature.
+            sqlx::query("UPDATE engine.chat_sessions SET last_active_at = now() WHERE id = $1")
+                .bind(session_id)
+                .execute(&mut *tx)
+                .await?;
+            tx.commit().await?;
             return Ok(VoiceUserInsert::Inserted(id));
         }
         // Conflict → a row with this (session_id, client_msg_id) already exists.
@@ -970,14 +981,16 @@ impl<'a> ChatRepo<'a> {
         )
         .bind(session_id)
         .bind(client_msg_id)
-        .fetch_one(self.pool)
+        .fetch_one(&mut *tx)
         .await?;
+        tx.commit().await?;
         Ok(VoiceUserInsert::Duplicate(existing))
     }
 
     /// Persist an assistant turn on the voice channel: `role='assistant'`,
     /// `assistant_action_type='reply'`, `channel='voice'`. No filter audit, no
-    /// continues_from — voice replies are single, whole messages.
+    /// continues_from — voice replies are single, whole messages. Bumps
+    /// `last_active_at` in the same transaction as the insert.
     #[allow(clippy::too_many_arguments)]
     pub async fn insert_voice_assistant_message(
         &self,
@@ -991,6 +1004,7 @@ impl<'a> ChatRepo<'a> {
         truncated: bool,
         metadata: Option<&serde_json::Value>,
     ) -> Result<(), sqlx::Error> {
+        let mut tx = self.pool.begin().await?;
         sqlx::query(
             "INSERT INTO engine.chat_messages \
              (id, session_id, role, content, user_message_id, truncated, model, usage, \
@@ -1006,8 +1020,13 @@ impl<'a> ChatRepo<'a> {
         .bind(usage)
         .bind(generation_id)
         .bind(metadata)
-        .execute(self.pool)
+        .execute(&mut *tx)
         .await?;
+        sqlx::query("UPDATE engine.chat_sessions SET last_active_at = now() WHERE id = $1")
+            .bind(session_id)
+            .execute(&mut *tx)
+            .await?;
+        tx.commit().await?;
         Ok(())
     }
 
@@ -2967,6 +2986,158 @@ mod tests {
         assert!(
             matches!(out, VoiceUserInsert::Duplicate(_)),
             "voice insert colliding with a gift_user row must be Duplicate, got {out:?}"
+        );
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn voice_user_insert_bumps_last_active_at(pool: PgPool) {
+        let session_id = throwaway_session(&pool).await.id;
+        let repo = ChatRepo { pool: &pool };
+
+        // Backdate so the bump is unambiguous regardless of clock resolution.
+        sqlx::query(
+            "UPDATE engine.chat_sessions SET last_active_at = now() - interval '1 hour' \
+             WHERE id = $1",
+        )
+        .bind(session_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+        let before: DateTime<Utc> =
+            sqlx::query_scalar("SELECT last_active_at FROM engine.chat_sessions WHERE id = $1")
+                .bind(session_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+
+        let out = repo
+            .insert_voice_user_message(session_id, "hi", "01J9000000000000000000BUMP1")
+            .await
+            .unwrap();
+        assert!(
+            matches!(out, VoiceUserInsert::Inserted(_)),
+            "expected Inserted, got {out:?}"
+        );
+
+        let after: DateTime<Utc> =
+            sqlx::query_scalar("SELECT last_active_at FROM engine.chat_sessions WHERE id = $1")
+                .bind(session_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert!(
+            after > before,
+            "a fresh voice user insert must bump last_active_at"
+        );
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn voice_user_insert_duplicate_does_not_bump_last_active_at(pool: PgPool) {
+        let session_id = throwaway_session(&pool).await.id;
+        let repo = ChatRepo { pool: &pool };
+        let cmid = "01J9000000000000000000BUMP2";
+
+        let first = match repo
+            .insert_voice_user_message(session_id, "hi", cmid)
+            .await
+            .unwrap()
+        {
+            VoiceUserInsert::Inserted(id) => id,
+            other => panic!("expected Inserted, got {other:?}"),
+        };
+
+        // Backdate so a stray bump on the duplicate branch would be visible.
+        sqlx::query(
+            "UPDATE engine.chat_sessions SET last_active_at = now() - interval '1 hour' \
+             WHERE id = $1",
+        )
+        .bind(session_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+        let before: DateTime<Utc> =
+            sqlx::query_scalar("SELECT last_active_at FROM engine.chat_sessions WHERE id = $1")
+                .bind(session_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+
+        let out = repo
+            .insert_voice_user_message(session_id, "hi again", cmid)
+            .await
+            .unwrap();
+        match out {
+            VoiceUserInsert::Duplicate(id) => assert_eq!(id, first),
+            other => panic!("expected Duplicate, got {other:?}"),
+        }
+
+        let after: DateTime<Utc> =
+            sqlx::query_scalar("SELECT last_active_at FROM engine.chat_sessions WHERE id = $1")
+                .bind(session_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            after, before,
+            "a duplicate voice user insert must NOT bump last_active_at (would reorder \
+             sibling-session selection for a replayed client_msg_id)"
+        );
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn voice_assistant_insert_bumps_last_active_at(pool: PgPool) {
+        let session_id = throwaway_session(&pool).await.id;
+        let repo = ChatRepo { pool: &pool };
+
+        let user_message_id = match repo
+            .insert_voice_user_message(session_id, "hi", "01J9000000000000000000BUMP3")
+            .await
+            .unwrap()
+        {
+            VoiceUserInsert::Inserted(id) => id,
+            other => panic!("expected Inserted, got {other:?}"),
+        };
+
+        // Backdate so the assistant-insert bump is unambiguous.
+        sqlx::query(
+            "UPDATE engine.chat_sessions SET last_active_at = now() - interval '1 hour' \
+             WHERE id = $1",
+        )
+        .bind(session_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+        let before: DateTime<Utc> =
+            sqlx::query_scalar("SELECT last_active_at FROM engine.chat_sessions WHERE id = $1")
+                .bind(session_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+
+        let aid: Uuid = ulid::Ulid::new().into();
+        repo.insert_voice_assistant_message(
+            session_id,
+            user_message_id,
+            aid,
+            "hi there",
+            Some("primary"),
+            None,
+            Some("gen-1"),
+            false,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let after: DateTime<Utc> =
+            sqlx::query_scalar("SELECT last_active_at FROM engine.chat_sessions WHERE id = $1")
+                .bind(session_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert!(
+            after > before,
+            "a voice assistant insert must bump last_active_at"
         );
     }
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -60,6 +60,13 @@ channel-scoped — a voice-channel start never resumes a text session (and
 vice versa). Voice clients must obtain their session here with
 `"channel": "voice"` before calling the voice turn endpoint.
 
+Optional `force_new` field: when `true`, skip resume entirely and always
+create a fresh session (`is_new: true`), even if a resumable one exists for
+this user × instance × channel. Default `false`/omitted keeps the normal
+resume-or-create behavior. Recommended for voice calls — start every call
+with `{"channel": "voice", "force_new": true}` so each call gets its own
+session instead of continuing a previous one.
+
 Optional `instance_id` field: an explicit `persona_instance` id. When absent,
 the server picks (or auto-creates) the user's instance for the supplied
 `genome_id`; `genome_id` is required only when `instance_id` is absent.
@@ -412,9 +419,34 @@ otherwise) — obtain one via `POST /comp/chat/start` with
 `[tasks.chat_voice]` block in the model config the endpoint returns
 `501 voice_disabled`.
 
-The prompt is deliberately thin: persona + voice directive + one
-relationship line derived from the session's affinity (bond/chemistry
-tiers). No vector recall, no memories, no traits/scopes/heavy blocks.
+The prompt is lean but not memoryless: persona + voice directive + a
+first-turn **bootstrap snapshot** (frozen once per session, then re-injected
+verbatim every turn) + one relationship line derived from the session's
+affinity (bond/chemistry tiers) + this turn's **recall block**. History is
+the last 8 messages (4 exchanges) — shorter than the chat path's window,
+since the bootstrap and recall carry the longer-range memory instead. Voice
+still writes **no** memories of any kind (no insight extraction, no vector
+writes) — a call's content only becomes reachable from a *later* call, via
+the bootstrap snapshot below.
+
+**Bootstrap snapshot** (first turn only, then frozen into
+`chat_sessions.metadata.voice_bootstrap` and replayed on every later turn —
+the provider is stateless, so there is no "inject once" on the wire): a
+`[关于他]` block of `human_insights` bullets (Neutral tier by default; see
+`memory_scope` below) plus a `[上次通话]` block, the previous voice call's
+last 8 messages rendered as a transcript. The two parts degrade
+independently and silently — a failed assembly leaves the marker unwritten
+so the next turn retries.
+
+**Per-turn recall** (every turn, read-only): a small vector-search pass over
+the same `companion_memories` layers the chat path uses, gated by
+`memory_scope` and budgeted at 300 ms — a timeout or search failure just
+drops the block for that turn, never an error. An utterance under 4
+alphanumeric characters after stripping whitespace/punctuation (嗯 / 好啊 /
+哈哈-style backchannels) skips recall entirely, with no embedding call.
+Deployments can force recall off regardless of the request via
+`[tasks.chat_voice] recall = false` (default `true` — see
+[model-config.md](model-config.md)).
 
 Body fields:
 
@@ -426,10 +458,17 @@ Body fields:
   to inject this turn: `"none"`, `"bond"`, `"chemistry"`, `"both"`
   (default `"both"`). The resolved value is recorded on the assistant
   row's `metadata.relationship_scope`.
+- `memory_scope` (optional) — same field name, enum, and default
+  (`"neutral_and_relationship"`) as the
+  [chat message stream](#post-compchatsession_idmessagestream). On the
+  session's **first** turn, the resolved insight tier picks the bootstrap
+  snapshot's `[关于他]` tier and is frozen for the rest of the call; every
+  turn it also gates that turn's recall block. Later turns cannot change
+  the snapshot's tier.
 
 ```bash
 curl -N -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json" \
-  -d '{"content":"你今天在干嘛？","client_msg_id":"01JABCDEFGHJKMNPQRSTVWXYZ0","relationship_scope":"both"}' \
+  -d '{"content":"你今天在干嘛？","client_msg_id":"01JABCDEFGHJKMNPQRSTVWXYZ0","relationship_scope":"both","memory_scope":"neutral_and_relationship"}' \
   http://localhost:8080/comp/voice/{session_id}/turn/stream
 ```
 
@@ -638,6 +677,10 @@ The body is the canonical start body plus one BFF-only field:
 - `genome_id` / `instance_id` — identify the persona (same as canonical).
 - `is_demo` — optional, same as canonical.
 - `history_limit` — optional bundled-history page size; default 50, capped at 50.
+- `force_new` — optional, same as canonical. Passed through to
+  `StartChatRequest::force_new` — skip resume and always create a fresh
+  session (`is_new: true`); recommended for voice calls (see the
+  [voice section](#post-compvoicesession_idturnstream) above).
 
 ```json
 {

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -65,7 +65,9 @@ create a fresh session (`is_new: true`), even if a resumable one exists for
 this user × instance × channel. Default `false`/omitted keeps the normal
 resume-or-create behavior. Recommended for voice calls — start every call
 with `{"channel": "voice", "force_new": true}` so each call gets its own
-session instead of continuing a previous one.
+session instead of continuing a previous one. `POST /comp/chat/start` has no
+built-in rate limit, so deployments that expose `force_new` may want
+request-level rate limiting downstream.
 
 Optional `instance_id` field: an explicit `persona_instance` id. When absent,
 the server picks (or auto-creates) the user's instance for the supplied
@@ -461,10 +463,10 @@ Body fields:
 - `memory_scope` (optional) — same field name, enum, and default
   (`"neutral_and_relationship"`) as the
   [chat message stream](#post-compchatsession_idmessagestream). On the
-  session's **first** turn, the resolved insight tier picks the bootstrap
-  snapshot's `[关于他]` tier and is frozen for the rest of the call; every
-  turn it also gates that turn's recall block. Later turns cannot change
-  the snapshot's tier.
+  session's **first successfully-assembling** turn, the resolved insight
+  tier picks the bootstrap snapshot's `[关于他]` tier and is frozen for the
+  rest of the call; every turn it also gates that turn's recall block.
+  Later turns cannot change the snapshot's tier.
 
 ```bash
 curl -N -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json" \

--- a/docs/api-reference.zh.md
+++ b/docs/api-reference.zh.md
@@ -61,7 +61,8 @@ curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json"
 （`is_new: true`），即使这个用户 × instance × channel 组合本有可以恢复的
 session。默认 `false`/缺省保持原本的恢复优先行为。语音通话推荐使用：每通
 电话都用 `{"channel": "voice", "force_new": true}` 开始，让每通电话都拿到
-自己的 session，而不是接着上一通的。
+自己的 session，而不是接着上一通的。`POST /comp/chat/start` 本身没有内置
+速率限制，暴露 `force_new` 的部署可能需要在下游做请求级别的限流。
 
 可选的 `instance_id` 字段：显式指定 `persona_instance` id。缺省时服务器为
 所给 `genome_id` 挑选（或自动创建）该用户的 instance；仅当 `instance_id`
@@ -400,10 +401,10 @@ Body 字段：
   `metadata.relationship_scope` 上。
 - `memory_scope`（可选）—— 字段名、枚举值、默认值
   （`"neutral_and_relationship"`）都与
-  [聊天消息流](#post-compchatsession_idmessagestream) 相同。session 的
-  **首轮**里，解析出的 insight 档位会决定引导快照 `[关于他]` 部分的档位，
-  并为整通电话冻结；每一轮它还会门控当轮的召回块。之后的轮次改不了快照的
-  档位。
+  [聊天消息流](#post-compchatsession_idmessagestream) 相同。session 里
+  **首个成功组装快照的轮次**中，解析出的 insight 档位会决定引导快照
+  `[关于他]` 部分的档位，并为整通电话冻结；每一轮它还会门控当轮的召回块。
+  之后的轮次改不了快照的档位。
 
 ```bash
 curl -N -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json" \

--- a/docs/api-reference.zh.md
+++ b/docs/api-reference.zh.md
@@ -57,6 +57,12 @@ curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json"
 ——语音频道的 start 永远不会恢复一个文本 session，反之亦然。语音客户端必须先
 在这里用 `"channel": "voice"` 拿到 session，才能去调语音轮次端点。
 
+可选的 `force_new` 字段：为 `true` 时跳过恢复，总是创建一个全新 session
+（`is_new: true`），即使这个用户 × instance × channel 组合本有可以恢复的
+session。默认 `false`/缺省保持原本的恢复优先行为。语音通话推荐使用：每通
+电话都用 `{"channel": "voice", "force_new": true}` 开始，让每通电话都拿到
+自己的 session，而不是接着上一通的。
+
 可选的 `instance_id` 字段：显式指定 `persona_instance` id。缺省时服务器为
 所给 `genome_id` 挑选（或自动创建）该用户的 instance；仅当 `instance_id`
 缺省时 `genome_id` 才是必填。
@@ -362,8 +368,26 @@ session 必须是**语音频道** session（否则 `409 wrong_channel`）——�
 开启的：model config 里没有 `[tasks.chat_voice]` 块时，该端点返回
 `501 voice_disabled`。
 
-prompt 刻意做得很薄：人格 + 语音指令 + 一行由该 session 好感度推导出的关系描述
-（bond/chemistry 档位）。不做向量召回，不带记忆，不带 traits/scopes 等较大的上下文块。
+prompt 精简但不再失忆：人格 + 语音指令 + 首轮生成、此后每轮原样重发的
+**引导快照（bootstrap snapshot）** + 一行由该 session 好感度推导出的关系描述
+（bond/chemistry 档位）+ 本轮的**召回块**。历史窗口是最近 8 条消息（4 个来回）
+——比聊天路径的窗口短，因为更长程的记忆改由引导快照和召回承担。语音依旧
+**不写**任何记忆（不做 insight 抽取，不写向量）——一通电话的内容只会通过
+引导快照，被*之后*的通话读到。
+
+**引导快照**（仅首轮组装，随后冻结进 `chat_sessions.metadata.voice_bootstrap`，
+此后每轮原样重新注入——provider 是无状态的，线路上不存在"只注入一次"这回事）：
+一个 `[关于他]` 块（`human_insights` bullets，默认中性档，见下面的
+`memory_scope`）加一个 `[上次通话]` 块（上一通语音通话最后 8 条消息渲染出的
+文字记录）。两部分各自独立、静默降级——组装失败时标记位不落，下一轮重试。
+
+**每轮召回**（每轮都跑，只读）：对聊天路径同样的 `companion_memories` 分层
+做一次更小的向量检索，受 `memory_scope` 门控，300 ms 预算内完成——超时或
+检索失败只是丢掉这一轮的召回块，绝不报错。去掉空白和标点后不足 4 个字母
+数字字符的话语（嗯 / 好啊 / 哈哈这类应和词）直接跳过召回，不发起 embedding
+调用。部署方可以用 `[tasks.chat_voice] recall = false`（默认 `true`）强制
+关闭召回，不管请求里传了什么 `memory_scope`——详见
+[model-config.zh.md](model-config.zh.md)。
 
 Body 字段：
 
@@ -374,10 +398,16 @@ Body 字段：
 - `relationship_scope`（可选）—— 本轮注入关系描述的哪几半：`"none"`、`"bond"`、
   `"chemistry"`、`"both"`（默认 `"both"`）。解析后的取值记录在 assistant 行的
   `metadata.relationship_scope` 上。
+- `memory_scope`（可选）—— 字段名、枚举值、默认值
+  （`"neutral_and_relationship"`）都与
+  [聊天消息流](#post-compchatsession_idmessagestream) 相同。session 的
+  **首轮**里，解析出的 insight 档位会决定引导快照 `[关于他]` 部分的档位，
+  并为整通电话冻结；每一轮它还会门控当轮的召回块。之后的轮次改不了快照的
+  档位。
 
 ```bash
 curl -N -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json" \
-  -d '{"content":"你今天在干嘛？","client_msg_id":"01JABCDEFGHJKMNPQRSTVWXYZ0","relationship_scope":"both"}' \
+  -d '{"content":"你今天在干嘛？","client_msg_id":"01JABCDEFGHJKMNPQRSTVWXYZ0","relationship_scope":"both","memory_scope":"neutral_and_relationship"}' \
   http://localhost:8080/comp/voice/{session_id}/turn/stream
 ```
 
@@ -570,6 +600,9 @@ canonical `/comp/*` 路由永遠不會為了遷就前端而被改形狀——而
 - `genome_id` / `instance_id` —— 標識人格（同 canonical）。
 - `is_demo` —— 可選，同 canonical。
 - `history_limit` —— 可選，打包歷史的頁大小；默認 50，上限 50。
+- `force_new` —— 可选，同 canonical。透传给 `StartChatRequest::force_new`
+  ——跳过恢复，总是创建一个全新 session（`is_new: true`）；语音通话推荐
+  使用（见上面的[语音小节](#post-compvoicesession_idturnstream)）。
 
 ```json
 {

--- a/docs/memory-layers.md
+++ b/docs/memory-layers.md
@@ -127,6 +127,41 @@ evaluation still run; there is currently no scope value that suppresses
 writing. The frontend's `/comp/user/{user_id}/profile` endpoint returns the
 `companion_insights` JSONB as a human-readable view of what's been collected.
 
+### Voice turns
+
+The voice endpoint (`POST /comp/voice/{session_id}/turn/stream`) reads from
+the same two layers through a leaner, voice-specific path — see
+[api-reference.md](api-reference.md#post-compvoicesession_idturnstream) for
+the request shape and [model-config.md](model-config.md) for the
+`[tasks.chat_voice]` block.
+
+- **Bootstrap snapshot** — assembled once, on a session's first turn, and
+  frozen into `chat_sessions.metadata.voice_bootstrap`; re-injected verbatim
+  on every later turn (OpenRouter is stateless, so there is no "inject once"
+  on the wire — later turns cannot change it). Two parts: `human_insights`
+  bullets at Neutral tier by default (tunable via that first turn's
+  `memory_scope`), and the previous voice call's last 8 messages rendered as
+  a plain transcript. Each part degrades independently; a failed assembly
+  leaves the marker unwritten so the next turn retries.
+- **Per-turn recall** — the same `companion_memories` search as the chat
+  path (`memory_scope`-gated, cross-layer dedup via `memory_hygiene`) but at
+  a much smaller K: grouped profile 1/category + raw fallback 2 +
+  relationship 2 (chat's tier is 2/4/3), wrapped in a 300 ms budget — a
+  timeout or search error just drops that turn's recall block, with a warn
+  log, never an error frame. An utterance under 4 alphanumeric characters
+  after stripping whitespace/punctuation (嗯 / 好啊 / 哈哈-style
+  backchannels) skips recall entirely, with no embedding call. Deployment
+  kill-switch: `[tasks.chat_voice] recall = false` (default `true`) always
+  wins over the request's `memory_scope`.
+- **Read-only** — voice never writes to `companion_memories`: no raw-turn
+  embed, no dreaming-lite extraction (the sweeper still excludes
+  `channel = 'voice'` sessions). A call's own content is not searchable by
+  itself; it only becomes reachable from a *later* sibling voice call, via
+  the bootstrap snapshot above.
+
+Design spec:
+[2026-08-09-voice-memory-bootstrap-recall-design.md](superpowers/specs/2026-08-09-voice-memory-bootstrap-recall-design.md).
+
 ## Source
 
 - `crates/eros-engine-store/src/memory.rs` — `MemoryRepo` (upsert + search, 7 sqlx::test integration tests)
@@ -136,6 +171,7 @@ writing. The frontend's `/comp/user/{user_id}/profile` endpoint returns the
 - `crates/eros-engine-server/src/pipeline/post_process.rs` — raw-turn write path
 - `crates/eros-engine-server/src/pipeline/dreaming.rs` — dreaming-lite sweeper
 - `crates/eros-engine-server/src/pipeline/handlers.rs` — retrieval + prompt injection
+- `crates/eros-engine-server/src/pipeline/voice.rs` — voice-turn bootstrap snapshot + per-turn recall
 - `crates/eros-engine-store/migrations/0003_memory.sql` — schema + index DDL
 - `crates/eros-engine-store/migrations/0006_memory_category.sql` — `category` column
 - `crates/eros-engine-store/migrations/0032_companion_memories_metadata.sql` — `metadata` column

--- a/docs/memory-layers.zh.md
+++ b/docs/memory-layers.zh.md
@@ -121,6 +121,35 @@ handler（`pipeline::handlers`）从两个来源拼出画像 / 关系上下文�
 `/comp/user/{user_id}/profile` 端点返回 `companion_insights` JSONB，作为已收集
 内容的人类可读视图。
 
+### 语音轮次
+
+语音端点（`POST /comp/voice/{session_id}/turn/stream`）读取同样的两层，但走
+一条更精简的语音专属路径——请求体见
+[api-reference.zh.md](api-reference.zh.md#post-compvoicesession_idturnstream)，
+`[tasks.chat_voice]` 块见 [model-config.zh.md](model-config.zh.md)。
+
+- **引导快照** —— 仅在 session 首轮组装一次，冻结进
+  `chat_sessions.metadata.voice_bootstrap`，此后每轮原样重新注入（OpenRouter
+  是无状态的，线路上不存在"只注入一次"这回事——之后的轮次也改不了它）。分两
+  部分：默认中性档的 `human_insights` bullets（档位可由首轮的 `memory_scope`
+  调整），加上上一通语音通话最后 8 条消息渲染出的纯文字记录。两部分各自独立
+  降级；组装失败时标记位不落，下一轮重试。
+- **逐轮召回** —— 与聊天路径相同的 `companion_memories` 检索（受
+  `memory_scope` 门控，经 `memory_hygiene` 做跨层去重），但 K 值小得多：
+  分组画像 1/类别 + 原始兜底 2 + 关系记忆 2（聊天路径是 2/4/3），整体包在
+  300 ms 预算里——超时或检索出错只是丢掉这一轮的召回块，打一条 warn 日志，
+  绝不是 error 帧。去掉空白和标点后不足 4 个字母数字字符的话语（嗯 / 好啊 /
+  哈哈这类应和词）直接跳过召回，不发起 embedding 调用。部署方可以用
+  `[tasks.chat_voice] recall = false`（默认 `true`）强制关闭，优先级高于
+  请求里的 `memory_scope`。
+- **只读** —— 语音路径从不往 `companion_memories` 写入：没有逐轮原文写入，
+  也没有 dreaming-lite 抽取（清扫器仍然排除 `channel = 'voice'` 的
+  session）。一通电话自己的内容不能被自己检索到；只有*之后*的同频道语音
+  通话，才能通过上面的引导快照读到它。
+
+设计文档：
+[2026-08-09-voice-memory-bootstrap-recall-design.md](superpowers/specs/2026-08-09-voice-memory-bootstrap-recall-design.md)。
+
 ## 源碼
 
 - `crates/eros-engine-store/src/memory.rs`——`MemoryRepo`（upsert + search，7 个 sqlx::test 集成测试）
@@ -130,6 +159,7 @@ handler（`pipeline::handlers`）从两个来源拼出画像 / 关系上下文�
 - `crates/eros-engine-server/src/pipeline/post_process.rs`——逐轮原文写入路径
 - `crates/eros-engine-server/src/pipeline/dreaming.rs`——dreaming-lite 清扫器
 - `crates/eros-engine-server/src/pipeline/handlers.rs`——检索 + prompt 注入
+- `crates/eros-engine-server/src/pipeline/voice.rs`——语音轮次的引导快照 + 逐轮召回
 - `crates/eros-engine-store/migrations/0003_memory.sql`——schema + 索引 DDL
 - `crates/eros-engine-store/migrations/0006_memory_category.sql`——`category` 列
 - `crates/eros-engine-store/migrations/0032_companion_memories_metadata.sql`——`metadata` 列

--- a/docs/model-config.md
+++ b/docs/model-config.md
@@ -519,6 +519,34 @@ its own resolver, `ModelConfig::resolve_embedding()`, called once at boot
 from `main.rs` to build the `EmbeddingRouter`. See "`[tasks.embedding]` —
 active" below.
 
+### `[tasks.chat_voice]` — voice-channel companion reply (opt-in)
+
+Powers `POST /comp/voice/{session_id}/turn/stream`
+(`pipeline::voice::run_voice_turn`, reached from `routes::voice` via
+`resolve_voice()`). Off unless this task block exists.
+
+- `model` — **must** be a single fixed, non-empty id. Unlike every other
+  task, the round-robin array, the weighted table, and `tiers` all refuse to
+  boot on `chat_voice` (mixing models mid-call isn't supported). `fallback`
+  is still allowed as a sequential outage-retry chain.
+- `filter_prompt` — optional voice directive override. Unlike
+  `chat_vision`/`chat_product_qa`, a blank or absent value does **not**
+  disable the feature — it falls back to the built-in directive (short,
+  spoken, no markdown/emoji/bracketed stage directions).
+- `tts_audio_tags` (bool, default `false`) — when `true`, the effective
+  directive invites inline audio tags (`[laughs]`, `[whispers]`, …) that
+  Gemini-family TTS models render as delivery cues. Tags pass through
+  verbatim (streamed, persisted, replayed); the client must feed the text to
+  a TTS model that understands them. Composes with a custom `filter_prompt`
+  — the tag guidance is appended to it.
+- `recall` (bool, default `true`) — per-turn read-only vector recall on the
+  voice path. `false` keeps the voice prompt recall-free on every turn
+  regardless of the request's `memory_scope` — config always wins over the
+  per-request scope. See
+  [memory-layers.md](memory-layers.md#voice-turns).
+
+Call site: `crates/eros-engine-server/src/pipeline/voice.rs::run_voice_turn`.
+
 ### `[tasks.pde_decision]` — opt-in LLM PDE judge
 
 By default the engine uses the built-in rule engine (`eros-engine-core/src/pde.rs`) to decide the per-turn action (reply / ghost / proactive). Setting `filter_prompt` in this block switches on an LLM judge:

--- a/docs/model-config.zh.md
+++ b/docs/model-config.zh.md
@@ -462,6 +462,30 @@ SSE `final` frame 的 `filtered` 字段在客户端收到的是非原始输出�
 `ModelConfig::resolve_embedding()`，在 `main.rs` 启动时调用一次来构建
 `EmbeddingRouter`。见下文“`[tasks.embedding]` — 已激活”。
 
+### `[tasks.chat_voice]` — 语音通道的伴侣回复（opt-in）
+
+支撑 `POST /comp/voice/{session_id}/turn/stream`
+（`pipeline::voice::run_voice_turn`，由 `routes::voice` 经 `resolve_voice()`
+调用）。任务块缺失时功能关闭。
+
+- `model` —— **必须**是单个固定、非空的 id。与这里其它任务不同，round-robin
+  数组、加权表、`tiers` 在 `chat_voice` 上都会拒绝启动（正在进行的通话不支持
+  中途换模型）。`fallback` 仍然可用，作为顺序重试的故障切换链。
+- `filter_prompt` —— 可选的语音指令覆盖。与 `chat_vision`/`chat_product_qa`
+  不同，留空或缺省**不会**关闭该功能——会回退到内置指令（简短、口语化，
+  不带 markdown/emoji/括号舞台提示）。
+- `tts_audio_tags`（bool，默认 `false`）—— 为 `true` 时，生效的指令会邀请
+  模型插入行内音频标签（`[laughs]`、`[whispers]` 等），Gemini 系 TTS 模型
+  会把它们渲染成语气/动作提示。标签原样透传（流式、落库、重放都不处理）；
+  客户端需要把文本喂给能理解这些标签的 TTS 模型。可以和自定义
+  `filter_prompt` 叠加——标签说明会追加在其后。
+- `recall`（bool，默认 `true`）—— 语音路径上的逐轮只读向量召回。设为
+  `false` 会让语音 prompt 永远不带召回块，不管请求里的 `memory_scope` 是
+  什么——配置永远优先于请求里的 scope。见
+  [memory-layers.zh.md](memory-layers.zh.md#语音轮次)。
+
+调用点：`crates/eros-engine-server/src/pipeline/voice.rs::run_voice_turn`。
+
 ### `[tasks.pde_decision]` — opt-in LLM PDE 判断器
 
 默认情况下，引擎使用内置规则引擎（`eros-engine-core/src/pde.rs`）决定每轮动作（reply / ghost / proactive）。在此块中设置 `filter_prompt` 会启用 LLM 判断器：

--- a/docs/superpowers/specs/2026-08-09-voice-memory-bootstrap-recall-design.md
+++ b/docs/superpowers/specs/2026-08-09-voice-memory-bootstrap-recall-design.md
@@ -103,7 +103,11 @@ a successful-but-empty read writes the marker with that part empty):
 **Persistence**: one conditional jsonb UPDATE that only writes when the key is
 absent — idempotent under concurrent first turns:
 `metadata.voice_bootstrap = { insights, prev_call, prev_session_id, created_at }`.
-UPDATE failure ⇒ use the in-memory copy this turn, warn, retry next turn.
+UPDATE failure (a query `Err`) ⇒ use the in-memory copy this turn, warn, retry
+next turn. `rows_affected == 0` (the key was already there — a concurrent
+first turn won the race) is different: the loser reloads and injects the
+*winner's* stored snapshot instead of its own, falling back to its in-memory
+copy only if that reload itself fails (query `Err`, key missing, malformed).
 
 **Injection** (every turn) — system prompt order:
 

--- a/docs/superpowers/specs/2026-08-09-voice-memory-bootstrap-recall-design.md
+++ b/docs/superpowers/specs/2026-08-09-voice-memory-bootstrap-recall-design.md
@@ -1,0 +1,237 @@
+# Voice memory: bootstrap snapshot + per-turn recall — design
+
+- Date: 2026-08-09
+- Status: design agreed, implementation plan pending
+- Repo: `eros-engine`
+- Amends: `2026-07-07-voice-call-parts-design.md` (thin-prompt & memory-exclusion sections)
+
+## Background & goals
+
+The voice turn's prompt is deliberately thin: persona + voice directive + one
+relationship line + the last 12 in-session turns. Users notice the companion is
+amnesiac on calls — no structured profile, no long-term memory, no awareness of
+the previous call. This spec adds *just enough* memory without losing the
+thin/low-latency character:
+
+1. **Session bootstrap (first turn)** — freeze a snapshot of the user's
+   structured profile (`human_insights` bullets) plus the tail of the previous
+   voice call, and inject it every turn as a static prompt prefix.
+2. **Per turn** — vector recall only (read-only), time-budgeted, silently
+   degrading. No writes of any kind on the voice path.
+3. **Best practice becomes one session per call** — enabled by a new
+   `force_new` flag on `chat/start`.
+
+So a voice call's memory comes from: the bootstrap snapshot (insights +
+previous-call transcript), the per-turn vector recall, and the in-session
+8-message window.
+
+## Non-goals
+
+- No per-turn memory writes, no insight extraction, no affinity eval on voice
+  (all unchanged).
+- No dreaming changes. Post-call vector writes of voice content are a planned
+  **follow-up PR** (below); this spec only lays its hooks.
+- No STT/TTS or audio concerns (unchanged).
+- No changes to the text path's prompt, recall tiers, or write pipeline.
+
+## Prerequisite (separate small PR, ships first)
+
+**Affinity dead-row fix.** `companion_affinity` is keyed one row per session
+(`session_id UNIQUE`), and rows are only ever created by the text pipeline —
+so a voice-channel session never has one, `AffinityRepo::load(session_id)` is
+always `None` on voice, and the relationship line (PR #209) never renders in
+production. Fix: resolve affinity for voice via user × instance (the latest
+text-session affinity row). That resolution is naturally compatible with
+per-call voice sessions. No hard ordering dependency with this spec, but it
+ships first as an independent bug fix.
+
+## Follow-up (out of scope, designed for)
+
+**Post-call vector writes via dreaming-lite.** A later PR flips the
+`channel IS NULL` filters in `pipeline/dreaming.rs` (session claim + message
+read) so ended voice sessions are swept and their content becomes
+`companion_memories` rows — making previous calls reachable by per-turn recall
+too. Voice content must only ever be written **after** a call ends, never
+per-turn. Hooks this spec lays:
+
+- Voice inserts bump `last_active_at`, giving the sweeper a correct
+  "call ended + idle" signal (without it, a long call would be swept
+  mid-call, and per-call ordering would be wrong).
+- Per-call sessions give dreaming a natural one-call classification unit.
+
+Once that lands, the previous call appears both verbatim (bootstrap tail) and
+semantically (recall snippets) — complementary, not redundant; minor overlap
+is acceptable.
+
+## 1. `force_new` on `chat/start`
+
+`StartChatRequest` gains `force_new: Option<bool>` (default `false`, backwards
+compatible). `true` skips `resume_latest_session` and always creates a fresh
+session (`is_new: true`). Works for any channel — this completes the half of
+issue #157 that the channel-scoping PR (#158) left out.
+
+Consumer best practice: start every call with
+`{"channel": "voice", "force_new": true}`.
+
+OpenAPI + `docs/api-reference.md` (+ zh mirror) updated.
+
+## 2. History window 12 → 8
+
+`VOICE_HISTORY_WINDOW` drops from 12 to 8 — same unit as today (8 messages =
+4 user/assistant exchanges).
+
+## 3. First-turn bootstrap snapshot
+
+**Trigger**: the session row's `metadata` lacks the `voice_bootstrap` key.
+Checked every turn for free (the route already loads the full session row);
+in practice only the first successful turn assembles it. Keying on the
+metadata marker — not on history length — self-heals a failed first turn
+(user row persisted, generation died, client retried).
+
+**Assembly** (two parts, each degrades independently — a failed read omits
+that part this turn and leaves the marker unwritten so the next turn retries;
+a successful-but-empty read writes the marker with that part empty):
+
+- `insights` — `human_insights` rendered by the existing
+  `human_insights_to_bullets`, tier = the **first turn's** resolved
+  `InsightMode` (default `neutral_and_relationship` ⇒ Neutral).
+- `prev_call` — the latest sibling voice session
+  (`user_id × instance_id`, `channel = 'voice'`, `id != current`,
+  `ORDER BY last_active_at DESC LIMIT 1`), its last 8 messages rendered as a
+  plain transcript. No sibling ⇒ part omitted (first-ever call).
+
+**Persistence**: one conditional jsonb UPDATE that only writes when the key is
+absent — idempotent under concurrent first turns:
+`metadata.voice_bootstrap = { insights, prev_call, prev_session_id, created_at }`.
+UPDATE failure ⇒ use the in-memory copy this turn, warn, retry next turn.
+
+**Injection** (every turn) — system prompt order:
+
+```
+persona → directive → bootstrap block → relationship line → recall block
+```
+
+The bootstrap block renders as `[关于他]` (insights) + `[上次通话]`
+(prev_call transcript). Static content first, per-turn recall last: the
+prefix is byte-stable for the whole call, so provider-side prefix caching
+keeps working. Reading the snapshot costs zero extra queries.
+
+**Frozen semantics**: the snapshot's insight tier is decided by the first
+turn's `memory_scope` and never changes mid-call. Later turns' `memory_scope`
+gates that turn's recall layers only.
+
+**Reused sessions**: per-call sessions are a best practice the engine cannot
+enforce. A downstream that keeps reusing one voice session gets the correct
+no-re-injection behavior (the marker never rewrites) but keeps the original
+snapshot forever; `created_at` is recorded in the snapshot should a refresh
+policy ever be wanted.
+
+## 4. `memory_scope` on the voice request
+
+`VoiceTurnRequest` gains `memory_scope: Option<MemoryScope>` — same field
+name, enum, wire values, and default as the chat stream
+(`neutral_and_relationship`). On voice it means:
+
+- **First turn**: the resolved `InsightMode` picks the bootstrap insight tier —
+  Neutral by default; `full` / `insights_only` give Full; `relationship_only` /
+  `none` give Off (no insight part for the whole call).
+- **Every turn**: the resolved `(x_on, y_on)` gates that turn's recall layers,
+  exactly like chat.
+- `relationship_scope` is unchanged and orthogonal.
+
+Neutral-by-default is deliberate: a call is a more intimate setting than text,
+and a companion that pre-knows the Full-tier fields (love values, relationship
+history, family, finances) reads as creepy. Downstream can opt up via
+`memory_scope`.
+
+## 5. Per-turn vector recall (read-only)
+
+- **Query text**: `req.content` verbatim (voice has no input-filter rewrite).
+- **Backchannel skip**: calls are full of backchannel utterances
+  (嗯 / 好啊 / 哈哈). After trimming whitespace and punctuation, content
+  shorter than a named threshold (default 4 chars) skips recall entirely —
+  no embedding round trip, no queries. Bootstrap + history still carry the
+  turn. This removes a sizable share of per-turn round trips at zero risk.
+- **Concurrency**: `embed_query` runs `join!`-ed with the persona / affinity /
+  history loads. The whole recall future (embed + pgvector) is wrapped in a
+  **300 ms budget** (named constant; tune down with real-world latency data);
+  timeout or error ⇒ no recall block, warn log, the reply is never blocked
+  (the text path's silent-degradation pattern).
+- **Queries**: reuse `recall_memory_with_embedding` + `memory_hygiene` with
+  the K constants parameterized. Voice tier: grouped 1/category + raw
+  fallback 2 + relationship 2. Text tier (2 / 4 / 3) unchanged.
+- **Rendering**: reuse the `[user_profile]` / `[shared_memories]` vocabulary
+  via a helper extracted from `build_prompt`; the block sits at the end of the
+  system prompt (dynamic content last).
+- **No similarity threshold** — deliberate: the store returns pure top-K and
+  plumbs no score (parity with the text path), and the backchannel skip
+  removes the worst garbage-nearest-neighbor case (meaningless short
+  queries). Revisit only if call transcripts show noise.
+- **Config kill-switch**: `[tasks.chat_voice] recall = false` (default true).
+  Config wins over any per-request `memory_scope`. Embedding availability
+  follows the same `[tasks.embedding]` resolution as the text path.
+- **No writes**: no `embed_document`, no memory inserts, no post-process on
+  voice (unchanged).
+
+## 6. `last_active_at` bump (reverses a 2026-07-07 decision)
+
+`insert_voice_user_message` / `insert_voice_assistant_message` now bump
+`chat_sessions.last_active_at` (parity with `append_message`). Motivations:
+correct "previous call" ordering for the bootstrap; the idle signal the
+dreaming follow-up needs; no effect on the text path. The original reason for
+not bumping — keeping voice out of the recency/dreaming machinery — is
+obsoleted by the follow-up premise. Dreaming still filters voice out until the
+follow-up PR flips it.
+
+## 7. Error handling
+
+Every new path degrades and none blocks: bootstrap parts are omitted
+independently; a snapshot write failure falls back to the in-memory copy and
+retries next turn; recall timeout/failure just drops the recall block. All
+warn-level logs. Never an `error` frame for a memory problem; the reply always
+ships.
+
+## 8. Testing
+
+- `force_new`: `true` creates a fresh session; default still resumes; both
+  channels covered.
+- Bootstrap: first turn writes the metadata marker; second turn does not
+  rewrite; no sibling ⇒ insights-only snapshot; sibling selection excludes
+  the current session and non-voice channels; tier follows the first turn's
+  `memory_scope` (default Neutral; `none` ⇒ no insight part); failed first
+  turn retries on the next turn.
+- Injection: every turn's system prompt contains the bootstrap block; recall
+  block is last; window is 8.
+- Recall: embed failure and timeout degrade to no block; voice K tier
+  asserted; `recall = false` kills it; `memory_scope: "none"` issues no
+  embedding call and no pgvector queries.
+- Bump: both voice inserts advance `last_active_at`.
+- Regression locks: text-path prompt unchanged; dreaming still excludes voice
+  at this spec's stage.
+
+## Resolved decisions (Q&A log)
+
+- **Bootstrap source = previous voice session**, not the latest text session:
+  the text side is already covered by insights + vector recall, while a
+  previous call's content is otherwise unreachable (voice is never written to
+  memory until the follow-up PR).
+- **Insight tier default = Neutral**, downstream-tunable via `memory_scope`
+  (Full pre-knowledge is creepy on the more intimate voice channel).
+- **Field name = `memory_scope`** for exact chat parity — same enum, same
+  default, no new concepts.
+- **"8 turns" = 8 messages** (4 exchanges), the same unit as the old
+  `VOICE_HISTORY_WINDOW = 12`.
+- **Per-turn writes rejected**; voice content enters vector memory only via
+  the post-call dreaming follow-up.
+- **Cross-turn dedup of recalled memories rejected**: every turn is a
+  stateless re-send — earlier turns' system prompts are not in the message
+  history, so a memory suppressed at turn N is simply absent from turn N's
+  request. Re-injecting the currently-relevant snippets each turn is correct,
+  not waste. Same-turn cross-layer dedup (`memory_hygiene`) still applies.
+- **Injecting both `companion_insights` and `human_insights` rejected**:
+  `human_insights` is the projected rendering of the same JSONB — both would
+  be double tokens, zero information.
+- **Field-latency fallback recorded, not chosen**: if per-turn recall proves
+  too slow in the field, fold a one-shot top-K memory digest into the
+  bootstrap and disable per-turn recall — zero per-turn cost, at the price of
+  losing mid-call topicality.

--- a/docs/superpowers/specs/2026-08-09-voice-memory-bootstrap-recall-design.md
+++ b/docs/superpowers/specs/2026-08-09-voice-memory-bootstrap-recall-design.md
@@ -117,8 +117,8 @@ prefix is byte-stable for the whole call, so provider-side prefix caching
 keeps working. Reading the snapshot costs zero extra queries.
 
 **Frozen semantics**: the snapshot's insight tier is decided by the first
-turn's `memory_scope` and never changes mid-call. Later turns' `memory_scope`
-gates that turn's recall layers only.
+successfully-assembling turn's `memory_scope` and never changes mid-call.
+Later turns' `memory_scope` gates that turn's recall layers only.
 
 **Reused sessions**: per-call sessions are a best practice the engine cannot
 enforce. A downstream that keeps reusing one voice session gets the correct
@@ -132,9 +132,10 @@ policy ever be wanted.
 name, enum, wire values, and default as the chat stream
 (`neutral_and_relationship`). On voice it means:
 
-- **First turn**: the resolved `InsightMode` picks the bootstrap insight tier —
-  Neutral by default; `full` / `insights_only` give Full; `relationship_only` /
-  `none` give Off (no insight part for the whole call).
+- **First successfully-assembling turn**: the resolved `InsightMode` picks the
+  bootstrap insight tier — Neutral by default; `full` / `insights_only` give
+  Full; `relationship_only` / `none` give Off (no insight part for the whole
+  call).
 - **Every turn**: the resolved `(x_on, y_on)` gates that turn's recall layers,
   exactly like chat.
 - `relationship_scope` is unchanged and orthogonal.

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -691,3 +691,9 @@ model = "voyage-4-lite"
 # that understands them. Works with a custom filter_prompt too (the tag guidance
 # is appended to it).
 #tts_audio_tags = true
+
+# `recall` (OPTIONAL, default true): per-turn read-only vector recall on the
+# voice path (bootstrap snapshot + this turn's recalled memories). Set to
+# false to keep the voice prompt recall-free, regardless of the request's
+# memory_scope — config always wins over the per-request scope.
+#recall = false

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -693,7 +693,7 @@ model = "voyage-4-lite"
 #tts_audio_tags = true
 
 # `recall` (OPTIONAL, default true): per-turn read-only vector recall on the
-# voice path (bootstrap snapshot + this turn's recalled memories). Set to
-# false to keep the voice prompt recall-free, regardless of the request's
-# memory_scope — config always wins over the per-request scope.
+# voice path; the first-turn bootstrap snapshot is separate and unaffected.
+# Set to false to keep the voice prompt recall-free, regardless of the
+# request's memory_scope — config always wins over the per-request scope.
 #recall = false


### PR DESCRIPTION
## What

Voice calls stop being amnesiac, while the voice path stays thin. Spec: `docs/superpowers/specs/2026-08-09-voice-memory-bootstrap-recall-design.md` (committed here).

**Session bootstrap (first turn, frozen for the call)**
- Snapshot = `human_insights` bullets (`[关于他]`, Neutral tier by default) + the previous voice call's last 8 messages as a transcript (`[上次通话]`).
- Written once into `chat_sessions.metadata.voice_bootstrap` (atomic `NOT (metadata ? …)` guard); injected into the system prompt **every** turn — OpenRouter is stateless, and a byte-stable prefix keeps provider prefix-caching effective.
- Tier decided by the first successfully-assembling turn's `memory_scope`; race losers reload and inject the winner's stored snapshot. Assembly failures degrade part-wise and retry next turn; malformed markers are never rewritten.

**Per-turn vector recall (read-only)**
- `memory_scope` on the voice request — same enum/default as the chat stream (`neutral_and_relationship`).
- Voice K tier grouped 1/category + raw 2 + relationship 2 (text 2/4/3 untouched, now parameterized via `RecallTier`); 300 ms budget wrapping only the recall future; backchannel skip (<4 kept alphanumeric/CJK chars ⇒ no embedding round trip); silent degradation — a memory problem never delays, blocks, or error-frames the reply.
- Rendered via the extracted `render_recall_sections` (byte-stable for the text path — the three block-order regression locks pass unmodified), appended last as `[user_profile]`/`[shared_memories]`. Kill-switch: `[tasks.chat_voice] recall = false`.

**Enablers**
- `force_new` on `POST /comp/chat/start` (+ BFF passthrough) — completes the other half of #157; best practice is one voice session per call.
- `VOICE_HISTORY_WINDOW` 12 → 8.
- Voice inserts bump `last_active_at` (duplicate replays don't) — correct sibling ordering now, the idle signal the post-call dreaming follow-up needs later. Dreaming still excludes voice entirely.
- Voice writes **no** memories (no insight extraction, no vector writes) — post-call ingestion via dreaming-lite is a planned follow-up PR.

Builds on #234 (voice affinity resolved via user×instance).

## Docs

api-reference / model-config (new `[tasks.chat_voice]` section) / memory-layers + zh mirrors updated; stale "deliberately thin / no vector recall" claims removed; `examples/model_config.toml` documents `recall`.

## Verification

- 1210 workspace tests green (store 69 / llm 374 / server 571+ / core 196), incl. 30+ new: bootstrap freeze/race/retry/malformed e2e asserting on the outbound wire request, recall degradation (embed 500, timeout via delayed mock, scope none ⇒ 0 embedding hits, backchannel skip), window-8 on the wire, force_new HTTP + BFF passthrough, byte-stability locks.
- fmt / clippy `-D warnings` clean; openapi snapshot regenerated and CI-diffed.
- Every task passed an independent spec+quality review; final whole-branch review + codex review clean (codex's concurrency finding — race loser injecting its local snapshot — fixed in `3eb38f2` with a deterministic e2e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)