### PR TITLE
chore(release): v1.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,7 +511,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "eros-engine-core"
-version = "1.0.4-dev"
+version = "1.0.4"
 dependencies = [
  "chrono",
  "serde",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-llm"
-version = "1.0.4-dev"
+version = "1.0.4"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-server"
-version = "1.0.4-dev"
+version = "1.0.4"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-store"
-version = "1.0.4-dev"
+version = "1.0.4"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "1.0.4-dev"
+version = "1.0.4"
 edition = "2021"
 license = "AGPL-3.0-only"
 repository = "https://github.com/etherfunlab/eros-engine"

--- a/README.ja.md
+++ b/README.ja.md
@@ -67,14 +67,14 @@ eros-engine-llm   = "1.0"   # optional: model and embedding clients
 各 `v*` タグについて、複数アーキテクチャ対応のイメージを GitHub Container Registry へ公開しています。
 
 ```bash
-docker pull ghcr.io/etherfunlab/eros-engine:1.0.2
+docker pull ghcr.io/etherfunlab/eros-engine:1.0.4
 # Or follow the latest tagged release
 docker pull ghcr.io/etherfunlab/eros-engine:latest
 ```
 
 ```bash
 docker run --rm -p 8080:8080 --env-file .env \
-  ghcr.io/etherfunlab/eros-engine:1.0.2 serve
+  ghcr.io/etherfunlab/eros-engine:1.0.4 serve
 ```
 
 Postgres と `.env` は利用者側で用意してください。同じ `docker/Dockerfile` を任意のコンテナ環境へ配備できます。詳細は [Deploying](docs/deploying.md) を参照してください。

--- a/README.md
+++ b/README.md
@@ -68,14 +68,14 @@ eros-engine-llm   = "1.0"   # optional: model and embedding clients
 Multi-architecture images are published to GitHub Container Registry for every `v*` tag:
 
 ```bash
-docker pull ghcr.io/etherfunlab/eros-engine:1.0.3
+docker pull ghcr.io/etherfunlab/eros-engine:1.0.4
 # Or follow the latest tagged release
 docker pull ghcr.io/etherfunlab/eros-engine:latest
 ```
 
 ```bash
 docker run --rm -p 8080:8080 --env-file .env \
-  ghcr.io/etherfunlab/eros-engine:1.0.3 serve
+  ghcr.io/etherfunlab/eros-engine:1.0.4 serve
 ```
 
 Bring your own Postgres and `.env`; the same `docker/Dockerfile` can be deployed to any container host. See [Deploying](docs/deploying.md).

--- a/README.zh.md
+++ b/README.zh.md
@@ -67,14 +67,14 @@ eros-engine-llm   = "1.0"   # optional: model and embedding clients
 每个 `v*` tag 都会向 GitHub Container Registry 发布多架构镜像：
 
 ```bash
-docker pull ghcr.io/etherfunlab/eros-engine:1.0.2
+docker pull ghcr.io/etherfunlab/eros-engine:1.0.4
 # Or follow the latest tagged release
 docker pull ghcr.io/etherfunlab/eros-engine:latest
 ```
 
 ```bash
 docker run --rm -p 8080:8080 --env-file .env \
-  ghcr.io/etherfunlab/eros-engine:1.0.2 serve
+  ghcr.io/etherfunlab/eros-engine:1.0.4 serve
 ```
 
 你需要自行提供 Postgres 和 `.env`；同一个 `docker/Dockerfile` 可部署到任意容器托管平台。详见[部署](docs/deploying.zh.md)。

--- a/crates/eros-engine-llm/Cargo.toml
+++ b/crates/eros-engine-llm/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "openrouter", "voyage", "embeddings", "llm"]
 categories = ["api-bindings"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "1.0.4-dev" }
+eros-engine-core = { path = "../eros-engine-core", version = "1.0.4" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/eros-engine-server/Cargo.toml
+++ b/crates/eros-engine-server/Cargo.toml
@@ -13,9 +13,9 @@ name = "eros-engine"
 path = "src/main.rs"
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "1.0.4-dev" }
-eros-engine-llm  = { path = "../eros-engine-llm", version = "1.0.4-dev" }
-eros-engine-store = { path = "../eros-engine-store", version = "1.0.4-dev" }
+eros-engine-core = { path = "../eros-engine-core", version = "1.0.4" }
+eros-engine-llm  = { path = "../eros-engine-llm", version = "1.0.4" }
+eros-engine-store = { path = "../eros-engine-store", version = "1.0.4" }
 axum = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0-only",
       "identifier": "AGPL-3.0-only"
     },
-    "version": "1.0.4-dev"
+    "version": "1.0.4"
   },
   "servers": [
     {

--- a/crates/eros-engine-store/Cargo.toml
+++ b/crates/eros-engine-store/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "memory", "pgvector", "postgres", "sqlx"]
 categories = ["database"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "1.0.4-dev" }
+eros-engine-core = { path = "../eros-engine-core", version = "1.0.4" }
 sqlx = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
Version bump only — no behaviour change. Everything below already merged into `dev`.

## Delta since v1.0.3

**Features**
- #235 — voice memory: first-turn bootstrap snapshot + per-turn vector recall
- #236 — voice post-call memory ingestion via dreaming-lite
- #239 — `[[providers.*.body]]` rules reach the `chat_vision` pre-stage
- #240 — manual voice barge-in: explicit interrupt endpoint + regeneration repair (migration **0041**)

**Fixes**
- #234 — resolve affinity via user×instance; the relationship line was dead on voice-channel sessions
- #241 — refuse a text stream on a voice-channel session (`409 wrong_channel`)

**Docs**
- #237 — correct 14 inaccurate claims found by a docs-wide audit
- #238 — polish pass, 15 minor findings from the same audit
- #242 — bring the voice surface (README, architecture, memory-layers) up to date with barge-in

## Bump contents

- 6 version strings across 4 `Cargo.toml`s (workspace + the 5 path-dep pins), `Cargo.lock` regenerated
- `openapi.json` regenerated — `info.version` is `env!("CARGO_PKG_VERSION")`, so it drifts on every bump
- docker-pull version in **all three** READMEs

On that last point: `README.zh.md` and `README.ja.md` were still on **1.0.2**. v1.0.3 bumped only `README.md`, because that is the only one the release checklist names. Both are now on 1.0.4 alongside the English one, and the checklist needs updating so this doesn't recur.

## Operator note

This release contains **migration 0041** (partial unique index on `engine.chat_messages`). It must be applied before the new binary serves traffic — without it the voice reply path's `ON CONFLICT ... WHERE ...` raises Postgres 42P10 and every voice reply is dropped. The persist failure logs at `error!` so it will not be silent, but the ordering still has to hold.

## Verification

`cargo fmt --check`, `clippy --all-targets --all-features -D warnings`, `cargo test --workspace` (**1255 passed, 0 failed**), and the OpenAPI snapshot all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)