### PR TITLE
feat(voice): manual barge-in via explicit interrupt + regeneration repair

### DIFF
--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -693,6 +693,9 @@
               }
             }
           },
+          "401": {
+            "description": "missing or invalid bearer"
+          },
           "403": {
             "description": "",
             "content": {

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -642,6 +642,105 @@
         ]
       }
     },
+    "/comp/voice/{session_id}/turn/interrupt": {
+      "post": {
+        "tags": [
+          "companion"
+        ],
+        "summary": "Report a deliberate barge-in on the turn currently being spoken.",
+        "description": "Stopping generation is NOT this endpoint's job — aborting the SSE already\ndoes that (the stream generator is dropped, which closes the upstream\nconnection). This endpoint records what the user actually HEARD, which the\naborted generator can no longer do: its persist step sits after the\nstreaming loop and never runs.\n\nDeliberately has no `501 voice_disabled` gate — it makes no LLM call, and\ngating it on `[tasks.chat_voice]` would make an in-flight call's interrupt\nfail if the deployment's config changed mid-call.",
+        "operationId": "voice_turn_interrupt",
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "description": "Voice-channel session id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VoiceInterruptRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VoiceInterruptResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StreamPreErrorBody"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StreamPreErrorBody"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StreamPreErrorBody"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StreamPreErrorBody"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StreamPreErrorBody"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
     "/comp/voice/{session_id}/turn/stream": {
       "post": {
         "tags": [
@@ -2119,6 +2218,35 @@
                 "$ref": "#/components/schemas/LabelTransitionDto"
               }
             ]
+          }
+        }
+      },
+      "VoiceInterruptRequest": {
+        "type": "object",
+        "required": [
+          "client_msg_id",
+          "spoken_text"
+        ],
+        "properties": {
+          "client_msg_id": {
+            "type": "string",
+            "description": "The `client_msg_id` of the turn being interrupted. MUST be the\nsession's latest user turn — you can only barge in on what is\ncurrently being spoken."
+          },
+          "spoken_text": {
+            "type": "string",
+            "description": "What TTS actually played, verbatim. MAY be empty (the user cut in\nbefore the first audible word), in which case no assistant content is\nwritten and only the interrupt marker records the turn."
+          }
+        }
+      },
+      "VoiceInterruptResponse": {
+        "type": "object",
+        "properties": {
+          "message_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The assistant row that now holds the spoken text, or `null` when\nnothing was played and no reply row exists."
           }
         }
       },

--- a/crates/eros-engine-server/src/pipeline/voice.rs
+++ b/crates/eros-engine-server/src/pipeline/voice.rs
@@ -818,7 +818,16 @@ pub fn run_voice_turn(
                 )
                 .await
             {
-                tracing::warn!(error = %e, "voice: assistant persist failed");
+                // `error!`, not `warn!`: this is not a benign retry-later
+                // condition. Migration 0041's `ON CONFLICT ... WHERE ...`
+                // clause requires the partial unique index it creates; on a
+                // database where that migration has not run, EVERY voice
+                // reply's persist raises Postgres 42P10 here and is silently
+                // dropped while the SSE stream still looks healthy to the
+                // client (the text already streamed as `delta` frames before
+                // this point). A `warn!` would bury that under normal log
+                // noise instead of paging someone.
+                tracing::error!(error = %e, "voice: assistant persist failed — reply not saved");
             }
         }
 
@@ -3681,7 +3690,11 @@ data: [DONE]\n\n";
             .await
             .unwrap()
             .expect("session exists");
-        let repair = repo.voice_turn_repair_state(umid).await.unwrap();
+        let repair = repo
+            .voice_turn_repair_state(umid)
+            .await
+            .unwrap()
+            .expect("insert_voice_user_message produces an actual voice user turn");
         assert_eq!(
             repair.content, persisted_text,
             "sanity: repair state reads the persisted row, not a retry"
@@ -3791,7 +3804,11 @@ data: [DONE]\n\n";
             eros_engine_store::chat::VoiceUserInsert::Inserted(id) => id,
             other => panic!("expected Inserted, got {other:?}"),
         };
-        let repair = repo.voice_turn_repair_state(umid).await.unwrap();
+        let repair = repo
+            .voice_turn_repair_state(umid)
+            .await
+            .unwrap()
+            .expect("insert_voice_user_message produces an actual voice user turn");
         assert!(
             !repair.has_reply && !repair.interrupted,
             "must be the repairable shape"

--- a/crates/eros-engine-server/src/pipeline/voice.rs
+++ b/crates/eros-engine-server/src/pipeline/voice.rs
@@ -3598,4 +3598,254 @@ data: [DONE]\n\n";
         );
         assert_no_recall_block(&system_prompt_of(&last_request_body(&mock).await));
     }
+
+    // ─── duplicate-gate repair: content authority + bootstrap reuse ────
+    //
+    // The route's repair path (Task 5) reads `voice_turn_repair_state` and
+    // hands the PERSISTED content — never the retry body's — to `VoiceTurn`.
+    // These two tests drive `run_voice_turn` the way that repair does: persist
+    // the (orphaned) user row on its own, THEN construct `VoiceTurn` from the
+    // repair state, mirroring the route instead of the single-shot
+    // `run_bootstrap_turn` / `run_recall_turn` helpers above.
+
+    /// The per-turn recall embeds `turn.content` as its query text, so a
+    /// repair that used the retry body's copy would search on the wrong
+    /// query. Proven end to end: the embed mock answers ONLY the PERSISTED
+    /// utterance's exact text (any other query 404s, degrading recall to
+    /// nothing), and the one memory row it can find carries a marker no other
+    /// part of the prompt does — so a populated recall block IS the proof the
+    /// persisted text, not the retry's, drove the search.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn repair_uses_persisted_content_not_the_retry_body(pool: sqlx::PgPool) {
+        use eros_engine_llm::model_config::ModelConfig;
+        use eros_engine_store::memory::{MemoryLayer, MemoryRepo};
+        use futures_util::StreamExt;
+        use wiremock::matchers::{body_partial_json, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = bootstrap_mock().await;
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_instance(&pool, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id, "voice").await;
+
+        let persisted_text = "persisted words";
+        let retry_text = "different words";
+
+        // Abnormal disconnect: the FIRST attempt's utterance landed, nothing
+        // else — no reply, no marker.
+        let repo = ChatRepo { pool: &pool };
+        let umid = match repo
+            .insert_voice_user_message(session_id, persisted_text, "01J9CONTENT00000000000001")
+            .await
+            .unwrap()
+        {
+            eros_engine_store::chat::VoiceUserInsert::Inserted(id) => id,
+            other => panic!("expected Inserted, got {other:?}"),
+        };
+
+        // The embed mock answers ONLY a query built from the persisted text.
+        // A query built from `retry_text` (or anything else) gets no match —
+        // wiremock 404s it, `embed_query` fails, and recall degrades to no
+        // block at all.
+        let embed = MockServer::start().await;
+        Mock::given(wm_path("/v1/embeddings"))
+            .and(body_partial_json(
+                serde_json::json!({ "input": [persisted_text] }),
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                serde_json::json!({ "data": [ { "embedding": unit_embedding(7) } ] }),
+            ))
+            .mount(&embed)
+            .await;
+
+        // One memory row, findable only by the persisted-text query's vector.
+        MemoryRepo { pool: &pool }
+            .upsert(
+                MemoryLayer::Profile,
+                session_id,
+                user_id,
+                None,
+                "TOKYO_MARKER_SNIPPET",
+                &unit_embedding(7),
+                Some("preference"),
+                None,
+            )
+            .await
+            .unwrap();
+
+        // The repair leg: reload the session row and the persisted repair
+        // state — exactly what the fixed route reads on the retry — and use
+        // ITS content, never `retry_text`.
+        let session = repo
+            .get_session(session_id)
+            .await
+            .unwrap()
+            .expect("session exists");
+        let repair = repo.voice_turn_repair_state(umid).await.unwrap();
+        assert_eq!(
+            repair.content, persisted_text,
+            "sanity: repair state reads the persisted row, not a retry"
+        );
+        assert!(
+            !repair.has_reply && !repair.interrupted,
+            "must be the repairable shape"
+        );
+
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = Arc::new(
+            ModelConfig::from_toml_str(
+                "[tasks.chat_voice]\nmodel = \"primary\"\nmax_tokens = 100\nrecall = true\n",
+            )
+            .unwrap(),
+        );
+        state.openrouter = Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+        state.embed = Arc::new(embed_router(&embed.uri()));
+        let resolved = state.model_config.resolve_voice().unwrap();
+
+        let frames: Vec<ProtocolFrame> = run_voice_turn(
+            Arc::new(state),
+            VoiceTurn {
+                session_id,
+                instance_id,
+                user_id,
+                user_message_id: umid,
+                // The load-bearing line: the repair state's content, not
+                // `retry_text`.
+                content: repair.content,
+                relationship_scope: RelationshipScope::None,
+                memory_scope: MemoryScope::default(),
+                session_metadata: session.metadata,
+            },
+            resolved,
+        )
+        .collect()
+        .await;
+        assert_no_error_frame(&frames);
+
+        // The recall block (system message) proves the QUERY was the
+        // persisted text; the full wire body (system + history messages)
+        // proves the TRANSCRIPT is too, and that the retry's copy never
+        // leaks in anywhere.
+        let body = last_request_body(&mock).await;
+        let sys = system_prompt_of(&body);
+        assert!(
+            sys.contains("TOKYO_MARKER_SNIPPET"),
+            "recall must have used the PERSISTED text as its query — a wrong \
+             query would 404 the embed mock and leave no recall block: {sys}"
+        );
+        let wire = body.to_string();
+        assert!(
+            wire.contains(persisted_text),
+            "the persisted utterance must reach the wire prompt: {wire}"
+        );
+        assert!(
+            !wire.contains(retry_text),
+            "the retry body's text must never reach the wire prompt: {wire}"
+        );
+    }
+
+    /// `set_voice_bootstrap` is write-once: the marker a completed first turn
+    /// freezes is what a LATER repair injects, even though the repaired
+    /// turn's own user row was persisted (orphaned, no reply) before this
+    /// repair drove it — the two-step shape a duplicate-gate repair takes.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn repair_of_first_turn_reuses_frozen_bootstrap(pool: sqlx::PgPool) {
+        use futures_util::StreamExt;
+
+        let mock = bootstrap_mock().await;
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_instance(&pool, user_id).await;
+        seed_insights(&pool, user_id, serde_json::json!({ "city": "上海" })).await;
+        let session_id = seed_session(&pool, user_id, instance_id, "voice").await;
+
+        // Turn 1 completes normally and freezes the bootstrap snapshot.
+        let frames = run_bootstrap_turn(
+            &pool,
+            &mock,
+            session_id,
+            instance_id,
+            user_id,
+            "01J9BOOT0000000000000001",
+            MemoryScope::default(),
+        )
+        .await;
+        assert_no_error_frame(&frames);
+        let first = read_marker(&pool, session_id)
+            .await
+            .expect("marker written");
+
+        // Turn 2: an abnormal disconnect — the user row lands, nothing else —
+        // then gets repaired. The persist step happens on its own, exactly
+        // the shape the (fixed) route's duplicate-gate repair takes.
+        let repo = ChatRepo { pool: &pool };
+        let umid = match repo
+            .insert_voice_user_message(session_id, "still there?", "01J9BOOT0000000000000002")
+            .await
+            .unwrap()
+        {
+            eros_engine_store::chat::VoiceUserInsert::Inserted(id) => id,
+            other => panic!("expected Inserted, got {other:?}"),
+        };
+        let repair = repo.voice_turn_repair_state(umid).await.unwrap();
+        assert!(
+            !repair.has_reply && !repair.interrupted,
+            "must be the repairable shape"
+        );
+
+        // Reload the session row the way the route re-loads it on the retry
+        // — metadata now carries turn 1's frozen marker.
+        let session = repo
+            .get_session(session_id)
+            .await
+            .unwrap()
+            .expect("session exists");
+
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = Arc::new(
+            eros_engine_llm::model_config::ModelConfig::from_toml_str(
+                "[tasks.chat_voice]\nmodel = \"primary\"\nmax_tokens = 100\nrecall = false\n",
+            )
+            .unwrap(),
+        );
+        state.openrouter = Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+        let resolved = state.model_config.resolve_voice().unwrap();
+        let frames: Vec<ProtocolFrame> = run_voice_turn(
+            Arc::new(state),
+            VoiceTurn {
+                session_id,
+                instance_id,
+                user_id,
+                user_message_id: umid,
+                content: repair.content,
+                relationship_scope: RelationshipScope::None,
+                // Deliberately different from turn 1's scope — the frozen
+                // snapshot must not budge even if a retry's scope would have
+                // picked a different insight tier on a first turn.
+                memory_scope: MemoryScope::Full,
+                session_metadata: session.metadata,
+            },
+            resolved,
+        )
+        .collect()
+        .await;
+        assert_no_error_frame(&frames);
+
+        let second = read_marker(&pool, session_id)
+            .await
+            .expect("marker still there");
+        assert_eq!(
+            second, first,
+            "a repair must never reassemble the frozen bootstrap"
+        );
+    }
 }

--- a/crates/eros-engine-server/src/routes/voice.rs
+++ b/crates/eros-engine-server/src/routes/voice.rs
@@ -15,13 +15,15 @@ use std::time::Duration;
 use utoipa_axum::{router::OpenApiRouter, routes};
 use uuid::Uuid;
 
+use ulid::Ulid;
+
 use eros_engine_core::scope::{MemoryScope, RelationshipScope};
-use eros_engine_store::chat::{ChatRepo, VoiceUserInsert};
+use eros_engine_store::chat::{ChatRepo, LatestTurnLookup, VoiceUserInsert};
 use eros_engine_store::persona::PersonaRepo;
 
 use crate::auth::middleware::AuthUser;
 use crate::error::{AppError, StreamPreError};
-use crate::pipeline::stream::ProtocolFrame;
+use crate::pipeline::stream::{ulid_string, ProtocolFrame};
 use crate::pipeline::voice::{run_voice_turn, VoiceTurn};
 use crate::state::AppState;
 
