### PR TITLE
feat(voice): affinity_scope request field aligned with the chat stream

### DIFF
--- a/crates/eros-engine-core/src/scope.rs
+++ b/crates/eros-engine-core/src/scope.rs
@@ -140,6 +140,16 @@ impl AffinityScope {
         }
         s
     }
+    /// Any axis of the `bond()` half (warmth / intimacy / tension) active.
+    /// The voice relationship line injects at half granularity — these two
+    /// helpers are its flattening rule.
+    pub fn any_bond_axis(&self) -> bool {
+        self.warmth || self.intimacy || self.tension
+    }
+    /// Any axis of the `chemistry()` half (trust / intrigue / patience) active.
+    pub fn any_chemistry_axis(&self) -> bool {
+        self.trust || self.intrigue || self.patience
+    }
     pub fn contains(self, axis: AffinityAxis) -> bool {
         match axis {
             AffinityAxis::Warmth => self.warmth,
@@ -355,5 +365,22 @@ mod tests {
         // warmth ∈ bond, trust ∈ chemistry → both active → avg
         let s = AffinityScope::from_axes(&[AffinityAxis::Warmth, AffinityAxis::Trust]);
         assert!((s.length_score(&a).unwrap() - 0.7).abs() < 1e-9);
+    }
+
+    #[test]
+    fn affinity_scope_half_detection() {
+        assert!(AffinityScope::bond().any_bond_axis());
+        assert!(!AffinityScope::bond().any_chemistry_axis());
+        assert!(AffinityScope::chemistry().any_chemistry_axis());
+        assert!(!AffinityScope::chemistry().any_bond_axis());
+        assert!(AffinityScope::full().any_bond_axis());
+        assert!(AffinityScope::full().any_chemistry_axis());
+        assert!(!AffinityScope::none().any_bond_axis());
+        assert!(!AffinityScope::none().any_chemistry_axis());
+        // A single axis activates exactly its half.
+        let w = AffinityScope::from_axes(&[AffinityAxis::Warmth]);
+        assert!(w.any_bond_axis() && !w.any_chemistry_axis());
+        let t = AffinityScope::from_axes(&[AffinityAxis::Trust]);
+        assert!(t.any_chemistry_axis() && !t.any_bond_axis());
     }
 }

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -2385,6 +2385,17 @@
           "client_msg_id"
         ],
         "properties": {
+          "affinity_scope": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/AffinityScopeDto",
+                "description": "Which affinity halves feed this turn's relationship line — same field\nname, value space, and default (`bond`) as the chat message stream:\n`\"full\" | \"bond_and_chemistry\" | \"bond\" | \"chemistry\" | \"none\"`, or an\narray of axis names such as `[\"warmth\", \"trust\"]`. Axes flatten to the\ntwo injectable halves (any bond axis ⇒ bond half, any chemistry axis ⇒\nchemistry half). When both this and the deprecated `relationship_scope`\nare sent, this field wins."
+              }
+            ]
+          },
           "client_msg_id": {
             "type": "string"
           },
@@ -2403,7 +2414,7 @@
               "string",
               "null"
             ],
-            "description": "Which halves of the relationship line to inject this turn:\n`none | bond | chemistry | both`. Omitted ⇒ `both`."
+            "description": "**Deprecated** — superseded by `affinity_scope`; removed in the next\nminor release. Which halves of the relationship line to inject:\n`none | bond | chemistry | both`. Ignored when `affinity_scope` is\npresent. Note the two value spaces do not mix: `\"full\"` here (or\n`\"both\"` under `affinity_scope`) is a 422."
           }
         }
       }

--- a/crates/eros-engine-server/src/pipeline/voice.rs
+++ b/crates/eros-engine-server/src/pipeline/voice.rs
@@ -13,7 +13,7 @@ use uuid::Uuid;
 
 use eros_engine_core::affinity::{Affinity, BondLabel, ChemistryLabel};
 use eros_engine_core::persona::PersonaGenome;
-use eros_engine_core::scope::{InsightMode, MemoryScope, RelationshipScope};
+use eros_engine_core::scope::{AffinityScope, InsightMode, MemoryScope};
 use eros_engine_llm::model_config::ResolvedVoice;
 use eros_engine_llm::openrouter::{ChatMessage as WireMessage, ChatRequest, UsageBlock};
 use eros_engine_store::affinity::AffinityRepo;
