### PR TITLE
docs: polish pass — 15 minor findings from the docs-wide audit

### DIFF
--- a/docs/affinity-model.md
+++ b/docs/affinity-model.md
@@ -17,7 +17,7 @@ per-turn label transitions.
 | `trust` | 0.0 ↔ 1.0 | `0.0` | Topic depth, willingness to disclose self. Bond axis. |
 | `intrigue` | 0.0 ↔ 1.0 | `0.0` | Curiosity, follow-up questions, anti-ghost driver. Bond axis. |
 | `intimacy` | 0.0 ↔ 1.0 | `0.0` | Inside jokes, nicknames, callbacks to earlier details. Chemistry axis. |
-| `patience` | 0.0 ↔ 1.0 | `0.5` | Tolerance for short / low-effort messages; ghost-threshold input. The LLM gives an absolute read each turn (0–1, 0.1 steps) + a rule delta, written directly (bypasses EMA; still `[0,1]`-clamped). Excluded from both lines. |
+| `patience` | 0.0 ↔ 1.0 | `0.5` | Tolerance for short / low-effort messages; ghost-threshold input. When the LLM has an absolute read for the turn (0–1, 0.1 steps), it is combined with a rule delta and written directly (bypasses EMA); otherwise the rule delta alone goes through the ordinary EMA path (see below). Always `[0,1]`-clamped. Excluded from both lines. |
 | `tension` | 0.0 ↔ 1.0 | `0.0` | Push-pull, playful friction, tsundere affordance. Chemistry axis. |
 
 `warmth` is the only axis that can go negative. The other five are bounded to
@@ -73,7 +73,8 @@ re-rounded to the `0.1` grid (the grid constrains the LLM read only, so `R` can 
 the result off-grid). The ±0.4/−0.6 asymmetric caps are applied earlier, in
 `parse_affinity_eval`, to the five LLM delta axes only — patience is never subject to
 them. On persist, `apply_deltas` still runs first as usual (all six axes go through
-EMA smoothing + the `[0,1]` clamp), and patience is then **overwritten directly** with
+EMA smoothing + clamping to their own range — `[-1,1]` for `warmth`, `[0,1]` for the
+rest), and patience is then **overwritten directly** with
 `patience_target` — bypassing EMA smoothing (still `[0,1]`-clamped). Because both `L`
 and `R` are independent of the currently stored value, this write is race-safe with no
 read-modify-write needed.

--- a/docs/affinity-model.zh.md
+++ b/docs/affinity-model.zh.md
@@ -13,7 +13,7 @@
 | `trust` | 0.0 ↔ 1.0 | `0.0` | 话题深度，是否愿意暴露自己。Bond 轴。 |
 | `intrigue` | 0.0 ↔ 1.0 | `0.0` | 好奇心、追问动力，抗 ghost 的主力。Bond 轴。 |
 | `intimacy` | 0.0 ↔ 1.0 | `0.0` | 内部梗、昵称、回头呼应之前的细节。Chemistry 轴。 |
-| `patience` | 0.0 ↔ 1.0 | `0.5` | 对短消息/敷衍回复的容忍度；ghost 阈值的输入。LLM 每轮给绝对值（0~1，每 0.1 档）+ 规则 delta，直接写入（不走 EMA，仍夹钳到 `[0, 1]`）。不计入两条线。 |
+| `patience` | 0.0 ↔ 1.0 | `0.5` | 对短消息/敷衍回复的容忍度；ghost 阈值的输入。当该轮 LLM 给出绝对值读数时（0~1，每 0.1 档），与规则 delta 合并后直接写入（不走 EMA）；没有读数时规则 delta 单独走常规 EMA 路径（见下文）。始终夹钳到 `[0, 1]`。不计入两条线。 |
 | `tension` | 0.0 ↔ 1.0 | `0.0` | 推拉、玩闹式的小摩擦、傲娇空间。Chemistry 轴。 |
 
 只有 `warmth` 可以为负值。其余五个都限制在 `[0, 1]`。每次更新都会对六个轴做夹钳（clamp）。
