### PR TITLE
fix(chat): refuse a text stream on a voice-channel session

### DIFF
--- a/crates/eros-engine-server/src/routes/companion_stream.rs
+++ b/crates/eros-engine-server/src/routes/companion_stream.rs
@@ -390,6 +390,23 @@ pub async fn send_message_stream(
             original_user_message_id: None,
         }));
     }
+    // Channel-scoped, mirroring the voice endpoint's own gate: this handler
+    // writes text-channel rows, so it must not operate on a voice session.
+    // Without this, a text turn lands in a voice conversation's history and
+    // the two channels interleave in a single transcript — and it is what let
+    // a text `client_msg_id` collide with the voice barge-in lookups
+    // (2026-08-11-voice-barge-in-interrupt-design.md). Those lookups now filter
+    // `channel = 'voice'` themselves, so this is defence in depth on the
+    // writing side rather than the only guard.
+    if session.channel == "voice" {
+        return Err(AppError::StreamPre(StreamPreError {
+            status: StatusCode::CONFLICT,
+            code: "wrong_channel",
+            message: "session is a voice-channel session".into(),
+            user_message: "该会话是语音会话".into(),
+            original_user_message_id: None,
+        }));
+    }
     let instance_id = session.instance_id.ok_or_else(|| {
         AppError::StreamPre(StreamPreError {
             status: StatusCode::INTERNAL_SERVER_ERROR,
@@ -758,6 +775,62 @@ mod tests {
         let body = to_bytes(resp.into_body(), 1024).await.unwrap();
         let v: Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(v["code"], "unprocessable");
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn stream_409_when_session_is_voice_channel(pool: PgPool) {
+        // The text stream writes text-channel rows, so it must refuse a voice
+        // session — otherwise a text turn lands in a voice conversation's
+        // history and the two channels interleave in one transcript. Rejected
+        // BEFORE any row is persisted.
+        let user_id = Uuid::new_v4();
+        let genome_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata) \
+             VALUES ('S', 'p', '{}'::jsonb) RETURNING id",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let instance_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_instances (genome_id, owner_uid) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(genome_id).bind(user_id).fetch_one(&pool).await.unwrap();
+        let session_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_sessions (user_id, instance_id, channel) \
+             VALUES ($1, $2, 'voice') RETURNING id",
+        )
+        .bind(user_id)
+        .bind(instance_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        let mut app = build_router(crate::routes::companion::test_state(pool.clone()));
+        let token = mint_jwt(user_id);
+        let body = serde_json::to_vec(
+            &json!({"content":"typed","client_msg_id":"01J2222222222222222222222V"}),
+        )
+        .unwrap();
+        let req = Request::builder()
+            .method("POST")
+            .uri(format!("/comp/chat/{session_id}/message/stream"))
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        let resp = app.call(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+        let body = to_bytes(resp.into_body(), 1024).await.unwrap();
+        let v: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["code"], "wrong_channel");
+
+        let rows: i64 =
+            sqlx::query_scalar("SELECT count(*) FROM engine.chat_messages WHERE session_id = $1")
+                .bind(session_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(rows, 0, "a rejected text turn must not persist any row");
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -1005,12 +1005,19 @@ impl<'a> ChatRepo<'a> {
     ///   audit to the generator.
     /// - **unmarked** (both writers are ordinary generators — e.g. an orphaned
     ///   generator from a dead connection racing a client's retry of the same
-    ///   turn): last-writer-wins on EVERY column, `content` and `truncated`
-    ///   included. This keeps `content` and `generation_id` consistent with
-    ///   each other — the previous unconditional "refill audit columns only"
-    ///   rule could leave one generation's `content` paired with a DIFFERENT
-    ///   generation's `generation_id`, which OpenRouter reconciliation would
-    ///   silently mis-attribute.
+    ///   turn): last-writer-wins on every column this clause SETs — `content`
+    ///   and `truncated` included, alongside the audit trio. This keeps
+    ///   `content` and `generation_id` consistent with each other — the
+    ///   previous unconditional "refill audit columns only" rule could leave
+    ///   one generation's `content` paired with a DIFFERENT generation's
+    ///   `generation_id`, which OpenRouter reconciliation would silently
+    ///   mis-attribute.
+    ///
+    /// `metadata` is in NEITHER branch's SET list, so it is never refreshed on
+    /// conflict in either case: the first writer's metadata stands. That is
+    /// deliberate — it is what preserves an interrupt's `voice_interrupt`
+    /// marker (and the generator's `relationship_scope`) against a later
+    /// conflicting write, and the marker is the very key this CASE reads.
     ///
     /// `usage` additionally falls back to the existing row's value when the
     /// conflicting write's own `usage` is NULL (e.g. upstream never sent a

--- a/docs/superpowers/specs/2026-08-11-voice-barge-in-interrupt-design.md
+++ b/docs/superpowers/specs/2026-08-11-voice-barge-in-interrupt-design.md
@@ -131,6 +131,25 @@ the next turn.** That is the natural order anyway (you interrupt, then speak). A
 late interrupt is rejected and the turn degrades to the abnormal-disconnect
 state — recoverable, and strictly better than allowing history rewrites.
 
+#### The check-to-write window is deliberately left open
+
+The guard resolves the latest turn and then writes in a separate transaction,
+so a turn that was latest at check time can stop being latest before the write
+lands. Reviewers have flagged this twice as a TOCTOU hole; it is not one, and
+the reasoning is recorded here so it need not be re-derived.
+
+The reachable set is exactly "the turn that was latest **at check time**" —
+which is the caller's own just-interrupted turn. Nothing a client can do makes
+an arbitrary historical turn become latest again, so the property the guard
+actually protects — that a client cannot rewrite arbitrary historical assistant
+content — holds regardless of the window. What the window admits is only the
+benign case the ordering requirement above already describes: an interrupt that
+crosses paths with the next turn still lands on the turn it was about.
+
+Closing it would cost more than it buys. Revalidating latestness inside the
+write transaction would convert that crossing case from "works" into a 409 —
+and a client on a real network is exactly where the crossing happens.
+
 ### Semantics — upsert on the assistant reply
 
 Keyed by the user row's id:


### PR DESCRIPTION
Follow-up to #240 — the two items its reviews surfaced but left out of scope.

## 1. The channel guard (the real fix)

`send_message_stream` checked session ownership but never the session's **channel**. A text turn could therefore be written into a voice conversation, interleaving both channels in a single transcript.

It also had a second-order effect that #240's review traced: it is what made a text `client_msg_id` collide with the voice barge-in lookups. That review could only defend on the *reading* side (filtering `channel = 'voice'` in `voice_turn_repair_state` and `resolve_latest_voice_user_turn`); this closes it on the writing side.

Now `409 wrong_channel`, mirroring the voice endpoint's own gate, raised **before any row is persisted** — the test asserts zero rows, not just the status. The voice-side filters stay: this is defence in depth, not a replacement.

`409` was already in the endpoint's `#[utoipa::path]` responses, so the OpenAPI snapshot is unchanged.

## 2. Two documentation corrections

**`insert_voice_assistant_message`'s conflict doc overclaimed.** It said the unmarked branch is "last-writer-wins on EVERY column". `metadata` is in neither branch's `SET` list and is never refreshed on conflict — and that is deliberate, since it is exactly what preserves the `voice_interrupt` marker the `CASE` reads (and the generator's `relationship_scope`). Scoped the claim to the columns the clause actually SETs, and stated why metadata is excluded.

**Recorded why the latest-turn guard's check-to-write window is left open.** Two independent reviews have now flagged it as a TOCTOU hole. It is not one, and re-deriving that each time is waste:

> The reachable set is exactly "the turn that was latest **at check time**" — the caller's own just-interrupted turn. Nothing a client can do makes an arbitrary historical turn become latest again, so the property the guard actually protects — that a client cannot rewrite arbitrary historical assistant content — holds regardless of the window.

Closing it would also cost more than it buys: revalidating latestness inside the write transaction converts the benign "interrupt crosses the next turn" case from *works* into a 409, and a client on a real network is precisely where that crossing happens.

## Verification

`cargo fmt --check`, `clippy --all-targets --all-features -D warnings`, `cargo test --workspace` (**1255 passed, 0 failed**), and the OpenAPI snapshot diff all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)