### PR TITLE
docs: bring the voice surface up to date with barge-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,14 @@
 
 Most AI character apps eventually forget who you are. Their relationships reset to whatever fits in a prompt, and their personalities drift as the conversation grows. `eros-engine` makes those parts durable: a companion remembers you across sessions, the relationship changes through interaction, and each reply is chosen in character rather than improvised by a generic assistant.
 
-The engine has five foundations:
+The engine has six foundations:
 
 - 🧠 **Two-layer memory** — stable facts about the user live alongside shared moments, callbacks, and unfinished threads. → [Memory layers](docs/memory-layers.md)
 - 💞 **Evolving affinity** — six relationship dimensions change smoothly and decay with time, shaping tone, depth, and even whether the companion replies. → [Affinity model](docs/affinity-model.md) · [Ghost mechanics](docs/ghost-mechanics.md)
 - 🎭 **Persona Decision Engine (PDE)** — before generation, the engine chooses an action and inner state. Rules work out of the box; an LLM judge is optional. → [Model config](docs/model-config.md)
 - 🧩 **Structured user insight** — the engine builds a queryable profile that downstream products can use for onboarding, personalization, and analysis. → [API reference](docs/api-reference.md)
 - ⚡ **A complete chat path** — SSE streaming, image understanding and generation requests, prompt traits, per-task model selection, fallbacks, and call auditing. OpenRouter is the default; additional OpenAI-compatible chat and embedding providers can be configured through `[providers]`. → [API reference](docs/api-reference.md) · [Model config](docs/model-config.md)
