### PR TITLE
chore(dev): reopen 1.2.1-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,7 +511,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "eros-engine-core"
-version = "1.2.0"
+version = "1.2.1-dev"
 dependencies = [
  "chrono",
  "serde",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-llm"
-version = "1.2.0"
+version = "1.2.1-dev"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-server"
-version = "1.2.0"
+version = "1.2.1-dev"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-store"
-version = "1.2.0"
+version = "1.2.1-dev"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "1.2.0"
+version = "1.2.1-dev"
 edition = "2021"
 license = "AGPL-3.0-only"
 repository = "https://github.com/etherfunlab/eros-engine"

--- a/crates/eros-engine-llm/Cargo.toml
+++ b/crates/eros-engine-llm/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "openrouter", "voyage", "embeddings", "llm"]
 categories = ["api-bindings"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "1.2.0" }
+eros-engine-core = { path = "../eros-engine-core", version = "1.2.1-dev" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/eros-engine-server/Cargo.toml
+++ b/crates/eros-engine-server/Cargo.toml
@@ -13,9 +13,9 @@ name = "eros-engine"
 path = "src/main.rs"
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "1.2.0" }
-eros-engine-llm  = { path = "../eros-engine-llm", version = "1.2.0" }
-eros-engine-store = { path = "../eros-engine-store", version = "1.2.0" }
+eros-engine-core = { path = "../eros-engine-core", version = "1.2.1-dev" }
+eros-engine-llm  = { path = "../eros-engine-llm", version = "1.2.1-dev" }
+eros-engine-store = { path = "../eros-engine-store", version = "1.2.1-dev" }
 axum = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0-only",
       "identifier": "AGPL-3.0-only"
     },
-    "version": "1.2.0"
+    "version": "1.2.1-dev"
   },
   "servers": [
     {

--- a/crates/eros-engine-store/Cargo.toml
+++ b/crates/eros-engine-store/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "memory", "pgvector", "postgres", "sqlx"]
 categories = ["database"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "1.2.0" }
+eros-engine-core = { path = "../eros-engine-core", version = "1.2.1-dev" }
 sqlx = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
Version-only bump reopening `dev` for development after the v1.2.0 promote.

- Four `Cargo.toml`s (`1.2.0` → `1.2.1-dev`), `Cargo.lock`, `openapi.json`.
- README docker-pull examples deliberately stay at `1.2.0` — they point at the
  last released image, not the in-development version.

`main` and `dev` are the same commit after the fast-forward promote, so there is
no ancestry to repair; this is the only follow-up the release leaves behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)