### PR TITLE
fix(store): 0042 backfill must let the JSONB source win, and drop null array elements

### DIFF
--- a/crates/eros-engine-store/migrations/0042_drop_companion_insights.sql
+++ b/crates/eros-engine-store/migrations/0042_drop_companion_insights.sql
@@ -1,7 +1,14 @@
 -- SPDX-License-Identifier: AGPL-3.0-only
 -- Teardown of engine.companion_insights (spec 2026-08-11):
---   1. belt-and-braces gap-fill of human_insights from the JSONB (existing
---      human_insights values win; the live mirror should already match),
+--   1. reconciliation backfill of human_insights from the JSONB. The JSONB
+--      WINS on conflict, because it is the source and human_insights is the
+--      projection of it: the old write path committed the companion_insights
+--      merge first and then treated a failed project_from_insights as a
+--      `warn!`, so any user whose projection ever failed has a stale typed
+--      row and an authoritative blob. Letting the typed row win would pin
+--      that user to the stale value and then destroy the good one at step 2,
+--      silently and permanently. Only genuinely absent JSONB values (NULL
+--      scalar, empty array) leave the existing typed value in place.
 --   2. drop the table (off-schema JSONB keys are not projected and are
 --      discarded with it),
 --   3. create human_insights_snapshot; the sweeper now snapshots
@@ -13,7 +20,14 @@
 --      decodes (ColumnNotFound) — run this migration at deploy time with
 --      old instances stopping, not hours ahead.
 