@@ -93,7 +93,7 @@ fn render_recall_block(
 
 /// Assemble the thin voice system prompt: persona + voice directive +
 /// the (already rendered) bootstrap block + one optional relationship line
-/// (bond/chemistry-derived, gated by `relationship_scope`) + this turn's
+/// (bond/chemistry-derived, gated by `affinity_scope`) + this turn's
 /// (already rendered) recall block. Deliberately excludes traits, scopes, and
 /// every heavy block the text path's `build_prompt` composes.
 ///
@@ -107,7 +107,7 @@ pub fn build_voice_prompt(
     directive: &str,
     bootstrap: Option<&str>,
     affinity: Option<&Affinity>,
-    relationship_scope: RelationshipScope,
+    affinity_scope: AffinityScope,
     recall: Option<&str>,
 ) -> String {
     let mut s = String::with_capacity(genome.system_prompt.len() + directive.len() + 384);
@@ -118,7 +118,7 @@ pub fn build_voice_prompt(
         s.push_str("\n\n");
         s.push_str(block);
     }
-    if let Some(line) = affinity.and_then(|a| relationship_line(a, relationship_scope)) {
+    if let Some(line) = affinity.and_then(|a| relationship_line(a, affinity_scope)) {
         s.push_str("\n\n");
         s.push_str(&line);
     }
@@ -375,8 +375,10 @@ async fn reload_bootstrap_winner(
 /// One relationship-tone line, derived at read time from the affinity row's
 /// bond/chemistry tiers — never from the cached `relationship_label`, which
 /// the voice path (no per-turn affinity eval) would leave stale forever.
-/// `scope` gates which halves are injected.
-fn relationship_line(affinity: &Affinity, scope: RelationshipScope) -> Option<String> {
+/// The resolved `AffinityScope` flattens to the two halves this line can
+/// inject: any bond axis ⇒ the bond half, any chemistry axis ⇒ the
+/// chemistry half.
+fn relationship_line(affinity: &Affinity, scope: AffinityScope) -> Option<String> {
     let base = || {
         match affinity.bond_label() {
         BondLabel::Acquaintance => {
@@ -408,11 +410,24 @@ fn relationship_line(affinity: &Affinity, scope: RelationshipScope) -> Option<St
         }
     }
     };
-    match scope {
-        RelationshipScope::None => None,
-        RelationshipScope::Bond => Some(base().to_string()),
-        RelationshipScope::Chemistry => Some(clause().to_string()),
-        RelationshipScope::Both => Some(format!("{} {}", base(), clause())),
+    match (scope.any_bond_axis(), scope.any_chemistry_axis()) {
+        (false, false) => None,
+        (true, false) => Some(base().to_string()),
+        (false, true) => Some(clause().to_string()),
+        (true, true) => Some(format!("{} {}", base(), clause())),
+    }
+}
+
+/// Back-projection of the resolved scope into the legacy audit vocabulary.
+/// The assistant row's `relationship_scope` key keeps this shape for one
+/// release (spec 2026-08-12) so deployers reading the old key see identical
+/// values; next release the key becomes the resolved `affinity_scope`.
+fn legacy_scope_label(scope: &AffinityScope) -> &'static str {
+    match (scope.any_bond_axis(), scope.any_chemistry_axis()) {
+        (false, false) => "none",
+        (true, false) => "bond",
+        (false, true) => "chemistry",
+        (true, true) => "both",
     }
 }
 
@@ -428,7 +443,7 @@ pub struct VoiceTurn {
     /// This turn's utterance verbatim — the per-turn recall query text (voice
     /// has no input-filter rewrite).
     pub content: String,
-    pub relationship_scope: RelationshipScope,
+    pub affinity_scope: AffinityScope,
     /// This turn's memory scope. On the FIRST turn its resolved `InsightMode`
     /// picks the bootstrap snapshot's insight tier — frozen for the whole call
     /// from then on.
@@ -642,7 +657,7 @@ pub fn run_voice_turn(
             &resolved.directive,
             bootstrap_block.as_deref(),
             affinity.as_ref(),
-            turn.relationship_scope,
+            turn.affinity_scope,
             recall_block.as_deref(),
         );
 
@@ -803,7 +818,10 @@ pub fn run_voice_turn(
         // gets the FULL unfiltered usage; the wire `Done` frame below gets a
         // separate, hidden-keys-filtered copy (mirrors the text/replay paths).
         let usage_full = last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok());
-        let scope_metadata = serde_json::json!({ "relationship_scope": turn.relationship_scope });
+        let scope_metadata = serde_json::json!({
+            "relationship_scope": legacy_scope_label(&turn.affinity_scope),
+            "memory_scope": turn.memory_scope,
+        });
         if !acc.is_empty() {
             if let Err(e) = chat_repo
                 .insert_voice_assistant_message(
@@ -923,7 +941,7 @@ mod tests {
             "DIRECTIVE",
             None,
             None,
-            RelationshipScope::default(),
+            AffinityScope::full(),
             None,
         );
         assert_eq!(p, "You are Mia.\n\nDIRECTIVE");
@@ -944,7 +962,7 @@ mod tests {
             "DIRECTIVE",
             render_bootstrap(&s).as_deref(),
             None,
-            RelationshipScope::None,
+            AffinityScope::none(),
             None,
         );
         assert_eq!(
@@ -965,7 +983,7 @@ mod tests {
             "DIRECTIVE",
             render_bootstrap(&s).as_deref(),
             Some(&a),
-            RelationshipScope::default(),
+            AffinityScope::full(),
             None,
         );
         let directive = p.find("DIRECTIVE").expect("directive present");
@@ -988,7 +1006,7 @@ mod tests {
             "DIRECTIVE",
             render_bootstrap(&s).as_deref(),
             None,
-            RelationshipScope::None,
+            AffinityScope::none(),
             None,
         );
         assert_eq!(p, "You are Mia.\n\nDIRECTIVE\n\n[上次通话]\n用户：你好");
@@ -1003,7 +1021,7 @@ mod tests {
             "DIRECTIVE",
             render_bootstrap(&s).as_deref(),
             None,
-            RelationshipScope::None,
+            AffinityScope::none(),
             None,
         );
         assert_eq!(p, "You are Mia.\n\nDIRECTIVE\n\n[关于他]\n- 城市：上海");
@@ -1021,7 +1039,7 @@ mod tests {
             "DIRECTIVE",
             render_bootstrap(&empty).as_deref(),
             None,
-            RelationshipScope::None,
+            AffinityScope::none(),
             None,
         );
         assert_eq!(p, "You are Mia.\n\nDIRECTIVE");
@@ -1101,7 +1119,7 @@ mod tests {
             "DIRECTIVE",
             render_bootstrap(&s).as_deref(),
             Some(&a),
-            RelationshipScope::default(),
+            AffinityScope::full(),
             block.as_deref(),
         );
         assert_eq!(
@@ -1149,7 +1167,7 @@ mod tests {
             "DIRECTIVE",
             None,
             Some(&a),
-            RelationshipScope::Bond,
+            AffinityScope::bond(),
             None,
         );
         let with_empty = build_voice_prompt(
@@ -1157,7 +1175,7 @@ mod tests {
             "DIRECTIVE",
             None,
             Some(&a),
-            RelationshipScope::Bond,
+            AffinityScope::bond(),
             render_recall_block(vec![], vec![]).as_deref(),
         );
         assert_eq!(with_none, with_empty);
@@ -1186,7 +1204,7 @@ mod tests {
                     "DIRECTIVE",
                     render_bootstrap(&s).as_deref(),
                     Some(&a),
-                    RelationshipScope::default(),
+                    AffinityScope::full(),
                     render_recall_block(groups.clone(), facts.clone()).as_deref(),
                 );
                 for ph in PLACEHOLDERS {
@@ -1291,7 +1309,7 @@ mod tests {
             "DIRECTIVE",
             None,
             Some(&a),
-            RelationshipScope::default(),
+            AffinityScope::full(),
             None,
         );
         assert!(p.contains("still getting to know each other"));
@@ -1308,7 +1326,7 @@ mod tests {
             "DIRECTIVE",
             None,
             Some(&a),
-            RelationshipScope::default(),
+            AffinityScope::full(),
             None,
         );
         assert!(p.contains("know each other inside out"));
@@ -1328,7 +1346,7 @@ mod tests {
             "DIRECTIVE",
             None,
             Some(&a),
-            RelationshipScope::default(),
+            AffinityScope::full(),
             None,
         );
         assert!(p.contains("close friends"));
@@ -1344,7 +1362,7 @@ mod tests {
             "D",
             None,
             Some(&low),
-            RelationshipScope::default(),
+            AffinityScope::full(),
             None,
         );
         assert!(p_low.contains("faint, unspoken spark"));
@@ -1356,7 +1374,7 @@ mod tests {
             "D",
             None,
             Some(&high),
-            RelationshipScope::default(),
+            AffinityScope::full(),
             None,
         );
         assert!(p_high.contains("growing attraction"));
@@ -1371,7 +1389,7 @@ mod tests {
             "DIRECTIVE",
             None,
             Some(&a),
-            RelationshipScope::None,
+            AffinityScope::none(),
             None,
         );
         assert_eq!(p, "You are Mia.\n\nDIRECTIVE");
@@ -1385,7 +1403,7 @@ mod tests {
             "DIRECTIVE",
             None,
             Some(&a),
-            RelationshipScope::Bond,
+            AffinityScope::bond(),
             None,
         );
         assert!(p.contains("close friends"));
@@ -1400,11 +1418,43 @@ mod tests {
             "DIRECTIVE",
             None,
             Some(&a),
-            RelationshipScope::Chemistry,
+            AffinityScope::chemistry(),
             None,
         );
         assert!(!p.contains("close friends"));
         assert!(p.contains("deeply in love"));
+    }
+
+    #[test]
+    fn relationship_line_flattens_axis_subsets_to_halves() {
+        let a = affinity_at(0.0, 0.0, 0.0, 0.0, 0.0); // the file's existing fixture; any tiers work — the two half-lines always differ
+        let warmth_only =
+            AffinityScope::from_axes(&[eros_engine_core::scope::AffinityAxis::Warmth]);
+        let trust_only = AffinityScope::from_axes(&[eros_engine_core::scope::AffinityAxis::Trust]);
+        let bond_line = relationship_line(&a, AffinityScope::bond()).unwrap();
+        let chem_line = relationship_line(&a, AffinityScope::chemistry()).unwrap();
+        // One active axis injects exactly its half's full line.
+        assert_eq!(relationship_line(&a, warmth_only).unwrap(), bond_line);
+        assert_eq!(relationship_line(&a, trust_only).unwrap(), chem_line);
+        // Mixed halves ⇒ the full two-half line.
+        let mixed = AffinityScope::from_axes(&[
+            eros_engine_core::scope::AffinityAxis::Warmth,
+            eros_engine_core::scope::AffinityAxis::Trust,
+        ]);
+        assert_eq!(
+            relationship_line(&a, mixed).unwrap(),
+            relationship_line(&a, AffinityScope::full()).unwrap()
+        );
+    }
+
+    #[test]
+    fn legacy_scope_label_projects_halves() {
+        assert_eq!(legacy_scope_label(&AffinityScope::full()), "both");
+        assert_eq!(legacy_scope_label(&AffinityScope::bond()), "bond");
+        assert_eq!(legacy_scope_label(&AffinityScope::chemistry()), "chemistry");
+        assert_eq!(legacy_scope_label(&AffinityScope::none()), "none");
+        let w = AffinityScope::from_axes(&[eros_engine_core::scope::AffinityAxis::Warmth]);
+        assert_eq!(legacy_scope_label(&w), "bond");
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
@@ -1485,7 +1535,7 @@ data: [DONE]\n\n";
                 user_id,
                 user_message_id: umid,
                 content: "hello".into(),
-                relationship_scope: RelationshipScope::default(),
+                affinity_scope: AffinityScope::full(),
                 memory_scope: MemoryScope::default(),
                 session_metadata: serde_json::json!({}),
             },
@@ -1530,6 +1580,20 @@ data: [DONE]\n\n";
         .await
         .unwrap();
         assert_eq!(scope_meta.as_deref(), Some("both"));
+
+        let ms: Option<String> = sqlx::query_scalar(
+            "SELECT metadata->>'memory_scope' FROM engine.chat_messages \
+             WHERE session_id = $1 AND role = 'assistant'",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            ms.as_deref(),
+            Some("neutral_and_relationship"),
+            "voice assistant rows now audit the resolved memory_scope"
+        );
     }
 
     /// Task 0 (affinity dead-row fix): `companion_affinity` is session-keyed
@@ -1608,7 +1672,12 @@ data: [DONE]\n\n";
         // Persist the user turn as the route would.
         let repo = ChatRepo { pool: &pool };
         let umid = match repo
-            .insert_voice_user_message(voice_session_id, "hello", "01J9000000000000000000VOIC7", None)
+            .insert_voice_user_message(
+                voice_session_id,
+                "hello",
+                "01J9000000000000000000VOIC7",
+                None,
+            )
             .await
             .unwrap()
         {
@@ -1640,7 +1709,7 @@ data: [DONE]\n\n";
                 user_id,
                 user_message_id: umid,
                 content: "hello".into(),
-                relationship_scope: RelationshipScope::default(),
+                affinity_scope: AffinityScope::full(),
                 memory_scope: MemoryScope::default(),
                 session_metadata: serde_json::json!({}),
             },
@@ -1752,7 +1821,7 @@ data: [DONE]\n\n";
                 user_id,
                 user_message_id: umid,
                 content: "hello".into(),
-                relationship_scope: RelationshipScope::default(),
+                affinity_scope: AffinityScope::full(),
                 memory_scope: MemoryScope::default(),
                 session_metadata: serde_json::json!({}),
             },
@@ -1887,7 +1956,7 @@ data: [DONE]\n\n";
                 user_id,
                 user_message_id: umid,
                 content: "hello".into(),
-                relationship_scope: RelationshipScope::default(),
+                affinity_scope: AffinityScope::full(),
                 memory_scope: MemoryScope::default(),
                 session_metadata: serde_json::json!({}),
             },
@@ -2022,7 +2091,7 @@ data: [DONE]\n\n";
                 user_id,
                 user_message_id: umid,
                 content: "hello".into(),
-                relationship_scope: RelationshipScope::default(),
+                affinity_scope: AffinityScope::full(),
                 memory_scope: MemoryScope::default(),
                 session_metadata: serde_json::json!({}),
             },
@@ -2150,7 +2219,7 @@ data: [DONE]\n\n";
                 user_id,
                 user_message_id: umid,
                 content: "hello".into(),
-                relationship_scope: RelationshipScope::default(),
+                affinity_scope: AffinityScope::full(),
                 memory_scope: MemoryScope::default(),
                 session_metadata: serde_json::json!({}),
             },
@@ -2269,7 +2338,7 @@ data: [DONE]\n\n";
                 user_id,
                 user_message_id: umid,
                 content: "hello".into(),
-                relationship_scope: RelationshipScope::default(),
+                affinity_scope: AffinityScope::full(),
                 memory_scope: MemoryScope::default(),
                 session_metadata: serde_json::json!({}),
             },
@@ -2394,7 +2463,7 @@ data: [DONE]\n\n";
                 user_id,
                 user_message_id: umid,
                 content: "hello".into(),
-                relationship_scope: RelationshipScope::default(),
+                affinity_scope: AffinityScope::full(),
                 memory_scope: MemoryScope::default(),
                 session_metadata: serde_json::json!({}),
             },
@@ -2617,7 +2686,7 @@ data: [DONE]\n\n";
                 user_id,
                 user_message_id: umid,
                 content: "hello".into(),
-                relationship_scope: RelationshipScope::None,
+                affinity_scope: AffinityScope::none(),
                 memory_scope,
                 session_metadata: session.metadata,
             },
@@ -2827,7 +2896,7 @@ data: [DONE]\n\n";
                 user_id,
                 user_message_id: umid,
                 content: "hello".into(),
-                relationship_scope: RelationshipScope::None,
+                affinity_scope: AffinityScope::none(),
                 memory_scope: MemoryScope::default(),
                 // The stale read a race loser actually saw: the marker isn't
                 // in it yet, even though the winner already wrote it to the
@@ -3276,7 +3345,7 @@ data: [DONE]\n\n";
         /// The utterance — also the recall query text.
         content: &'a str,
         memory_scope: MemoryScope,
-        relationship_scope: RelationshipScope,
+        affinity_scope: AffinityScope,
         /// `[tasks.chat_voice] recall = …`
         recall: bool,
     }
@@ -3288,7 +3357,7 @@ data: [DONE]\n\n";
                 // 6 alphanumeric chars — comfortably past the backchannel floor.
                 content: "带我去东京吧",
                 memory_scope: MemoryScope::default(),
-                relationship_scope: RelationshipScope::None,
+                affinity_scope: AffinityScope::none(),
                 recall: true,
             }
         }
