### PR TITLE
feat(llm): body rules reach the chat_vision pre-stage

### DIFF
--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -2439,8 +2439,15 @@ pub const KNOWN_CHAT_TASKS: &[&str] = &[
 ];
 
 /// Tasks that make outbound calls but build their own bodies — body rules
-/// never reach them (spec: chat/completions `WireRequest` paths only).
-const BODY_UNSUPPORTED_TASKS: &[&str] = &["chat_vision", "embedding"];
+/// never reach them. `embedding` takes no chat-shaped parameters at all, so
+/// there is nothing for a rule to carry there.
+const BODY_UNSUPPORTED_TASKS: &[&str] = &["embedding"];
+
+/// Tasks that build their own wire body yet still run it through the body-rule
+/// merge (issue #225). `chat_vision` posts a `VisionRequest` block-array body
+/// rather than a `ChatRequest`, so it is deliberately absent from
+/// [`KNOWN_CHAT_TASKS`] — but a rule naming it does apply, so it must not warn.
+const BODY_SUPPORTED_NON_CHAT_TASKS: &[&str] = &["chat_vision"];
 
 /// Pure warn-decision for one `[[providers.*.body]].tasks` entry —
 /// unit-testable without a tracing subscriber.
@@ -2455,7 +2462,7 @@ enum BodyTaskWarning {
 fn body_rule_task_warning(task: &str) -> Option<BodyTaskWarning> {
     if BODY_UNSUPPORTED_TASKS.contains(&task) {
         Some(BodyTaskWarning::Unsupported)
-    } else if !KNOWN_CHAT_TASKS.contains(&task) {
+    } else if !KNOWN_CHAT_TASKS.contains(&task) && !BODY_SUPPORTED_NON_CHAT_TASKS.contains(&task) {
         Some(BodyTaskWarning::Unknown)
     } else {
         None
@@ -5069,10 +5076,10 @@ filter_prompt = "只根据产品资料作答。"
     #[test]
     fn body_rule_task_warning_semantics() {
         assert_eq!(body_rule_task_warning("chat_companion"), None);
-        assert_eq!(
-            body_rule_task_warning("chat_vision"),
-            Some(BodyTaskWarning::Unsupported)
-        );
+        // issue #225: vision bodies now run through the merge, so naming
+        // `chat_vision` is legitimate and must NOT warn — even though it is
+        // absent from KNOWN_CHAT_TASKS (it is not a ChatRequest task).
+        assert_eq!(body_rule_task_warning("chat_vision"), None);
         assert_eq!(
             body_rule_task_warning("embedding"),
             Some(BodyTaskWarning::Unsupported)

--- a/crates/eros-engine-llm/src/openrouter.rs
+++ b/crates/eros-engine-llm/src/openrouter.rs
@@ -116,6 +116,11 @@ pub struct VisionRequest {
     pub reasoning: Option<ReasoningConfig>,
 }
 
+/// Task name the vision pre-stage matches body rules under. `VisionRequest`
+/// carries no `task` field because the stage is single-purpose — there is
+/// exactly one task that posts this body shape.
+const VISION_TASK: &str = "chat_vision";
+
 /// Build the OpenRouter wire body for one vision attempt against `model`. Pure
 /// (no I/O) so the block shape is unit-testable. A non-blank `caption` becomes
 /// the text block; otherwise a default describe instruction is used.
@@ -793,6 +798,23 @@ impl OpenRouterClient {
                 // that `build_vision_body` bakes in unconditionally, so strip
                 // it back out here, mirroring `WireRequest::for_endpoint`.
                 strip_openrouter_vision_fields(&mut body);
+            }
+            // Body rules reach the vision pre-stage too (issue #225). Applied
+            // AFTER the subset strip, mirroring `call_once`'s strip-then-merge
+            // order: that is what lets a rule on a custom endpoint put back an
+            // extension the strip removed. `messages` (a block array here, not
+            // the chat shape) can't be clobbered — it is refused at boot along
+            // with `model`/`stream`.
+            let rules: &[crate::model_config::BodyRule] = match ep.name {
+                None => &self.openrouter_body_rules,
+                Some(p) => self
+                    .providers
+                    .get(p)
+                    .map(|e| e.body_rules.as_slice())
+                    .unwrap_or(&[]),
+            };
+            if let Some(map) = body.as_object_mut() {
+                apply_body_rules(map, rules, Some(VISION_TASK));
             }
             let mut builder = ep.http.post(ep.url).bearer_auth(ep.api_key);
             if let Some(h) = ep.headers {
@@ -3972,6 +3994,215 @@ data: [DONE]\n\n";
             keys,
             ["max_tokens", "messages", "model", "temperature"],
             "task must never serialize; no rules ⇒ no extra keys"
+        );
+    }
+
+    // ---- body rules on the vision pre-stage (issue #225) ----
+
+    fn vision_req() -> VisionRequest {
+        VisionRequest {
+            model: "vis/m".into(),
+            fallback_model: vec![],
+            system_prompt: "describe".into(),
+            image_url: "https://x/y.png".into(),
+            caption: Some("a caption".into()),
+            temperature: 0.0,
+            max_tokens: 64,
+            reasoning: Some(ReasoningConfig {
+                enabled: Some(false),
+                ..Default::default()
+            }),
+        }
+    }
+
+    fn vision_ok() -> serde_json::Value {
+        serde_json::json!({
+            "id": "v-gen",
+            "model": "vis/m",
+            "choices": [{ "message": { "content": "{\"desc\":\"a cat\"}" } }]
+        })
+    }
+
+    #[tokio::test]
+    async fn vision_body_rule_reaches_the_wire_and_beats_task_reasoning() {
+        // The gap issue #225 closes: a deployer knob such as `reasoning_effort`
+        // (a top-level field, NOT part of the `reasoning` object) had no way to
+        // reach the vision pre-stage. It now merges, and — as on the chat path
+        // — a rule's params beat the engine-built fields.
+        let mock = MockServer::start().await;
+        Mock::given(path("/api/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(vision_ok()))
+            .expect(1)
+            .mount(&mock)
+            .await;
+        let client = OpenRouterClient::with_base_url(
+            "k".into(),
+            format!("{}/api/v1/chat/completions", mock.uri()),
+        )
+        .with_openrouter_body_rules(vec![rule(
+            Some(&["chat_vision"]),
+            serde_json::json!({"reasoning_effort": "none", "reasoning": {"enabled": true}}),
+        )]);
+        client.execute_vision(vision_req()).await.unwrap();
+        let body: serde_json::Value =
+            serde_json::from_slice(&mock.received_requests().await.unwrap()[0].body).unwrap();
+        assert_eq!(body["reasoning_effort"], "none");
+        assert_eq!(
+            body["reasoning"]["enabled"], true,
+            "rule params beat [tasks.chat_vision].reasoning"
+        );
+    }
+
+    #[tokio::test]
+    async fn vision_body_rule_cannot_flatten_the_block_array_messages() {
+        // Vision's `messages` is structurally unlike chat's — the user turn's
+        // `content` is a block array. `messages` is engine-owned and refused at
+        // boot (`validate_providers`), so no rule can reach it; this pins that
+        // the merge leaves the block array intact even when the rule is
+        // otherwise the widest possible (untargeted, top-level keys).
+        let mock = MockServer::start().await;
+        Mock::given(path("/api/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(vision_ok()))
+            .expect(1)
+            .mount(&mock)
+            .await;
+        let client = OpenRouterClient::with_base_url(
+            "k".into(),
+            format!("{}/api/v1/chat/completions", mock.uri()),
+        )
+        .with_openrouter_body_rules(vec![rule(
+            None,
+            serde_json::json!({"provider": {"sort": "price"}}),
+        )]);
+        client.execute_vision(vision_req()).await.unwrap();
+        let body: serde_json::Value =
+            serde_json::from_slice(&mock.received_requests().await.unwrap()[0].body).unwrap();
+        assert_eq!(body["provider"]["sort"], "price", "untargeted rule applies");
+        assert_eq!(body["messages"][0]["role"], "system");
+        let blocks = body["messages"][1]["content"]
+            .as_array()
+            .expect("user content stays a block array");
+        assert_eq!(blocks[0]["type"], "text");
+        assert_eq!(blocks[0]["text"], "a caption");
+        assert_eq!(blocks[1]["type"], "image_url");
+        assert_eq!(blocks[1]["image_url"]["url"], "https://x/y.png");
+    }
+
+    #[tokio::test]
+    async fn vision_body_rule_skipped_for_unlisted_task() {
+        // A rule scoped to a chat task must not bleed into the vision stage.
+        let mock = MockServer::start().await;
+        Mock::given(path("/api/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(vision_ok()))
+            .expect(1)
+            .mount(&mock)
+            .await;
+        let client = OpenRouterClient::with_base_url(
+            "k".into(),
+            format!("{}/api/v1/chat/completions", mock.uri()),
+        )
+        .with_openrouter_body_rules(vec![rule(
+            Some(&["chat_companion"]),
+            serde_json::json!({"reasoning_effort": "none"}),
+        )]);
+        client.execute_vision(vision_req()).await.unwrap();
+        let body: serde_json::Value =
+            serde_json::from_slice(&mock.received_requests().await.unwrap()[0].body).unwrap();
+        assert!(
+            body.get("reasoning_effort").is_none(),
+            "unlisted task must not merge"
+        );
+        assert_eq!(
+            body["reasoning"]["enabled"], false,
+            "request's own reasoning survives"
+        );
+    }
+
+    #[tokio::test]
+    async fn vision_custom_provider_strips_then_merges() {
+        // Custom endpoints strip OpenRouter-only fields first, then merge —
+        // so a rule on that provider can deliberately put `reasoning` back,
+        // exactly as `custom_provider_strips_then_merges` pins for chat.
+        let mock = MockServer::start().await;
+        Mock::given(path("/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(vision_ok()))
+            .expect(1)
+            .mount(&mock)
+            .await;
+        let client =
+            OpenRouterClient::with_base_url("or-key".into(), "https://unused.test/v1".into())
+                .with_providers(std::collections::HashMap::from([(
+                    "venice".to_string(),
+                    crate::provider::ProviderEndpoint {
+                        base_url: format!("{}/v1/chat/completions", mock.uri()),
+                        api_key: "v-key".into(),
+                        headers: reqwest::header::HeaderMap::new(),
+                        body_rules: vec![rule(
+                            Some(&["chat_vision"]),
+                            serde_json::json!({
+                                "venice_parameters": {"x": 1},
+                                "reasoning": {"strip_thinking_response": true},
+                            }),
+                        )],
+                    },
+                )]));
+        client
+            .execute_vision(VisionRequest {
+                model: "vis@venice".into(),
+                ..vision_req()
+            })
+            .await
+            .unwrap();
+        let body: serde_json::Value =
+            serde_json::from_slice(&mock.received_requests().await.unwrap()[0].body).unwrap();
+        assert_eq!(body["model"], "vis", "bare model on a custom endpoint");
+        assert_eq!(body["venice_parameters"]["x"], 1);
+        assert_eq!(
+            body["reasoning"]["strip_thinking_response"], true,
+            "a rule may put back what the subset strip removed"
+        );
+        assert!(
+            body["reasoning"].get("enabled").is_none(),
+            "the stripped [tasks.chat_vision].reasoning must not resurface"
+        );
+    }
+
+    #[tokio::test]
+    async fn vision_openrouter_rules_do_not_leak_to_a_custom_provider() {
+        // Mirrors `each_endpoint_gets_only_its_own_rules` for the vision path.
+        let mock = MockServer::start().await;
+        Mock::given(path("/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(vision_ok()))
+            .expect(1)
+            .mount(&mock)
+            .await;
+        let client =
+            OpenRouterClient::with_base_url("or-key".into(), "https://unused.test/v1".into())
+                .with_providers(std::collections::HashMap::from([(
+                    "venice".to_string(),
+                    crate::provider::ProviderEndpoint {
+                        base_url: format!("{}/v1/chat/completions", mock.uri()),
+                        api_key: "v-key".into(),
+                        headers: reqwest::header::HeaderMap::new(),
+                        body_rules: Vec::new(),
+                    },
+                )]))
+                .with_openrouter_body_rules(vec![rule(
+                    None,
+                    serde_json::json!({"reasoning_effort": "none"}),
+                )]);
+        client
+            .execute_vision(VisionRequest {
+                model: "vis@venice".into(),
+                ..vision_req()
+            })
+            .await
+            .unwrap();
+        let body: serde_json::Value =
+            serde_json::from_slice(&mock.received_requests().await.unwrap()[0].body).unwrap();
+        assert!(
+            body.get("reasoning_effort").is_none(),
+            "openrouter-entry rules must not reach a custom provider's vision call"
         );
     }
 }

--- a/docs/model-config.md
+++ b/docs/model-config.md
@@ -224,14 +224,14 @@ Deployer-defined JSON merged into the chat/completions request body, per
 task. `params` is passed through verbatim (TOML → JSON) — the engine never
 interprets it. `tasks` scopes the rule to specific engine task names
 (exact, case-sensitive; see the task table below); omit it to apply to
-every chat task this provider serves. Rules apply in declaration order,
+every task this provider serves. Rules apply in declaration order,
 later rules win on key conflicts, and merged params win over engine-built
 fields — declaring `reasoning` on the `openrouter` entry therefore
 overrides `[tasks.*].reasoning` for the scoped tasks. `model`, `messages`,
-and `stream` are engine-owned and refuse to boot. A rule naming
-`chat_vision` or `embedding` warns and never applies (those calls build
-their own bodies). Custom providers must declare `chat` to use body rules;
-the reserved `openrouter` entry may declare rules alone.
+and `stream` are engine-owned and refuse to boot. A rule naming `embedding`
+warns and never applies (that call builds its own body and takes no
+chat-shaped parameters). Custom providers must declare `chat` to use body
+rules; the reserved `openrouter` entry may declare rules alone.
 
 ```toml
 [providers.venice]
@@ -249,9 +249,28 @@ The second example is the replacement for the removed
 `[defaults].ignore_providers` / `[defaults].provider_sort` keys: OpenRouter
 routing prefs are now ordinary body params (bare OpenRouter provider slugs,
 no `@openrouter` suffix), scopable per task like any other rule. The old
-keys refuse to boot with this migration message. Note the removed keys also
-fed the `chat_vision` body; body rules do not cover vision, so vision calls
-no longer send `provider` prefs at all.
+keys refuse to boot with this migration message. The removed keys also fed
+the `chat_vision` body; since body rules now cover vision too, an
+untargeted rule like the one above reaches the vision call as well — scope
+it with `tasks` if you want routing prefs on chat only.
+
+`chat_vision` is covered even though it is not a chat/completions task: its
+describe call builds its own body, but that body runs through the same
+merge, so a knob the `reasoning` object cannot express still reaches the
+vision pre-stage.
+
+```toml
+[[providers.openrouter.body]]
+tasks  = ["chat_vision"]
+params = { reasoning_effort = "none" }
+```
+
+This matters because some models ignore `reasoning = { enabled = false }`,
+reason anyway, and bill for it — and `reasoning_effort` is a separate
+top-level field, not part of the `reasoning` object, so `[tasks.*].reasoning`
+cannot express it. Vision's `messages` is a block array (text +
+`image_url`) rather than the chat shape, but `messages` is engine-owned and
+refused at boot, so no rule can flatten it.
 
 ### `model_name_display_override` (chat task only)
 
@@ -758,6 +777,11 @@ with a non-blank `filter_prompt`. `retry_depth` defaults to `1` (primary +
 first fallback). Pick a vision-capable model; the example uses
 `google/gemini-3.1-flash-lite`.
 
+Wire parameters beyond this block's own keys reach the describe call through
+`[[providers.<name>.body]]` rules scoped to `tasks = ["chat_vision"]` — the
+route for anything the `reasoning` object cannot express, `reasoning_effort`
+included. See "`[[providers.<name>.body]]` — custom body parameters" above.
+
 Call site: `crates/eros-engine-server/src/pipeline/stream.rs` via
 `resolve_vision()` in `model_config.rs`.
 
@@ -1065,8 +1089,8 @@ What may still change without notice:
   `[[providers.<name>.body]]` rules on the `openrouter` entry — see
   "`[[providers.<name>.body]]` — custom body parameters" above. A leftover
   key refuses to boot with a migration message. The removed keys also fed
-  the `chat_vision` request body; body rules are chat-only, so vision calls
-  no longer send `provider` prefs.
+  the `chat_vision` request body; body rules reach vision as well, so an
+  untargeted rule restores `provider` prefs on the vision call.
 
 ## What this config does NOT control
 

--- a/docs/model-config.zh.md
+++ b/docs/model-config.zh.md
@@ -209,13 +209,14 @@ headers    = { "HTTP-Referer" = "https://eros.example", "X-OpenRouter-Title" = "
 部署方自定义的 JSON，按任务合并进 chat/completions 请求体。`params` 原样
 透传（TOML → JSON）——引擎从不解读它的内容。`tasks` 把规则限定到指定的
 引擎任务名（精确匹配，区分大小写；任务名表见下文）；省略则应用于该
-provider 服务的所有 chat 任务。规则按声明顺序生效，后面的规则在 key 冲突
+provider 服务的所有任务。规则按声明顺序生效，后面的规则在 key 冲突
 时获胜，且合并进的 params 会覆盖引擎自己构建的字段——例如在 `openrouter`
 条目上声明 `reasoning`，就会覆盖被该规则限定的任务上的
 `[tasks.*].reasoning`。`model`、`messages`、`stream` 是引擎自有字段，声明
-它们会拒绝启动。规则若指名 `chat_vision` 或 `embedding` 会记录警告且永不
-生效（这两类调用自己构建请求体）。自定义 provider 必须声明 `chat` 才能使用
-body 规则；保留名 `openrouter` 条目可以只声明规则而不覆盖端点。
+它们会拒绝启动。规则若指名 `embedding` 会记录警告且永不生效（该调用自己
+构建请求体，也不接受任何 chat 形态的参数）。自定义 provider 必须声明
+`chat` 才能使用 body 规则；保留名 `openrouter` 条目可以只声明规则而不覆盖
+端点。
 
 ```toml
 [providers.venice]
@@ -233,8 +234,25 @@ params = { provider = { ignore = ["some-bad-provider"], sort = "price" } }
 `[defaults].provider_sort` 的替代写法：OpenRouter 路由偏好现在是普通的
 body 参数（裸 OpenRouter provider slug，不带 `@openrouter` 后缀），可以像
 任何其他规则一样按任务限定范围。旧的两个 key 会拒绝启动，并给出这条迁移
-提示。注意被移除的两个 key 以前也会喂给 `chat_vision` 的请求体；body 规则
-不覆盖 vision，所以 vision 调用现在完全不再发送 `provider` 偏好。
+提示。注意被移除的两个 key 以前也会喂给 `chat_vision` 的请求体；由于 body
+规则现在同样覆盖 vision，上面这条未限定 `tasks` 的规则也会作用到 vision
+调用——若只想让路由偏好作用于 chat，请用 `tasks` 限定范围。
+
+`chat_vision` 虽然不是 chat/completions 任务，但同样被覆盖：它的 describe
+调用自己构建请求体，而该请求体也会走同一套合并，因此 `reasoning` 对象表达
+不了的参数照样能到达 vision 前置阶段。
+
+```toml
+[[providers.openrouter.body]]
+tasks  = ["chat_vision"]
+params = { reasoning_effort = "none" }
+```
+
+这一点很重要：有些模型会无视 `reasoning = { enabled = false }`，照样推理并
+照样计费——而 `reasoning_effort` 是独立的顶层字段，不属于 `reasoning` 对象，
+`[tasks.*].reasoning` 表达不了它。vision 的 `messages` 是块数组（text +
+`image_url`）而不是 chat 的形态，但 `messages` 属于引擎自有字段、启动时就会
+被拒绝，所以任何规则都不可能把它压平。
 
 ### `model_name_display_override`（仅限 chat 任务）
 
@@ -606,6 +624,8 @@ b = """
 
 此功能**默认关闭**，仅当此任务块存在且 `filter_prompt` 非空白时激活。`retry_depth` 默认为 `1`（primary + 第一个 fallback）。请选择支持视觉的模型；示例使用 `google/gemini-3.1-flash-lite`。
 
+除本块自身的 key 外，其他 wire 参数通过限定 `tasks = ["chat_vision"]` 的 `[[providers.<name>.body]]` 规则送达 describe 调用——凡是 `reasoning` 对象表达不了的（包括 `reasoning_effort`）都走这条路。参见上文“`[[providers.<name>.body]]` — 自定义 body 参数”。
+
 调用点：`crates/eros-engine-server/src/pipeline/stream.rs`，通过 `model_config.rs` 中的 `resolve_vision()`。
 
 ### `[tasks.chat_product_qa]` — 出戏产品问答（opt-in）
@@ -870,7 +890,8 @@ model = { "x-ai/grok-4.20" = 0.8, "z-ai/glm-4.7-flash" = 0.2 }  # weighted rando
   路由偏好现在是 `openrouter` 条目上的 `[[providers.<name>.body]]` 规则——
   参见上文“`[[providers.<name>.body]]` — 自定义 body 参数”。残留 key 会
   拒绝启动并给出迁移提示。被移除的两个 key 以前也会喂给 `chat_vision` 的
-  请求体；body 规则只覆盖 chat，所以 vision 调用不再发送 `provider` 偏好。
+  请求体；body 规则同样覆盖 vision，所以一条未限定 `tasks` 的规则可以让
+  vision 调用重新带上 `provider` 偏好。
 
 ## 此配置不控制的内容
 

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -54,13 +54,21 @@
 #   [[providers.<name>.body]] rules, see below) you declare for that entry.
 # - Under MODEL_CONFIG_DIR, [providers] merges as ONE top-level key.
 #
-# Per-provider custom body parameters (chat/completions only). `params` is
-# merged into the request body verbatim; `tasks` scopes the rule (omit = all
-# chat tasks on this provider). Later rules win; params win over engine
-# fields. model/messages/stream are engine-owned (boot refusal).
+# Per-provider custom body parameters. `params` is merged into the request
+# body verbatim; `tasks` scopes the rule (omit = every task on this
+# provider). Later rules win; params win over engine fields.
+# model/messages/stream are engine-owned (boot refusal).
 #[[providers.venice.body]]
 #tasks  = ["chat_companion"]
 #params = { venice_parameters = { include_venice_system_prompt = false } }
+#
+# Covers chat_vision too, even though that stage builds its own body — the
+# lever for models that ignore `reasoning = { enabled = false }`, reason
+# anyway, and bill for it (`reasoning_effort` is a separate top-level field,
+# not part of the `reasoning` object). Only `embedding` is uncovered.
+#[[providers.openrouter.body]]
+#tasks  = ["chat_vision"]
+#params = { reasoning_effort = "none" }
 #
 # OpenRouter routing prefs (the former [defaults].ignore_providers /
 # provider_sort) are now body params on the reserved openrouter entry —


### PR DESCRIPTION
Closes #225

Takes the issue's leaning — **option 1**, run vision bodies through `apply_body_rules` — over the narrower `ReasoningConfig.effort` patch, which would have serialized one config struct into two wire shapes to fix exactly one parameter.

## The gap

`[[providers.<name>.body]]` (spec `2026-08-02-provider-body-params`) covers chat/completions only. `execute_vision` hand-builds its wire body and never called `apply_body_rules`, so the vision pre-stage's only reasoning lever was the `reasoning` **object**. `reasoning_effort` is a separate top-level field, not part of that object, so `[tasks.chat_vision].reasoning` cannot express it and no deployer knob could reach the call.

That costs real money: models that ignore `reasoning = { enabled = false }` reason anyway and bill for it — measured downstream (etherfunlab/eros-engine-web#526) at **120 completion tokens under `enabled:false` vs 7 under `reasoning_effort:"none"`**, with `exclude:true` merely hiding the chain and still billing 140. Vision turns are the most expensive path in the pipeline.

## Change

`execute_vision` resolves the endpoint's rules exactly as `call_once` does (openrouter entry vs. the custom provider's own `body_rules`) and merges them under the task name `chat_vision`.

The merge runs **after** the custom-endpoint subset strip, mirroring `call_once`'s strip-then-merge order — that ordering is what lets a rule on a custom endpoint deliberately put back an extension the strip removed.

`chat_vision` leaves `BODY_UNSUPPORTED_TASKS`; only `embedding` remains there, and for a different reason (it takes no chat-shaped parameters at all, so there is nothing for a rule to carry). It deliberately stays **out** of `KNOWN_CHAT_TASKS`, which means what it says — tasks that post a `ChatRequest`. A new `BODY_SUPPORTED_NON_CHAT_TASKS` keeps the boot validator from reporting a legitimate `chat_vision` rule as a typo, instead of stretching `KNOWN_CHAT_TASKS` to cover a task that isn't one.

The boot-time warning the issue called "load-bearing" is now simply unnecessary for this task, as predicted.

## Safety of the block-array `messages`

Vision's `messages` is structurally unlike chat's — the user turn's `content` is a block array (text + `image_url`), which a shallow top-level merge could flatten. It can't: `messages` is in the engine-owned refusal set (`model`/`messages`/`stream`) rejected at boot by `validate_providers`. `vision_body_rule_cannot_flatten_the_block_array_messages` pins that end-to-end with the widest possible rule (untargeted, top-level keys), asserting both blocks survive intact — the test the issue asked for.

## Tests

Five new wiremock tests on the vision path, mirroring the chat-path body-rule suite one for one:

| test | pins |
|---|---|
| `vision_body_rule_reaches_the_wire_and_beats_task_reasoning` | `reasoning_effort` reaches the wire; rule params beat `[tasks.chat_vision].reasoning` |
| `vision_body_rule_cannot_flatten_the_block_array_messages` | untargeted rule applies, block array intact |
| `vision_body_rule_skipped_for_unlisted_task` | a `chat_companion`-scoped rule does not bleed into vision |
| `vision_custom_provider_strips_then_merges` | strip-then-merge order; a rule may restore `reasoning` |
| `vision_openrouter_rules_do_not_leak_to_a_custom_provider` | per-endpoint rule isolation |

`body_rule_task_warning_semantics` updated: `chat_vision` no longer warns, `embedding` still does.

## Docs

`model-config.md` + `.zh.md`: the `[[providers.<name>.body]]` section (coverage claim, `reasoning_effort` example, block-array note), the `[tasks.chat_vision]` section (pointer to the body-rule route), and both `[defaults].ignore_providers` migration notes — those said vision "no longer sends `provider` prefs at all", which is now wrong: an untargeted rule reaches vision again. `examples/model_config.toml` gains a commented `chat_vision` rule.

## Verification

`cargo fmt --check`, `clippy --all-targets --all-features -D warnings`, `cargo test --workspace` (1229 passed, 0 failed), and the openapi snapshot diff (no drift) all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)