@@ -50,7 +50,7 @@ tension  = clamp(tension  − 0.005 × days_elapsed, 0.0, 1.0)
 
 PDE 仍照常计算这一轮回复/主动消息的规则 delta `R`（`predict_reply_deltas`：长消息 +0.02 / 极短消息 −0.02 / 超过 24 小时未活动 −0.05）——这部分不变。
 
-本轮目标值为 `patience_target = clamp(L + R, 0, 1)`；该和值**不会**再被四舍五入回 0.1 档（网格只约束 LLM 读数，`R` 可以把结果推离网格）。±0.4/−0.6 非对称上限在更早的 `parse_affinity_eval` 中就已作用于五个 LLM delta 轴——patience 从不受这两项上限约束。持久化时，`apply_deltas` 照常先跑一遍（六轴统一走 EMA 平滑 + `[0, 1]` 夹钳），随后 patience 被 `patience_target` **直接覆盖**——绕过 EMA 平滑（仍会夹钳到 `[0, 1]`）。因为 `L` 和 `R` 都与当前存储值无关，这个写入在并发场景下是安全的，不需要读改写。
+本轮目标值为 `patience_target = clamp(L + R, 0, 1)`；该和值**不会**再被四舍五入回 0.1 档（网格只约束 LLM 读数，`R` 可以把结果推离网格）。±0.4/−0.6 非对称上限在更早的 `parse_affinity_eval` 中就已作用于五个 LLM delta 轴——patience 从不受这两项上限约束。持久化时，`apply_deltas` 照常先跑一遍（六轴统一走 EMA 平滑，再各自夹钳到自己的区间——`warmth` 为 `[-1, 1]`，其余为 `[0, 1]`），随后 patience 被 `patience_target` **直接覆盖**——绕过 EMA 平滑（仍会夹钳到 `[0, 1]`）。因为 `L` 和 `R` 都与当前存储值无关，这个写入在并发场景下是安全的，不需要读改写。
 
 **兜底：** 当本轮没有 LLM patience 读数时——Proactive、用户消息过短、助手回复为空、`no_persona_or_affinity`（persona 加载失败或不存在好感度行）、或评估调用报错/超时/模型省略了 `patience` 字段——`patience_target` 为 `None`，patience 走**旧路径**：把 `R` 通过 EMA 叠加并夹钳。
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -48,6 +48,7 @@ curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json"
 ```json
 {
   "session_id": "5f7e…",
+  "instance_id": "…",
   "persona_name": "Aria",
   "is_new": true
 }
@@ -352,8 +353,9 @@ The reference kind is not recorded.
 Validation: `force` + `tips_amount_usd` on the same turn → `422`. `force`
 while `[tasks.chat_image_prompt_compose]` is not configured → `422` (the
 composer is the only prompt source; without it a forced image could only be a
-generic portrait). An unsupported `aspect_ratio` returns `422 BadRequest` as a
-pre-stream error. All are pre-stream: no user row is persisted.
+generic portrait). An unsupported `aspect_ratio` returns `422 Unprocessable
+Entity` (`code: "unprocessable"`) as a pre-stream error. All are pre-stream:
+no user row is persisted.
 
 **`image_request` SSE frame** — emitted once per image turn in place of any
 in-engine draw. The engine composes the prompt; the consumer draws it via its

--- a/docs/api-reference.zh.md
+++ b/docs/api-reference.zh.md
@@ -46,6 +46,7 @@ curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json"
 ```json
 {
   "session_id": "5f7e…",
+  "instance_id": "…",
   "persona_name": "Aria",
   "is_new": true
 }
@@ -262,7 +263,7 @@ URL，需带 host、不含空白、≤ 2048 字符。带图时引擎先跑一段
 `tips_amount_usd` 同一轮互斥。URL 非法时作为 pre-stream 错误返回
 `422 Unprocessable Entity`（`code: "unprocessable"`）。仅当
 `[tasks.chat_vision]` 配了非空 `filter_prompt` 时 vision 才生效（见
