### PR TITLE
chore(release): v1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,7 +511,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "eros-engine-core"
-version = "1.0.5-dev"
+version = "1.1.0"
 dependencies = [
  "chrono",
  "serde",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-llm"
-version = "1.0.5-dev"
+version = "1.1.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-server"
-version = "1.0.5-dev"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-store"
-version = "1.0.5-dev"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "1.0.5-dev"
+version = "1.1.0"
 edition = "2021"
 license = "AGPL-3.0-only"
 repository = "https://github.com/etherfunlab/eros-engine"

--- a/README.ja.md
+++ b/README.ja.md
@@ -67,14 +67,14 @@ eros-engine-llm   = "1.0"   # optional: model and embedding clients
 各 `v*` タグについて、複数アーキテクチャ対応のイメージを GitHub Container Registry へ公開しています。
 
 ```bash
-docker pull ghcr.io/etherfunlab/eros-engine:1.0.4
+docker pull ghcr.io/etherfunlab/eros-engine:1.1.0
 # Or follow the latest tagged release
 docker pull ghcr.io/etherfunlab/eros-engine:latest
 ```
 
 ```bash
 docker run --rm -p 8080:8080 --env-file .env \
-  ghcr.io/etherfunlab/eros-engine:1.0.4 serve
+  ghcr.io/etherfunlab/eros-engine:1.1.0 serve
 ```
 
 Postgres と `.env` は利用者側で用意してください。同じ `docker/Dockerfile` を任意のコンテナ環境へ配備できます。詳細は [Deploying](docs/deploying.md) を参照してください。

--- a/README.md
+++ b/README.md
@@ -68,14 +68,14 @@ eros-engine-llm   = "1.0"   # optional: model and embedding clients
 Multi-architecture images are published to GitHub Container Registry for every `v*` tag:
 
 ```bash
-docker pull ghcr.io/etherfunlab/eros-engine:1.0.4
+docker pull ghcr.io/etherfunlab/eros-engine:1.1.0
 # Or follow the latest tagged release
 docker pull ghcr.io/etherfunlab/eros-engine:latest
 ```
 
 ```bash
 docker run --rm -p 8080:8080 --env-file .env \
-  ghcr.io/etherfunlab/eros-engine:1.0.4 serve
+  ghcr.io/etherfunlab/eros-engine:1.1.0 serve
 ```
 
 Bring your own Postgres and `.env`; the same `docker/Dockerfile` can be deployed to any container host. See [Deploying](docs/deploying.md).

--- a/README.zh.md
+++ b/README.zh.md
@@ -67,14 +67,14 @@ eros-engine-llm   = "1.0"   # optional: model and embedding clients
 每个 `v*` tag 都会向 GitHub Container Registry 发布多架构镜像：
 
 ```bash
-docker pull ghcr.io/etherfunlab/eros-engine:1.0.4
+docker pull ghcr.io/etherfunlab/eros-engine:1.1.0
 # Or follow the latest tagged release
 docker pull ghcr.io/etherfunlab/eros-engine:latest
 ```
 
 ```bash
 docker run --rm -p 8080:8080 --env-file .env \
-  ghcr.io/etherfunlab/eros-engine:1.0.4 serve
+  ghcr.io/etherfunlab/eros-engine:1.1.0 serve
 ```
 
 你需要自行提供 Postgres 和 `.env`；同一个 `docker/Dockerfile` 可部署到任意容器托管平台。详见[部署](docs/deploying.zh.md)。

--- a/crates/eros-engine-llm/Cargo.toml
+++ b/crates/eros-engine-llm/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "openrouter", "voyage", "embeddings", "llm"]
 categories = ["api-bindings"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "1.0.5-dev" }
+eros-engine-core = { path = "../eros-engine-core", version = "1.1.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/eros-engine-server/Cargo.toml
+++ b/crates/eros-engine-server/Cargo.toml
@@ -13,9 +13,9 @@ name = "eros-engine"
 path = "src/main.rs"
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "1.0.5-dev" }
-eros-engine-llm  = { path = "../eros-engine-llm", version = "1.0.5-dev" }
-eros-engine-store = { path = "../eros-engine-store", version = "1.0.5-dev" }
+eros-engine-core = { path = "../eros-engine-core", version = "1.1.0" }
+eros-engine-llm  = { path = "../eros-engine-llm", version = "1.1.0" }
+eros-engine-store = { path = "../eros-engine-store", version = "1.1.0" }
 axum = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0-only",
       "identifier": "AGPL-3.0-only"
     },
-    "version": "1.0.5-dev"
+    "version": "1.1.0"
   },
   "servers": [
     {

--- a/crates/eros-engine-store/Cargo.toml
+++ b/crates/eros-engine-store/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "memory", "pgvector", "postgres", "sqlx"]
 categories = ["database"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "1.0.5-dev" }
+eros-engine-core = { path = "../eros-engine-core", version = "1.1.0" }
 sqlx = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
Version bump for **v1.1.0**. Minor rather than patch: #245 drops `companion_insights` and narrows the wire surface, so this is breaking for API consumers.

Six version strings + `Cargo.lock` + `openapi.json` `info.version` + the `docker pull` example in **all three** READMEs (`README.md`, `README.zh.md`, `README.ja.md`).

## What ships in v1.1.0

Everything merged into `dev` after the v1.0.4 release PR (#243).

**Breaking**
- #245 — `refactor(insights)!`: drop `companion_insights`; the extractor writes `human_insights` directly. Migration `0042` drops the table and `chat_sessions.lead_score`; `lead_score` / CTA / `training_level` leave the wire surface and the profile DTO is retyped.

**Features**
- #247 — sampling knobs (`top_p` / `frequency_penalty` / `presence_penalty`) reach every non-embedding task instead of only `chat_companion`, grouped into one `Sampling` struct, plus a new `repetition_penalty`. Boot now refuses out-of-range values and `[tasks.embedding]`. Closes #246.
- #248 — `affinity_scope` request field on the voice turn, aligned with the chat stream.
- #249 — the PDE judge receives its intimacy rung and patience band as engine-computed facts rather than deriving them from raw axes.

**Fixes**
- #250 — migration `0042`'s reconciliation backfill let the stale typed row win over the authoritative JSONB and kept JSON `null` array elements. Found in the pre-promotion review of #245; both paths could have destroyed profile data permanently on first run.

**Chore**
- #244 — reopen `1.0.5-dev` (superseded by this bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)