+- 🎙️ **A voice turn path built for interruption** — a lean, low-latency turn endpoint on its own channel, with barge-in: the client stops playback and reports what was actually spoken, so history records what the user *heard* rather than what the model produced. A turn lost to a dropped connection can be regenerated instead of stranded. → [API reference](docs/api-reference.md#post-compvoicesession_idturnstream)
 
 This is not a generic agent framework. It is the stateful core for products where one persona gets to know the same person over time: companions, journals, coaches, tutors, and character chat.
 
@@ -110,7 +111,7 @@ The server listens on `0.0.0.0:8080` by default, with Scalar API docs at `/docs`
 
 ## API surface
 
-The main flow is simple: start a persona session, then send turns to the SSE streaming endpoint. The engine also exposes history, session, profile, and optional affinity-debug routes. Authentication uses Supabase JWTs by default and can be replaced through `AuthValidator`. See the [API reference](docs/api-reference.md) for paths, payloads, and stream frames.
+The main flow is simple: start a persona session, then send turns to the SSE streaming endpoint. Voice runs on its own channel — start the session with `channel: "voice"` and use the voice turn endpoint, which carries a leaner prompt and a barge-in call; the two channels never write into each other's sessions. The engine also exposes history, session, profile, and optional affinity-debug routes. Authentication uses Supabase JWTs by default and can be replaced through `AuthValidator`. See the [API reference](docs/api-reference.md) for paths, payloads, and stream frames.
 
 ## Configuration
 
@@ -121,7 +122,7 @@ The complete environment list is in [`.env.example`](.env.example), operational 
 ## Roadmap
 
 - [ ] **Agents playground** — multiple personas sharing a session with each other and the user.
-- [ ] **Voice messages** and **native audio I/O** — the low-latency voice-turn API already ships; STT/TTS currently stay on the caller's side.
+- [ ] **Native audio I/O** — the low-latency voice-turn API and barge-in already ship; STT/TTS currently stay on the caller's side.
 - [ ] **Video generation** for companion-sent clips.
 
 ## Non-goals

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -127,6 +127,14 @@ body with `code`, `message`, `user_message` and — for
 [spec](superpowers/specs/2026-05-19-sse-streaming-chat-0.2-design.md#13-pre-stream-errors-http-status-json-body)
 for the full code table.
 
+**This endpoint is text-channel only.** A `session_id` belonging to a
+voice-channel session is rejected with `409 wrong_channel` before any row is
+persisted — it writes text-channel messages, and letting them land in a voice
+conversation would interleave both channels in one transcript. Voice turns go
+to [`POST /comp/voice/{session_id}/turn/stream`](#post-compvoicesession_idturnstream)
+instead. The gate mirrors the voice endpoint's, so the two channels are
+symmetric: neither endpoint will write into the other's sessions.
+
 Once the first SSE byte has been written, terminal failures arrive as an
 in-band `error` frame and the stream closes; the HTTP response has already
 committed `200 OK`.

--- a/docs/api-reference.zh.md
+++ b/docs/api-reference.zh.md
@@ -117,6 +117,12 @@ data: {"type":"final","lead_score":0.42,"should_show_cta":false,"agent_training_
 时还会带 `original_user_message_id`。完整错误码表见
 [设计文档](superpowers/specs/2026-05-19-sse-streaming-chat-0.2-design.md#13-pre-stream-errors-http-status-json-body)。
 
+**该端点仅限文本频道。** 传入语音频道 session 的 `session_id` 会在落库任何
+一行之前被拒绝，返回 `409 wrong_channel` —— 它写的是文本频道消息，让这些行
+落进语音会话会使两个频道在同一份 transcript 里交错。语音轮次请改用
+[`POST /comp/voice/{session_id}/turn/stream`](#post-compvoicesession_idturnstream)。
+这道闸与语音端点自己的闸对称：两个端点都不会写进对方的 session。
+
 一旦第一个 SSE 字节写出，终端错误以带内 `error` 帧的形式到达并关闭流；
 此时 HTTP 响应已提交 `200 OK`。
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -123,6 +123,25 @@ replay, and client history. Dreaming is the exception: it also reads
 `'voice'` rows by default (once a call goes idle; opt out with
 `DREAMING_VOICE_DISABLED`), but still excludes `'product_qa'`.
 
+**Channel ownership is enforced on writes, both ways.** `companion_stream`
+refuses a voice session and `voice` refuses a non-voice one, each with
+`409 wrong_channel` before persisting anything. Without that symmetry a text
+turn could land in a voice conversation, and its `client_msg_id` could then
+collide with the voice-turn lookups.
+
+**A voice turn holds at most one assistant reply**, enforced by a partial
+unique index on `(user_message_id) WHERE role='assistant' AND channel='voice'`
+(migration 0041). The text path has no such constraint — it legitimately
+writes several assistant rows per user turn via `continues_from_message_id`.
+The index exists because a voice turn has two possible writers: the streaming
+generator, and the barge-in interrupt endpoint reporting what the client
+actually played. They are ordered by a shared `FOR UPDATE` lock on the user
+row, and `content` belongs to the interrupt while the audit columns
+(`model` / `usage` / `generation_id`) belong to the generator. A user row
+carrying `metadata.voice_interrupt` marks a turn the user deliberately cut
+off — which is also what tells a retry apart from a repairable disconnect.
+See [voice barge-in](superpowers/specs/2026-08-11-voice-barge-in-interrupt-design.md).
+
 ## Why pure-domain core
 
 Two reasons:

--- a/docs/architecture.zh.md
+++ b/docs/architecture.zh.md
@@ -118,6 +118,22 @@ post-process spawn 返回 `()` 是 fire-and-forget 設計——用戶面前的�
 dreaming 是例外：它默认也会读 `'voice'` 的行（通话空闲后才读；可用
 `DREAMING_VOICE_DISABLED` 关掉），但仍然排除 `'product_qa'`。
 
+**频道归属在写入侧双向强制。** `companion_stream` 拒绝语音 session，`voice`
+拒绝非语音 session，两者都在落库任何一行之前返回 `409 wrong_channel`。少了
+这层对称性，文本轮次会落进语音会话，它的 `client_msg_id` 还会和语音轮次的
+查找撞车。
+
+**一个语音轮次最多挂一条 assistant 回复**，由
+`(user_message_id) WHERE role='assistant' AND channel='voice'` 上的 partial
+unique index 保证（migration 0041）。文本路径没有这条约束——它本来就会通过
+`continues_from_message_id` 为同一个用户轮次写多条 assistant 行。这条索引存在
+是因为一个语音轮次有两个可能的写入方：流式生成器，以及上报客户端实际播出内容
+的 barge-in interrupt 端点。两者靠 user 行上共享的 `FOR UPDATE` 锁排序：
+`content` 归 interrupt，审计列（`model` / `usage` / `generation_id`）归生成器。
+user 行上带 `metadata.voice_interrupt` 表示这一轮是用户主动打断的——这也正是
+区分「重试」与「可修复的掉线」的依据。详见
+[voice barge-in](superpowers/specs/2026-08-11-voice-barge-in-interrupt-design.md)。
+
 ## 為甚麼 core 必須純領域
 
 兩個原因：

--- a/docs/memory-layers.md
+++ b/docs/memory-layers.md
@@ -167,6 +167,12 @@ the request shape and [model-config.md](model-config.md) for the
   text-only sweeper filter; note that a call swept while the flag was on is
   never re-swept after turning it off (`classified_at` is stamped once).
   Relationship-layer rows are still never written from voice.
+- **What a barge-in leaves behind** — an interrupted turn contributes the text
+  the client reported as actually spoken, not the full generation, so the
+  sweeper distills what the user *heard*. A turn cut off before the first
+  audible word contributes only the user's line, because no assistant row is
+  written at all. Either way the transcript matches the call, which is the
+  whole point of recording the interrupt.
 
 Design specs:
 [2026-08-09-voice-memory-bootstrap-recall-design.md](superpowers/specs/2026-08-09-voice-memory-bootstrap-recall-design.md)

--- a/docs/memory-layers.zh.md
+++ b/docs/memory-layers.zh.md
@@ -154,6 +154,10 @@ handler（`pipeline::handlers`）从两个来源拼出画像 / 关系上下文�
   `DREAMING_VOICE_DISABLED=1` 整个关掉，恢复到早先只扫文字的过滤条件；注意
   在开关打开期间已被扫过的通话，关掉开关后不会重扫（`classified_at` 只盖一次）。
   关系层的行仍然从不由语音写入。
+- **被打断的那轮留下什么** —— 被打断的轮次贡献的是客户端上报的「实际播出」
+  文本，而不是完整生成内容，所以清扫器蒸馏的是用户**听到**的东西。在首个可听
+  词之前就被切断的轮次只贡献用户那一行，因为根本没有写入 assistant 行。两种
+  情况下通话记录都与这通电话本身一致——这正是记录 interrupt 的意义所在。
 
 设计文档：
 [2026-08-09-voice-memory-bootstrap-recall-design.md](superpowers/specs/2026-08-09-voice-memory-bootstrap-recall-design.md)


### PR DESCRIPTION
Follow-up to #240 / #241. Those landed the behaviour but the documentation only reached `api-reference.md`'s endpoint sections — everything a reader meets *before* that page still described voice as it was two PRs ago, and one change shipped undocumented outright.

## The gap that matters most

**#241 added `409 wrong_channel` to the text stream and documented it nowhere.** A client hitting it today gets a status code that appears in no reference. Fixed in both `api-reference.md` and `.zh.md`, framed as the symmetry it is: neither endpoint will write into the other channel's sessions.

## The rest

- **`architecture.md` / `.zh.md`** — the `chat_messages.channel` section explained which rows get excluded from recall, but nothing about what makes a voice turn structurally different. Now covers channel ownership enforced on writes both ways, and the one-assistant-reply-per-turn invariant from migration 0041 — including why the text path deliberately has no such constraint (it legitimately writes several assistant rows per turn via `continues_from_message_id`), plus the two-writer arrangement the index exists for.

- **`memory-layers.md` / `.zh.md`** — what a barge-in leaves behind for the dreaming sweeper. An interrupted turn contributes the *spoken* text rather than the full generation, and a turn cut off before the first audible word contributes only the user's line. So the distilled memories match the call rather than the model's output. That is a real interaction and not derivable from the existing text, which predates the feature.

- **`README.md`** — voice appeared only as a roadmap aside, despite the turn API having shipped some time ago. Now a Highlights foundation (with "five foundations" corrected to six), the roadmap line narrowed to what actually remains (native audio I/O; STT/TTS stay caller-side), and the API-surface paragraph says the two channels never cross.

## Verification

Docs-only — no code touched. `cargo fmt --check` and `cargo test --workspace` clean; every new anchor link matches the slug style already used in these files (`#post-compvoicesession_idturnstream` et al., verified against the existing headings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)