@@ -50,6 +52,25 @@ pub struct VoiceTurnRequest {
     pub memory_scope: Option<MemoryScope>,
 }
 
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
+pub struct VoiceInterruptRequest {
+    /// The `client_msg_id` of the turn being interrupted. MUST be the
+    /// session's latest user turn — you can only barge in on what is
+    /// currently being spoken.
+    pub client_msg_id: String,
+    /// What TTS actually played, verbatim. MAY be empty (the user cut in
+    /// before the first audible word), in which case no assistant content is
+    /// written and only the interrupt marker records the turn.
+    pub spoken_text: String,
+}
+
+#[derive(Debug, serde::Serialize, utoipa::ToSchema)]
+pub struct VoiceInterruptResponse {
+    /// The assistant row that now holds the spoken text, or `null` when
+    /// nothing was played and no reply row exists.
+    pub message_id: Option<String>,
+}
+
 fn pre(status: StatusCode, code: &'static str, message: &str, user_message: &str) -> AppError {
     AppError::StreamPre(StreamPreError {
         status,
@@ -75,6 +96,31 @@ fn validate(req: &VoiceTurnRequest) -> Result<(), AppError> {
             "unprocessable",
             "content too long",
             "消息过长，请缩短后重试",
+        ));
+    }
+    let n = req.client_msg_id.len();
+    let bad_chars = req
+        .client_msg_id
+        .chars()
+        .any(|c| c.is_whitespace() || !c.is_ascii() || !c.is_ascii_graphic());
+    if !(MIN_CLIENT_MSG_ID_LEN..=MAX_CLIENT_MSG_ID_LEN).contains(&n) || bad_chars {
+        return Err(pre(
+            StatusCode::BAD_REQUEST,
+            "invalid_payload",
+            "client_msg_id invalid",
+            "请求无效",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_interrupt(req: &VoiceInterruptRequest) -> Result<(), AppError> {
+    if req.spoken_text.chars().count() > MAX_CONTENT_CHARS {
+        return Err(pre(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "unprocessable",
+            "spoken_text too long",
+            "请求无效",
         ));
     }
     let n = req.client_msg_id.len();
@@ -249,8 +295,109 @@ pub async fn voice_turn_stream(
     ))
 }
 
+/// Report a deliberate barge-in on the turn currently being spoken.
+///
+/// Stopping generation is NOT this endpoint's job — aborting the SSE already
+/// does that (the stream generator is dropped, which closes the upstream
+/// connection). This endpoint records what the user actually HEARD, which the
+/// aborted generator can no longer do: its persist step sits after the
+/// streaming loop and never runs.
+///
+/// Deliberately has no `501 voice_disabled` gate — it makes no LLM call, and
+/// gating it on `[tasks.chat_voice]` would make an in-flight call's interrupt
+/// fail if the deployment's config changed mid-call.
+#[utoipa::path(
+    post,
+    path = "/comp/voice/{session_id}/turn/interrupt",
+    tag = "voice",
+    params(("session_id" = Uuid, Path, description = "Voice-channel session id")),
+    request_body = VoiceInterruptRequest,
+    responses(
+        (status = 200, body = VoiceInterruptResponse),
+        (status = 400, body = crate::routes::companion_stream::StreamPreErrorBody),
+        (status = 403, body = crate::routes::companion_stream::StreamPreErrorBody),
+        (status = 404, body = crate::routes::companion_stream::StreamPreErrorBody),
+        (status = 409, body = crate::routes::companion_stream::StreamPreErrorBody),
+        (status = 422, body = crate::routes::companion_stream::StreamPreErrorBody),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn voice_turn_interrupt(
+    State(state): State<AppState>,
+    Path(session_id): Path<Uuid>,
+    Extension(AuthUser(user_id)): Extension<AuthUser>,
+    Json(req): Json<VoiceInterruptRequest>,
+) -> Result<Json<VoiceInterruptResponse>, AppError> {
+    validate_interrupt(&req)?;
+
+    let chat_repo = ChatRepo { pool: &state.pool };
+    let session = chat_repo.get_session(session_id).await?.ok_or_else(|| {
+        pre(
+            StatusCode::NOT_FOUND,
+            "session_not_found",
+            "session not found",
+            "会话不存在",
+        )
+    })?;
+    if session.user_id != user_id {
+        return Err(pre(
+            StatusCode::FORBIDDEN,
+            "session_forbidden",
+            "session not owned by JWT user",
+            "无权访问该会话",
+        ));
+    }
+    if session.channel != "voice" {
+        return Err(pre(
+            StatusCode::CONFLICT,
+            "wrong_channel",
+            "session is not a voice-channel session",
+            "该会话不是语音会话",
+        ));
+    }
+
+    let user_message_id = match chat_repo
+        .resolve_latest_voice_user_turn(session_id, &req.client_msg_id)
+        .await?
+    {
+        LatestTurnLookup::Latest(id) => id,
+        LatestTurnLookup::NotFound => {
+            return Err(pre(
+                StatusCode::NOT_FOUND,
+                "turn_not_found",
+                "no such client_msg_id in this session",
+                "该消息不存在",
+            ));
+        }
+        // Guarding this is what stops a client rewriting the content of ANY
+        // past assistant reply through the upsert below.
+        LatestTurnLookup::Stale => {
+            return Err(pre(
+                StatusCode::CONFLICT,
+                "not_latest_turn",
+                "only the session's latest turn can be interrupted",
+                "该回合已结束",
+            ));
+        }
+    };
+
+    let message_id = chat_repo
+        .upsert_voice_interrupt(
+            session_id,
+            user_message_id,
+            Ulid::new().into(),
+            &req.spoken_text,
+        )
+        .await?
+        .map(|id| ulid_string(Ulid::from(id)));
+
+    Ok(Json(VoiceInterruptResponse { message_id }))
+}
+
 pub fn router() -> OpenApiRouter<AppState> {
-    OpenApiRouter::new().routes(routes!(voice_turn_stream))
+    OpenApiRouter::new()
+        .routes(routes!(voice_turn_stream))
+        .routes(routes!(voice_turn_interrupt))
 }
 
 #[cfg(test)]
@@ -486,6 +633,225 @@ mod tests {
                 .await
                 .unwrap();
         assert_eq!(count, 0, "wrong-channel rejection must not persist a turn");
+    }
+
+    async fn post_interrupt(
+        app: &mut Router,
+        session_id: Uuid,
+        jwt: &str,
+        body: serde_json::Value,
+    ) -> axum::http::Response<Body> {
+        let req = Request::builder()
+            .method("POST")
+            .uri(format!("/comp/voice/{session_id}/turn/interrupt"))
+            .header(header::AUTHORIZATION, format!("Bearer {jwt}"))
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        app.call(req).await.unwrap()
+    }
+
+    /// Persist a voice user turn directly, returning its id.
+    async fn seed_user_turn(pool: &PgPool, session_id: Uuid, cid: &str) -> Uuid {
+        sqlx::query_scalar(
+            "INSERT INTO engine.chat_messages (session_id, role, content, channel, client_msg_id) \
+             VALUES ($1,'user','hello','voice',$2) RETURNING id",
+        )
+        .bind(session_id)
+        .bind(cid)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn interrupt_persists_spoken_text(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let session_id = seed(&pool, user_id).await;
+        seed_user_turn(&pool, session_id, "01J9INTERRUPT0000000000001").await;
+        let mut app = build_router(with_voice(crate::routes::companion::test_state(
+            pool.clone(),
+        )));
+
+        let resp = post_interrupt(
+            &mut app,
+            session_id,
+            &mint_jwt(user_id),
+            json!({
+                "client_msg_id": "01J9INTERRUPT0000000000001",
+                "spoken_text": "你今天过得"
+            }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let content: String = sqlx::query_scalar(
+            "SELECT content FROM engine.chat_messages \
+              WHERE session_id = $1 AND role = 'assistant'",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(content, "你今天过得");
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn interrupt_with_empty_text_writes_marker_only(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let session_id = seed(&pool, user_id).await;
+        let uid = seed_user_turn(&pool, session_id, "01J9INTERRUPT0000000000002").await;
+        let mut app = build_router(with_voice(crate::routes::companion::test_state(
+            pool.clone(),
+        )));
+
+        let resp = post_interrupt(
+            &mut app,
+            session_id,
+            &mint_jwt(user_id),
+            json!({
+                "client_msg_id": "01J9INTERRUPT0000000000002",
+                "spoken_text": ""
+            }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let n: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM engine.chat_messages WHERE session_id = $1 AND role='assistant'",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(n, 0);
+        let marked: bool = sqlx::query_scalar(
+            "SELECT COALESCE(metadata->>'voice_interrupt','false')::bool \
+               FROM engine.chat_messages WHERE id = $1",
+        )
+        .bind(uid)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert!(marked);
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn interrupt_is_idempotent(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let session_id = seed(&pool, user_id).await;
+        seed_user_turn(&pool, session_id, "01J9INTERRUPT0000000000003").await;
+        let mut app = build_router(with_voice(crate::routes::companion::test_state(
+            pool.clone(),
+        )));
+        let jwt = mint_jwt(user_id);
+        let body = json!({"client_msg_id":"01J9INTERRUPT0000000000003","spoken_text":"半句"});
+
+        assert_eq!(
+            post_interrupt(&mut app, session_id, &jwt, body.clone())
+                .await
+                .status(),
+            StatusCode::OK
+        );
+        assert_eq!(
+            post_interrupt(&mut app, session_id, &jwt, body)
+                .await
+                .status(),
+            StatusCode::OK
+        );
+
+        let n: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM engine.chat_messages WHERE session_id = $1 AND role='assistant'",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(n, 1, "repeat interrupts must not multiply rows");
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn interrupt_409_when_not_latest_turn(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let session_id = seed(&pool, user_id).await;
+        seed_user_turn(&pool, session_id, "01J9INTERRUPT0000000000004").await;
+        seed_user_turn(&pool, session_id, "01J9INTERRUPT0000000000005").await;
+        let mut app = build_router(with_voice(crate::routes::companion::test_state(
+            pool.clone(),
+        )));
+
+        let resp = post_interrupt(
+            &mut app,
+            session_id,
+            &mint_jwt(user_id),
+            json!({
+                "client_msg_id": "01J9INTERRUPT0000000000004",
+                "spoken_text": "rewrite attempt"
+            }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+
+        let n: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM engine.chat_messages WHERE session_id = $1 AND role='assistant'",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(n, 0, "a stale interrupt must not touch history");
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn interrupt_404_when_client_msg_id_unknown(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let session_id = seed(&pool, user_id).await;
+        let mut app = build_router(with_voice(crate::routes::companion::test_state(pool)));
+        let resp = post_interrupt(
+            &mut app,
+            session_id,
+            &mint_jwt(user_id),
+            json!({
+                "client_msg_id": "01J9INTERRUPT0000000000009", "spoken_text": "x"
+            }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn interrupt_403_when_not_owner(pool: PgPool) {
+        let owner = Uuid::new_v4();
+        let session_id = seed(&pool, owner).await;
+        seed_user_turn(&pool, session_id, "01J9INTERRUPT0000000000006").await;
+        let mut app = build_router(with_voice(crate::routes::companion::test_state(pool)));
+        let resp = post_interrupt(
+            &mut app,
+            session_id,
+            &mint_jwt(Uuid::new_v4()),
+            json!({
+                "client_msg_id": "01J9INTERRUPT0000000000006", "spoken_text": "x"
+            }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn interrupt_409_when_session_not_voice_channel(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let session_id = seed_channel(&pool, user_id, "text").await;
+        let mut app = build_router(with_voice(crate::routes::companion::test_state(pool)));
+        let resp = post_interrupt(
+            &mut app,
+            session_id,
+            &mint_jwt(user_id),
+            json!({
+                "client_msg_id": "01J9INTERRUPT0000000000007", "spoken_text": "x"
+            }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/crates/eros-engine-server/src/routes/voice.rs
+++ b/crates/eros-engine-server/src/routes/voice.rs
@@ -325,7 +325,7 @@ pub async fn voice_turn_stream(
 #[utoipa::path(
     post,
     path = "/comp/voice/{session_id}/turn/interrupt",
-    tag = "voice",
+    tag = "companion",
     params(("session_id" = Uuid, Path, description = "Voice-channel session id")),
     request_body = VoiceInterruptRequest,
     responses(

--- a/crates/eros-engine-server/src/routes/voice.rs
+++ b/crates/eros-engine-server/src/routes/voice.rs
@@ -250,7 +250,24 @@ pub async fn voice_turn_stream(
     {
         VoiceUserInsert::Inserted(id) => (id, req.content),
         VoiceUserInsert::Duplicate(id) => {
+            // `insert_voice_user_message`'s conflict lookup is deliberately
+            // role-agnostic (see its doc comment) — the colliding row can be a
+            // `gift_user` tip row, or even a text-channel `user` row reached
+            // via `message/stream` against this same session id, since that
+            // route has no channel guard. `voice_turn_repair_state` is scoped
+            // to `role = 'user' AND channel = 'voice'` and returns `None` for
+            // anything else, so such a collision falls back to the ordinary
+            // unconditional 409 instead of being treated as a repairable
+            // voice turn (which would regenerate against the wrong row).
             let st = chat_repo.voice_turn_repair_state(id).await?;
+            let Some(st) = st else {
+                return Err(pre(
+                    StatusCode::CONFLICT,
+                    "duplicate",
+                    "duplicate client_msg_id for this session",
+                    "这条消息已在处理",
+                ));
+            };
             if st.has_reply || st.interrupted {
                 return Err(pre(
                     StatusCode::CONFLICT,
@@ -260,6 +277,10 @@ pub async fn voice_turn_stream(
                 ));
             }
             if st.content != req.content {
+                // Deliberately omits the differing text — this repo forbids
+                // logging chat content. Do not "improve" this by adding the
+                // diff between `st.content` and `req.content`; that would leak
+                // user utterances into the logs.
                 tracing::warn!(
                     session_id = %session_id,
                     "voice: repair retry carried different content; using the persisted turn",
@@ -331,6 +352,7 @@ pub async fn voice_turn_stream(
     responses(
         (status = 200, body = VoiceInterruptResponse),
         (status = 400, body = crate::routes::companion_stream::StreamPreErrorBody),
+        (status = 401, description = "missing or invalid bearer"),
         (status = 403, body = crate::routes::companion_stream::StreamPreErrorBody),
         (status = 404, body = crate::routes::companion_stream::StreamPreErrorBody),
         (status = 409, body = crate::routes::companion_stream::StreamPreErrorBody),
@@ -397,6 +419,13 @@ pub async fn voice_turn_interrupt(
         }
     };
 
+    // TOCTOU: the turn resolved as "latest" above can stop being latest
+    // before the upsert below runs (a new turn lands in between). This is
+    // safe to leave as-is — it only WIDENS the legitimate window in which a
+    // barge-in on the just-resolved turn is accepted, it can never let a
+    // client reach an OLDER turn than the one it named (the `Stale` check
+    // above already rejected that). Do not "fix" this by re-checking
+    // latest-ness right before the upsert.
     let message_id = chat_repo
         .upsert_voice_interrupt(
             session_id,
@@ -673,6 +702,65 @@ mod tests {
             n, 1,
             "repair reuses the persisted user row, never adds a second"
         );
+    }
+
+    /// `insert_voice_user_message`'s conflict lookup is deliberately
+    /// role-agnostic (see its doc comment: "the conflicting row may be a
+    /// `user` OR a `gift_user` (tip) row"). Before the repair relaxation that
+    /// only ever produced a 409, so the role-agnosticism was harmless. Now
+    /// that a duplicate with no reply and no interrupt marker regenerates,
+    /// a `client_msg_id` collision against a NON-voice-user row (a
+    /// `gift_user` tip row, seeded here — the realistic case per the plan;
+    /// also possible via a text-channel `user` row, since `message/stream`
+    /// has no channel guard against being pointed at this session id) must
+    /// still fall back to the ordinary unconditional 409, never regenerate.
+    /// Regenerating would embed the tip marker text as the recall query and
+    /// write a `channel='voice'` assistant row whose `user_message_id`
+    /// points at a tip row.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn voice_409_and_no_regen_on_non_voice_user_row_collision(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let session_id = seed(&pool, user_id).await;
+        let client_msg_id = "01J9GIFTCOLLIDE00000000001";
+
+        // Seed a gift_user (tip) row directly, colliding on
+        // (session_id, client_msg_id) — the same collision surface
+        // `insert_voice_user_message`'s ON CONFLICT resolves against.
+        sqlx::query(
+            "INSERT INTO engine.chat_messages \
+                (session_id, role, content, client_msg_id, metadata) \
+             VALUES ($1, 'gift_user', '(打赏 $20)', $2, \
+                     '{\"tips_amount_usd\": 20.0}'::jsonb)",
+        )
+        .bind(session_id)
+        .bind(client_msg_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let resp = post_voice(
+            &mut build_router(with_voice(crate::routes::companion::test_state(
+                pool.clone(),
+            ))),
+            session_id,
+            &mint_jwt(user_id),
+            json!({"content": "hello", "client_msg_id": client_msg_id}),
+        )
+        .await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::CONFLICT,
+            "a client_msg_id collision with a non-voice-user row must not be treated as repairable"
+        );
+
+        let n: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM engine.chat_messages WHERE session_id = $1 AND role = 'assistant'",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(n, 0, "must not have regenerated an assistant reply");
     }
 
     /// A 512-dim one-hot vector — a query embedded at the same seed is the

--- a/crates/eros-engine-server/src/routes/voice.rs
+++ b/crates/eros-engine-server/src/routes/voice.rs
@@ -238,21 +238,37 @@ pub async fn voice_turn_stream(
             )
         })?;
 
-    // Persist the user turn (idempotent on (session_id, client_msg_id)). A
-    // duplicate client_msg_id must NOT trigger a second assistant reply /
-    // second upstream LLM call — return 409 instead of regenerating.
-    let user_message_id = match chat_repo
+    // Persist the user turn (idempotent on (session_id, client_msg_id)).
+    // A duplicate is only a conflict when the turn actually PRODUCED something:
+    // an existing reply (retrying would double-bill) or a deliberate barge-in
+    // (nothing to repair). A duplicate with neither is an abnormal disconnect —
+    // or an upstream failure, which already told the client `retryable: true` —
+    // so it regenerates against the persisted user row.
+    let (user_message_id, persisted_content) = match chat_repo
         .insert_voice_user_message(session_id, &req.content, &req.client_msg_id)
         .await?
     {
-        VoiceUserInsert::Inserted(id) => id,
-        VoiceUserInsert::Duplicate(_) => {
-            return Err(pre(
-                StatusCode::CONFLICT,
-                "duplicate",
-                "duplicate client_msg_id for this session",
-                "这条消息已在处理",
-            ));
+        VoiceUserInsert::Inserted(id) => (id, req.content),
+        VoiceUserInsert::Duplicate(id) => {
+            let st = chat_repo.voice_turn_repair_state(id).await?;
+            if st.has_reply || st.interrupted {
+                return Err(pre(
+                    StatusCode::CONFLICT,
+                    "duplicate",
+                    "duplicate client_msg_id for this session",
+                    "这条消息已在处理",
+                ));
+            }
+            if st.content != req.content {
+                tracing::warn!(
+                    session_id = %session_id,
+                    "voice: repair retry carried different content; using the persisted turn",
+                );
+            }
+            // The persisted utterance is authoritative — the engine never
+            // rewrites history, and the per-turn recall embeds this text as its
+            // query, so a repair must not let the same turn's recall drift.
+            (id, st.content)
         }
     };
 
@@ -264,7 +280,7 @@ pub async fn voice_turn_stream(
         // Verbatim: the per-turn recall embeds it as the query text (voice has
         // no input-filter rewrite). Already persisted above as the latest
         // history row — the wire messages still come from there.
-        content: req.content,
+        content: persisted_content,
         relationship_scope: req.relationship_scope.unwrap_or_default(),
         memory_scope: req.memory_scope.unwrap_or_default(),
         // Handed over from the row loaded above — the pipeline reads the
@@ -581,14 +597,31 @@ mod tests {
         // Pre-seed a user voice row with this client_msg_id, as if a first
         // request already landed it.
         let chat_repo = ChatRepo { pool: &pool };
-        match chat_repo
+        let user_message_id = match chat_repo
             .insert_voice_user_message(session_id, "hi", client_msg_id)
             .await
             .unwrap()
         {
-            VoiceUserInsert::Inserted(_) => {}
+            VoiceUserInsert::Inserted(id) => id,
             other => panic!("expected Inserted, got {other:?}"),
-        }
+        };
+        // A duplicate is only a conflict when the turn PRODUCED something.
+        // Seed the reply so this test still pins the double-billing guard
+        // rather than the (now relaxed) unconditional rule.
+        chat_repo
+            .insert_voice_assistant_message(
+                session_id,
+                user_message_id,
+                Uuid::new_v4(),
+                "hello back",
+                None,
+                None,
+                None,
+                false,
+                None,
+            )
+            .await
+            .unwrap();
 
         let mut app = build_router(with_voice(crate::routes::companion::test_state(pool)));
         let jwt = mint_jwt(user_id);
@@ -602,6 +635,72 @@ mod tests {
         )
         .await;
         assert_eq!(resp.status(), StatusCode::CONFLICT);
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn duplicate_regenerates_when_turn_has_no_reply(pool: PgPool) {
+        // Abnormal disconnect: user row persisted, no reply, no marker.
+        let user_id = Uuid::new_v4();
+        let session_id = seed(&pool, user_id).await;
+        seed_user_turn(&pool, session_id, "01J9REPAIR0000000000000001").await;
+        let mut app = build_router(with_voice(crate::routes::companion::test_state(
+            pool.clone(),
+        )));
+
+        let resp = post_voice(
+            &mut app,
+            session_id,
+            &mint_jwt(user_id),
+            json!({
+                "content": "hello", "client_msg_id": "01J9REPAIR0000000000000001"
+            }),
+        )
+        .await;
+        assert_ne!(
+            resp.status(),
+            StatusCode::CONFLICT,
+            "a turn with no reply and no interrupt marker must be repairable"
+        );
+
+        let n: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM engine.chat_messages WHERE session_id = $1 AND role='user'",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            n, 1,
+            "repair reuses the persisted user row, never adds a second"
+        );
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn duplicate_still_409_after_interrupt(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let session_id = seed(&pool, user_id).await;
+        let uid = seed_user_turn(&pool, session_id, "01J9REPAIR0000000000000002").await;
+        sqlx::query(
+            "UPDATE engine.chat_messages \
+                SET metadata = COALESCE(metadata,'{}'::jsonb) || '{\"voice_interrupt\": true}'::jsonb \
+              WHERE id = $1",
+        ).bind(uid).execute(&pool).await.unwrap();
+        let mut app = build_router(with_voice(crate::routes::companion::test_state(pool)));
+
+        let resp = post_voice(
+            &mut app,
+            session_id,
+            &mint_jwt(user_id),
+            json!({
+                "content": "hello", "client_msg_id": "01J9REPAIR0000000000000002"
+            }),
+        )
+        .await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::CONFLICT,
+            "a deliberate barge-in has nothing to repair"
+        );
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/crates/eros-engine-server/src/routes/voice.rs
+++ b/crates/eros-engine-server/src/routes/voice.rs
@@ -675,6 +675,169 @@ mod tests {
         );
     }
 
+    /// A 512-dim one-hot vector — a query embedded at the same seed is the
+    /// exact nearest neighbour of a row stored at it. Mirrors
+    /// `pipeline::voice::tests::unit_embedding`.
+    fn unit_embedding(seed: usize) -> Vec<f32> {
+        let mut v = vec![0.0_f32; 512];
+        v[seed % 512] = 1.0;
+        v
+    }
+
+    /// An `EmbeddingRouter` whose read backend is a wiremock server. Mirrors
+    /// `pipeline::voice::tests::embed_router`.
+    fn embed_router(uri: &str) -> eros_engine_llm::embedding::EmbeddingRouter {
+        let cfg = eros_engine_llm::model_config::ModelConfig::from_toml_str(&format!(
+            "[providers.mockembed]\nembeddings = \"{uri}/v1/embeddings\"\n\
+             [tasks.embedding]\nmodel = \"mock-embed@mockembed\"\n"
+        ))
+        .expect("embedding provider config parses");
+        eros_engine_llm::embedding::EmbeddingRouter::from_config_with(&cfg, |k| {
+            (k == "MOCKEMBED_API_KEY").then(|| "test-key".to_string())
+        })
+        .expect("mock embedding router builds")
+    }
+
+    /// The route-level counterpart to
+    /// `pipeline::voice::tests::repair_uses_persisted_content_not_the_retry_body`:
+    /// that test proves `run_voice_turn` respects whatever `VoiceTurn.content`
+    /// it is handed, but never reaches the `Duplicate` arm where the ACTUAL
+    /// choice between `st.content` (persisted) and `req.content` (retry body)
+    /// is made. This drives the real HTTP route end to end — orphaned turn,
+    /// then a retry whose body carries DIFFERENT content — and inspects the
+    /// upstream request the route's regeneration actually issued.
+    ///
+    /// Same discrimination technique as the pipeline test: the embed mock
+    /// answers ONLY a query built from the persisted text (any other query,
+    /// e.g. the retry body's, 404s and recall degrades to nothing), and the
+    /// one memory row it can find carries a marker that appears nowhere else
+    /// in the prompt — so a populated recall block in the CAPTURED upstream
+    /// request is proof the persisted text, not the retry's, drove the
+    /// search. Reverting `content: persisted_content` back to
+    /// `content: req.content` at the route's `Duplicate` arm makes this test
+    /// fail (verified — see the task report's sabotage transcript).
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn duplicate_regenerates_using_persisted_content_not_retry_body(pool: PgPool) {
+        use eros_engine_store::memory::{MemoryLayer, MemoryRepo};
+        use wiremock::matchers::{body_partial_json, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let user_id = Uuid::new_v4();
+        let session_id = seed(&pool, user_id).await;
+
+        let persisted_text = "persisted words";
+        let retry_text = "different words";
+        let client_msg_id = "01J9CONTENT0000000000000003";
+
+        // Abnormal disconnect: the FIRST attempt's utterance landed, nothing
+        // else — no reply, no marker.
+        let chat_repo = ChatRepo { pool: &pool };
+        match chat_repo
+            .insert_voice_user_message(session_id, persisted_text, client_msg_id)
+            .await
+            .unwrap()
+        {
+            VoiceUserInsert::Inserted(_) => {}
+            other => panic!("expected Inserted, got {other:?}"),
+        }
+
+        // The embed mock answers ONLY a query built from the persisted text.
+        let embed = MockServer::start().await;
+        Mock::given(wm_path("/v1/embeddings"))
+            .and(body_partial_json(
+                serde_json::json!({ "input": [persisted_text] }),
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                serde_json::json!({ "data": [ { "embedding": unit_embedding(7) } ] }),
+            ))
+            .mount(&embed)
+            .await;
+
+        // One memory row, findable only by the persisted-text query's vector.
+        MemoryRepo { pool: &pool }
+            .upsert(
+                MemoryLayer::Profile,
+                session_id,
+                user_id,
+                None,
+                "TOKYO_MARKER_SNIPPET",
+                &unit_embedding(7),
+                Some("preference"),
+                None,
+            )
+            .await
+            .unwrap();
+
+        let mock = MockServer::start().await;
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(
+                        "data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}],\
+                         \"id\":\"gen-route-repair\",\"model\":\"primary\"}\n\n\
+                         data: [DONE]\n\n",
+                        "text/event-stream",
+                    ),
+            )
+            .mount(&mock)
+            .await;
+
+        let mut state = with_voice(crate::routes::companion::test_state(pool.clone()));
+        state.openrouter = Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+        state.embed = Arc::new(embed_router(&embed.uri()));
+        let mut app = build_router(state);
+
+        // The RETRY: same client_msg_id, but DIFFERENT content — must be
+        // discarded in favour of the persisted row.
+        let resp = post_voice(
+            &mut app,
+            session_id,
+            &mint_jwt(user_id),
+            json!({ "content": retry_text, "client_msg_id": client_msg_id }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Drive the SSE body to completion so the mocked upstream is actually
+        // hit (the pipeline's async_stream! only runs as the body is polled).
+        let bytes = axum::body::to_bytes(resp.into_body(), 256 * 1024)
+            .await
+            .unwrap();
+        let sse_text = String::from_utf8(bytes.to_vec()).unwrap();
+        assert!(
+            !sse_text.contains("\"type\":\"error\""),
+            "no error frame expected: {sse_text}"
+        );
+
+        let received = mock
+            .received_requests()
+            .await
+            .expect("recording enabled by default");
+        let last = received.last().expect("at least one upstream request");
+        let wire: serde_json::Value = serde_json::from_slice(&last.body).unwrap();
+        let wire_str = wire.to_string();
+
+        assert!(
+            wire_str.contains("TOKYO_MARKER_SNIPPET"),
+            "recall must have used the PERSISTED text as its query — a wrong \
+             query would 404 the embed mock and leave no recall block: {wire_str}"
+        );
+        assert!(
+            wire_str.contains(persisted_text),
+            "the persisted utterance must reach the upstream request: {wire_str}"
+        );
+        assert!(
+            !wire_str.contains(retry_text),
+            "the retry body's text must never reach the upstream request: {wire_str}"
+        );
+    }
+
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
     async fn duplicate_still_409_after_interrupt(pool: PgPool) {
         let user_id = Uuid::new_v4();

--- a/crates/eros-engine-store/migrations/0041_voice_assistant_reply_uidx.sql
+++ b/crates/eros-engine-store/migrations/0041_voice_assistant_reply_uidx.sql
@@ -1,0 +1,30 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+--
+-- One assistant reply per voice user turn.
+--
+-- Barge-in (spec 2026-08-11-voice-barge-in-interrupt-design.md) introduces a
+-- second writer for the same row: the interrupt endpoint reports what TTS
+-- actually played. The client aborts the SSE and then POSTs the interrupt, but
+-- the server may not have processed the FIN yet, so `run_voice_turn`'s
+-- generator can still be alive and later run its own insert. Without this index
+-- that produces two assistant rows for one user turn.
+--
+-- With it the outcome is order-independent: whichever writer arrives second
+-- takes the ON CONFLICT path, so `content` always ends up the interrupt's
+-- report and the audit columns always the generator's.
+--
+-- Partial, because only voice replies are one-per-turn — the text pipeline
+-- writes several assistant rows against a single user turn (multi-part replies
+-- via `continues_from_message_id`), and `user_message_id` is NULL on user rows,
+-- which a unique index ignores anyway.
+--
+-- Existing data should already satisfy this (voice writes exactly one reply per
+-- turn today). If a deployment has duplicates this migration fails loudly
+-- rather than silently dropping rows; find them with:
+--   SELECT user_message_id FROM engine.chat_messages
+--    WHERE role='assistant' AND channel='voice'
+--    GROUP BY 1 HAVING count(*) > 1;
+
+CREATE UNIQUE INDEX IF NOT EXISTS chat_messages_voice_assistant_reply_uidx
+    ON engine.chat_messages (user_message_id)
+    WHERE role = 'assistant' AND channel = 'voice';

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -3222,6 +3222,7 @@ mod tests {
     }
 
     #[sqlx::test(migrations = "./migrations")]
+    #[allow(clippy::type_complexity)] // sqlx tuple query — type alias would add noise
     async fn voice_assistant_insert_is_idempotent_on_user_message(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
         let (session_id, user_mid) = seed_voice_turn(&pool, "hello").await;
@@ -3258,8 +3259,14 @@ mod tests {
         .await
         .unwrap();
 
-        let rows: Vec<(String, Option<String>, Option<String>, bool)> = sqlx::query_as(
-            "SELECT content, model, generation_id, truncated FROM engine.chat_messages \
+        let rows: Vec<(
+            String,
+            Option<String>,
+            Option<String>,
+            bool,
+            Option<serde_json::Value>,
+        )> = sqlx::query_as(
+            "SELECT content, model, generation_id, truncated, usage FROM engine.chat_messages \
              WHERE user_message_id = $1 AND role = 'assistant' AND channel = 'voice'",
         )
         .bind(user_mid)
@@ -3282,6 +3289,11 @@ mod tests {
         assert!(
             rows[0].3,
             "truncated must not be downgraded by the audit refill"
+        );
+        assert_eq!(
+            rows[0].4,
+            Some(serde_json::json!({"total_tokens": 7})),
+            "usage must be refilled by the audit refill"
         );
     }
 

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -995,8 +995,21 @@ impl<'a> ChatRepo<'a> {
     /// Idempotent on `user_message_id` (migration 0041): a second writer for the
     /// same turn refills only `model`/`usage`/`generation_id` and never touches
     /// `content`, `truncated` or `metadata`. That is what lets the interrupt
-    /// endpoint and a still-live generator race safely in either order —
-    /// content belongs to the interrupt, billing audit to the generator.
+    /// endpoint and a still-live generator race safely when a reply already
+    /// exists — content belongs to the interrupt, billing audit to the
+    /// generator.
+    ///
+    /// The insert is additionally **skipped entirely** when the user row is
+    /// already marked `voice_interrupt` and no assistant reply exists yet —
+    /// that combination means the client reported nothing was heard, and the
+    /// "absent + empty" contract cell requires no assistant row at all. Without
+    /// this guard a still-live generator could win a race against an
+    /// empty-text interrupt and leave a full, untruncated reply with no
+    /// interrupt marker: indistinguishable from a normal completion. The first
+    /// statement below takes `FOR UPDATE` on the user row — the SAME row
+    /// `upsert_voice_interrupt` locks first — so the two writers cannot
+    /// interleave their check and their write; whichever commits first is the
+    /// one the other observes. This lock is load-bearing, not incidental.
     #[allow(clippy::too_many_arguments)]
     pub async fn insert_voice_assistant_message(
         &self,
@@ -1011,11 +1024,26 @@ impl<'a> ChatRepo<'a> {
         metadata: Option<&serde_json::Value>,
     ) -> Result<(), sqlx::Error> {
         let mut tx = self.pool.begin().await?;
+        // Same row `upsert_voice_interrupt` locks first (via its user-row
+        // UPDATE) — serializes the two writers so the marker check below can't
+        // race a concurrent empty-text interrupt.
+        sqlx::query("SELECT 1 FROM engine.chat_messages WHERE id = $1 FOR UPDATE")
+            .bind(user_message_id)
+            .execute(&mut *tx)
+            .await?;
         sqlx::query(
             "INSERT INTO engine.chat_messages AS m \
              (id, session_id, role, content, user_message_id, truncated, model, usage, \
               generation_id, assistant_action_type, channel, metadata) \
-             VALUES ($1, $2, 'assistant', $3, $4, $5, $6, $7, $8, 'reply', 'voice', $9) \
+             SELECT $1, $2, 'assistant', $3, $4, $5, $6, $7, $8, 'reply', 'voice', $9 \
+             WHERE NOT ( \
+                 COALESCE((SELECT u.metadata->>'voice_interrupt' \
+                             FROM engine.chat_messages u WHERE u.id = $4), 'false')::bool \
+                 AND NOT EXISTS ( \
+                     SELECT 1 FROM engine.chat_messages a \
+                      WHERE a.user_message_id = $4 AND a.role = 'assistant' AND a.channel = 'voice' \
+                 ) \
+             ) \
              ON CONFLICT (user_message_id) WHERE role = 'assistant' AND channel = 'voice' \
              DO UPDATE SET model = EXCLUDED.model, \
                            usage = EXCLUDED.usage, \
@@ -1219,10 +1247,22 @@ impl<'a> ChatRepo<'a> {
     /// interrupt. That keeps the "never persist empty assistant content"
     /// invariant `run_voice_turn` holds.
     ///
-    /// The insert carries its own `ON CONFLICT` (rather than branching on a
-    /// prior SELECT) so a generator that is still alive cannot slip between the
-    /// check and the write. Combined with `insert_voice_assistant_message`'s
-    /// audit-only conflict path, the pair is order-independent.
+    /// Two different mechanisms protect the two branches against a still-live
+    /// generator, because a plain "check then write" is unsafe in general:
+    /// - **non-empty `spoken_text`**: the insert carries its own `ON CONFLICT`
+    ///   (rather than branching on a prior `SELECT`), so a concurrent
+    ///   `insert_voice_assistant_message` cannot slip between the check and
+    ///   the write — whichever arrives second just refills its own half
+    ///   (content here, audit columns there).
+    /// - **empty `spoken_text`**: there is no row to `ON CONFLICT` against
+    ///   when none exists yet, so the race is closed differently — this
+    ///   function's first statement (the marker `UPDATE ... WHERE id =
+    ///   user_message_id`) takes a row lock on the user row, and
+    ///   `insert_voice_assistant_message` takes the SAME lock as ITS first
+    ///   statement before checking the marker. The two transactions therefore
+    ///   serialize on that lock: whichever commits first is what the other
+    ///   observes, so the generator's marker check can never read a stale
+    ///   "not yet interrupted" state.
     pub async fn upsert_voice_interrupt(
         &self,
         session_id: Uuid,
@@ -1233,6 +1273,12 @@ impl<'a> ChatRepo<'a> {
         const MARKER: &str = r#"{"voice_interrupt": true}"#;
         let mut tx = self.pool.begin().await?;
 
+        // This UPDATE is also the lock acquisition: it takes a row lock on
+        // the user row that `insert_voice_assistant_message` takes too
+        // (there, via an explicit `FOR UPDATE`) before consulting this same
+        // marker. That serializes the two writers on the empty-text branch,
+        // where there is no row to `ON CONFLICT` against yet. Load-bearing,
+        // not incidental — do not reorder this below the branch that follows.
         sqlx::query(
             "UPDATE engine.chat_messages \
                 SET metadata = COALESCE(metadata, '{}'::jsonb) || $2::jsonb \
@@ -4048,6 +4094,52 @@ mod tests {
         .await
         .unwrap();
         assert!(marked, "still distinguishable from a disconnect");
+    }
+
+    /// The race the empty-text branch cannot close with `ON CONFLICT` alone:
+    /// the client hears nothing and interrupts BEFORE the generator commits.
+    /// `insert_voice_assistant_message` must see the marker (via the shared
+    /// user-row lock) and decline to insert — the "absent + empty" contract
+    /// cell requires no assistant row at all, not a full untruncated reply
+    /// masquerading as a normal completion.
+    #[sqlx::test(migrations = "./migrations")]
+    async fn empty_interrupt_then_generator_leaves_no_assistant_row(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let (session_id, user_mid) = seed_voice_turn(&pool, "hello").await;
+
+        let out = repo
+            .upsert_voice_interrupt(session_id, user_mid, Uuid::new_v4(), "")
+            .await
+            .unwrap();
+        assert!(out.is_none());
+
+        // The generator was still alive and only now reaches its own insert.
+        repo.insert_voice_assistant_message(
+            session_id,
+            user_mid,
+            Uuid::new_v4(),
+            "generated much more",
+            Some("m/1"),
+            None,
+            Some("gen-late"),
+            false,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let n: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM engine.chat_messages \
+              WHERE user_message_id = $1 AND role = 'assistant'",
+        )
+        .bind(user_mid)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            n, 0,
+            "the generator must decline to insert once the turn is marked interrupted with nothing played"
+        );
     }
 
     #[sqlx::test(migrations = "./migrations")]

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -1130,6 +1130,88 @@ impl<'a> ChatRepo<'a> {
     }
 }
 
+/// What the repair gate needs to know about one voice turn, in a single query.
+#[derive(Debug, Clone)]
+pub struct VoiceTurnRepair {
+    /// An assistant reply already exists — retrying would double-bill.
+    pub has_reply: bool,
+    /// The turn was deliberately interrupted — there is nothing to repair.
+    pub interrupted: bool,
+    /// The PERSISTED utterance. The repair path regenerates from this, never
+    /// from the retry body, so the turn's vector recall cannot drift between
+    /// attempts.
+    pub content: String,
+}
+
+/// Outcome of resolving a `client_msg_id` for the interrupt endpoint.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LatestTurnLookup {
+    /// No user row with this `client_msg_id` in this session.
+    NotFound,
+    /// Found, but a newer user turn exists — you can only barge in on what is
+    /// currently being spoken.
+    Stale,
+    Latest(Uuid),
+}
+
+impl<'a> ChatRepo<'a> {
+    /// Read the two facts the `turn/stream` duplicate gate needs, plus the
+    /// persisted utterance, in one round trip.
+    pub async fn voice_turn_repair_state(
+        &self,
+        user_message_id: Uuid,
+    ) -> Result<VoiceTurnRepair, sqlx::Error> {
+        let (content, interrupted, has_reply): (String, bool, bool) = sqlx::query_as(
+            "SELECT u.content, \
+                    COALESCE(u.metadata->>'voice_interrupt', 'false')::bool, \
+                    EXISTS ( \
+                        SELECT 1 FROM engine.chat_messages a \
+                         WHERE a.user_message_id = u.id \
+                           AND a.role = 'assistant' AND a.channel = 'voice' \
+                    ) \
+               FROM engine.chat_messages u \
+              WHERE u.id = $1",
+        )
+        .bind(user_message_id)
+        .fetch_one(self.pool)
+        .await?;
+        Ok(VoiceTurnRepair {
+            has_reply,
+            interrupted,
+            content,
+        })
+    }
+
+    /// Resolve a `client_msg_id` to its user row and report whether it is the
+    /// session's most recent user turn. Separating `NotFound` from `Stale` lets
+    /// the route return 404 vs. 409 without a second round trip.
+    pub async fn resolve_latest_voice_user_turn(
+        &self,
+        session_id: Uuid,
+        client_msg_id: &str,
+    ) -> Result<LatestTurnLookup, sqlx::Error> {
+        let row: Option<(Uuid, bool)> = sqlx::query_as(
+            "SELECT m.id, \
+                    m.id = ( \
+                        SELECT l.id FROM engine.chat_messages l \
+                         WHERE l.session_id = $1 AND l.role = 'user' \
+                         ORDER BY l.sent_at DESC, l.id DESC LIMIT 1 \
+                    ) \
+               FROM engine.chat_messages m \
+              WHERE m.session_id = $1 AND m.client_msg_id = $2 AND m.role = 'user'",
+        )
+        .bind(session_id)
+        .bind(client_msg_id)
+        .fetch_optional(self.pool)
+        .await?;
+        Ok(match row {
+            None => LatestTurnLookup::NotFound,
+            Some((_, false)) => LatestTurnLookup::Stale,
+            Some((id, true)) => LatestTurnLookup::Latest(id),
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3294,6 +3376,114 @@ mod tests {
             rows[0].4,
             Some(serde_json::json!({"total_tokens": 7})),
             "usage must be refilled by the audit refill"
+        );
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn repair_state_reports_reply_marker_and_content(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let (session_id, user_mid) = seed_voice_turn(&pool, "hello there").await;
+
+        // Fresh turn: nothing yet.
+        let st = repo.voice_turn_repair_state(user_mid).await.unwrap();
+        assert!(!st.has_reply);
+        assert!(!st.interrupted);
+        assert_eq!(
+            st.content, "hello there",
+            "the persisted utterance comes back"
+        );
+
+        // A reply flips has_reply.
+        repo.insert_voice_assistant_message(
+            session_id,
+            user_mid,
+            Uuid::new_v4(),
+            "hi",
+            None,
+            None,
+            None,
+            false,
+            None,
+        )
+        .await
+        .unwrap();
+        let st = repo.voice_turn_repair_state(user_mid).await.unwrap();
+        assert!(st.has_reply);
+        assert!(!st.interrupted);
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn repair_state_reports_interrupt_marker(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let (_session_id, user_mid) = seed_voice_turn(&pool, "hello").await;
+        sqlx::query(
+            "UPDATE engine.chat_messages \
+             SET metadata = COALESCE(metadata,'{}'::jsonb) || '{\"voice_interrupt\": true}'::jsonb \
+             WHERE id = $1",
+        )
+        .bind(user_mid)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let st = repo.voice_turn_repair_state(user_mid).await.unwrap();
+        assert!(
+            st.interrupted,
+            "the marker must be visible to the repair gate"
+        );
+        assert!(!st.has_reply);
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn latest_turn_lookup_classifies_missing_stale_and_latest(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let (session_id, _first) = seed_voice_turn(&pool, "one").await;
+
+        // Give the first turn a client_msg_id, then add a newer one.
+        sqlx::query(
+            "UPDATE engine.chat_messages SET client_msg_id = 'CID-ONE' WHERE session_id = $1",
+        )
+        .bind(session_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        assert!(matches!(
+            repo.resolve_latest_voice_user_turn(session_id, "NOPE")
+                .await
+                .unwrap(),
+            LatestTurnLookup::NotFound
+        ));
+        assert!(matches!(
+            repo.resolve_latest_voice_user_turn(session_id, "CID-ONE")
+                .await
+                .unwrap(),
+            LatestTurnLookup::Latest(_)
+        ));
+
+        let second: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_messages (session_id, role, content, channel, client_msg_id) \
+             VALUES ($1,'user','two','voice','CID-TWO') RETURNING id",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert!(
+            matches!(
+                repo.resolve_latest_voice_user_turn(session_id, "CID-ONE")
+                    .await
+                    .unwrap(),
+                LatestTurnLookup::Stale
+            ),
+            "an older turn must not be interruptible"
+        );
+        assert_eq!(
+            repo.resolve_latest_voice_user_turn(session_id, "CID-TWO")
+                .await
+                .unwrap(),
+            LatestTurnLookup::Latest(second)
         );
     }
 

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -991,6 +991,12 @@ impl<'a> ChatRepo<'a> {
     /// `assistant_action_type='reply'`, `channel='voice'`. No filter audit, no
     /// continues_from — voice replies are single, whole messages. Bumps
     /// `last_active_at` in the same transaction as the insert.
+    ///
+    /// Idempotent on `user_message_id` (migration 0041): a second writer for the
+    /// same turn refills only `model`/`usage`/`generation_id` and never touches
+    /// `content`, `truncated` or `metadata`. That is what lets the interrupt
+    /// endpoint and a still-live generator race safely in either order —
+    /// content belongs to the interrupt, billing audit to the generator.
     #[allow(clippy::too_many_arguments)]
     pub async fn insert_voice_assistant_message(
         &self,
@@ -1006,10 +1012,14 @@ impl<'a> ChatRepo<'a> {
     ) -> Result<(), sqlx::Error> {
         let mut tx = self.pool.begin().await?;
         sqlx::query(
-            "INSERT INTO engine.chat_messages \
+            "INSERT INTO engine.chat_messages AS m \
              (id, session_id, role, content, user_message_id, truncated, model, usage, \
               generation_id, assistant_action_type, channel, metadata) \
-             VALUES ($1, $2, 'assistant', $3, $4, $5, $6, $7, $8, 'reply', 'voice', $9)",
+             VALUES ($1, $2, 'assistant', $3, $4, $5, $6, $7, $8, 'reply', 'voice', $9) \
+             ON CONFLICT (user_message_id) WHERE role = 'assistant' AND channel = 'voice' \
+             DO UPDATE SET model = EXCLUDED.model, \
+                           usage = EXCLUDED.usage, \
+                           generation_id = EXCLUDED.generation_id",
         )
         .bind(id)
         .bind(session_id)
@@ -3191,6 +3201,87 @@ mod tests {
         assert!(
             after > before,
             "a voice assistant insert must bump last_active_at"
+        );
+    }
+
+    /// Seeds a fresh voice session plus its one user turn via the real store
+    /// methods (`throwaway_session` + `insert_voice_user_message`) rather than
+    /// duplicating their genome/instance/session SQL inline.
+    async fn seed_voice_turn(pool: &PgPool, content: &str) -> (Uuid, Uuid) {
+        let session_id = throwaway_session(pool).await.id;
+        let repo = ChatRepo { pool };
+        let user_mid = match repo
+            .insert_voice_user_message(session_id, content, &format!("cmid-{}", Uuid::new_v4()))
+            .await
+            .unwrap()
+        {
+            VoiceUserInsert::Inserted(id) => id,
+            other => panic!("expected Inserted, got {other:?}"),
+        };
+        (session_id, user_mid)
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn voice_assistant_insert_is_idempotent_on_user_message(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let (session_id, user_mid) = seed_voice_turn(&pool, "hello").await;
+
+        // First writer wins the content.
+        repo.insert_voice_assistant_message(
+            session_id,
+            user_mid,
+            Uuid::new_v4(),
+            "first",
+            None,
+            None,
+            None,
+            true,
+            None,
+        )
+        .await
+        .unwrap();
+
+        // Second writer must NOT create a second row, must NOT touch content,
+        // and must refill the audit columns it carries.
+        let usage = serde_json::json!({"total_tokens": 7});
+        repo.insert_voice_assistant_message(
+            session_id,
+            user_mid,
+            Uuid::new_v4(),
+            "second",
+            Some("m/1"),
+            Some(&usage),
+            Some("gen-1"),
+            false,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let rows: Vec<(String, Option<String>, Option<String>, bool)> = sqlx::query_as(
+            "SELECT content, model, generation_id, truncated FROM engine.chat_messages \
+             WHERE user_message_id = $1 AND role = 'assistant' AND channel = 'voice'",
+        )
+        .bind(user_mid)
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            rows.len(),
+            1,
+            "exactly one assistant reply per voice user turn"
+        );
+        assert_eq!(rows[0].0, "first", "content belongs to the first writer");
+        assert_eq!(
+            rows[0].1.as_deref(),
+            Some("m/1"),
+            "audit columns get refilled"
+        );
+        assert_eq!(rows[0].2.as_deref(), Some("gen-1"));
+        assert!(
+            rows[0].3,
+            "truncated must not be downgraded by the audit refill"
         );
     }
 

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -993,11 +993,28 @@ impl<'a> ChatRepo<'a> {
     /// `last_active_at` in the same transaction as the insert.
     ///
     /// Idempotent on `user_message_id` (migration 0041): a second writer for the
-    /// same turn refills only `model`/`usage`/`generation_id` and never touches
-    /// `content`, `truncated` or `metadata`. That is what lets the interrupt
-    /// endpoint and a still-live generator race safely when a reply already
-    /// exists — content belongs to the interrupt, billing audit to the
-    /// generator.
+    /// same turn hits `ON CONFLICT`, whose behaviour depends on whether the
+    /// EXISTING row already carries the interrupt marker
+    /// (`metadata ? 'voice_interrupt'`):
+    /// - **marked** (an interrupt inserted or touched this row first): `content`
+    ///   and `truncated` are left as they are — the interrupt's report is
+    ///   authoritative — while `model`/`usage`/`generation_id` still refill from
+    ///   the conflicting write, so a still-live generator's billing audit is
+    ///   not lost. This is what lets the interrupt endpoint and a still-live
+    ///   generator race safely — content belongs to the interrupt, billing
+    ///   audit to the generator.
+    /// - **unmarked** (both writers are ordinary generators — e.g. an orphaned
+    ///   generator from a dead connection racing a client's retry of the same
+    ///   turn): last-writer-wins on EVERY column, `content` and `truncated`
+    ///   included. This keeps `content` and `generation_id` consistent with
+    ///   each other — the previous unconditional "refill audit columns only"
+    ///   rule could leave one generation's `content` paired with a DIFFERENT
+    ///   generation's `generation_id`, which OpenRouter reconciliation would
+    ///   silently mis-attribute.
+    ///
+    /// `usage` additionally falls back to the existing row's value when the
+    /// conflicting write's own `usage` is NULL (e.g. upstream never sent a
+    /// usage payload), so a race never downgrades known usage to unknown.
     ///
     /// The insert is additionally **skipped entirely** when the user row is
     /// already marked `voice_interrupt` and no assistant reply exists yet —
@@ -1045,8 +1062,12 @@ impl<'a> ChatRepo<'a> {
                  ) \
              ) \
              ON CONFLICT (user_message_id) WHERE role = 'assistant' AND channel = 'voice' \
-             DO UPDATE SET model = EXCLUDED.model, \
-                           usage = EXCLUDED.usage, \
+             DO UPDATE SET content   = CASE WHEN m.metadata ? 'voice_interrupt' \
+                                             THEN m.content ELSE EXCLUDED.content END, \
+                           truncated = CASE WHEN m.metadata ? 'voice_interrupt' \
+                                             THEN m.truncated ELSE EXCLUDED.truncated END, \
+                           model = EXCLUDED.model, \
+                           usage = COALESCE(EXCLUDED.usage, m.usage), \
                            generation_id = EXCLUDED.generation_id",
         )
         .bind(id)
@@ -1184,12 +1205,22 @@ pub enum LatestTurnLookup {
 
 impl<'a> ChatRepo<'a> {
     /// Read the two facts the `turn/stream` duplicate gate needs, plus the
-    /// persisted utterance, in one round trip.
+    /// persisted utterance, in one round trip. Scoped to `role = 'user' AND
+    /// channel = 'voice'` — `insert_voice_user_message`'s conflict lookup
+    /// that supplies `user_message_id` is deliberately role-agnostic (the
+    /// colliding row can be a `gift_user` tip row, or even a text-channel
+    /// `user` row reached via `message/stream` against the same session id,
+    /// since that route has no channel guard). Returns `None` when the row
+    /// is not an actual voice user turn, so the caller can fall back to the
+    /// ordinary unconditional 409 instead of treating a tip or text row as a
+    /// repairable voice turn — regenerating against it would embed the
+    /// wrong text as the recall query and write a `channel='voice'`
+    /// assistant row pointing at a non-voice user row.
     pub async fn voice_turn_repair_state(
         &self,
         user_message_id: Uuid,
-    ) -> Result<VoiceTurnRepair, sqlx::Error> {
-        let (content, interrupted, has_reply): (String, bool, bool) = sqlx::query_as(
+    ) -> Result<Option<VoiceTurnRepair>, sqlx::Error> {
+        let row: Option<(String, bool, bool)> = sqlx::query_as(
             "SELECT u.content, \
                     COALESCE(u.metadata->>'voice_interrupt', 'false')::bool, \
                     EXISTS ( \
@@ -1198,16 +1229,18 @@ impl<'a> ChatRepo<'a> {
                            AND a.role = 'assistant' AND a.channel = 'voice' \
                     ) \
                FROM engine.chat_messages u \
-              WHERE u.id = $1",
+              WHERE u.id = $1 AND u.role = 'user' AND u.channel = 'voice'",
         )
         .bind(user_message_id)
-        .fetch_one(self.pool)
+        .fetch_optional(self.pool)
         .await?;
-        Ok(VoiceTurnRepair {
-            has_reply,
-            interrupted,
-            content,
-        })
+        Ok(
+            row.map(|(content, interrupted, has_reply)| VoiceTurnRepair {
+                has_reply,
+                interrupted,
+                content,
+            }),
+        )
     }
 
     /// Resolve a `client_msg_id` to its user row and report whether it is the
@@ -3423,29 +3456,39 @@ mod tests {
         (session_id, user_mid)
     }
 
+    /// Generator-vs-generator race, no interrupt marker involved: e.g. an
+    /// orphaned generator from a dead connection is still alive (TCP
+    /// retransmission keeps it going for tens of seconds) when the client's
+    /// retry lands its OWN generator for the same turn. Migration 0041 keeps
+    /// this to one row, but the surviving row must be entirely the SAME
+    /// call's data — `content`, `truncated`, AND the audit columns —  never a
+    /// mix of one generation's `content` with a DIFFERENT generation's
+    /// `generation_id` (which would corrupt OpenRouter reconciliation).
     #[sqlx::test(migrations = "./migrations")]
     #[allow(clippy::type_complexity)] // sqlx tuple query — type alias would add noise
     async fn voice_assistant_insert_is_idempotent_on_user_message(pool: PgPool) {
         let repo = ChatRepo { pool: &pool };
         let (session_id, user_mid) = seed_voice_turn(&pool, "hello").await;
 
-        // First writer wins the content.
+        // Generator A writes first — no interrupt marker on the user row.
         repo.insert_voice_assistant_message(
             session_id,
             user_mid,
             Uuid::new_v4(),
             "first",
+            Some("m/0"),
             None,
-            None,
-            None,
+            Some("gen-0"),
             true,
             None,
         )
         .await
         .unwrap();
 
-        // Second writer must NOT create a second row, must NOT touch content,
-        // and must refill the audit columns it carries.
+        // Generator B conflicts on the same row with DIFFERENT content AND a
+        // DIFFERENT generation_id. Must NOT create a second row; must be
+        // last-writer-wins on every column (content included), so the
+        // surviving row never pairs A's content with B's generation_id.
         let usage = serde_json::json!({"total_tokens": 7});
         repo.insert_voice_assistant_message(
             session_id,
@@ -3481,21 +3524,28 @@ mod tests {
             1,
             "exactly one assistant reply per voice user turn"
         );
-        assert_eq!(rows[0].0, "first", "content belongs to the first writer");
+        assert_eq!(
+            rows[0].0, "second",
+            "no interrupt marker ⇒ last-writer-wins on content, not first-writer-wins"
+        );
         assert_eq!(
             rows[0].1.as_deref(),
             Some("m/1"),
-            "audit columns get refilled"
+            "audit columns come from the SAME (surviving) writer as content"
         );
-        assert_eq!(rows[0].2.as_deref(), Some("gen-1"));
+        assert_eq!(
+            rows[0].2.as_deref(),
+            Some("gen-1"),
+            "generation_id must match the surviving content's call, never a stale earlier generation"
+        );
         assert!(
-            rows[0].3,
-            "truncated must not be downgraded by the audit refill"
+            !rows[0].3,
+            "truncated must come from the same writer as content"
         );
         assert_eq!(
             rows[0].4,
             Some(serde_json::json!({"total_tokens": 7})),
-            "usage must be refilled by the audit refill"
+            "usage must come from the same writer as content"
         );
     }
 
@@ -3505,7 +3555,11 @@ mod tests {
         let (session_id, user_mid) = seed_voice_turn(&pool, "hello there").await;
 
         // Fresh turn: nothing yet.
-        let st = repo.voice_turn_repair_state(user_mid).await.unwrap();
+        let st = repo
+            .voice_turn_repair_state(user_mid)
+            .await
+            .unwrap()
+            .expect("seed_voice_turn produces an actual voice user turn");
         assert!(!st.has_reply);
         assert!(!st.interrupted);
         assert_eq!(
@@ -3527,7 +3581,11 @@ mod tests {
         )
         .await
         .unwrap();
-        let st = repo.voice_turn_repair_state(user_mid).await.unwrap();
+        let st = repo
+            .voice_turn_repair_state(user_mid)
+            .await
+            .unwrap()
+            .expect("still an actual voice user turn");
         assert!(st.has_reply);
         assert!(!st.interrupted);
     }
@@ -3546,12 +3604,61 @@ mod tests {
         .await
         .unwrap();
 
-        let st = repo.voice_turn_repair_state(user_mid).await.unwrap();
+        let st = repo
+            .voice_turn_repair_state(user_mid)
+            .await
+            .unwrap()
+            .expect("still an actual voice user turn");
         assert!(
             st.interrupted,
             "the marker must be visible to the repair gate"
         );
         assert!(!st.has_reply);
+    }
+
+    /// `insert_voice_user_message`'s conflict lookup that supplies
+    /// `user_message_id` is deliberately role-agnostic (the colliding row can
+    /// be a `gift_user` tip row, or a text-channel `user` row reached via
+    /// `message/stream` against the same session id, since that route has no
+    /// channel guard). The repair gate must independently refuse to treat
+    /// either as a repairable voice turn.
+    #[sqlx::test(migrations = "./migrations")]
+    async fn repair_state_is_none_for_non_voice_user_rows(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let session_id = throwaway_session(&pool).await.id;
+
+        let gift_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_messages (session_id, role, content, client_msg_id, metadata) \
+             VALUES ($1, 'gift_user', '(打赏 $20)', 'cid-gift', '{\"tips_amount_usd\": 20.0}'::jsonb) \
+             RETURNING id",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert!(
+            repo.voice_turn_repair_state(gift_id)
+                .await
+                .unwrap()
+                .is_none(),
+            "a gift_user row must never be reported as a repairable voice turn"
+        );
+
+        let text_user_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_messages (session_id, role, content, client_msg_id) \
+             VALUES ($1, 'user', 'hi', 'cid-text') RETURNING id",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert!(
+            repo.voice_turn_repair_state(text_user_id)
+                .await
+                .unwrap()
+                .is_none(),
+            "a channel-less (text) user row must never be reported as a repairable voice turn"
+        );
     }
 
     #[sqlx::test(migrations = "./migrations")]

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -1243,9 +1243,19 @@ impl<'a> ChatRepo<'a> {
         )
     }
 
-    /// Resolve a `client_msg_id` to its user row and report whether it is the
-    /// session's most recent user turn. Separating `NotFound` from `Stale` lets
-    /// the route return 404 vs. 409 without a second round trip.
+    /// Resolve a `client_msg_id` to its **voice** user row and report whether it
+    /// is the session's most recent voice user turn. Separating `NotFound` from
+    /// `Stale` lets the route return 404 vs. 409 without a second round trip.
+    ///
+    /// Both the target row and the "latest" subquery filter `channel = 'voice'`,
+    /// and that is load-bearing on both sides. A voice session can contain
+    /// non-voice user rows — `routes/companion_stream.rs` has no session-channel
+    /// gate, so a text turn can land in one — and without the filter on `m` such
+    /// a row is interruptible, letting a caller mark it and hang a
+    /// `channel='voice'` assistant reply off a text turn. Without the filter on
+    /// `l`, a newer text row would make a genuine voice turn look `Stale` and
+    /// block a legitimate barge-in. The comparison belongs entirely within the
+    /// voice channel.
     pub async fn resolve_latest_voice_user_turn(
         &self,
         session_id: Uuid,
@@ -1256,10 +1266,12 @@ impl<'a> ChatRepo<'a> {
                     m.id = ( \
                         SELECT l.id FROM engine.chat_messages l \
                          WHERE l.session_id = $1 AND l.role = 'user' \
+                           AND l.channel = 'voice' \
                          ORDER BY l.sent_at DESC, l.id DESC LIMIT 1 \
                     ) \
                FROM engine.chat_messages m \
-              WHERE m.session_id = $1 AND m.client_msg_id = $2 AND m.role = 'user'",
+              WHERE m.session_id = $1 AND m.client_msg_id = $2 AND m.role = 'user' \
+                AND m.channel = 'voice'",
         )
         .bind(session_id)
         .bind(client_msg_id)
@@ -3711,6 +3723,54 @@ mod tests {
                 .await
                 .unwrap(),
             LatestTurnLookup::Latest(second)
+        );
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn latest_turn_lookup_ignores_non_voice_rows_on_both_sides(pool: PgPool) {
+        // A voice session can hold non-voice user rows: `routes/companion_stream.rs`
+        // has no session-channel gate, so a text turn can land in one. Both sides
+        // of the lookup must stay inside the voice channel.
+        let repo = ChatRepo { pool: &pool };
+        let (session_id, _voice) = seed_voice_turn(&pool, "spoken").await;
+        sqlx::query(
+            "UPDATE engine.chat_messages SET client_msg_id = 'CID-VOICE' WHERE session_id = $1",
+        )
+        .bind(session_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // A NEWER text-channel user row lands in the same session.
+        sqlx::query(
+            "INSERT INTO engine.chat_messages (session_id, role, content, client_msg_id) \
+             VALUES ($1,'user','typed','CID-TEXT')",
+        )
+        .bind(session_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // The text row must not be interruptible — otherwise a caller could mark
+        // it and hang a channel='voice' assistant reply off a text turn.
+        assert_eq!(
+            repo.resolve_latest_voice_user_turn(session_id, "CID-TEXT")
+                .await
+                .unwrap(),
+            LatestTurnLookup::NotFound,
+            "a text-channel row must never resolve as an interruptible voice turn"
+        );
+
+        // And it must not shadow the genuine voice turn into Stale, which would
+        // block a legitimate barge-in.
+        assert!(
+            matches!(
+                repo.resolve_latest_voice_user_turn(session_id, "CID-VOICE")
+                    .await
+                    .unwrap(),
+                LatestTurnLookup::Latest(_)
+            ),
+            "a newer text row must not make the latest voice turn look stale"
         );
     }
 

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -1210,6 +1210,80 @@ impl<'a> ChatRepo<'a> {
             Some((id, true)) => LatestTurnLookup::Latest(id),
         })
     }
+
+    /// Record a deliberate barge-in: mark the user row, and make the assistant
+    /// reply say what TTS actually played.
+    ///
+    /// `spoken_text` empty ⇒ NO assistant content is ever written (neither
+    /// inserted nor overwritten); the user-row marker alone records the
+    /// interrupt. That keeps the "never persist empty assistant content"
+    /// invariant `run_voice_turn` holds.
+    ///
+    /// The insert carries its own `ON CONFLICT` (rather than branching on a
+    /// prior SELECT) so a generator that is still alive cannot slip between the
+    /// check and the write. Combined with `insert_voice_assistant_message`'s
+    /// audit-only conflict path, the pair is order-independent.
+    pub async fn upsert_voice_interrupt(
+        &self,
+        session_id: Uuid,
+        user_message_id: Uuid,
+        candidate_assistant_id: Uuid,
+        spoken_text: &str,
+    ) -> Result<Option<Uuid>, sqlx::Error> {
+        const MARKER: &str = r#"{"voice_interrupt": true}"#;
+        let mut tx = self.pool.begin().await?;
+
+        sqlx::query(
+            "UPDATE engine.chat_messages \
+                SET metadata = COALESCE(metadata, '{}'::jsonb) || $2::jsonb \
+              WHERE id = $1",
+        )
+        .bind(user_message_id)
+        .bind(MARKER)
+        .execute(&mut *tx)
+        .await?;
+
+        let assistant_id: Option<Uuid> = if spoken_text.is_empty() {
+            sqlx::query_scalar(
+                "UPDATE engine.chat_messages \
+                    SET metadata = COALESCE(metadata, '{}'::jsonb) || $2::jsonb \
+                  WHERE user_message_id = $1 AND role = 'assistant' AND channel = 'voice' \
+                  RETURNING id",
+            )
+            .bind(user_message_id)
+            .bind(MARKER)
+            .fetch_optional(&mut *tx)
+            .await?
+        } else {
+            Some(
+                sqlx::query_scalar(
+                    "INSERT INTO engine.chat_messages AS m \
+                     (id, session_id, role, content, user_message_id, truncated, \
+                      assistant_action_type, channel, metadata) \
+                     VALUES ($1, $2, 'assistant', $3, $4, true, 'reply', 'voice', $5::jsonb) \
+                     ON CONFLICT (user_message_id) WHERE role = 'assistant' AND channel = 'voice' \
+                     DO UPDATE SET content = EXCLUDED.content, \
+                                   truncated = true, \
+                                   metadata = COALESCE(m.metadata, '{}'::jsonb) || EXCLUDED.metadata \
+                     RETURNING m.id",
+                )
+                .bind(candidate_assistant_id)
+                .bind(session_id)
+                .bind(spoken_text)
+                .bind(user_message_id)
+                .bind(MARKER)
+                .fetch_one(&mut *tx)
+                .await?,
+            )
+        };
+
+        sqlx::query("UPDATE engine.chat_sessions SET last_active_at = now() WHERE id = $1")
+            .bind(session_id)
+            .execute(&mut *tx)
+            .await?;
+        tx.commit().await?;
+        Ok(assistant_id)
+    }
 }
 
 #[cfg(test)]
@@ -3908,5 +3982,226 @@ mod tests {
             "pre-existing metadata keys must survive the merge"
         );
         assert_eq!(loaded.metadata["voice_bootstrap"], snapshot);
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn interrupt_inserts_spoken_text_and_marks_user_row(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let (session_id, user_mid) = seed_voice_turn(&pool, "hello").await;
+
+        let aid = repo
+            .upsert_voice_interrupt(session_id, user_mid, Uuid::new_v4(), "你今天过得")
+            .await
+            .unwrap()
+            .expect("a row is written when text was played");
+
+        let (content, truncated): (String, bool) =
+            sqlx::query_as("SELECT content, truncated FROM engine.chat_messages WHERE id = $1")
+                .bind(aid)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(content, "你今天过得");
+        assert!(truncated);
+
+        let marked: bool = sqlx::query_scalar(
+            "SELECT COALESCE(metadata->>'voice_interrupt','false')::bool \
+               FROM engine.chat_messages WHERE id = $1",
+        )
+        .bind(user_mid)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert!(marked, "the user row carries the marker");
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn interrupt_with_empty_text_marks_but_writes_no_row(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let (session_id, user_mid) = seed_voice_turn(&pool, "hello").await;
+
+        let out = repo
+            .upsert_voice_interrupt(session_id, user_mid, Uuid::new_v4(), "")
+            .await
+            .unwrap();
+        assert!(
+            out.is_none(),
+            "empty spoken_text must never write assistant content"
+        );
+
+        let n: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM engine.chat_messages \
+              WHERE user_message_id = $1 AND role = 'assistant'",
+        )
+        .bind(user_mid)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(n, 0);
+
+        let marked: bool = sqlx::query_scalar(
+            "SELECT COALESCE(metadata->>'voice_interrupt','false')::bool \
+               FROM engine.chat_messages WHERE id = $1",
+        )
+        .bind(user_mid)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert!(marked, "still distinguishable from a disconnect");
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn interrupt_after_completion_overwrites_content_keeps_audit(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let (session_id, user_mid) = seed_voice_turn(&pool, "hello").await;
+        let usage = serde_json::json!({"total_tokens": 42});
+        let scope = serde_json::json!({"relationship_scope": "both"});
+        repo.insert_voice_assistant_message(
+            session_id,
+            user_mid,
+            Uuid::new_v4(),
+            "the whole sentence",
+            Some("m/1"),
+            Some(&usage),
+            Some("gen-9"),
+            false,
+            Some(&scope),
+        )
+        .await
+        .unwrap();
+
+        repo.upsert_voice_interrupt(session_id, user_mid, Uuid::new_v4(), "the whole")
+            .await
+            .unwrap()
+            .expect("returns the existing row's id");
+
+        let (content, model, gen, truncated, meta): (
+            String,
+            Option<String>,
+            Option<String>,
+            bool,
+            serde_json::Value,
+        ) = sqlx::query_as(
+            "SELECT content, model, generation_id, truncated, metadata \
+               FROM engine.chat_messages \
+              WHERE user_message_id = $1 AND role = 'assistant'",
+        )
+        .bind(user_mid)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(content, "the whole", "content is what was actually heard");
+        assert_eq!(model.as_deref(), Some("m/1"), "billing audit survives");
+        assert_eq!(gen.as_deref(), Some("gen-9"));
+        assert!(truncated);
+        assert_eq!(
+            meta["relationship_scope"], "both",
+            "generator metadata preserved"
+        );
+        assert_eq!(
+            meta["voice_interrupt"], true,
+            "marker merged in, not replacing"
+        );
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn interrupt_with_empty_text_leaves_completed_reply_alone(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+        let (session_id, user_mid) = seed_voice_turn(&pool, "hello").await;
+        repo.insert_voice_assistant_message(
+            session_id,
+            user_mid,
+            Uuid::new_v4(),
+            "already said this",
+            None,
+            None,
+            None,
+            false,
+            None,
+        )
+        .await
+        .unwrap();
+
+        repo.upsert_voice_interrupt(session_id, user_mid, Uuid::new_v4(), "")
+            .await
+            .unwrap();
+
+        let content: String = sqlx::query_scalar(
+            "SELECT content FROM engine.chat_messages \
+              WHERE user_message_id = $1 AND role = 'assistant'",
+        )
+        .bind(user_mid)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            content, "already said this",
+            "degenerate case is non-destructive"
+        );
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn double_write_race_is_order_independent(pool: PgPool) {
+        let repo = ChatRepo { pool: &pool };
+
+        // Order A: interrupt first, generator second.
+        let (s1, u1) = seed_voice_turn(&pool, "hello").await;
+        repo.upsert_voice_interrupt(s1, u1, Uuid::new_v4(), "heard this much")
+            .await
+            .unwrap();
+        repo.insert_voice_assistant_message(
+            s1,
+            u1,
+            Uuid::new_v4(),
+            "generated much more",
+            Some("m/1"),
+            None,
+            Some("gen-a"),
+            false,
+            None,
+        )
+        .await
+        .unwrap();
+
+        // Order B: generator first, interrupt second.
+        let (s2, u2) = seed_voice_turn(&pool, "hello").await;
+        repo.insert_voice_assistant_message(
+            s2,
+            u2,
+            Uuid::new_v4(),
+            "generated much more",
+            Some("m/1"),
+            None,
+            Some("gen-b"),
+            false,
+            None,
+        )
+        .await
+        .unwrap();
+        repo.upsert_voice_interrupt(s2, u2, Uuid::new_v4(), "heard this much")
+            .await
+            .unwrap();
+
+        for (uid, gen) in [(u1, "gen-a"), (u2, "gen-b")] {
+            let rows: Vec<(String, Option<String>)> = sqlx::query_as(
+                "SELECT content, generation_id FROM engine.chat_messages \
+                  WHERE user_message_id = $1 AND role = 'assistant'",
+            )
+            .bind(uid)
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+            assert_eq!(rows.len(), 1, "one row regardless of arrival order");
+            assert_eq!(
+                rows[0].0, "heard this much",
+                "content is always the interrupt's"
+            );
+            assert_eq!(
+                rows[0].1.as_deref(),
+                Some(gen),
+                "audit is always the generator's"
+            );
+        }
     }
 }

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -460,8 +460,20 @@ Body fields:
 
 - `content` — the user utterance. Max 4096 chars.
 - `client_msg_id` — 26..36 ASCII-printable chars (any UUID or ULID).
-  Replaying the same `(session_id, client_msg_id)` returns `409 duplicate`
-  rather than generating a second reply.
+  Replaying the same `(session_id, client_msg_id)` is a conflict **only when
+  the turn already produced something**: an assistant reply already exists
+  (retrying would double-bill), or the turn was deliberately interrupted (see
+  [`turn/interrupt`](#post-compvoicesession_idturninterrupt) below) — either
+  way returns `409 duplicate`. With neither — an abnormal disconnect, or an
+  upstream failure that exhausted every candidate model — the replay
+  **regenerates**: it reuses the persisted user row and issues a fresh call
+  rather than erroring. On that repair path the request body's `content` is
+  **ignored**; the previously persisted utterance is authoritative (a
+  mismatch is only logged as a warning, never rejected), because the
+  per-turn recall embeds that text as its query and must not drift between
+  attempts. This also means a retry after an `Error { retryable: true }`
+  frame now actually succeeds, instead of being turned away by the very
+  duplicate check the client was told it could pass.
 - `relationship_scope` (optional) — which halves of the relationship line
   to inject this turn: `"none"`, `"bond"`, `"chemistry"`, `"both"`
   (default `"both"`). The resolved value is recorded on the assistant
@@ -478,6 +490,93 @@ Body fields:
 curl -N -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json" \
   -d '{"content":"你今天在干嘛？","client_msg_id":"01JABCDEFGHJKMNPQRSTVWXYZ0","relationship_scope":"both","memory_scope":"neutral_and_relationship"}' \
   http://localhost:8080/comp/voice/{session_id}/turn/stream
+```
+
+### `POST /comp/voice/{session_id}/turn/interrupt`
+
+Reports a deliberate barge-in: the user started talking while the client was
+still playing the companion's reply.
+
+**This endpoint does not stop generation.** Aborting the client's SSE
+connection to `turn/stream` already does that — the stream generator is
+dropped at its current await point, which drops the upstream connection with
+it. This endpoint's only job is to record **what was actually heard**, which
+the aborted generator can no longer do itself: its persist step sits after
+the streaming loop and never runs on a drop. Plain JSON in, plain JSON out —
+this is not an SSE route.
+
+**No `501 voice_disabled` gate**, unlike `turn/stream`. This endpoint makes
+no LLM call, so gating it on `[tasks.chat_voice]` would make an in-flight
+call's interrupt fail if the deployment's config changed mid-call.
+
+Body:
+
+```json
+{ "client_msg_id": "01JABCDEFGHJKMNPQRSTVWXYZ0", "spoken_text": "你今天过得" }
+```
+
+- `client_msg_id` — the turn being interrupted, same 26..36 ASCII-printable
+  format as `turn/stream`. It **must be the session's latest user turn** —
+  see the guard below.
+- `spoken_text` — what TTS actually played, verbatim. MAY be empty (the user
+  cut in before any audible word); an empty string writes no assistant
+  content at all — only the marker on the user row records that an interrupt
+  happened. Max 4096 chars.
+
+Response `200`:
+
+```json
+{ "message_id": "01JABCDEFGHJKMNPQRSTVWXYZ0" }
+```
+
+`message_id` is the assistant row that now holds the spoken text, or `null`
+when nothing was played and no reply row exists to point at.
+
+**Latest-turn guard.** A `client_msg_id` naming anything other than the
+session's most recent user row is rejected with `409 not_latest_turn`.
+Without this guard, the upsert below would let a client overwrite the
+`content` of **any** past assistant reply — you can only barge in on what is
+currently being spoken. This puts an ordering requirement on the client:
+**send the interrupt before starting the next turn.** A late interrupt is
+rejected and the turn simply degrades to the abnormal-disconnect state
+(recoverable via `turn/stream`'s regeneration, described above) rather than
+rewriting history.
+
+**Upsert semantics (completion race).** The abort and the interrupt POST are
+two separate round trips, so the server may not have processed the SSE
+disconnect yet — `turn/stream`'s own post-stream persist can still land
+concurrently. Both writers target the same assistant row (keyed on the user
+row's id, `ON CONFLICT (user_message_id) WHERE role='assistant' AND
+channel='voice'`), so exactly one row survives regardless of arrival order,
+and its `content` always ends up as the interrupt's report:
+
+| Assistant row | `spoken_text` | Result |
+|---|---|---|
+| absent | non-empty | inserted, `truncated = true` |
+| absent | empty | no assistant row written |
+| already exists (race) | non-empty | `content` overwritten, `truncated = true`; `model` / `usage` / `generation_id` and `relationship_scope` metadata preserved |
+| already exists (race) | empty | `content` left untouched |
+
+Repeated interrupt calls for the same turn are idempotent — the marker and
+the upsert both key off the user row's id, so a retry cannot multiply rows.
+
+Status ladder:
+
+| Status | Code | When |
+|---|---|---|
+| 200 | — | interrupt recorded (see body above) |
+| 400 | `invalid_payload` | `client_msg_id` outside 26..36 ASCII-printable chars |
+| 403 | `session_forbidden` | session not owned by the JWT user |
+| 404 | `session_not_found` | unknown `session_id` |
+| 404 | `turn_not_found` | `client_msg_id` names no user row in this session |
+| 409 | `wrong_channel` | session is not a voice-channel session |
+| 409 | `not_latest_turn` | the named turn is not the session's latest user row |
+| 422 | `unprocessable` | `spoken_text` longer than 4096 chars |
+
+```bash
+curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json" \
+  -d '{"client_msg_id":"01JABCDEFGHJKMNPQRSTVWXYZ0","spoken_text":"你今天过得"}' \
+  http://localhost:8080/comp/voice/{session_id}/turn/interrupt
 ```
 
 ## Persona
@@ -797,7 +896,10 @@ The streaming routes (`POST /comp/chat/{session_id}/message/stream`, `POST
 /persona/{instance_id}/image/compose`) are the exception: most of the
 failure modes on all three routes use the `code` / `message` /
 `user_message` shape described under "Pre-stream errors" above, with no
-`"error"` key. The table below covers the plain shape:
+`"error"` key. `POST /comp/voice/{session_id}/turn/interrupt` shares that
+same error body shape even though it is not itself a stream (its success
+response is plain JSON) — it reuses the voice turn's precondition checks and
+error type. The table below covers the plain shape:
 
 | Status | Code | When |
 |--------|------|------|

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -560,12 +560,22 @@ and its `content` always ends up as the interrupt's report:
 Repeated interrupt calls for the same turn are idempotent — the marker and
 the upsert both key off the user row's id, so a retry cannot multiply rows.
 
+**A race outside this table: two `turn/stream` generators for the same
+turn**, e.g. an orphaned generator from a dead connection still alive
+(TCP retransmission) when the client's retry starts its own. No interrupt is
+involved, so none of the four rows above apply — there is no marker to make
+one writer authoritative. That case is last-writer-wins on `content`,
+`truncated`, and the audit columns together (never a mix of one generation's
+text with a different generation's `generation_id`); see
+`insert_voice_assistant_message` in `crates/eros-engine-store/src/chat.rs`.
+
 Status ladder:
 
 | Status | Code | When |
 |---|---|---|
 | 200 | — | interrupt recorded (see body above) |
 | 400 | `invalid_payload` | `client_msg_id` outside 26..36 ASCII-printable chars |
+| 401 | `unauthorized` | missing / malformed / expired / wrong-secret JWT |
 | 403 | `session_forbidden` | session not owned by the JWT user |
 | 404 | `session_not_found` | unknown `session_id` |
 | 404 | `turn_not_found` | `client_msg_id` names no user row in this session |

--- a/docs/api-reference.zh.md
+++ b/docs/api-reference.zh.md
@@ -400,8 +400,17 @@ Body 字段：
 
 - `content` —— 用户说的那句话。最长 4096 字符。
 - `client_msg_id` —— 26..36 个 ASCII 可打印字符（任意 UUID 或 ULID）。同一组
-  `(session_id, client_msg_id)` 重放会返回 `409 duplicate`，而不是再生成一条
-  回复。
+  `(session_id, client_msg_id)` 重放，**只有在该轮次已经产生了结果时**才算
+  冲突：已经存在一条 assistant 回复（重试会重复计费），或者该轮次被主动
+  打断过（见下面的
+  [`turn/interrupt`](#post-compvoicesession_idturninterrupt)）——这两种情况
+  都返回 `409 duplicate`。两者都不成立时——异常断连，或者候选模型全部失败、
+  上游调用耗尽——重放会**重新生成**：复用已落库的 user 行，发起一次新的调用，
+  而不是报错。走这条修复路径时，请求体里的 `content` 会被**忽略**；已落库
+  的那句话才是权威版本（内容不一致只会记一条 warn 日志，绝不会拒绝请求），
+  因为每轮召回会把这段文字当作查询向量，同一轮次的多次尝试之间不能漂移。
+  这也意味着：客户端在收到 `Error { retryable: true }` 帧之后再重试，现在
+  真的能成功了，不会再被本该放行的重复检查挡回去。
 - `relationship_scope`（可选）—— 本轮注入关系描述的哪几半：`"none"`、`"bond"`、
   `"chemistry"`、`"both"`（默认 `"both"`）。解析后的取值记录在 assistant 行的
   `metadata.relationship_scope` 上。
@@ -416,6 +425,84 @@ Body 字段：
 curl -N -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json" \
   -d '{"content":"你今天在干嘛？","client_msg_id":"01JABCDEFGHJKMNPQRSTVWXYZ0","relationship_scope":"both","memory_scope":"neutral_and_relationship"}' \
   http://localhost:8080/comp/voice/{session_id}/turn/stream
+```
+
+### `POST /comp/voice/{session_id}/turn/interrupt`
+
+上报一次主动打断（barge-in）：companion 的回复还在播放的时候，用户开始说话了。
+
+**这个端点不负责停止生成。** 客户端断开 `turn/stream` 的 SSE 连接就已经做到
+这件事——stream 生成器在当前的 await 点被 drop，连带把上游连接也关掉了。这个
+端点唯一的任务是记录**用户实际听到了什么**，这正是被 drop 掉的生成器再也做不
+到的事：它的落库步骤在流式循环之后才跑，drop 时根本不会执行到。这里是纯 JSON
+的请求/响应——不是 SSE 路由。
+
+**没有 `501 voice_disabled` 门槛**，跟 `turn/stream` 不一样。这个端点不发起
+任何 LLM 调用，只是写几行数据库记录；把它也挂在 `[tasks.chat_voice]` 上，会
+导致部署方运行中途改配置时，一通正在进行的电话的打断请求跟着失败。
+
+Body：
+
+```json
+{ "client_msg_id": "01JABCDEFGHJKMNPQRSTVWXYZ0", "spoken_text": "你今天过得" }
+```
+
+- `client_msg_id` —— 被打断的那个轮次，格式跟 `turn/stream` 一样：26..36 个
+  ASCII 可打印字符。**必须是该 session 最新的一个 user 轮次**——见下面的守卫。
+- `spoken_text` —— TTS 实际播放出来的内容，原样传。可以是空字符串（用户在
+  任何声音播出之前就打断了）；空字符串不会写入任何 assistant 内容——只有
+  user 行上的标记会记录下发生过一次打断。最长 4096 字符。
+
+Response `200`：
+
+```json
+{ "message_id": "01JABCDEFGHJKMNPQRSTVWXYZ0" }
+```
+
+`message_id` 是现在持有这段话的 assistant 行 id；如果什么都没播出、也没有
+回复行可指，就是 `null`。
+
+**最新轮次守卫。** 如果 `client_msg_id` 指向的不是该 session 最新的 user 行，
+会被 `409 not_latest_turn` 拒绝。没有这层守卫，下面的 upsert 就能让客户端改写
+**任意一条历史** assistant 回复的 `content`——你只能打断正在说的那句话。这给
+客户端加了一条顺序要求：**打断请求要在下一轮开始之前发出。** 迟到的打断会被
+拒绝，该轮次就退化成异常断连状态（可以走上面 `turn/stream` 的重新生成路径
+恢复），而不会去改写历史。
+
+**Upsert 语义（完成竞态）。** 断连和打断 POST 是两次独立的往返请求，服务器
+可能还没处理完 SSE 的断开信号，`turn/stream` 自己在流式结束后的落库就有可能
+同时落地。两个写入者落的是同一条 assistant 行（以 user 行的 id 为键，
+`ON CONFLICT (user_message_id) WHERE role='assistant' AND channel='voice'`），
+所以不管到达顺序如何，最终都只会剩一行，而它的 `content` 永远以打断上报的为
+准：
+
+| assistant 行 | `spoken_text` | 结果 |
+|---|---|---|
+| 不存在 | 非空 | 插入一行，`truncated = true` |
+| 不存在 | 空 | 不写 assistant 行 |
+| 已存在（竞态） | 非空 | 覆盖 `content`，`truncated = true`；保留 `model` / `usage` / `generation_id` 和 `relationship_scope` 元数据 |
+| 已存在（竞态） | 空 | `content` 保持不动 |
+
+同一轮次重复调用打断接口是幂等的——标记和 upsert 都以 user 行的 id 为键，重试
+不会让行数翻倍。
+
+状态码梯度：
+
+| 状态码 | code | 何时 |
+|---|---|---|
+| 200 | — | 打断已记录（见上面的 body） |
+| 400 | `invalid_payload` | `client_msg_id` 不在 26..36 个 ASCII 可打印字符范围内 |
+| 403 | `session_forbidden` | session 不属于该 JWT 用户 |
+| 404 | `session_not_found` | `session_id` 不存在 |
+| 404 | `turn_not_found` | `client_msg_id` 在该 session 里找不到对应的 user 行 |
+| 409 | `wrong_channel` | session 不是语音频道 session |
+| 409 | `not_latest_turn` | 指定的轮次不是该 session 最新的 user 行 |
+| 422 | `unprocessable` | `spoken_text` 超过 4096 字符 |
+
+```bash
+curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json" \
+  -d '{"client_msg_id":"01JABCDEFGHJKMNPQRSTVWXYZ0","spoken_text":"你今天过得"}' \
+  http://localhost:8080/comp/voice/{session_id}/turn/interrupt
 ```
 
 ## Persona
@@ -706,7 +793,10 @@ time-decay），或最近一次事件早于 affinity migration `0014`。`event_t
 /comp/voice/{session_id}/turn/stream`、`POST
 /persona/{instance_id}/image/compose`）是例外：这三个路由的大多数失败情形
 用的是上文"流前错误"段落描述的 `code` / `message` /
-`user_message` 形状，没有 `"error"` 字段。下表覆盖的是普通形状：
+`user_message` 形状，没有 `"error"` 字段。`POST
+/comp/voice/{session_id}/turn/interrupt` 本身不是流式接口（成功时返回的是
+普通 JSON），但复用了语音轮次的前置检查和错误类型，错误响应用的也是这同一套
+形状。下表覆盖的是普通形状：
 
 | 狀態碼 | code | 何時 |
 |--------|------|------|

--- a/docs/api-reference.zh.md
+++ b/docs/api-reference.zh.md
@@ -486,12 +486,22 @@ Response `200`：
 同一轮次重复调用打断接口是幂等的——标记和 upsert 都以 user 行的 id 为键，重试
 不会让行数翻倍。
 
+**这张表之外还有一种竞态：同一轮次的两个 `turn/stream` 生成器。** 比如一个
+因断连而孤儿化、但还存活的生成器（TCP 重传会让它再活几十秒），撞上了客户端
+重试发起的另一个生成器——这里没有打断参与，上面四行都不适用，因为没有标记
+能让某一方权威。这种情况是 `content`、`truncated` 和审计列**一起**由后落地
+的那一次调用说了算（last-writer-wins），绝不会出现某一次生成的正文配上另一
+次生成的 `generation_id`；实现见
+`crates/eros-engine-store/src/chat.rs` 里 `insert_voice_assistant_message`
+的 `ON CONFLICT` 子句。
+
 状态码梯度：
 
 | 状态码 | code | 何时 |
 |---|---|---|
 | 200 | — | 打断已记录（见上面的 body） |
 | 400 | `invalid_payload` | `client_msg_id` 不在 26..36 个 ASCII 可打印字符范围内 |
+| 401 | `unauthorized` | JWT 缺失 / 格式错 / 过期 / 密钥不符 |
 | 403 | `session_forbidden` | session 不属于该 JWT 用户 |
 | 404 | `session_not_found` | `session_id` 不存在 |
 | 404 | `turn_not_found` | `client_msg_id` 在该 session 里找不到对应的 user 行 |

--- a/docs/superpowers/specs/2026-08-11-voice-barge-in-interrupt-design.md
+++ b/docs/superpowers/specs/2026-08-11-voice-barge-in-interrupt-design.md
@@ -142,6 +142,23 @@ Keyed by the user row's id:
 | exists (completion race) | non-empty | overwrite `content`, set `truncated = true`; **keep** `model`, `usage`, `generation_id` |
 | exists (completion race) | empty | leave `content` untouched |
 
+**A fifth cell, outside this table: generator vs. generator, no interrupt
+involved at all.** Two orphaned/live `insert_voice_assistant_message` writers
+can race for the same turn — the branch's own premise (TCP retransmission
+keeps a disconnected generator alive for tens of seconds) applies just as
+well to a still-live generator racing the client's retry as it does to the
+interrupt racing a generator. Migration 0041 still keeps this to one row, but
+neither writer is the interrupt, so none of the four rows above apply — there
+is no marker to make one side authoritative. The rule there is last-writer-
+wins on **every** column (`content`, `truncated`, and the audit columns
+together), never the audit-only refill the table above implies: refilling
+only `model`/`usage`/`generation_id` while leaving a stale `content` in place
+would pair one generation's text with a DIFFERENT generation's
+`generation_id`, corrupting OpenRouter reconciliation. See
+`insert_voice_assistant_message`'s `ON CONFLICT` clause in
+`crates/eros-engine-store/src/chat.rs`, keyed off whether the existing row
+carries the interrupt marker.
+
 **An empty `spoken_text` never writes assistant content** — neither inserting
 nor overwriting. The codebase holds a "never persist empty assistant content"
 invariant (`voice.rs:791` refuses an empty `done`, `voice.rs:806` guards the
@@ -174,17 +191,24 @@ an interrupt-inserted row simply has none.
 
 ### New store methods
 
-- `voice_turn_repair_state(user_message_id) -> VoiceTurnRepair { has_reply: bool, interrupted: bool }`
-  — one query returning both facts.
+- `voice_turn_repair_state(user_message_id) -> Option<VoiceTurnRepair> { has_reply: bool, interrupted: bool }`
+  — one query returning both facts. `None` when `user_message_id` does not
+  name an actual voice user turn (`role = 'user' AND channel = 'voice'`) —
+  the id handed to this function comes from `insert_voice_user_message`'s
+  conflict lookup, which is deliberately role-agnostic (a colliding row can
+  be a `gift_user` tip row, or a text-channel `user` row), so the repair gate
+  must independently confirm the row before treating it as repairable; the
+  route falls back to the ordinary unconditional 409 on `None`.
 - `resolve_latest_voice_user_turn(session_id, client_msg_id) -> LatestTurnLookup`
   — resolves the `client_msg_id` to a user row id and reports whether it is the
   session's most recent user row, so the route can separate 404 (no such turn)
   from `409 not_latest_turn` in one round trip.
 - `upsert_voice_interrupt(session_id, user_message_id, candidate_assistant_id, spoken_text) -> Option<Uuid>`
   — marker write plus the assistant upsert in one transaction. Returns the
-  assistant row's id when a row exists afterwards (inserted or updated), `None`
-  for the empty-text case. `candidate_assistant_id` is used only on insert; on
-  the race path the existing row's id is returned.
+  assistant row's id when a row exists afterwards (inserted or updated),
+  `None` only when nothing was played and no reply row exists (spoken_text
+  empty and no completion race). `candidate_assistant_id` is used only on
+  insert; on the race path the existing row's id is returned.
 
 ## 3. Regeneration repair path
 

--- a/docs/superpowers/specs/2026-08-11-voice-barge-in-interrupt-design.md
+++ b/docs/superpowers/specs/2026-08-11-voice-barge-in-interrupt-design.md
@@ -1,0 +1,306 @@
+# Voice barge-in via explicit interrupt + regeneration repair — design
+
+- Date: 2026-08-11
+- Status: design agreed, implementation plan pending
+- Repo: `eros-engine`
+- Touches the voice turn path shipped by `2026-07-07-voice-call-parts-design.md`
+  and extended by `2026-08-09-voice-memory-bootstrap-recall-design.md` /
+  `2026-08-09-voice-dreaming-ingestion-design.md`.
+
+## Background & goals
+
+Downstream wants **manual barge-in**: while the companion is speaking, the user
+starts talking, the client stops playback and the engine stops generating.
+
+Half of that is already free. `run_voice_turn` is a single `async_stream::stream!`
+generator with no `tokio::spawn` anywhere in `pipeline/voice.rs`; axum's `Sse`
+body owns it, so a client disconnect drops the generator at its current await
+point, which drops the `DeltaStream` and closes the upstream connection. No
+fallback candidate is tried, because the candidate loop only advances on
+observed upstream conditions (open error/timeout `voice.rs:709`/`715`,
+mid-stream `Some(Err(_))` `769`, clean-but-empty `775`, total timeout `738`) —
+a disconnect is none of those. It is cancellation, not failure.
+
+The other half is missing and is what barge-in actually depends on: **the
+interrupted reply is never persisted.** `insert_voice_assistant_message` sits at
+`voice.rs:807`, after the streaming loop, so a mid-stream drop destroys the
+generator before it runs. The user row was already persisted by the route
+(`routes/voice.rs:198`). The turn therefore leaves an orphaned `role='user'` row
+with no assistant reply — even though the human *heard* part of a reply. The
+next turn's history window (`VOICE_HISTORY_WINDOW = 8`) then shows two
+consecutive user messages and a companion that never spoke. Barge-in exists to
+make interruption frequent, so this compounds.
+
+**Intent cannot be inferred at the transport layer.** The generator is dropped,
+not resumed with an error; `Drop` has no error parameter and axum does not
+expose the TCP close reason to the handler. Even a raw FIN/RST signal would not
+help: a deliberate `abort()` with unread data in the socket — exactly the
+barge-in case, since the server is mid-delta — produces **RST**, while a proxy
+closing a dead network path produces **FIN**, and a mobile handoff produces
+nothing at all until TCP retransmission gives up. The mapping is not merely
+noisy, it is inverted for the case we care about.
+
+So the client must say so explicitly. The presence or absence of an explicit
+interrupt call becomes the classifier, and it is the only reliable one.
+
+Goals:
+
+1. A deliberate barge-in persists **what the user actually heard**.
+2. An abnormal disconnect (network, crash) is repairable — the turn can be
+   regenerated instead of being lost.
+3. The two are distinguished by an explicit signal, never by inference.
+
+## Non-goals
+
+- No engine-side detection of *why* a connection closed. Out of reach, by
+  design.
+- No resume/continuation of a partially generated reply. A repaired turn is
+  **regenerated from scratch**, not continued.
+- No change to how generation stops. Disconnect already stops it; this spec
+  adds no cancellation machinery.
+- No streaming of `generation_id` to the client. `ProtocolFrame::Delta` keeps
+  its `{message_id, content}` shape.
+- No change to the text (`chat/stream`) path. It has the same
+  persist-after-deltas structure (`stream.rs:581`, `// Persist BEFORE yielding
+  Done`), but text clients do not barge in; if that changes it is a separate
+  spec.
+- No per-turn memory writes. The voice turn path stays read-only per
+  `2026-08-09-voice-dreaming-ingestion-design.md`; an interrupted turn's rows
+  are picked up post-call by the dreaming sweeper like any other.
+
+## 1. Turn state machine
+
+A voice turn's user row is always persisted first (`routes/voice.rs:198`).
+The turn then reaches one of four terminal states:
+
+| Terminal state | assistant row | interrupt marker | How it arises |
+|---|---|---|---|
+| Normal completion | yes | no | stream completes, `Done` |
+| Deliberate barge-in | yes (spoken text) / no (nothing played) | **yes** | client aborts, then POSTs interrupt |
+| Abnormal disconnect | no | no | abort or network death, no interrupt arrives |
+| Upstream failure | no | no | all candidates failed, `Error` frame |
+
+Retry of the same `client_msg_id` is decided by those two columns alone:
+
+```
+has assistant reply   → 409  (unchanged; this is what protects against double billing)
+has interrupt marker  → 409  (deliberate; there is nothing to repair)
+neither               → regenerate, reusing the existing user row
+```
+
+**This also fixes an existing bug.** The fourth state — upstream failure — is an
+orphaned user row today. The engine emits `Error { retryable: true }`
+(`voice.rs:794`) and then refuses the retry with 409 (`routes/voice.rs:203`).
+The engine currently tells the client "retryable" and then rejects the retry.
+The relaxation above repairs that case for free, with no extra mechanism.
+
+## 2. The interrupt endpoint
+
+```
+POST /comp/voice/{session_id}/turn/interrupt
+{ "client_msg_id": "01J…", "spoken_text": "你今天过得" }
+→ 200 { "message_id": "01J…" | null }
+```
+
+`client_msg_id` travels in the body, matching the existing
+`POST /comp/voice/{session_id}/turn/stream`. `spoken_text` is what TTS actually
+played and MAY be an empty string.
+
+Preconditions reuse the turn endpoint's ladder: session exists (404), owned by
+the JWT user (403), session is voice-channel (409 `wrong_channel`). A
+`client_msg_id` that names no row in this session is 404; one that names a row
+which is not the session's latest user turn is `409 not_latest_turn` (see
+below).
+
+**No `501 voice_disabled` gate.** This endpoint makes no LLM call; it only
+writes rows. Gating it on `[tasks.chat_voice]` would make an in-flight call's
+interrupt fail if the deployment's config changed mid-call.
+
+### Latest-turn guard
+
+The named turn MUST be the session's most recent user row; otherwise the
+request is rejected with `409 not_latest_turn`. Without this, the upsert below
+would let a client overwrite the `content` of **any** past assistant reply —
+assistant text is engine-generated, and the client having full control of *user*
+content is not a reason to hand it control of the companion's words too. You can
+only barge in on what is currently being spoken, so "latest turn" is also the
+honest description of the feature.
+
+The cost is an ordering requirement on the client: **send the interrupt before
+the next turn.** That is the natural order anyway (you interrupt, then speak). A
+late interrupt is rejected and the turn degrades to the abnormal-disconnect
+state — recoverable, and strictly better than allowing history rewrites.
+
+### Semantics — upsert on the assistant reply
+
+Keyed by the user row's id:
+
+| assistant row | `spoken_text` | Action |
+|---|---|---|
+| absent | non-empty | insert, `truncated = true` |
+| absent | empty | write no assistant row |
+| exists (completion race) | non-empty | overwrite `content`, set `truncated = true`; **keep** `model`, `usage`, `generation_id` |
+| exists (completion race) | empty | leave `content` untouched |
+
+**An empty `spoken_text` never writes assistant content** — neither inserting
+nor overwriting. The codebase holds a "never persist empty assistant content"
+invariant (`voice.rs:791` refuses an empty `done`, `voice.rs:806` guards the
+insert); an empty row would mislead history assembly and dreaming ingestion
+alike. The fourth case is genuinely degenerate — generation finished but the
+client played nothing — and leaving the completed reply in place is the least
+destructive reading.
+
+All four cases write the interrupt marker on the **user** row, so an empty
+`spoken_text` is still distinguishable from a disconnect. Repeated interrupt
+calls for the same turn are idempotent.
+
+The governing split: **content belongs to the interrupt (it knows what was
+played); billing audit belongs to the generator (it knows what actually
+happened).**
+
+### Marker and metadata shapes
+
+User row, merged so unrelated keys survive:
+
+```sql
+metadata = COALESCE(metadata, '{}'::jsonb) || '{"voice_interrupt": true}'::jsonb
+```
+
+Assistant row: an interrupt-inserted row gets `{"voice_interrupt": true}`. On
+the completion-race update the same key is **merged** into the existing
+metadata, preserving the `relationship_scope` the generator wrote
+(`voice.rs:805`). The interrupt request does not carry `relationship_scope`, so
+an interrupt-inserted row simply has none.
+
+### New store methods
+
+- `voice_turn_repair_state(user_message_id) -> VoiceTurnRepair { has_reply: bool, interrupted: bool }`
+  — one query returning both facts.
+- `resolve_latest_voice_user_turn(session_id, client_msg_id) -> LatestTurnLookup`
+  — resolves the `client_msg_id` to a user row id and reports whether it is the
+  session's most recent user row, so the route can separate 404 (no such turn)
+  from `409 not_latest_turn` in one round trip.
+- `upsert_voice_interrupt(session_id, user_message_id, candidate_assistant_id, spoken_text) -> Option<Uuid>`
+  — marker write plus the assistant upsert in one transaction. Returns the
+  assistant row's id when a row exists afterwards (inserted or updated), `None`
+  for the empty-text case. `candidate_assistant_id` is used only on insert; on
+  the race path the existing row's id is returned.
+
+## 3. Regeneration repair path
+
+`routes/voice.rs`'s `Duplicate` branch stops being an unconditional 409:
+
+```rust
+VoiceUserInsert::Duplicate(existing_id) => {
+    let st = chat_repo.voice_turn_repair_state(existing_id).await?;
+    if st.has_reply || st.interrupted {
+        return Err(pre(StatusCode::CONFLICT, "duplicate", ...));  // wording unchanged
+    }
+    existing_id   // reuse the row; run the pipeline as normal
+}
+```
+
+The existing user row is reused — no second user row, no duplicated utterance in
+history.
+
+**Content authority.** On the repair path the request body's `content` is
+**ignored**; the persisted row is authoritative and the engine never rewrites
+history. A mismatch is logged as a warn (it is a client bug and should not pass
+silently). This has teeth beyond bookkeeping: the per-turn vector recall embeds
+`turn.content` as its query text (`voice.rs:218-221`), so a repair must use the
+persisted text or the same turn's recall drifts between attempts.
+
+**Bootstrap is unaffected.** `set_voice_bootstrap` runs at `voice.rs:577`,
+before the candidate loop, and is write-once. A repaired first turn therefore
+reads `BootstrapPlan::Frozen` and reuses the snapshot. If the disconnect landed
+before that line, no marker was written and the repair assembles it once. Both
+orders are safe.
+
+**No extra rate limiting.** The repair path is reachable only when the previous
+attempt produced no reply at all — which is precisely when a retry *should*
+issue a new call. The per-user in-flight cap (`CONCURRENT_STREAMS_PER_USER`)
+still applies, and a client wanting to burn calls can already do so today with
+fresh `client_msg_id`s, so this opens no new surface.
+
+## 4. Migration 0041 — the double-write race
+
+The client aborts the SSE and then POSTs the interrupt, but the server may not
+have processed the FIN yet, so the generator can still be alive and later run
+its own insert at `voice.rs:807`. Without a constraint that produces **two
+assistant rows for one user turn**.
+
+```sql
+CREATE UNIQUE INDEX IF NOT EXISTS chat_messages_voice_assistant_reply_uidx
+  ON engine.chat_messages (user_message_id)
+  WHERE role = 'assistant' AND channel = 'voice';
+```
+
+`insert_voice_assistant_message` then becomes conflict-aware, refilling **only**
+the audit columns and never touching `content` or `truncated`:
+
+```sql
+ON CONFLICT (user_message_id) WHERE role = 'assistant' AND channel = 'voice'
+DO UPDATE SET model = EXCLUDED.model,
+              usage = EXCLUDED.usage,
+              generation_id = EXCLUDED.generation_id
+```
+
+The result is order-independent: whichever of the two arrives second fills in
+its own half, and the final `content` is the interrupt's report either way. The
+design does not depend on timing.
+
+Operator note: voice writes exactly one assistant row per turn today, so
+existing data should satisfy the index. If a deployment has duplicates the
+migration fails loudly rather than silently dropping rows — check with
+`SELECT user_message_id FROM engine.chat_messages WHERE role='assistant' AND
+channel='voice' GROUP BY 1 HAVING count(*) > 1` before applying.
+
+## 5. Known cost — audit nulls on interrupted turns
+
+Barge-in kills the upstream connection, so the `Done` frame never arrives and an
+interrupted row typically has `model`, `usage` and `generation_id` all NULL.
+This is the same shape as the `companion_affinity_events` NULL trio: the turn
+did not complete, which is a fact about the turn, not lost data. Reconciliation
+continues to go through OpenRouter's own logs.
+
+The client cannot supply them either — `ProtocolFrame::Delta` exposes only
+`message_id` and `content`, and putting `generation_id` on the wire is a
+non-goal above.
+
+## 6. Testing
+
+Following the existing `sqlx::test` + wiremock style in
+`pipeline/voice.rs` / `routes/voice.rs`:
+
+**Interrupt endpoint**
+- non-empty `spoken_text` → assistant row with that content, `truncated = true`, marker on the user row
+- empty `spoken_text` → no assistant row, marker still written
+- completion race: assistant row pre-exists → `content` overwritten, `model`/`usage`/`generation_id` preserved, `relationship_scope` metadata preserved
+- completion race with empty `spoken_text` → existing `content` left untouched, marker still written
+- called twice → idempotent, still exactly one assistant row
+- 403 non-owner; 409 on a text-channel session; 404 for a `client_msg_id` not in this session
+- latest-turn guard: interrupt naming an older turn → `409 not_latest_turn`, and that turn's content is left untouched
+
+**Regeneration**
+- disconnect (no reply, no marker) + same `client_msg_id` → regenerates, and asserts **no second user row**
+- upstream failure then retry → regenerates
+- reply already present → still 409
+- interrupt marker present → still 409
+- retry body carrying different `content` → the persisted content is used
+
+**Race and migration**
+- generator and interrupt both write, tested in **both arrival orders** → exactly one row, `content` from the interrupt in both
+
+**Bootstrap**
+- first turn interrupted, then regenerated → frozen snapshot reused, not reassembled
+
+## 7. Documentation to update
+
+- `docs/api-reference.md` + `.zh.md` — the new endpoint, and the changed 409
+  semantics on `turn/stream` (a retry after a failed/disconnected turn now
+  regenerates instead of conflicting).
+- `docs/architecture.md` + `.zh.md` — the voice turn terminal states, if the
+  voice section enumerates them.
+
+OpenAPI: the new route needs `utoipa` annotations and a regenerated
+`crates/eros-engine-server/openapi.json` (CI diffs the snapshot).


### PR DESCRIPTION
Spec: [`docs/superpowers/specs/2026-08-11-voice-barge-in-interrupt-design.md`](docs/superpowers/specs/2026-08-11-voice-barge-in-interrupt-design.md) (committed in this branch).

## Why

Stopping generation on a barge-in was already free: the voice turn is one `async_stream` generator with no `tokio::spawn`, so a client disconnect drops it and closes the upstream connection, and the fallback chain never advances — a disconnect is cancellation, not an observed upstream failure.

What was missing is the half barge-in actually depends on: **the interrupted reply was never persisted.** `insert_voice_assistant_message` sits after the streaming loop, so a mid-stream drop left an orphaned `role='user'` row and — from the next turn's `VOICE_HISTORY_WINDOW` — a companion that never spoke, even though the human *heard* half a sentence.

**Intent cannot be inferred at the transport layer.** The generator is dropped rather than resumed with an error, and FIN/RST is inverted for this case anyway: a deliberate `abort()` with unread data (exactly barge-in, since the server is mid-delta) yields **RST**, while a proxy closing a dead path yields **FIN**. So the client signals explicitly, and the presence or absence of that signal is the classifier.

## What

**1. `POST /comp/voice/{session_id}/turn/interrupt`** — the client reports the text TTS actually played. It does **not** stop generation (aborting the SSE already did); it records what was heard. Empty `spoken_text` writes no assistant content at all — only a marker on the user row — preserving the never-empty-assistant-content invariant.

Guarded to the session's **latest** turn (`409 not_latest_turn`). That guard is a security control, not ergonomics: without it the upsert would let a client overwrite the `content` of *any* past assistant reply. The client already controls *user* content; that is no reason to hand it the companion's words.

No `501 voice_disabled` gate, deliberately — it makes no LLM call, and gating it on `[tasks.chat_voice]` would make an in-flight call's interrupt fail if config changed mid-call.

**2. Conditional duplicate-`client_msg_id` 409 on `turn/stream`** — 409 only when the turn produced something (an existing reply, or a barge-in marker). With neither it was an abnormal disconnect or an upstream failure, and the retry regenerates against the persisted user row. The request body's `content` is ignored on that path: the per-turn vector recall embeds `turn.content` as its query, so using the retry's copy would let the same turn's recall drift between attempts.

This **fixes a live bug**: on upstream failure the engine emitted `Error { retryable: true }` and then refused the retry with 409 — telling the client "retryable" and rejecting the retry.

**3. Migration 0041** — partial unique index (`user_message_id` WHERE `role='assistant' AND channel='voice'`), a conflict-aware insert, and a shared user-row `FOR UPDATE` lock. The interrupt and a still-live generator are order-independent in every interleaving: content ends up the interrupt's, audit columns the generator's.

## Review findings worth calling out

Three substantive issues were caught and fixed during review rather than shipped:

- The **empty-`spoken_text` branch** was a check-then-write; a still-live generator could persist the full reply after it, recording text the user never heard. Closed by making the generator interrupt-aware *and* serializing both writers on the user row — the marker check alone loses in mirror image.
- **`voice_turn_repair_state` had no role/channel guard.** Reachable in practice: `insert_voice_user_message`'s duplicate lookup is deliberately role-agnostic (it must classify `gift_user` tip rows), so a colliding `client_msg_id` would have regenerated against a tip row instead of conflicting.
- **Generator-vs-generator**: two retries could both pass the gate, leaving generation A's content with generation B's `generation_id` — a reconciliation id not matching the persisted text. The conflict path now keys off the interrupt marker.

## Verification

`cargo fmt --check`, `clippy --all-targets --all-features -D warnings`, `cargo test --workspace` (**1253 passed, 0 failed**), and the OpenAPI snapshot diff all clean on the final tree.

## Follow-up (not in this branch)

`routes/companion_stream.rs` has no session-channel guard, so a text stream can write a row into a voice session — that is what makes the tip/text collision above reachable at all. Pre-existing; deserves its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)