-[model-config.md](model-config.md)）。
+[model-config.zh.md](model-config.zh.md)）。
 
 ```bash
 curl -N -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json" \
@@ -309,7 +310,8 @@ curl -N -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/js
 校验：同一轮同时有 `force` 和 `tips_amount_usd` → `422`。`force` 而部署未配置
 `[tasks.chat_image_prompt_compose]` → `422`（合成器是唯一的提示词来源；没有它，
 强制出图只能产出一张无视用户消息的通用肖像）。`aspect_ratio` 不在允许集时，作为
-pre-stream 错误返回 `422 BadRequest`。以上全部是 pre-stream 错误：不会落任何用户行。
+pre-stream 错误返回 `422 Unprocessable Entity`（`code: "unprocessable"`）。以上
+全部是 pre-stream 错误：不会落任何用户行。
 
 **`image_request` SSE 帧** — 每个图片轮次发出一次，取代任何引擎内绘图。引擎负责组装提示词；由消费方通过自己的图像供应商绘制（引擎没有绘图端点）。聊天流本身不绘图、不回传图像字节、不持久化绘图结果。
 
@@ -715,7 +717,7 @@ time-decay），或最近一次事件早于 affinity migration `0014`。`event_t
 | 500 | `internal` | 其餘一切（DB 錯、LLM API 錯等） |
 | 502 | `upstream` | 上游供应商调用失败（目前仅 persona compose 端点——合成器链条全部失败） |
 
-## 源碼
+## 源码
 
 - `crates/eros-engine-server/src/routes/companion.rs`——对话生命周期 / 画像 handler
 - `crates/eros-engine-server/src/routes/companion_stream.rs`——流式对话轮（`message/stream`），含打赏 + `image_url` 处理