@@ -3348,7 +3417,7 @@ data: [DONE]\n\n";
                 user_id,
                 user_message_id: umid,
                 content: opts.content.to_string(),
-                relationship_scope: opts.relationship_scope,
+                affinity_scope: opts.affinity_scope,
                 memory_scope: opts.memory_scope,
                 session_metadata: session.metadata,
             },
@@ -3413,7 +3482,7 @@ data: [DONE]\n\n";
             instance_id,
             user_id,
             RecallTurnOpts {
-                relationship_scope: RelationshipScope::default(),
+                affinity_scope: AffinityScope::full(),
                 ..Default::default()
             },
         )
@@ -3645,7 +3714,12 @@ data: [DONE]\n\n";
         // else — no reply, no marker.
         let repo = ChatRepo { pool: &pool };
         let umid = match repo
-            .insert_voice_user_message(session_id, persisted_text, "01J9CONTENT00000000000001", None)
+            .insert_voice_user_message(
+                session_id,
+                persisted_text,
+                "01J9CONTENT00000000000001",
+                None,
+            )
             .await
             .unwrap()
         {
@@ -3731,7 +3805,7 @@ data: [DONE]\n\n";
                 // The load-bearing line: the repair state's content, not
                 // `retry_text`.
                 content: repair.content,
-                relationship_scope: RelationshipScope::None,
+                affinity_scope: AffinityScope::none(),
                 memory_scope: MemoryScope::default(),
                 session_metadata: session.metadata,
             },
@@ -3845,7 +3919,7 @@ data: [DONE]\n\n";
                 user_id,
                 user_message_id: umid,
                 content: repair.content,
-                relationship_scope: RelationshipScope::None,
+                affinity_scope: AffinityScope::none(),
                 // Deliberately different from turn 1's scope — the frozen
                 // snapshot must not budge even if a retry's scope would have
                 // picked a different insight tier on a first turn.

--- a/crates/eros-engine-server/src/pipeline/voice.rs
+++ b/crates/eros-engine-server/src/pipeline/voice.rs
@@ -1453,7 +1453,7 @@ data: [DONE]\n\n";
         // Persist the user turn as the route would.
         let repo = ChatRepo { pool: &pool };
         let umid = match repo
