### PR TITLE
chore(release): v1.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,7 +531,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "eros-engine-core"
-version = "1.2.1-dev"
+version = "1.2.1"
 dependencies = [
  "chrono",
  "serde",
@@ -541,7 +541,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-llm"
-version = "1.2.1-dev"
+version = "1.2.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-server"
-version = "1.2.1-dev"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-store"
-version = "1.2.1-dev"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "1.2.1-dev"
+version = "1.2.1"
 edition = "2021"
 license = "AGPL-3.0-only"
 repository = "https://github.com/etherfunlab/eros-engine"

--- a/README.ja.md
+++ b/README.ja.md
@@ -69,14 +69,14 @@ eros-engine-llm   = "1.0"   # optional: model and embedding clients
 各 `v*` タグについて、複数アーキテクチャ対応のイメージを GitHub Container Registry へ公開しています。
 
 ```bash
-docker pull ghcr.io/etherfunlab/eros-engine:1.2.0
+docker pull ghcr.io/etherfunlab/eros-engine:1.2.1
 # Or follow the latest tagged release
 docker pull ghcr.io/etherfunlab/eros-engine:latest
 ```
 
 ```bash
 docker run --rm -p 8080:8080 --env-file .env \
-  ghcr.io/etherfunlab/eros-engine:1.2.0 serve
+  ghcr.io/etherfunlab/eros-engine:1.2.1 serve
 ```
 
 Postgres と `.env` は利用者側で用意してください。同じ `docker/Dockerfile` を任意のコンテナ環境へ配備できます。詳細は [Deploying](docs/deploying.md) を参照してください。

--- a/README.md
+++ b/README.md
@@ -69,14 +69,14 @@ eros-engine-llm   = "1.0"   # optional: model and embedding clients
 Multi-architecture images are published to GitHub Container Registry for every `v*` tag:
 
 ```bash
-docker pull ghcr.io/etherfunlab/eros-engine:1.2.0
+docker pull ghcr.io/etherfunlab/eros-engine:1.2.1
 # Or follow the latest tagged release
 docker pull ghcr.io/etherfunlab/eros-engine:latest
 ```
 
 ```bash
 docker run --rm -p 8080:8080 --env-file .env \
-  ghcr.io/etherfunlab/eros-engine:1.2.0 serve
+  ghcr.io/etherfunlab/eros-engine:1.2.1 serve
 ```
 
 Bring your own Postgres and `.env`; the same `docker/Dockerfile` can be deployed to any container host. See [Deploying](docs/deploying.md).

--- a/README.zh.md
+++ b/README.zh.md
@@ -69,14 +69,14 @@ eros-engine-llm   = "1.0"   # optional: model and embedding clients
 每个 `v*` tag 都会向 GitHub Container Registry 发布多架构镜像：
 
 ```bash
-docker pull ghcr.io/etherfunlab/eros-engine:1.2.0
+docker pull ghcr.io/etherfunlab/eros-engine:1.2.1
 # Or follow the latest tagged release
 docker pull ghcr.io/etherfunlab/eros-engine:latest
 ```
 
 ```bash
 docker run --rm -p 8080:8080 --env-file .env \
-  ghcr.io/etherfunlab/eros-engine:1.2.0 serve
+  ghcr.io/etherfunlab/eros-engine:1.2.1 serve
 ```
 
 你需要自行提供 Postgres 和 `.env`；同一个 `docker/Dockerfile` 可部署到任意容器托管平台。详见[部署](docs/deploying.zh.md)。

--- a/crates/eros-engine-llm/Cargo.toml
+++ b/crates/eros-engine-llm/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "openrouter", "voyage", "embeddings", "llm"]
 categories = ["api-bindings"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "1.2.1-dev" }
+eros-engine-core = { path = "../eros-engine-core", version = "1.2.1" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/eros-engine-server/Cargo.toml
+++ b/crates/eros-engine-server/Cargo.toml
@@ -13,9 +13,9 @@ name = "eros-engine"
 path = "src/main.rs"
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "1.2.1-dev" }
-eros-engine-llm  = { path = "../eros-engine-llm", version = "1.2.1-dev" }
-eros-engine-store = { path = "../eros-engine-store", version = "1.2.1-dev" }
+eros-engine-core = { path = "../eros-engine-core", version = "1.2.1" }
+eros-engine-llm  = { path = "../eros-engine-llm", version = "1.2.1" }
+eros-engine-store = { path = "../eros-engine-store", version = "1.2.1" }
 axum = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0-only",
       "identifier": "AGPL-3.0-only"
     },
-    "version": "1.2.1-dev"
+    "version": "1.2.1"
   },
   "servers": [
     {

--- a/crates/eros-engine-store/Cargo.toml
+++ b/crates/eros-engine-store/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "memory", "pgvector", "postgres", "sqlx"]
 categories = ["database"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "1.2.1-dev" }
+eros-engine-core = { path = "../eros-engine-core", version = "1.2.1" }
 sqlx = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
Version bump only. Six version strings, three READMEs, `Cargo.lock`, `openapi.json`.

## Delta since v1.2.0

Derived from PRs merged into `dev` after #258 (`chore(release): v1.2.0`), not from `git log`.

**Features**
- #260 — image-composer and vision audit events; remove voice `relationship_scope`
- #261 — **affinity 3.1**: `affinity_scope` steers the write side. A bond-half-only scope boosts the bond-exclusive axes by a constant; any scope touching the chemistry half puts the chemistry-exclusive ones through a grade ladder. Shared `warmth` exempt both ways, losses never steered.

**Fixes**
- #262 — the cross-line penalty is charged **in proportion to the applied grade** rather than as a flat toll on any non-zero grade. Removes the case where an all-positive judge verdict lowered the score; the double-high lock survives at own tier 5 past a counterpart of ≈0.761.

**Chore**
- #263 — bump `quinn-proto` to 0.11.16 (dependabot #2; not compiled in this workspace, lockfile hygiene)

## Config added this release

| Env var | Default | Identity (feature off) |
|---|---|---|
| `AFFINITY_SCOPE_BOND_BOOST` | `1.5` | `1.0` |
| `AFFINITY_SCOPE_CHEM_LADDER` | `0,0,1,3,4` | `0,1,2,3,4` |

Both optional. #262 has no knob — `κ` remains the dial.

## Deployer note

#261 and #262 together retune affinity scoring for **every** session, not a subset: the suppress path takes whichever `affinity_scope` value dominates your traffic. Audit keys `scope_mode`, `effective_grades` and `cross_penalty_assessed` land in `companion_affinity_events.context` to make the effect observable. Specs: `docs/superpowers/specs/2026-08-14-affinity-31-scope-steering-design.md` and `…-cross-penalty-by-grade-design.md`.

No migration this release. Rollback = pin the previous image, or set the two knobs to their identities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)