@@ -725,4 +727,4 @@ time-decay），或最近一次事件早于 affinity migration `0014`。`event_t
 - `crates/eros-engine-server/src/routes/bff/affinity.rs`——BFF `/bff/v1/comp/affinity/*`
 - `crates/eros-engine-server/src/routes/debug.rs`——好感度 debug 路由（向量 + 事件日志）
 - `crates/eros-engine-server/src/routes/health.rs`——`/healthz`
-- `crates/eros-engine-server/src/openapi.rs`——Scalar UI spec 元數據
+- `crates/eros-engine-server/src/openapi.rs`——Scalar UI spec 元数据

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -148,7 +148,7 @@ crates/
 │       ├── voyage.rs         # 512-dim embeddings, fail-loud on empty key
 │       └── model_config.rs   # TOML loader
 ├── eros-engine-store/
-│   ├── migrations/           # 0000_schema → 0039_world_worldviews
+│   ├── migrations/           # 0000_schema → 0040_persona_instance_fks
 │   └── src/
 │       ├── pool.rs           # PgPoolOptions builder
 │       ├── chat.rs           # ChatRepo
@@ -158,7 +158,7 @@ crates/
 │       └── persona.rs        # PersonaRepo (upsert_genome for seeding)
 └── eros-engine-server/
     └── src/
-        ├── main.rs           # serve | migrate | seed-personas subcommands
+        ├── main.rs           # serve | migrate | seed-personas | backfill-human-insights | print-openapi subcommands
         ├── state.rs          # AppState (pool/auth/openrouter/embed/config)
         ├── error.rs          # AppError → axum IntoResponse
         ├── auth/             # AuthValidator trait + Supabase impl + middleware

--- a/docs/architecture.zh.md
+++ b/docs/architecture.zh.md
@@ -143,7 +143,7 @@ crates/
 │       ├── voyage.rs         # 512 維 embedding，空 key 直接 fail
 │       └── model_config.rs   # TOML 加載器
 ├── eros-engine-store/
-│   ├── migrations/           # 0000_schema → 0039_world_worldviews
+│   ├── migrations/           # 0000_schema → 0040_persona_instance_fks
 │   └── src/
 │       ├── pool.rs           # PgPoolOptions 構造
 │       ├── chat.rs           # ChatRepo
@@ -153,7 +153,7 @@ crates/
 │       └── persona.rs        # PersonaRepo（upsert_genome 給 seed 用）
 └── eros-engine-server/
     └── src/
-        ├── main.rs           # serve | migrate | seed-personas 子命令
+        ├── main.rs           # serve | migrate | seed-personas | backfill-human-insights | print-openapi 子命令
         ├── state.rs          # AppState（pool / auth / openrouter / embed / config）
         ├── error.rs          # AppError → axum IntoResponse
         ├── auth/             # AuthValidator trait + Supabase 實現 + 中間件

--- a/docs/ghost-mechanics.md
+++ b/docs/ghost-mechanics.md
@@ -128,7 +128,7 @@ If the persona never ghosts → check that LLM affinity-evaluation is actually m
 
 ## Source
 
-- `crates/eros-engine-core/src/ghost.rs` — score + ghost_permitted + decide (11 unit tests)
+- `crates/eros-engine-core/src/ghost.rs` — score + ghost_permitted + decide (12 unit tests)
 - `crates/eros-engine-server/src/pipeline/stream.rs::run_stream` — the `ActionType::Ghost` arm: stamps the row and records the ghost, building no chat request
 - `crates/eros-engine-store/src/affinity.rs::record_ghost` — persistence (increments streak, total_ghosts, last_ghost_at), plus a zero-delta `companion_affinity_events` row with `event_type='ghost'`
 - `crates/eros-engine-store/src/chat.rs::mark_user_message_ghosted` — sets `chat_messages.ghost_decision = true` on the user row, so replay can tell a ghost outcome from a still-generating turn

--- a/docs/ghost-mechanics.zh.md
+++ b/docs/ghost-mechanics.zh.md
@@ -121,13 +121,13 @@ score = (1−0.05)×0.4 + (1−0.05)×0.4 + 0×0.2
 ## Ghost 不是甚麼
 
 - **不是** 错误响应。HTTP 路由仍返 200。由于引擎采用 SSE 流式传输，ghost 轮会发出三帧后关闭流：`meta(action_type=ghost, model=null)` → `done(usage=null, generation_id=null)` → `final`。不会发出 `delta` 帧，也不会调用任何 LLM。
-- **不是** LLM 調用失敗。走默认规则引擎时决策纯 Rust，从不问 LLM。配置了可选的 LLM PDE 判断器之后，由判断器提出动作，但 `ghost_permitted` 仍会否决硬安全规则不允许的 ghost，而 `ghosting` 开关可以把每一个 ghost 判定强行拉回 `reply_text`——见 [model-config.zh.md](model-config.zh.md)。
+- **不是** LLM 调用失败。走默认规则引擎时决策纯 Rust，从不问 LLM。配置了可选的 LLM PDE 判断器之后，由判断器提出动作，但 `ghost_permitted` 仍会否决硬安全规则不允许的 ghost，而 `ghosting` 开关可以把每一个 ghost 判定强行拉回 `reply_text`——见 [model-config.zh.md](model-config.zh.md)。
 - **不是** 回合沉默的唯一成因。回复文本解析为空是另一条路径：模型返回了空补全，或 `apply_output_regex` 把一条纯 artifact 的回复剥到一无所剩（那里的 fail-safe 是刻意移除的）。这种回合照常落一行内容为空的助手回复行，在线上表现为 `done(ghost_fallback=true)`、`metadata.fallback_reason` 为 `empty_completion` 或 `regex_strip`，并且 **不动** `ghost_streak` / `total_ghosts` / `last_ghost_at`——人格没有做任何决定，只是这条回复回来就是空的。
 - **不是** 永遠沉默。時間衰退會恢復 `patience`、軟化 `tension`；最終人格會回應下一條消息。
 
 ## 源碼
 
-- `crates/eros-engine-core/src/ghost.rs`——score + ghost_permitted + decide（11 個單元測試）
+- `crates/eros-engine-core/src/ghost.rs`——score + ghost_permitted + decide（12 個單元測試）
 - `crates/eros-engine-server/src/pipeline/stream.rs::run_stream`——其中的 `ActionType::Ghost` 分支：标记该行并记录 ghost，不构建 chat 请求
 - `crates/eros-engine-store/src/affinity.rs::record_ghost`——持久化（增加 streak、total_ghosts、last_ghost_at），并插入一行 `event_type='ghost'`、增量全零的 `companion_affinity_events` 事件
 - `crates/eros-engine-store/src/chat.rs::mark_user_message_ghosted`——把用户行的 `chat_messages.ghost_decision` 置为 true，让重放能把 ghost 结局和还在生成中的回合区分开

--- a/docs/llm-audit.md
+++ b/docs/llm-audit.md
@@ -88,7 +88,8 @@ Behaviour:
 - Unset or empty → today's pass-through behaviour.
 
 Background paths (`pipeline::dreaming`, `pipeline::post_process`,
-`pipeline::world_director`) emit usage only as `tracing::info!` fields:
+`pipeline::world`, `pipeline::story`) emit usage only as `tracing::info!`
+fields:
 
 ```
 openrouter: call completed session=… generation_id=… model=…
@@ -112,6 +113,14 @@ prompt_tokens=… completion_tokens=… total_tokens=… cost=…
   usage/cost emitted as tracing fields via
   `log_openrouter_usage("world_reply", None, …)`; nothing on any client
   frame.
+- `world_stories_director` — World Stories director (background), module
+  `pipeline::story`. Runs as the second phase of the same sweeper tick as
+  `world_director`; one call per claimed persona instance per its own
+  `interval_hours`. `user` = `11111111-1111-1111-1111-111111111113` (story
+  subsystem sentinel, continuing the dreaming/world sequence). Usage/cost
+  emitted as tracing fields via
+  `log_openrouter_usage("world_stories_director", None, …)`; nothing on any
+  client frame.
 
 ## App-attribution headers
 

--- a/docs/llm-audit.zh.md
+++ b/docs/llm-audit.zh.md
@@ -82,7 +82,7 @@ OPENROUTER_USAGE_HIDDEN_KEYS=cost,cost_details
 - 未设或空 → 维持现状（完整透传）。
 
 后台路径（`pipeline::dreaming`、`pipeline::post_process`、
-`pipeline::world_director`）的 usage 只通过 `tracing::info!` 字段输出：
+`pipeline::world`、`pipeline::story`）的 usage 只通过 `tracing::info!` 字段输出：
 
 ```
 openrouter: call completed session=… generation_id=… model=…
@@ -101,6 +101,13 @@ prompt_tokens=… completion_tokens=… total_tokens=… cost=…
 - `world_reply` —— World Town 回复响应器（后台）。每条经防抖的用户留言调一
   次，按 owner 每 UTC 自然日封顶。同一个哨兵 user；usage/cost 通过 tracing
   字段输出，走 `log_openrouter_usage("world_reply", None, …)`；不出现在任何
+  client 帧上。
+- `world_stories_director` —— World Stories 导演（后台），模块
+  `pipeline::story`。作为 `world_director` 同一个 sweeper tick 的第二阶段
+  运行；每个被认领的 persona instance 按自己的 `interval_hours` 调一次。
+  `user` = `11111111-1111-1111-1111-111111111113`（story 子系统哨兵，延续
+  dreaming/world 的序列）。Usage/cost 通过 tracing 字段输出，走
+  `log_openrouter_usage("world_stories_director", None, …)`；不出现在任何
   client 帧上。
 
 ## App-attribution headers

--- a/docs/memory-layers.zh.md
+++ b/docs/memory-layers.zh.md
@@ -102,7 +102,7 @@ Relationship 层查询改为过滤 `instance_id = $2`，并多一条 `content NO
 ## 检索与注入
 
 每轮对话都会把记忆读回 prompt，由每次请求的 `memory_scope` 控制（取值与默认值
-见 [api-reference.md](api-reference.md)；默认 `neutral_and_relationship`）。回复
+见 [api-reference.zh.md](api-reference.zh.md)；默认 `neutral_and_relationship`）。回复
 handler（`pipeline::handlers`）从两个来源拼出画像 / 关系上下文块：
 
 - **画像层** —— 由两个来源合并。基础画像 bullet 来自扁平的 **`human_insights`**

--- a/docs/model-config.md
+++ b/docs/model-config.md
@@ -359,7 +359,7 @@ override them — the same rule as every other task).
 
 | Predicate | Type | Semantics |
 |---|---|---|
-| `random` | `f64` in `(0.0, 1.0]` | Probability that this turn passes. `random = 0.3` → ~30 % of turns are filtered. |
+| `random` | `f64` in `(0.0, 1.0]` | Probability that this turn passes. `random = 0.3` → ~30 % of turns are filtered. Unlike `input_filter`, this range is **not validated at boot**: the per-turn draw is uniform in `[0.0, 1.0)`, so `random ≥ 1.0` always fires and `random ≤ 0.0` never fires — no load-time or runtime error either way. |
 | `models` | `Array<String>` | Turn passes only if the producing model id is in the list. |
 | `traits` | `{ any = [...], when = "present" \| "absent" }` | Turn passes only if at least one tag in `any` is present (`when = "present"`) or absent (`when = "absent"`) among the tags **actually injected** into the prompt — i.e. after tier `allow_traits` gating, the same set reported in the `final` frame's `prompt_injected`. A trait the tier dropped does not count as present. |
 

--- a/docs/model-config.zh.md
+++ b/docs/model-config.zh.md
@@ -332,7 +332,7 @@ Per-tier 子表（`[tasks.chat_output_filter.tiers.<tier>]`）可以覆盖 `mode
 
 | 谓词 | 类型 | 语义 |
 |---|---|---|
-| `random` | `(0.0, 1.0]` 范围内的 `f64` | 当前轮次通过的概率。`random = 0.3` → 约 30% 的轮次会被过滤。 |
+| `random` | `(0.0, 1.0]` 范围内的 `f64` | 当前轮次通过的概率。`random = 0.3` → 约 30% 的轮次会被过滤。与 `input_filter` 不同，该范围**不会在启动时校验**：由于每轮抽样均匀分布于 `[0.0, 1.0)`，`random ≥ 1.0` 会一直触发，`random ≤ 0.0` 则永不触发——加载和运行时都不会报错。 |
 | `models` | `Array<String>` | 仅当生成回复的 model id 在列表中时，当前轮次才通过。 |
 | `traits` | `{ any = [...], when = "present" \| "absent" }` | 仅当 `any` 中至少一个 tag 在**实际注入** prompt 的 tag 中存在（`when = "present"`）或不存在（`when = "absent"`）时，当前轮次才通过；这里指经过 tier `allow_traits` 门控后、与 `final` frame 的 `prompt_injected` 所报告内容相同的集合。被 tier 丢弃的 trait 不算存在。 |
 

--- a/docs/prompt-traits.zh.md
+++ b/docs/prompt-traits.zh.md
@@ -57,7 +57,7 @@ system prompt 的 `[additional_guidance]` 段落下，位置在 `[topics]` 与
   - `allow_traits = []` —— 丢弃所有 trait。
   - `allow_traits = ["a", "b"]` —— 白名单，只注入列表中的 tag。
 - 请求的 `tier` 字段选择 tier 块（见
-  [api-reference.zh.md](api-reference.zh.md)）。
+  [api-reference.zh.md](api-reference.zh.md#post-compchatsession_idmessagestream)）。
   tier 未知或缺省时使用任务默认块的 `allow_traits`。
 
 ## 限制


### PR DESCRIPTION
## Summary

The second half of the docs-wide audit that produced #237. That PR fixed the 14 claims an integrator or operator would act on and be wrong; **this one applies the 15 minor findings** — counts, links, stale enumerations, and script artifacts. Docs-only, no behavior change.

> **Stacked on #237.** This branch is cut from `docs/accuracy-pass`, because both PRs edit the same files. Merge #237 first and this diff collapses to its own commit.

### What changed

**Wrong numbers and stale enumerations**
- `ghost-mechanics`: `ghost.rs` has **12** unit tests, not 11.
- `architecture`: migrations run to **0040**, not 0039; the `main.rs` subcommand list was missing `backfill-human-insights` and `print-openapi` — the latter being what CI's openapi-drift job actually runs.
- `llm-audit`: `pipeline::world_director` is a **task name**, not a module — the module is `pipeline::world`. And `pipeline::story` was missing from the background-path list entirely, along with its `world_stories_director` task.

**Self-contradictions**
- `affinity-model` claimed all six axes clamp to `[0,1]`, while `warmth` clamps to `[-1,1]` — as the same document states correctly two sections earlier. The six-axis table also presented patience's direct write as unconditional; it falls back to the rule-delta EMA path when there is no LLM read, which the prose below the table already said.

**Behavior worth stating rather than omitting**
- `model-config`: `chat_output_filter`'s `trigger.random` range is not boot-validated, unlike `input_filter`'s. Rather than just noting the absence, the doc now says what actually happens: the draw is uniform on `[0,1)` compared with `draw < p`, so `>= 1.0` always fires and `<= 0.0` never does — a saturating clamp, not an error. That is the part an operator needs.

**API details**
- `api-reference`: invalid `aspect_ratio` returns `422 unprocessable`, not "422 BadRequest" (a `422` paired with `400`'s reason phrase); the `/comp/chat/start` example response omitted the always-present `instance_id`.

**Cross-language links**
- `memory-layers.zh.md` and `api-reference.zh.md` each linked to an **English** sibling; `prompt-traits.zh.md` linked to `api-reference.zh.md` without the anchor its English twin uses. The added anchor was derived from the Chinese file's own heading, not assumed from the English one.

**Chinese script**
- Fixed script-mixing *inside otherwise-Simplified sentences* (`調用失敗`→`调用失败`, `源碼`→`源码`, `元數據`→`元数据`).
- **Pre-existing uniformly-Traditional sections and headings are left as they are** — `## 鑒權`, `## 對話生命周期`, `## 用戶畫像`, `## 錯誤響應`, `## Ghost 不是甚麼`, and all of `architecture.zh.md`. This pass does not retro-convert; a sweeping script conversion would bury the real changes in noise. The rule applied throughout: convert a heading only when the whole block beneath it is already Simplified.

### One finding deliberately not applied

The stated `+0.2 / −0.3` per-turn axis maxima in `affinity-model` is **exact** for the evaluator cap it documents, and off by ≤0.015 on two of six axes only once a separate rule-engine bump is summed in before EMA. That bump belongs to a different section. Splitting a clean illustrative line into a per-axis footnote would cost more clarity than the precision buys. Recorded here rather than silently dropped.

### Verification

Every number was re-derived independently rather than taken from the audit — the failure mode this whole exercise addresses is docs asserting unverified facts, and accepting a new number on faith would repeat it. The assembled diff was then reviewed by a fresh pass that re-counted the test count, re-listed the migrations and subcommands, re-read the clamp code, re-derived the anchor slug, and checked that the two agents' independent Chinese-script judgment calls were consistent with each other.

## Test plan

Docs-only; no code paths touched.

- [x] `cargo fmt --all` — n/a, no Rust changed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — n/a
- [x] `cargo test --workspace` — n/a
- [x] Every changed number and module path re-derived from the current tree
- [x] Every modified link target and anchor slug resolved
- [x] EN/ZH parity checked on every fix that belongs in both

## Checklist

- [x] CLA signed via cla-assistant.io
- [x] Conventional Commits format on commits
- [x] DCO sign-off (`git commit -s`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