--- 1. Gap-fill. Array/typeof guards mirror 0018.
+-- 1. Reconciliation backfill. Array/typeof guards mirror 0018.
+--
+-- Array elements are filtered for NULL: `jsonb_array_elements_text` turns a
+-- JSON `null` element into a SQL NULL, and `ARRAY(...)` would keep it, giving
+-- a text[] with a NULL element. The Rust rows type these columns `Vec<String>`
+-- (human_insight.rs), so sqlx cannot decode such a row — every later profile
+-- read, prompt build and reverse projection for that user would fail, with the
+-- source JSON already dropped at step 2. `["coffee", null]` is enough.
 INSERT INTO engine.human_insights (
     user_id, city, occupation, mbti_guess, love_values, emotional_needs,
     life_rhythm, interests, personality_traits, preferred_gender,
@@ -31,12 +45,14 @@ SELECT
     ci.insights->>'life_rhythm',
     COALESCE(
         CASE WHEN jsonb_typeof(ci.insights->'interests') = 'array'
-             THEN ARRAY(SELECT jsonb_array_elements_text(ci.insights->'interests')) END,
+             THEN ARRAY(SELECT v FROM jsonb_array_elements_text(ci.insights->'interests') AS t(v)
+                        WHERE v IS NOT NULL) END,
         '{}'
     ),
     COALESCE(
         CASE WHEN jsonb_typeof(ci.insights->'personality_traits') = 'array'
-             THEN ARRAY(SELECT jsonb_array_elements_text(ci.insights->'personality_traits')) END,
+             THEN ARRAY(SELECT v FROM jsonb_array_elements_text(ci.insights->'personality_traits') AS t(v)
+                        WHERE v IS NOT NULL) END,
         '{}'
     ),
     ci.insights->'matching_preferences'->>'preferred_gender',
@@ -56,7 +72,8 @@ SELECT
     END,
     COALESCE(
         CASE WHEN jsonb_typeof(ci.insights->'matching_preferences'->'deal_breakers') = 'array'
-             THEN ARRAY(SELECT jsonb_array_elements_text(ci.insights->'matching_preferences'->'deal_breakers')) END,
+             THEN ARRAY(SELECT v FROM jsonb_array_elements_text(ci.insights->'matching_preferences'->'deal_breakers') AS t(v)
+                        WHERE v IS NOT NULL) END,
         '{}'
     ),
     ci.insights->>'location',
@@ -70,32 +87,39 @@ SELECT
     ci.insights->>'finance_status',
     now()
 FROM engine.companion_insights ci
+-- EXCLUDED (the JSONB source) wins; the typed row only survives where the
+-- source has nothing to say. Empty array == absent, matching the scalars'
+-- NULL: these columns are NOT NULL DEFAULT '{}', so COALESCE never fires on
+-- them and the emptiness test has to be explicit.
 ON CONFLICT (user_id) DO UPDATE SET
-    city                 = COALESCE(human_insights.city, EXCLUDED.city),
-    occupation           = COALESCE(human_insights.occupation, EXCLUDED.occupation),
-    mbti_guess           = COALESCE(human_insights.mbti_guess, EXCLUDED.mbti_guess),
-    love_values          = COALESCE(human_insights.love_values, EXCLUDED.love_values),
-    emotional_needs      = COALESCE(human_insights.emotional_needs, EXCLUDED.emotional_needs),
-    life_rhythm          = COALESCE(human_insights.life_rhythm, EXCLUDED.life_rhythm),
-    interests            = CASE WHEN human_insights.interests = '{}'
-                                THEN EXCLUDED.interests ELSE human_insights.interests END,
-    personality_traits   = CASE WHEN human_insights.personality_traits = '{}'
-                                THEN EXCLUDED.personality_traits ELSE human_insights.personality_traits END,
-    preferred_gender     = COALESCE(human_insights.preferred_gender, EXCLUDED.preferred_gender),
-    age_min              = COALESCE(human_insights.age_min, EXCLUDED.age_min),
-    age_max              = COALESCE(human_insights.age_max, EXCLUDED.age_max),
-    deal_breakers        = CASE WHEN human_insights.deal_breakers = '{}'
-                                THEN EXCLUDED.deal_breakers ELSE human_insights.deal_breakers END,
-    location             = COALESCE(human_insights.location, EXCLUDED.location),
-    hometown             = COALESCE(human_insights.hometown, EXCLUDED.hometown),
-    nationality          = COALESCE(human_insights.nationality, EXCLUDED.nationality),
-    education            = COALESCE(human_insights.education, EXCLUDED.education),
-    family               = COALESCE(human_insights.family, EXCLUDED.family),
-    relationship_history = COALESCE(human_insights.relationship_history, EXCLUDED.relationship_history),
-    social_pattern       = COALESCE(human_insights.social_pattern, EXCLUDED.social_pattern),
-    future_plans         = COALESCE(human_insights.future_plans, EXCLUDED.future_plans),
-    finance_status       = COALESCE(human_insights.finance_status, EXCLUDED.finance_status),
-    updated_at           = human_insights.updated_at;
+    city                 = COALESCE(EXCLUDED.city, human_insights.city),
+    occupation           = COALESCE(EXCLUDED.occupation, human_insights.occupation),
+    mbti_guess           = COALESCE(EXCLUDED.mbti_guess, human_insights.mbti_guess),
+    love_values          = COALESCE(EXCLUDED.love_values, human_insights.love_values),
+    emotional_needs      = COALESCE(EXCLUDED.emotional_needs, human_insights.emotional_needs),
+    life_rhythm          = COALESCE(EXCLUDED.life_rhythm, human_insights.life_rhythm),
+    interests            = CASE WHEN EXCLUDED.interests = '{}'
+                                THEN human_insights.interests ELSE EXCLUDED.interests END,
+    personality_traits   = CASE WHEN EXCLUDED.personality_traits = '{}'
+                                THEN human_insights.personality_traits ELSE EXCLUDED.personality_traits END,
+    preferred_gender     = COALESCE(EXCLUDED.preferred_gender, human_insights.preferred_gender),
+    age_min              = COALESCE(EXCLUDED.age_min, human_insights.age_min),
+    age_max              = COALESCE(EXCLUDED.age_max, human_insights.age_max),
+    deal_breakers        = CASE WHEN EXCLUDED.deal_breakers = '{}'
+                                THEN human_insights.deal_breakers ELSE EXCLUDED.deal_breakers END,
+    location             = COALESCE(EXCLUDED.location, human_insights.location),
+    hometown             = COALESCE(EXCLUDED.hometown, human_insights.hometown),
+    nationality          = COALESCE(EXCLUDED.nationality, human_insights.nationality),
+    education            = COALESCE(EXCLUDED.education, human_insights.education),
+    family               = COALESCE(EXCLUDED.family, human_insights.family),
+    relationship_history = COALESCE(EXCLUDED.relationship_history, human_insights.relationship_history),
+    social_pattern       = COALESCE(EXCLUDED.social_pattern, human_insights.social_pattern),
+    future_plans         = COALESCE(EXCLUDED.future_plans, human_insights.future_plans),
+    finance_status       = COALESCE(EXCLUDED.finance_status, human_insights.finance_status),
+    -- Was `human_insights.updated_at` when the typed row won and nothing could
+    -- change. Now a conflicting row can actually be rewritten, so the stamp has
+    -- to move or it would claim a freshness the values no longer have.
+    updated_at           = EXCLUDED.updated_at;
 
 -- 2. The table (and any off-schema keys inside it) goes away.
 DROP TABLE engine.companion_insights;

--- a/docs/superpowers/specs/2026-08-11-companion-insights-teardown-design.md
+++ b/docs/superpowers/specs/2026-08-11-companion-insights-teardown-design.md
@@ -121,14 +121,34 @@ Changes are at the ends of the pipeline:
 
 ## §3 Migration `0042_drop_companion_insights.sql`
 
-1. **Final reconciliation backfill** (belt-and-braces — the live mirror should
-   already be in sync): per-column projection `FROM engine.companion_insights` with
-   `ON CONFLICT (user_id) DO UPDATE` — existing `human_insights` values win;
-   only gaps are filled. Scalars: `COALESCE(hi.col, projected)`. Arrays are
+1. **Final reconciliation backfill:** per-column projection
+   `FROM engine.companion_insights` with `ON CONFLICT (user_id) DO UPDATE` —
+   **the projected JSONB wins; the typed row survives only where the source has
+   nothing to say.** Scalars: `COALESCE(projected, hi.col)`. Arrays are
    `NOT NULL DEFAULT '{}'` so COALESCE never fires; use
-   `CASE WHEN hi.col = '{}' THEN projected ELSE hi.col END`. Off-schema keys
-   the JSONB may have accumulated are not projected and are discarded with the
-   table.
+   `CASE WHEN projected = '{}' THEN hi.col ELSE projected END`. `updated_at`
+   moves to `now()`, since a conflicting row can now actually be rewritten.
+
+   ⚠️ **This precedence was reversed during the pre-promotion review, and the
+   reversal is the point.** The original draft had the typed row win, on the
+   reasoning that the live mirror should already be in sync. It is not
+   guaranteed to be: the old write path (`post_process.rs`) committed the
+   `companion_insights` merge and then treated a failed `project_from_insights`
+   as `warn!` and moved on. Any user whose projection ever failed therefore has
+   a **stale typed row and an authoritative blob** — exactly the case the
+   backfill exists for — and letting the typed row win would pin them to the
+   stale value and then destroy the good one at step 2, silently and with no
+   recovery path but a database backup. Read "mirror" throughout this document
+   as *projection of the source*, never as *equal to the source*.
+
+   Array elements are filtered `WHERE v IS NOT NULL`: `jsonb_array_elements_text`
+   maps a JSON `null` element to SQL NULL, `ARRAY(...)` keeps it, and the Rust
+   rows type these columns `Vec<String>` — one `["coffee", null]` would make
+   every later read of that user's row fail to decode, with the source already
+   dropped.
+
+   Off-schema keys the JSONB may have accumulated are not projected and are
+   discarded with the table.
 2. `DROP TABLE engine.companion_insights;`
 3. `CREATE TABLE engine.human_insights_snapshot (id UUID PK DEFAULT
    gen_random_uuid(), user_id UUID NOT NULL, snapshot JSONB NOT NULL,


### PR DESCRIPTION
Pre-promotion review of #245 (combined with #247, ahead of the v1.1.0 promotion) turned up two ways migration `0042_drop_companion_insights.sql` could destroy user profile data. **prod is still on 1.0.4, so this migration has never run anywhere real** — it is clean to fix now, and expensive to fix later.

## 1. The backfill's precedence was backwards

The conflict clause resolved with `COALESCE(human_insights.col, EXCLUDED.col)` — the existing typed row winning — on the stated reasoning that *"the live mirror should already match"*.

It need not match. The old write path (`post_process.rs`, pre-#245) was:

```rust
match insights_repo.merge(user_id, new_insights).await {   // companion_insights committed
    Ok(row) => { ...project_from_insights(...)             // then projected into human_insights
                 tracing::warn!("human_insights projection failed: {e}"); }   // failure only warns
    Err(e) => tracing::warn!("companion_insights merge failed: {e}"),
}
```

So `companion_insights` is the **source** and `human_insights` is its **projection**, and a projection failure was never retried or rolled back — it warned and the turn moved on. Any user who ever hit that has a stale typed row next to an authoritative blob. That is exactly the population a reconciliation backfill exists to repair, and the old precedence did the opposite: it pinned them to the stale value, then `DROP TABLE` destroyed the good one. Silent, permanent, no recovery path but a database backup.

Reversed — the source wins; the typed row survives only where the source is silent (NULL scalar, empty array).

## 2. JSON `null` array elements produced undecodable rows

`jsonb_array_elements_text` maps a JSON `null` element to SQL `NULL`, and `ARRAY(...)` keeps it, yielding a `text[]` with a NULL element. `interests` / `personality_traits` / `deal_breakers` are typed `Vec<String>` in `human_insight.rs`, not `Vec<Option<String>>` — sqlx cannot decode such a row.

A single `{"interests": ["coffee", null]}` would break every later profile read, prompt build and reverse projection for that user, **after** the source JSON had been dropped. Now filtered `WHERE v IS NOT NULL`.

`updated_at` also moves to `EXCLUDED.updated_at`: it was pinned to the old value back when a conflicting row could never change, which is no longer true.

## Verification

Ran the real step-1 statement against a throwaway schema with deliberately divergent rows:

| case | setup | result |
|---|---|---|
| projection had failed | typed `Shanghai` / `{tea}`, source `Beijing` / `{coffee,hiking}` | `Beijing`, `{coffee,hiking}` — source wins |
| null array elements | `["coffee",null]`, `[null]`, `["smoking",null]` | `{coffee}`, `{}`, `{smoking}` — no NULL element in any of the three |
| source silent | typed `Taipei` / `{reading}`, source has only `occupation` | `Taipei` and `{reading}` kept, `occupation` filled in — not clobbered |

Plus `cargo fmt --check` · `clippy --all-targets --all-features` zero warnings · `cargo test --workspace` 1,275 passed.

## Not changed

The review also flagged that the backfill/drop window races with still-running old instances. That is a real window, but the migration's own header already documents it as an operational constraint (*"run this migration at deploy time with old instances stopping, not hours ahead"*), and deployment is downstream's concern rather than part of this repo. Left as documented.

The spec's §3 is updated to match, including why the precedence reads the way it now does — the original wording is what led to the defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)