-            .insert_voice_user_message(session_id, "hello", "01J9000000000000000000VOICE")
+            .insert_voice_user_message(session_id, "hello", "01J9000000000000000000VOICE", None)
             .await
             .unwrap()
         {
@@ -1608,7 +1608,7 @@ data: [DONE]\n\n";
         // Persist the user turn as the route would.
         let repo = ChatRepo { pool: &pool };
         let umid = match repo
-            .insert_voice_user_message(voice_session_id, "hello", "01J9000000000000000000VOIC7")
+            .insert_voice_user_message(voice_session_id, "hello", "01J9000000000000000000VOIC7", None)
             .await
             .unwrap()
         {
@@ -1720,7 +1720,7 @@ data: [DONE]\n\n";
         // Persist the user turn as the route would.
         let repo = ChatRepo { pool: &pool };
         let umid = match repo
-            .insert_voice_user_message(session_id, "hello", "01J9000000000000000000VOIC3")
+            .insert_voice_user_message(session_id, "hello", "01J9000000000000000000VOIC3", None)
             .await
             .unwrap()
         {
@@ -1853,7 +1853,7 @@ data: [DONE]\n\n";
         // Persist the user turn as the route would.
         let repo = ChatRepo { pool: &pool };
         let umid = match repo
-            .insert_voice_user_message(session_id, "hello", "01J9000000000000000000VOIC4")
+            .insert_voice_user_message(session_id, "hello", "01J9000000000000000000VOIC4", None)
             .await
             .unwrap()
         {
@@ -1990,7 +1990,7 @@ data: [DONE]\n\n";
         // Persist the user turn as the route would.
         let repo = ChatRepo { pool: &pool };
         let umid = match repo
-            .insert_voice_user_message(session_id, "hello", "01J9000000000000000000VOIC2")
+            .insert_voice_user_message(session_id, "hello", "01J9000000000000000000VOIC2", None)
             .await
             .unwrap()
         {
@@ -2115,7 +2115,7 @@ data: [DONE]\n\n";
         // Persist the user turn as the route would.
         let repo = ChatRepo { pool: &pool };
         let umid = match repo
-            .insert_voice_user_message(session_id, "hello", "01J9000000000000000000VOIC5")
+            .insert_voice_user_message(session_id, "hello", "01J9000000000000000000VOIC5", None)
             .await
             .unwrap()
         {
@@ -2238,7 +2238,7 @@ data: [DONE]\n\n";
 
         let repo = ChatRepo { pool: &pool };
         let umid = match repo
-            .insert_voice_user_message(session_id, "hello", "01J9000000000000000000VOIC8")
+            .insert_voice_user_message(session_id, "hello", "01J9000000000000000000VOIC8", None)
             .await
             .unwrap()
         {
@@ -2360,7 +2360,7 @@ data: [DONE]\n\n";
         // Persist the user turn as the route would.
         let repo = ChatRepo { pool: &pool };
         let umid = match repo
-            .insert_voice_user_message(session_id, "hello", "01J9000000000000000000VOIC6")
+            .insert_voice_user_message(session_id, "hello", "01J9000000000000000000VOIC6", None)
             .await
             .unwrap()
         {
@@ -2587,7 +2587,7 @@ data: [DONE]\n\n";
             .unwrap()
             .expect("session exists");
         let umid = match repo
-            .insert_voice_user_message(session_id, "hello", client_msg_id)
+            .insert_voice_user_message(session_id, "hello", client_msg_id, None)
             .await
             .unwrap()
         {
@@ -2797,7 +2797,7 @@ data: [DONE]\n\n";
         assert_eq!(rows, 1, "the winner's own write must succeed");
 
         let umid = match repo
-            .insert_voice_user_message(session_id, "hello", "01J9BOOTRACE0000000001")
+            .insert_voice_user_message(session_id, "hello", "01J9BOOTRACE0000000001", None)
             .await
             .unwrap()
         {
@@ -3315,7 +3315,7 @@ data: [DONE]\n\n";
             .unwrap()
             .expect("session exists");
         let umid = match repo
-            .insert_voice_user_message(session_id, opts.content, opts.client_msg_id)
+            .insert_voice_user_message(session_id, opts.content, opts.client_msg_id, None)
             .await
             .unwrap()
         {
@@ -3645,7 +3645,7 @@ data: [DONE]\n\n";
         // else — no reply, no marker.
         let repo = ChatRepo { pool: &pool };
         let umid = match repo
-            .insert_voice_user_message(session_id, persisted_text, "01J9CONTENT00000000000001")
+            .insert_voice_user_message(session_id, persisted_text, "01J9CONTENT00000000000001", None)
             .await
             .unwrap()
         {
@@ -3798,7 +3798,7 @@ data: [DONE]\n\n";
         // the shape the (fixed) route's duplicate-gate repair takes.
         let repo = ChatRepo { pool: &pool };
         let umid = match repo
-            .insert_voice_user_message(session_id, "still there?", "01J9BOOT0000000000000002")
+            .insert_voice_user_message(session_id, "still there?", "01J9BOOT0000000000000002", None)
             .await
             .unwrap()
         {

--- a/crates/eros-engine-server/src/routes/companion_stream.rs
+++ b/crates/eros-engine-server/src/routes/companion_stream.rs
@@ -56,7 +56,7 @@ pub enum AffinityScopeDto {
 }
 
 impl AffinityScopeDto {
-    fn resolve(&self) -> AffinityScope {
+    pub(crate) fn resolve(&self) -> AffinityScope {
         match self {
             // bond (warmth+intimacy+tension) ∪ chemistry (trust+intrigue+patience)
             // covers all six axes — identical to Full.

--- a/crates/eros-engine-server/src/routes/voice.rs
+++ b/crates/eros-engine-server/src/routes/voice.rs
@@ -633,14 +633,37 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
     }
 
-    /// Drive one mocked voice turn to completion and return nothing — the
-    /// caller asserts on the DB rows it left behind.
+    /// Byte-anchors for the two relationship-line halves at a fresh
+    /// (all-default) affinity row — Acquaintance bond text / Spark chemistry
+    /// text. Distinctive substrings that appear nowhere else in the prompt.
+    const BOND_LINE_MARK: &str = "still getting to know each other";
+    const CHEM_LINE_MARK: &str = "unspoken spark";
+
+    /// Seed a default-tier affinity row for the session's (user, instance)
+    /// pair so the relationship line renders at all — the voice pipeline
+    /// resolves affinity by user × instance, not by session.
+    async fn seed_affinity(pool: &PgPool, session_id: Uuid, user_id: Uuid) {
+        sqlx::query(
+            "INSERT INTO engine.companion_affinity (session_id, user_id, instance_id) \
+             SELECT $1, $2, instance_id FROM engine.chat_sessions WHERE id = $1",
+        )
+        .bind(session_id)
+        .bind(user_id)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    /// Drive one mocked voice turn to completion and return the upstream
+    /// chat-completions request as its wire JSON string — the caller asserts
+    /// on the DB rows it left behind AND on the prompt actually served, so
+    /// the audit metadata can never drift from the prompt unnoticed.
     async fn run_mocked_turn(
         pool: &PgPool,
         session_id: Uuid,
         user_id: Uuid,
         body: serde_json::Value,
-    ) {
+    ) -> String {
         use wiremock::matchers::path as wm_path;
         use wiremock::{Mock, MockServer, ResponseTemplate};
         let mock = MockServer::start().await;
@@ -675,6 +698,14 @@ mod tests {
             !sse_text.contains("\"type\":\"error\""),
             "no error frame expected: {sse_text}"
         );
+        let received = mock
+            .received_requests()
+            .await
+            .expect("recording enabled by default");
+        let last = received.last().expect("at least one upstream request");
+        serde_json::from_slice::<serde_json::Value>(&last.body)
+            .unwrap()
+            .to_string()
     }
 
     /// Requirement: the two vocabularies must not cross. The legacy value
@@ -748,7 +779,8 @@ mod tests {
     async fn affinity_scope_wins_over_relationship_scope(pool: PgPool) {
         let user_id = Uuid::new_v4();
         let session_id = seed(&pool, user_id).await;
-        run_mocked_turn(
+        seed_affinity(&pool, session_id, user_id).await;
+        let wire = run_mocked_turn(
             &pool,
             session_id,
             user_id,
@@ -760,6 +792,12 @@ mod tests {
             }),
         )
         .await;
+        // The winner is `none`: with an affinity row seeded (the line WOULD
+        // render), neither half may reach the model.
+        assert!(
+            !wire.contains(BOND_LINE_MARK) && !wire.contains(CHEM_LINE_MARK),
+            "affinity_scope none must suppress the relationship line: {wire}"
+        );
         let (legacy, memory): (Option<String>, Option<String>) = sqlx::query_as(
             "SELECT metadata->>'relationship_scope', metadata->>'memory_scope' \
              FROM engine.chat_messages WHERE session_id = $1 AND role = 'assistant'",
@@ -787,13 +825,18 @@ mod tests {
     async fn omitted_scopes_default_to_bond_with_no_raw_audit(pool: PgPool) {
         let user_id = Uuid::new_v4();
         let session_id = seed(&pool, user_id).await;
-        run_mocked_turn(
+        seed_affinity(&pool, session_id, user_id).await;
+        let wire = run_mocked_turn(
             &pool,
             session_id,
             user_id,
             json!({"content": "hi", "client_msg_id": "01J9SCOPEDFLT0000000000001"}),
         )
         .await;
+        assert!(
+            wire.contains(BOND_LINE_MARK) && !wire.contains(CHEM_LINE_MARK),
+            "default bond must serve the bond half only: {wire}"
+        );
         let legacy: Option<String> = sqlx::query_scalar(
             "SELECT metadata->>'relationship_scope' \
              FROM engine.chat_messages WHERE session_id = $1 AND role = 'assistant'",
@@ -824,7 +867,8 @@ mod tests {
     async fn affinity_scope_axes_array_resolves_and_echoes_raw(pool: PgPool) {
         let user_id = Uuid::new_v4();
         let session_id = seed(&pool, user_id).await;
-        run_mocked_turn(
+        seed_affinity(&pool, session_id, user_id).await;
+        let wire = run_mocked_turn(
             &pool,
             session_id,
             user_id,
@@ -836,6 +880,11 @@ mod tests {
             }),
         )
         .await;
+        // trust ∈ chemistry half ⇒ the chemistry text alone reaches the model.
+        assert!(
+            wire.contains(CHEM_LINE_MARK) && !wire.contains(BOND_LINE_MARK),
+            "[\"trust\"] must serve the chemistry half only: {wire}"
+        );
         let legacy: Option<String> = sqlx::query_scalar(
             "SELECT metadata->>'relationship_scope' \
              FROM engine.chat_messages WHERE session_id = $1 AND role = 'assistant'",

--- a/crates/eros-engine-server/src/routes/voice.rs
+++ b/crates/eros-engine-server/src/routes/voice.rs
@@ -17,7 +17,7 @@ use uuid::Uuid;
 
 use ulid::Ulid;
 
-use eros_engine_core::scope::{MemoryScope, RelationshipScope};
+use eros_engine_core::scope::{AffinityScope, MemoryScope, RelationshipScope};
 use eros_engine_store::chat::{ChatRepo, LatestTurnLookup, VoiceUserInsert};
 use eros_engine_store::persona::PersonaRepo;
 
@@ -302,7 +302,12 @@ pub async fn voice_turn_stream(
         // no input-filter rewrite). Already persisted above as the latest
         // history row — the wire messages still come from there.
         content: persisted_content,
-        relationship_scope: req.relationship_scope.unwrap_or_default(),
+        affinity_scope: match req.relationship_scope.unwrap_or_default() {
+            RelationshipScope::None => AffinityScope::none(),
+            RelationshipScope::Bond => AffinityScope::bond(),
+            RelationshipScope::Chemistry => AffinityScope::chemistry(),
+            RelationshipScope::Both => AffinityScope::full(),
+        },
         memory_scope: req.memory_scope.unwrap_or_default(),
         // Handed over from the row loaded above — the pipeline reads the
         // `voice_bootstrap` marker from it instead of re-querying the session.

--- a/crates/eros-engine-server/src/routes/voice.rs
+++ b/crates/eros-engine-server/src/routes/voice.rs
@@ -245,7 +245,7 @@ pub async fn voice_turn_stream(
     // or an upstream failure, which already told the client `retryable: true` —
     // so it regenerates against the persisted user row.
     let (user_message_id, persisted_content) = match chat_repo
-        .insert_voice_user_message(session_id, &req.content, &req.client_msg_id)
+        .insert_voice_user_message(session_id, &req.content, &req.client_msg_id, None)
         .await?
     {
         VoiceUserInsert::Inserted(id) => (id, req.content),
@@ -627,7 +627,7 @@ mod tests {
         // request already landed it.
         let chat_repo = ChatRepo { pool: &pool };
         let user_message_id = match chat_repo
-            .insert_voice_user_message(session_id, "hi", client_msg_id)
+            .insert_voice_user_message(session_id, "hi", client_msg_id, None)
             .await
             .unwrap()
         {
@@ -821,7 +821,7 @@ mod tests {
         // else — no reply, no marker.
         let chat_repo = ChatRepo { pool: &pool };
         match chat_repo
-            .insert_voice_user_message(session_id, persisted_text, client_msg_id)
+            .insert_voice_user_message(session_id, persisted_text, client_msg_id, None)
             .await
             .unwrap()
         {

--- a/crates/eros-engine-server/src/routes/voice.rs
+++ b/crates/eros-engine-server/src/routes/voice.rs
@@ -861,6 +861,59 @@ mod tests {
         assert!(user_meta_null, "no fields sent ⇒ no raw audit keys");
     }
 
+    /// Invariant 7 (spec 2026-08-12): a caller still sending ONLY the legacy
+    /// field sees identical behavior — `both` keeps serving both halves of
+    /// the relationship line — and identical audit: the assistant row's
+    /// legacy key echoes `both`, while the legacy field produces NO raw echo
+    /// on the user row (its audit home stays the assistant row this release).
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn legacy_relationship_scope_alone_is_byte_compatible(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let session_id = seed(&pool, user_id).await;
+        seed_affinity(&pool, session_id, user_id).await;
+        let wire = run_mocked_turn(
+            &pool,
+            session_id,
+            user_id,
+            json!({
+                "content": "hi",
+                "client_msg_id": "01J9SCOPELEGACY00000000001",
+                "relationship_scope": "both"
+            }),
+        )
+        .await;
+        assert!(
+            wire.contains(BOND_LINE_MARK) && wire.contains(CHEM_LINE_MARK),
+            "legacy both must keep serving BOTH halves: {wire}"
+        );
+        let (legacy, memory): (Option<String>, Option<String>) = sqlx::query_as(
+            "SELECT metadata->>'relationship_scope', metadata->>'memory_scope' \
+             FROM engine.chat_messages WHERE session_id = $1 AND role = 'assistant'",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            legacy.as_deref(),
+            Some("both"),
+            "audit value unchanged for legacy callers"
+        );
+        assert_eq!(memory.as_deref(), Some("neutral_and_relationship"));
+        let user_meta_null: bool = sqlx::query_scalar(
+            "SELECT metadata IS NULL FROM engine.chat_messages \
+             WHERE session_id = $1 AND role = 'user'",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert!(
+            user_meta_null,
+            "the legacy field is never echoed as a raw key"
+        );
+    }
+
     /// The axes-array shape resolves (chemistry half from a chemistry axis)
     /// and is echoed verbatim as the raw audit value.
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/crates/eros-engine-server/src/routes/voice.rs
+++ b/crates/eros-engine-server/src/routes/voice.rs
@@ -718,6 +718,29 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
     }
 
+    /// Precedence never bypasses type validation: even when `affinity_scope`
+    /// is present (and would win), a garbage legacy value is still a 422 —
+    /// the whole body deserializes before precedence runs.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn voice_422_when_overridden_relationship_scope_is_garbage(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let session_id = seed(&pool, user_id).await;
+        let mut app = build_router(with_voice(crate::routes::companion::test_state(pool)));
+        let resp = post_voice(
+            &mut app,
+            session_id,
+            &mint_jwt(user_id),
+            json!({
+                "content": "hi",
+                "client_msg_id": "01J2222222222222222222222A",
+                "affinity_scope": "bond",
+                "relationship_scope": "romance"
+            }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
     /// Both fields sent ⇒ affinity_scope wins. Observable in the audit trail:
     /// the assistant row's legacy key carries the WINNER's projection, and the
     /// user row echoes only the new field's raw value.

--- a/crates/eros-engine-server/src/routes/voice.rs
+++ b/crates/eros-engine-server/src/routes/voice.rs
@@ -37,8 +37,20 @@ const SSE_KEEPALIVE_SECS: u64 = 15;
 pub struct VoiceTurnRequest {
     pub content: String,
     pub client_msg_id: String,
-    /// Which halves of the relationship line to inject this turn:
-    /// `none | bond | chemistry | both`. Omitted ⇒ `both`.
+    /// Which affinity halves feed this turn's relationship line — same field
+    /// name, value space, and default (`bond`) as the chat message stream:
+    /// `"full" | "bond_and_chemistry" | "bond" | "chemistry" | "none"`, or an
+    /// array of axis names such as `["warmth", "trust"]`. Axes flatten to the
+    /// two injectable halves (any bond axis ⇒ bond half, any chemistry axis ⇒
+    /// chemistry half). When both this and the deprecated `relationship_scope`
+    /// are sent, this field wins.
+    #[serde(default)]
+    pub affinity_scope: Option<crate::routes::companion_stream::AffinityScopeDto>,
+    /// **Deprecated** — superseded by `affinity_scope`; removed in the next
+    /// minor release. Which halves of the relationship line to inject:
+    /// `none | bond | chemistry | both`. Ignored when `affinity_scope` is
+    /// present. Note the two value spaces do not mix: `"full"` here (or
+    /// `"both"` under `affinity_scope`) is a 422.
     #[serde(default)]
     #[schema(value_type = Option<String>)]
     pub relationship_scope: Option<RelationshipScope>,
@@ -238,6 +250,38 @@ pub async fn voice_turn_stream(
             )
         })?;
 
+    // Resolution precedence: new field ⇒ legacy field ⇒ chat-parity default.
+    // The legacy enum still type-checks even when overridden (a garbage value
+    // 422s regardless), and maps onto the constructors that reproduce its old
+    // behavior exactly.
+    let affinity_scope = match (req.affinity_scope.as_ref(), req.relationship_scope) {
+        (Some(dto), _) => dto.resolve(),
+        (None, Some(rs)) => match rs {
+            RelationshipScope::None => AffinityScope::none(),
+            RelationshipScope::Bond => AffinityScope::bond(),
+            RelationshipScope::Chemistry => AffinityScope::chemistry(),
+            RelationshipScope::Both => AffinityScope::full(),
+        },
+        (None, None) => AffinityScope::default(), // bond — chat parity
+    };
+    // Pre-resolve raw snapshot on the user row, mirroring the chat stream's
+    // sparse `_raw` keys. The legacy field is NOT echoed here — its audit
+    // stays on the assistant row's legacy key for this release.
+    let mut raw = serde_json::Map::new();
+    if let Some(ms) = req.memory_scope.as_ref() {
+        raw.insert(
+            "memory_scope_raw".into(),
+            serde_json::to_value(ms).expect("MemoryScope serializes"),
+        );
+    }
+    if let Some(asd) = req.affinity_scope.as_ref() {
+        raw.insert(
+            "affinity_scope_raw".into(),
+            serde_json::to_value(asd).expect("AffinityScopeDto serializes"),
+        );
+    }
+    let raw_metadata = (!raw.is_empty()).then_some(serde_json::Value::Object(raw));
+
     // Persist the user turn (idempotent on (session_id, client_msg_id)).
     // A duplicate is only a conflict when the turn actually PRODUCED something:
     // an existing reply (retrying would double-bill) or a deliberate barge-in
@@ -245,7 +289,12 @@ pub async fn voice_turn_stream(
     // or an upstream failure, which already told the client `retryable: true` —
     // so it regenerates against the persisted user row.
     let (user_message_id, persisted_content) = match chat_repo
-        .insert_voice_user_message(session_id, &req.content, &req.client_msg_id, None)
+        .insert_voice_user_message(
+            session_id,
+            &req.content,
+            &req.client_msg_id,
+            raw_metadata.as_ref(),
+        )
         .await?
     {
         VoiceUserInsert::Inserted(id) => (id, req.content),
@@ -302,12 +351,7 @@ pub async fn voice_turn_stream(
         // no input-filter rewrite). Already persisted above as the latest
         // history row — the wire messages still come from there.
         content: persisted_content,
-        affinity_scope: match req.relationship_scope.unwrap_or_default() {
-            RelationshipScope::None => AffinityScope::none(),
-            RelationshipScope::Bond => AffinityScope::bond(),
-            RelationshipScope::Chemistry => AffinityScope::chemistry(),
-            RelationshipScope::Both => AffinityScope::full(),
-        },
+        affinity_scope,
         memory_scope: req.memory_scope.unwrap_or_default(),
         // Handed over from the row loaded above — the pipeline reads the
         // `voice_bootstrap` marker from it instead of re-querying the session.
@@ -587,6 +631,207 @@ mod tests {
         )
         .await;
         assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    /// Drive one mocked voice turn to completion and return nothing — the
+    /// caller asserts on the DB rows it left behind.
+    async fn run_mocked_turn(
+        pool: &PgPool,
+        session_id: Uuid,
+        user_id: Uuid,
+        body: serde_json::Value,
+    ) {
+        use wiremock::matchers::path as wm_path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+        let mock = MockServer::start().await;
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(
+                        "data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}],\
+                         \"id\":\"gen-scope-test\",\"model\":\"primary\"}\n\n\
+                         data: [DONE]\n\n",
+                        "text/event-stream",
+                    ),
+            )
+            .mount(&mock)
+            .await;
+        let mut state = with_voice(crate::routes::companion::test_state(pool.clone()));
+        state.openrouter = Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+        let mut app = build_router(state);
+        let resp = post_voice(&mut app, session_id, &mint_jwt(user_id), body).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 256 * 1024)
+            .await
+            .unwrap();
+        let sse_text = String::from_utf8(bytes.to_vec()).unwrap();
+        assert!(
+            !sse_text.contains("\"type\":\"error\""),
+            "no error frame expected: {sse_text}"
+        );
+    }
+
+    /// Requirement: the two vocabularies must not cross. The legacy value
+    /// `"both"` under the NEW field name is a payload error.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn voice_422_when_affinity_scope_uses_legacy_value(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let session_id = seed(&pool, user_id).await;
+        let mut app = build_router(with_voice(crate::routes::companion::test_state(pool)));
+        let resp = post_voice(
+            &mut app,
+            session_id,
+            &mint_jwt(user_id),
+            json!({
+                "content": "hi",
+                "client_msg_id": "01J2222222222222222222222A",
+                "affinity_scope": "both"
+            }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    /// And the mirror: the new vocabulary's `"full"` under the LEGACY field.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn voice_422_when_relationship_scope_uses_new_value(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let session_id = seed(&pool, user_id).await;
+        let mut app = build_router(with_voice(crate::routes::companion::test_state(pool)));
+        let resp = post_voice(
+            &mut app,
+            session_id,
+            &mint_jwt(user_id),
+            json!({
+                "content": "hi",
+                "client_msg_id": "01J2222222222222222222222A",
+                "relationship_scope": "full"
+            }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    /// Both fields sent ⇒ affinity_scope wins. Observable in the audit trail:
+    /// the assistant row's legacy key carries the WINNER's projection, and the
+    /// user row echoes only the new field's raw value.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn affinity_scope_wins_over_relationship_scope(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let session_id = seed(&pool, user_id).await;
+        run_mocked_turn(
+            &pool,
+            session_id,
+            user_id,
+            json!({
+                "content": "hi",
+                "client_msg_id": "01J9SCOPEPREC0000000000001",
+                "relationship_scope": "both",
+                "affinity_scope": "none"
+            }),
+        )
+        .await;
+        let (legacy, memory): (Option<String>, Option<String>) = sqlx::query_as(
+            "SELECT metadata->>'relationship_scope', metadata->>'memory_scope' \
+             FROM engine.chat_messages WHERE session_id = $1 AND role = 'assistant'",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(legacy.as_deref(), Some("none"), "affinity_scope must win");
+        assert_eq!(memory.as_deref(), Some("neutral_and_relationship"));
+        let raw: Option<String> = sqlx::query_scalar(
+            "SELECT metadata->>'affinity_scope_raw' \
+             FROM engine.chat_messages WHERE session_id = $1 AND role = 'user'",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(raw.as_deref(), Some("none"), "user row echoes the raw DTO");
+    }
+
+    /// Neither field ⇒ chat-parity default `bond` (deliberate change from the
+    /// old `both`), and NO raw keys on the user row (sparse audit).
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn omitted_scopes_default_to_bond_with_no_raw_audit(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let session_id = seed(&pool, user_id).await;
+        run_mocked_turn(
+            &pool,
+            session_id,
+            user_id,
+            json!({"content": "hi", "client_msg_id": "01J9SCOPEDFLT0000000000001"}),
+        )
+        .await;
+        let legacy: Option<String> = sqlx::query_scalar(
+            "SELECT metadata->>'relationship_scope' \
+             FROM engine.chat_messages WHERE session_id = $1 AND role = 'assistant'",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            legacy.as_deref(),
+            Some("bond"),
+            "omitted ⇒ chat default bond"
+        );
+        let user_meta_null: bool = sqlx::query_scalar(
+            "SELECT metadata IS NULL FROM engine.chat_messages \
+             WHERE session_id = $1 AND role = 'user'",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert!(user_meta_null, "no fields sent ⇒ no raw audit keys");
+    }
+
+    /// The axes-array shape resolves (chemistry half from a chemistry axis)
+    /// and is echoed verbatim as the raw audit value.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn affinity_scope_axes_array_resolves_and_echoes_raw(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let session_id = seed(&pool, user_id).await;
+        run_mocked_turn(
+            &pool,
+            session_id,
+            user_id,
+            json!({
+                "content": "hi",
+                "client_msg_id": "01J9SCOPEAXES0000000000001",
+                "affinity_scope": ["trust"],
+                "memory_scope": "none"
+            }),
+        )
+        .await;
+        let legacy: Option<String> = sqlx::query_scalar(
+            "SELECT metadata->>'relationship_scope' \
+             FROM engine.chat_messages WHERE session_id = $1 AND role = 'assistant'",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(legacy.as_deref(), Some("chemistry"));
+        let (raw_scope, raw_memory): (Option<serde_json::Value>, Option<String>) = sqlx::query_as(
+            "SELECT metadata->'affinity_scope_raw', metadata->>'memory_scope_raw' \
+             FROM engine.chat_messages WHERE session_id = $1 AND role = 'user'",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(raw_scope, Some(serde_json::json!(["trust"])));
+        assert_eq!(raw_memory.as_deref(), Some("none"));
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -3310,13 +3310,12 @@ mod tests {
             VoiceUserInsert::Inserted(id) => id,
             other => panic!("expected Inserted, got {other:?}"),
         };
-        let is_null: bool = sqlx::query_scalar(
-            "SELECT metadata IS NULL FROM engine.chat_messages WHERE id = $1",
-        )
-        .bind(id2)
-        .fetch_one(&pool)
-        .await
-        .unwrap();
+        let is_null: bool =
+            sqlx::query_scalar("SELECT metadata IS NULL FROM engine.chat_messages WHERE id = $1")
+                .bind(id2)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
         assert!(is_null, "no raw fields ⇒ metadata stays NULL");
     }
 
@@ -3509,7 +3508,12 @@ mod tests {
         let session_id = throwaway_session(pool).await.id;
         let repo = ChatRepo { pool };
         let user_mid = match repo
-            .insert_voice_user_message(session_id, content, &format!("cmid-{}", Uuid::new_v4()), None)
+            .insert_voice_user_message(
+                session_id,
+                content,
+                &format!("cmid-{}", Uuid::new_v4()),
+                None,
+            )
             .await
             .unwrap()
         {

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -942,6 +942,7 @@ impl<'a> ChatRepo<'a> {
         session_id: Uuid,
         content: &str,
         client_msg_id: &str,
+        metadata: Option<&serde_json::Value>,
     ) -> Result<VoiceUserInsert, sqlx::Error> {
         // Atomic: on a (session_id, client_msg_id) conflict — the partial unique
         // index chat_messages_client_msg_id_uidx (WHERE client_msg_id IS NOT NULL,
@@ -950,14 +951,15 @@ impl<'a> ChatRepo<'a> {
         // Duplicate, never a unique-violation 500).
         let mut tx = self.pool.begin().await?;
         let inserted: Option<Uuid> = sqlx::query_scalar(
-            "INSERT INTO engine.chat_messages (session_id, role, content, client_msg_id, channel) \
-             VALUES ($1, 'user', $2, $3, 'voice') \
+            "INSERT INTO engine.chat_messages (session_id, role, content, client_msg_id, channel, metadata) \
+             VALUES ($1, 'user', $2, $3, 'voice', $4) \
              ON CONFLICT (session_id, client_msg_id) WHERE client_msg_id IS NOT NULL DO NOTHING \
              RETURNING id",
         )
         .bind(session_id)
         .bind(content)
         .bind(client_msg_id)
+        .bind(metadata)
         .fetch_optional(&mut *tx)
         .await?;
         if let Some(id) = inserted {
@@ -3210,7 +3212,7 @@ mod tests {
         // User insert: idempotent on client_msg_id.
         let cmid = "01J9000000000000000000VOICE";
         let u1 = match repo
-            .insert_voice_user_message(session_id, "hello", cmid)
+            .insert_voice_user_message(session_id, "hello", cmid, None)
             .await
             .unwrap()
         {
@@ -3218,7 +3220,7 @@ mod tests {
             other => panic!("expected Inserted, got {other:?}"),
         };
         match repo
-            .insert_voice_user_message(session_id, "hello again", cmid)
+            .insert_voice_user_message(session_id, "hello again", cmid, None)
             .await
             .unwrap()
         {
@@ -3275,6 +3277,50 @@ mod tests {
     }
 
     #[sqlx::test(migrations = "./migrations")]
+    async fn voice_user_insert_writes_metadata_verbatim(pool: PgPool) {
+        let session_id = throwaway_session(&pool).await.id;
+        let repo = ChatRepo { pool: &pool };
+
+        let raw = serde_json::json!({
+            "affinity_scope_raw": "full",
+            "memory_scope_raw": "none",
+        });
+        let id = match repo
+            .insert_voice_user_message(session_id, "hi", "01J9RAWMETA000000000000001", Some(&raw))
+            .await
+            .unwrap()
+        {
+            VoiceUserInsert::Inserted(id) => id,
+            other => panic!("expected Inserted, got {other:?}"),
+        };
+        let meta: serde_json::Value =
+            sqlx::query_scalar("SELECT metadata FROM engine.chat_messages WHERE id = $1")
+                .bind(id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(meta, raw, "metadata must be written verbatim");
+
+        // None ⇒ SQL NULL, same shape as every pre-existing voice user row.
+        let id2 = match repo
+            .insert_voice_user_message(session_id, "hi", "01J9RAWMETA000000000000002", None)
+            .await
+            .unwrap()
+        {
+            VoiceUserInsert::Inserted(id) => id,
+            other => panic!("expected Inserted, got {other:?}"),
+        };
+        let is_null: bool = sqlx::query_scalar(
+            "SELECT metadata IS NULL FROM engine.chat_messages WHERE id = $1",
+        )
+        .bind(id2)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert!(is_null, "no raw fields ⇒ metadata stays NULL");
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
     async fn voice_insert_duplicate_against_gift_user_row_is_not_500(pool: PgPool) {
         // A voice request reusing a client_msg_id that already exists on a tip
         // (`gift_user`) row must be classified as Duplicate (→ 409), not error
@@ -3295,7 +3341,7 @@ mod tests {
         let repo = ChatRepo { pool: &pool };
         // Must NOT panic (no RowNotFound → no 500); must be Duplicate.
         let out = repo
-            .insert_voice_user_message(session_id, "hi", cmid)
+            .insert_voice_user_message(session_id, "hi", cmid, None)
             .await
             .unwrap();
         assert!(
@@ -3326,7 +3372,7 @@ mod tests {
                 .unwrap();
 
         let out = repo
-            .insert_voice_user_message(session_id, "hi", "01J9000000000000000000BUMP1")
+            .insert_voice_user_message(session_id, "hi", "01J9000000000000000000BUMP1", None)
             .await
             .unwrap();
         assert!(
@@ -3353,7 +3399,7 @@ mod tests {
         let cmid = "01J9000000000000000000BUMP2";
 
         let first = match repo
-            .insert_voice_user_message(session_id, "hi", cmid)
+            .insert_voice_user_message(session_id, "hi", cmid, None)
             .await
             .unwrap()
         {
@@ -3378,7 +3424,7 @@ mod tests {
                 .unwrap();
 
         let out = repo
-            .insert_voice_user_message(session_id, "hi again", cmid)
+            .insert_voice_user_message(session_id, "hi again", cmid, None)
             .await
             .unwrap();
         match out {
@@ -3405,7 +3451,7 @@ mod tests {
         let repo = ChatRepo { pool: &pool };
 
         let user_message_id = match repo
-            .insert_voice_user_message(session_id, "hi", "01J9000000000000000000BUMP3")
+            .insert_voice_user_message(session_id, "hi", "01J9000000000000000000BUMP3", None)
             .await
             .unwrap()
         {
@@ -3463,7 +3509,7 @@ mod tests {
         let session_id = throwaway_session(pool).await.id;
         let repo = ChatRepo { pool };
         let user_mid = match repo
-            .insert_voice_user_message(session_id, content, &format!("cmid-{}", Uuid::new_v4()))
+            .insert_voice_user_message(session_id, content, &format!("cmid-{}", Uuid::new_v4()), None)
             .await
             .unwrap()
         {

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -482,10 +482,27 @@ Body fields:
   attempts. This also means a retry after an `Error { retryable: true }`
   frame now actually succeeds, instead of being turned away by the very
   duplicate check the client was told it could pass.
-- `relationship_scope` (optional) — which halves of the relationship line
-  to inject this turn: `"none"`, `"bond"`, `"chemistry"`, `"both"`
-  (default `"both"`). The resolved value is recorded on the assistant
-  row's `metadata.relationship_scope`.
+- `affinity_scope` (optional) — same field name, value space, and default
+  (`"bond"`) as the
+  [chat message stream](#post-compchatsession_idmessagestream): a named
+  value `"full" | "bond_and_chemistry" | "bond" | "chemistry" | "none"`,
+  or an array of axis names such as `["warmth", "trust"]`. Voice injects
+  at half granularity, so the resolved axes flatten to the two halves of
+  the relationship line: any bond axis (warmth / intimacy / tension) ⇒
+  the bond half, any chemistry axis (trust / intrigue / patience) ⇒ the
+  chemistry half. The audit trail: the **user** row records the raw value
+  under `metadata.affinity_scope_raw` (and `metadata.memory_scope_raw`),
+  each only when the request carried the field; the **assistant** row
+  keeps the legacy `metadata.relationship_scope` key for one release
+  (`"none" | "bond" | "chemistry" | "both"`, projected from the resolved
+  halves) plus the resolved `metadata.memory_scope`.
+- `relationship_scope` (optional, **deprecated** — removed in the next
+  minor release) — the pre-`affinity_scope` name of the same switch:
+  `"none"`, `"bond"`, `"chemistry"`, `"both"`. Ignored when
+  `affinity_scope` is present. The two value spaces do not mix: `"full"`
+  here, or `"both"` under `affinity_scope`, is a 422. Callers still
+  sending only this field see unchanged behavior — but note the default
+  when **neither** field is sent is now `bond` (previously `both`).
 - `memory_scope` (optional) — same field name, enum, and default
   (`"neutral_and_relationship"`) as the
   [chat message stream](#post-compchatsession_idmessagestream). On the
@@ -496,7 +513,7 @@ Body fields:
 
 ```bash
 curl -N -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json" \
-  -d '{"content":"你今天在干嘛？","client_msg_id":"01JABCDEFGHJKMNPQRSTVWXYZ0","relationship_scope":"both","memory_scope":"neutral_and_relationship"}' \
+  -d '{"content":"你今天在干嘛？","client_msg_id":"01JABCDEFGHJKMNPQRSTVWXYZ0","affinity_scope":"bond","memory_scope":"neutral_and_relationship"}' \
   http://localhost:8080/comp/voice/{session_id}/turn/stream
 ```
 
@@ -562,7 +579,7 @@ and its `content` always ends up as the interrupt's report:
 |---|---|---|
 | absent | non-empty | inserted, `truncated = true` |
 | absent | empty | no assistant row written |
-| already exists (race) | non-empty | `content` overwritten, `truncated = true`; `model` / `usage` / `generation_id` and `relationship_scope` metadata preserved |
+| already exists (race) | non-empty | `content` overwritten, `truncated = true`; `model` / `usage` / `generation_id` and `relationship_scope` / `memory_scope` metadata preserved |
 | already exists (race) | empty | `content` left untouched |
 
 Repeated interrupt calls for the same turn are idempotent — the marker and

--- a/docs/api-reference.zh.md
+++ b/docs/api-reference.zh.md
@@ -417,9 +417,22 @@ Body 字段：
   因为每轮召回会把这段文字当作查询向量，同一轮次的多次尝试之间不能漂移。
   这也意味着：客户端在收到 `Error { retryable: true }` 帧之后再重试，现在
   真的能成功了，不会再被本该放行的重复检查挡回去。
-- `relationship_scope`（可选）—— 本轮注入关系描述的哪几半：`"none"`、`"bond"`、
-  `"chemistry"`、`"both"`（默认 `"both"`）。解析后的取值记录在 assistant 行的
-  `metadata.relationship_scope` 上。
+- `affinity_scope`（可选）—— 字段名、取值空间、默认值（`"bond"`）都与
+  [聊天消息流](#post-compchatsession_idmessagestream) 相同：命名值
+  `"full" | "bond_and_chemistry" | "bond" | "chemistry" | "none"`，或轴名
+  数组（如 `["warmth", "trust"]`）。语音按「半句」粒度注入，解析出的轴会
+  压平成关系描述的两半：bond 半（warmth / intimacy / tension 任一激活）与
+  chemistry 半（trust / intrigue / patience 任一激活）。审计：**user** 行在
+  `metadata.affinity_scope_raw`（及 `metadata.memory_scope_raw`）记录原样
+  取值，均为请求带了该字段才写；**assistant** 行的旧键
+  `metadata.relationship_scope` 保留一个版本（`"none" | "bond" |
+  "chemistry" | "both"`，由解析结果反投影而来），并新增解析后的
+  `metadata.memory_scope`。
+- `relationship_scope`（可选，**已废弃** —— 下个 minor 版本移除）——
+  `affinity_scope` 的旧名：`"none"`、`"bond"`、`"chemistry"`、`"both"`。
+  与 `affinity_scope` 同时出现时被忽略。两套取值空间不互通：在这里发
+  `"full"`，或在 `affinity_scope` 下发 `"both"`，都是 422。只发这个字段的
+  调用方行为不变——但**两个字段都不发**时的默认值已从 `both` 改为 `bond`。
 - `memory_scope`（可选）—— 字段名、枚举值、默认值
   （`"neutral_and_relationship"`）都与
   [聊天消息流](#post-compchatsession_idmessagestream) 相同。session 里
@@ -429,7 +442,7 @@ Body 字段：
 
 ```bash
 curl -N -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json" \
-  -d '{"content":"你今天在干嘛？","client_msg_id":"01JABCDEFGHJKMNPQRSTVWXYZ0","relationship_scope":"both","memory_scope":"neutral_and_relationship"}' \
+  -d '{"content":"你今天在干嘛？","client_msg_id":"01JABCDEFGHJKMNPQRSTVWXYZ0","affinity_scope":"bond","memory_scope":"neutral_and_relationship"}' \
   http://localhost:8080/comp/voice/{session_id}/turn/stream
 ```
 
@@ -486,7 +499,7 @@ Response `200`：
 |---|---|---|
 | 不存在 | 非空 | 插入一行，`truncated = true` |
 | 不存在 | 空 | 不写 assistant 行 |
-| 已存在（竞态） | 非空 | 覆盖 `content`，`truncated = true`；保留 `model` / `usage` / `generation_id` 和 `relationship_scope` 元数据 |
+| 已存在（竞态） | 非空 | 覆盖 `content`，`truncated = true`；保留 `model` / `usage` / `generation_id` 和 `relationship_scope` / `memory_scope` 元数据 |
 | 已存在（竞态） | 空 | `content` 保持不动 |
 
 同一轮次重复调用打断接口是幂等的——标记和 upsert 都以 user 行的 id 为键，重试

--- a/docs/superpowers/specs/2026-08-12-voice-affinity-scope-design.md
+++ b/docs/superpowers/specs/2026-08-12-voice-affinity-scope-design.md
@@ -1,0 +1,122 @@
+# Voice `affinity_scope` — align the voice turn's scope field with the chat stream
+
+**Date:** 2026-08-12
+**Status:** approved
+**Scope:** `eros-engine-server` (routes/voice, pipeline/voice, store/chat), docs, openapi
+
+## Problem
+
+The voice turn endpoint (`POST /comp/voice/{session_id}/turn/stream`) named its
+relationship-line switch `relationship_scope` with its own value vocabulary
+(`none | bond | chemistry | both`). The chat stream already had the right name
+and vocabulary for the same concept: `affinity_scope`
+(`full | bond_and_chemistry | bond | chemistry | none`, or an axes array).
+`relationship_scope` was a naming mistake — this spec converges voice on
+`affinity_scope` over two releases.
+
+Migration principle: **old values keep flowing unchanged; new values flow only
+under new names.** A deployer still sending the old field and reading the old
+audit key changes nothing this release. A deployer who adopts the new field (or
+notices the new audit keys) discovers the change from the new surface itself.
+Next release both old surfaces disappear at once.
+
+## Request contract (this release)
+
+`VoiceTurnRequest` gains one field and keeps one:
+
+- **`affinity_scope`** (new, optional) — exactly the chat stream's
+  `AffinityScopeDto`: a named value `full | bond_and_chemistry | bond |
+  chemistry | none`, **or** an axes array such as `["warmth", "trust"]`. The
+  DTO and its `resolve()` are reused from `routes/companion_stream.rs`
+  (`resolve()` becomes `pub(crate)`); no new type is introduced.
+- **`relationship_scope`** (kept one release, deprecated) — unchanged
+  vocabulary `none | bond | chemistry | both`.
+
+Rules:
+
+- The two vocabularies do not cross: `affinity_scope: "both"` → 422,
+  `relationship_scope: "full"` → 422. Both fall out of the existing typed
+  serde enums — no validation code.
+- Both fields present → `affinity_scope` wins, silently. The losing
+  `relationship_scope` still passes type validation first (a garbage value
+  422s even when overridden).
+- Neither present → default **`bond`**, matching the chat stream. This is a
+  deliberate behavior change: today an omitted field injects both halves
+  (`both`); after this release an omitted request injects only the bond half.
+
+## Resolution and internal representation
+
+The route resolves to the shared 6-bool `AffinityScope` struct, priority:
+
+1. `affinity_scope` present → `AffinityScopeDto::resolve()`.
+2. else `relationship_scope` present → map `None→none() / Bond→bond() /
+   Chemistry→chemistry() / Both→full()`.
+3. else → `AffinityScope::bond()`.
+
+Internals rename and retype accordingly:
+
+- `VoiceTurn.relationship_scope: RelationshipScope` →
+  `affinity_scope: AffinityScope`.
+- `build_voice_prompt` / `relationship_line` take `AffinityScope`.
+- `relationship_line` flattens the six axes to the two halves it can inject:
+  **bond half** iff any of warmth / intimacy / tension is active;
+  **chemistry half** iff any of trust / intrigue / patience is active.
+  The four legacy values map onto identical behavior through this flattening.
+
+`RelationshipScope` in `eros-engine-core` survives only as the wire type of
+the deprecated field; the pipeline no longer touches it.
+
+## Audit metadata (deliberately asymmetric this release)
+
+- **assistant row** — the old key **`relationship_scope` keeps being written**,
+  its value back-projected from the resolved halves into the old vocabulary
+  (`both / bond / chemistry / none`). Old-field requests audit byte-identical
+  to today; new-field and axes-array requests still land truthfully in the old
+  vocabulary. Additionally the row gains resolved **`memory_scope`** — the
+  audit the voice path always lacked, brought in line with the chat stream.
+- **user row** — `insert_voice_user_message` gains a metadata parameter and
+  writes **`affinity_scope_raw`** (the DTO verbatim: named string or axes
+  array) and **`memory_scope_raw`**, each only when the request carried the
+  field (sparse, matching the chat stream). Written on INSERT only: a repair
+  retry does not rewrite the first attempt's raw snapshot; the assistant row
+  records what was actually served.
+
+No resolved `affinity_scope` key is written anywhere this release — the new
+resolved key appears next release when the old key is removed (see below).
+
+## Tests
+
+New:
+
+- 422 on `affinity_scope: "both"` (and keep the existing
+  `relationship_scope: "romance"` case; add `relationship_scope: "full"`).
+- Precedence: both fields sent → assistant metadata reflects
+  `affinity_scope`'s projection.
+- Default: neither field → `bond` projection in metadata, bond half only in
+  the prompt.
+- Axes array resolves (e.g. `["trust"]` → chemistry half only).
+- Metadata audit on both rows: new keys present when fields sent, absent
+  otherwise; assistant row carries resolved `memory_scope`.
+
+Adapted:
+
+- `pipeline/voice.rs` test fixtures swap `RelationshipScope::*` for the
+  equivalent `AffinityScope` constructors (mechanical, ~30 sites).
+- Default-scope prompt expectations change from both halves to bond half.
+
+## Documentation
+
+- `docs/api-reference.md` / `docs/api-reference.zh.md` voice section:
+  document `affinity_scope` (same value space as `message/stream`, default
+  `bond`), mark `relationship_scope` deprecated with its removal slated for
+  the next minor release, document the audit keys on both rows.
+- `openapi.json` regenerated.
+- Historical specs/plans that mention `relationship_scope` are archives — not
+  updated.
+
+## Next release (not in this PR)
+
+- Delete the `relationship_scope` request field and the `RelationshipScope`
+  enum from `eros-engine-core`.
+- Assistant-row audit key `relationship_scope` is replaced by resolved
+  `affinity_scope` (6-bool, fully symmetric with the chat stream).


### PR DESCRIPTION
## Summary

`relationship_scope` on the voice turn endpoint was a naming mistake — the chat stream already had the right name and value space for the same concept. This PR converges voice on `affinity_scope` over two releases (spec: `docs/superpowers/specs/2026-08-12-voice-affinity-scope-design.md`).

**Migration principle: old values keep flowing unchanged; new values flow only under new names.** A deployer still sending the old field and reading the old audit key changes nothing this release.

### Wire contract (this release)
- New `affinity_scope` — exactly the chat stream's DTO: `full | bond_and_chemistry | bond | chemistry | none` or an axes array (`["warmth","trust"]`), flattened to the relationship line's two halves. Default **`bond`** (chat parity — deliberate change from the legacy `both` when *neither* field is sent).
- `relationship_scope` kept one release, deprecated. Vocabularies do not cross: `affinity_scope: "both"` ⇒ 422, `relationship_scope: "full"` ⇒ 422 (typed serde, no hand-written validation). Both fields sent ⇒ `affinity_scope` wins.

### Internals
- `VoiceTurn` / `build_voice_prompt` / `relationship_line` retyped from the 4-value `RelationshipScope` enum to the shared 6-bool `AffinityScope`; new core helpers `any_bond_axis()` / `any_chemistry_axis()` encode the halves flattening. `RelationshipScope` survives only as the deprecated field's wire type.

### Audit metadata (deliberately asymmetric this release)
- **assistant row**: legacy `relationship_scope` key keeps being written (back-projected into the old vocabulary — old-field requests audit byte-identical) + gains resolved `memory_scope` (the audit voice always lacked).
- **user row**: sparse `affinity_scope_raw` / `memory_scope_raw`, written only when the request carried the field; `insert_voice_user_message` gained a metadata parameter for this.

### Docs
- `api-reference.md` / `api-reference.zh.md` voice section rewritten (field, precedence, default change, audit keys, deprecation); `openapi.json` regenerated.

## Testing

- Full workspace suite green on the final tree: **1266 passed / 0 failed** (core 70, server 600, llm 390, store 206); fmt + clippy `-D warnings` clean; openapi snapshot drift-free.
- New coverage: cross-vocabulary 422s (incl. a pin that a garbage legacy value still 422s when overridden), precedence, omission default, axes-array resolution + verbatim raw echo, sparse-audit NULL, metadata verbatim write at the store layer.

## Next release (not in this PR)

- [ ] Delete `relationship_scope` (field + core enum); switch the assistant-row audit key to resolved `affinity_scope` (full chat symmetry); user-row raw key already has its final name.
- [ ] Ride-alongs for that removal PR: machine-readable `deprecated` on the schema field; one doc clause on metadata attribution in the two-generator race; optional shared `halves()` helper when `legacy_scope_label` dies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)