### PR TITLE
fix(llm): refuse to boot on a filter_prompt set for character_insight_structuring

### DIFF
--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -2463,6 +2463,49 @@ impl ModelConfig {
         Ok(())
     }
 
+    /// Boot gate for `[tasks.character_insight_structuring].filter_prompt` —
+    /// the second key in this config that parses but is never read.
+    ///
+    /// The character chain's structuring stage builds its prompt in
+    /// `prompt.rs`: the ten-column schema it must emit is the same schema
+    /// `project_columns` reads back, so letting an operator rewrite it would
+    /// let the two drift apart silently — every unrecognised key is dropped on
+    /// projection, so the symptom is columns that quietly stop filling, not an
+    /// error. `resolve_structuring` returns a `ResolvedModel`, which carries no
+    /// `filter_prompt` field at all, so a value set here was never read.
+    ///
+    /// Same treatment as [`Self::validate_affinity_prompt_unset`] and for the
+    /// same reason: dead config must never silently no-op. Rejects the key in
+    /// EVERY shape, blank included — blank leniency exists for keys that are
+    /// actually read, and here it would reproduce the exact silence this gate
+    /// removes. Every other field on the block (model, fallback, temperature,
+    /// max_tokens, sampling, reasoning) stays configurable; those are the whole
+    /// point of the block existing separately from stage 1.
+    ///
+    /// Deliberately NOT folded together with the affinity gate: they are two
+    /// short checks with different rationales, and this codebase prefers three
+    /// similar sites to a premature abstraction. The third — the human chain's
+    /// `insight_structuring`, once that split lands — is the moment to unify.
+    pub fn validate_structuring_prompt_unset(&self) -> Result<(), String> {
+        const STRUCTURING_TASK: &str = "character_insight_structuring";
+        let has_prompt = self
+            .tasks
+            .get(STRUCTURING_TASK)
+            .is_some_and(|t| t.filter_prompt.is_some());
+        if has_prompt {
+            return Err(format!(
+                "[tasks.{STRUCTURING_TASK}].filter_prompt is set, but the structuring stage's \
+                 prompt is engine-owned and deliberately not configurable — it was never read, \
+                 and eros-engine refuses to boot rather than let it silently no-op. The prompt \
+                 must stay in lockstep with the character_insights columns it fills. Remove the \
+                 key; model/fallback/temperature/max_tokens/sampling/reasoning remain \
+                 configurable. To change what stage 1 extracts, set \
+                 [tasks.character_insight_extraction].filter_prompt instead."
+            ));
+        }
+        Ok(())
+    }
+
     /// Boot gate for `[tasks.<name>.tiers.<tier>]` blocks under tasks that
     /// never resolve with a tier (issue #215).
     ///
@@ -5067,12 +5110,18 @@ filter_prompt = "   "
 
         // Stage 2 has NO configurable prompt (it is built in prompt.rs), so a
         // block without one is correct and must boot.
+        //
+        // "Not in THIS gate" is not "ungated": a filter_prompt set on stage 2
+        // is dead config and refused by `validate_structuring_prompt_unset`.
+        // The two gates are separate because they enforce opposite things —
+        // this one requires the key, that one forbids it.
         let ok = ModelConfig::from_toml_str(
             "[tasks.character_insight_extraction]\nmodel = \"m\"\nfilter_prompt = \"p\"\n\n\
              [tasks.character_insight_structuring]\nmodel = \"m2\"\n",
         )
         .unwrap();
         assert!(ok.validate_extraction_prompts().is_ok());
+        assert!(ok.validate_structuring_prompt_unset().is_ok());
     }
 
     #[test]
@@ -6666,6 +6715,87 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
     }
 
     // ─── validate_affinity_prompt_unset ──────────────────────────────────
+    #[test]
+    fn structuring_filter_prompt_absent_boots() {
+        // The shape the shipped example uses: parameters only.
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.character_insight_structuring]\nmodel = \"m\"\nmax_tokens = 600\n",
+        )
+        .unwrap();
+        assert!(cfg.validate_structuring_prompt_unset().is_ok());
+    }
+
+    #[test]
+    fn structuring_task_absent_boots() {
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.character_insight_extraction]\nmodel = \"m\"\nfilter_prompt = \"p\"\n",
+        )
+        .unwrap();
+        assert!(cfg.validate_structuring_prompt_unset().is_ok());
+    }
+
+    #[test]
+    fn structuring_filter_prompt_set_refuses_to_boot() {
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.character_insight_structuring]\nmodel = \"m\"\n\
+             filter_prompt = \"emit the ten columns\"\n",
+        )
+        .unwrap();
+        let err = cfg
+            .validate_structuring_prompt_unset()
+            .expect_err("a set filter_prompt must refuse to boot");
+        assert!(
+            err.contains("[tasks.character_insight_structuring].filter_prompt"),
+            "{err}"
+        );
+        assert!(err.contains("refuses to boot"), "{err}");
+        // The message must point at the key that IS configurable, or an
+        // operator who wanted to change extraction has nowhere to go.
+        assert!(
+            err.contains("[tasks.character_insight_extraction].filter_prompt"),
+            "error must name the configurable alternative: {err}"
+        );
+    }
+
+    #[test]
+    fn structuring_blank_filter_prompt_also_refuses_to_boot() {
+        // Blank is NOT the lenient "commented out" case: the key is dead config
+        // in every shape, so accepting blank would reproduce the exact silence
+        // this gate exists to remove.
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.character_insight_structuring]\nmodel = \"m\"\nfilter_prompt = \"\"\n",
+        )
+        .unwrap();
+        assert!(cfg.validate_structuring_prompt_unset().is_err());
+    }
+
+    #[test]
+    fn structuring_variant_shaped_filter_prompt_also_refuses_to_boot() {
+        // Shape-independent: a table/array-shaped prompt reads as `None` through
+        // `as_plain()`, so a resolver-based check would miss it entirely. This
+        // gate asks only whether the key exists.
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.character_insight_structuring]\nmodel = \"m\"\n\
+             filter_prompt = { a = \"x\", b = \"y\" }\n",
+        )
+        .unwrap();
+        assert!(cfg.validate_structuring_prompt_unset().is_err());
+    }
+
+    #[test]
+    fn structuring_gate_ignores_a_prompt_on_the_extraction_block() {
+        // Stage 1 is prompt-bearing and REQUIRED to have one. The two gates must
+        // not cross-fire.
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.character_insight_extraction]\nmodel = \"m\"\n\
+             filter_prompt = \"mine character facts\"\n\n\
+             [tasks.character_insight_structuring]\nmodel = \"m2\"\n",
+        )
+        .unwrap();
+        assert!(cfg.validate_structuring_prompt_unset().is_ok());
+        assert!(cfg.validate_extraction_prompts().is_ok());
+    }
+
     #[test]
     fn affinity_filter_prompt_absent_boots() {
         let cfg = ModelConfig::from_toml_str(

--- a/crates/eros-engine-server/src/main.rs
+++ b/crates/eros-engine-server/src/main.rs
@@ -570,6 +570,45 @@ mod tests {
         assert!(unset_err.contains("unset"), "{unset_err}");
     }
 
+    /// Ordering regression, sibling of the one above and the reason
+    /// `validate_structuring_prompt_unset` sits BEFORE `validate_prompt_variants`
+    /// in `main`. A variant-shaped `[tasks.character_insight_structuring]
+    /// .filter_prompt` trips both gates, so whichever runs first is the message
+    /// the operator actually sees. The structuring gate's is the actionable one:
+    /// it says the prompt is engine-owned and names the stage-1 key to edit
+    /// instead. The variant gate only reports that variants are unreadable here,
+    /// which would send an operator off to fix the shape of a key that must not
+    /// exist at all.
+    #[test]
+    fn variant_shaped_structuring_prompt_reports_the_actionable_error() {
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.character_insight_structuring]\nmodel = \"m\"\n\
+             filter_prompt = { a = \"x\", b = \"y\" }\n",
+        )
+        .expect("parses");
+
+        let gate_err = cfg
+            .validate_structuring_prompt_unset()
+            .expect_err("a variant-shaped structuring prompt must refuse to boot");
+        assert!(gate_err.contains("engine-owned"), "{gate_err}");
+        assert!(
+            gate_err.contains("[tasks.character_insight_extraction].filter_prompt"),
+            "the message an operator sees must name the key that IS configurable: {gate_err}"
+        );
+
+        // Pins the masking this ordering prevents: the variant gate also errors
+        // on this config, but its message is about prompt SHAPE — advice for a
+        // key that should simply be deleted.
+        let variant_err = cfg
+            .validate_prompt_variants()
+            .expect_err("the variant gate also rejects this config, for a shallower reason");
+        assert!(
+            !variant_err.contains("engine-owned"),
+            "if the variant gate ever gained the actionable wording, this ordering \
+             test stops meaning anything: {variant_err}"
+        );
+    }
+
     #[test]
     fn example_config_output_regex_compiles() {
         let text = include_str!("../../../examples/model_config.toml");

--- a/crates/eros-engine-server/src/main.rs
+++ b/crates/eros-engine-server/src/main.rs
@@ -242,6 +242,14 @@ async fn run_server() -> Result<()> {
         anyhow::bail!(msg);
     }
 
+    // Same placement rationale as the affinity gate directly above: shape-
+    // independent, so a variant-shaped filter_prompt under
+    // [tasks.character_insight_structuring] gets the accurate "this prompt is
+    // engine-owned" message rather than the generic variant one.
+    if let Err(msg) = model_config.validate_structuring_prompt_unset() {
+        anyhow::bail!(msg);
+    }
+
     // Prompt-variant shape gate runs before the resolver-based checks below
     // (extraction / product_qa). Those detect "unset" via
     // `PromptSpec::as_plain()`, under which a variant shape (array/table)
@@ -485,6 +493,17 @@ mod tests {
         let cfg = ModelConfig::from_toml_str(text).expect("examples/model_config.toml parses");
         cfg.validate_affinity_prompt_unset()
             .expect("shipped example must not set an affinity filter_prompt");
+    }
+
+    /// The shipped example's [tasks.character_insight_structuring] block is
+    /// parameters-only by design — it MUST pass the structuring dead-config
+    /// gate, or `main` bails on the config we tell people to copy.
+    #[test]
+    fn shipped_model_config_satisfies_structuring_prompt_boot_gate() {
+        let text = include_str!("../../../examples/model_config.toml");
+        let cfg = ModelConfig::from_toml_str(text).expect("examples/model_config.toml parses");
+        cfg.validate_structuring_prompt_unset()
+            .expect("shipped example must not set a structuring filter_prompt");
     }
 
     /// Every `[tasks.*.tiers.*]` block in the shipped example is commented out

--- a/docs/model-config.md
+++ b/docs/model-config.md
@@ -544,7 +544,7 @@ input filter has no triggers, timing, or tiers).
 | `chat_product_qa` | `pipeline::stream` via `resolve_product_qa()` (out-of-character product-QA executor for the PDE `product_qa` action; off when task block absent or `filter_prompt` blank; also requires the LLM PDE) | live (opt-in) |
 | `affinity_evaluation` | `pipeline::post_process` (per-turn affinity verdict — five graded axes plus an absolute patience read, converted to deltas engine-side; runs after each Reply turn, fire-and-forget; **takes no `filter_prompt`** — the prompt is engine-owned and setting the key refuses to boot — **in any form, an explicit blank included**. Unlike every other task here, blank does not mean "off", so omit the key entirely. See issue #210) | live |
 | `character_insight_extraction` | `pipeline::post_process` (stage 1 of the character chain — experimental, EXPERIMENTAL — per-turn fact miner for the AI **character**, the mirror of `insight_extraction`'s human-side mining. Prompt-bearing; joins the required-`filter_prompt` gate alongside `insight_extraction` / `memory_extraction`. This block is the whole chain's on/off switch — off when the task block is absent) | experimental (opt-in) |
-| `character_insight_structuring` | `pipeline::post_process` (stage 2 of the character chain — experimental — turns stage 1's mined facts plus the existing `character_insights` row into the typed ten-column object. **Parameters-only, takes no `filter_prompt`** — its prompt is built in `prompt.rs`. Note the contrast with `affinity_evaluation`: there is no boot gate on this key, so a value set on it is silently ignored dead config rather than a boot failure. Absent block ⇒ stage 2 resolves on stage 1's model/budget, never the global default) | experimental (opt-in) |
+| `character_insight_structuring` | `pipeline::post_process` (stage 2 of the character chain — experimental — turns stage 1's mined facts plus the existing `character_insights` row into the typed ten-column object. **Parameters-only, takes no `filter_prompt`** — its prompt is built in `prompt.rs` and must stay in lockstep with the `character_insights` columns it fills, so setting the key refuses to boot, **in any shape, an explicit blank included** — same treatment as `affinity_evaluation`. Absent block ⇒ stage 2 resolves on stage 1's model/budget, never the global default) | experimental (opt-in) |
 | `memory_extraction` | dreaming sweeper (session-end memory consolidation; off when task block absent) | live (opt-in) |
 | `chat_input_filter` | `pipeline::stream` (user-input rewrite filter; activated by `input_filter` on `[tasks.chat_companion]` and this task block; off by default) | live (opt-in) |
 | `chat_voice` | `pipeline::voice::run_voice_turn`, reached from `routes::voice` (`POST /comp/voice/{session_id}/turn/stream`) via `resolve_voice()` (voice-channel companion reply; a blank `filter_prompt` does NOT disable it — falls back to the built-in directive; off when the task block is absent) | live (opt-in) |
@@ -1009,9 +1009,13 @@ experimental character chain, §"Task names" above) are controlled by the
   the character chain — both stages — never runs).
 
 `character_insight_structuring` (stage 2 of the character chain) is
-**deliberately NOT in this gate** — unlike the three tasks above, it carries no
-`filter_prompt` at all (its prompt is built in `prompt.rs`, not configured), so
-there is nothing to validate. If you copy the shipped example and blank out
+**deliberately NOT in this gate**, because this gate *requires* a prompt and
+stage 2 must not have one. It is gated in the opposite direction instead: its
+prompt is built in `prompt.rs`, so setting `filter_prompt` on it refuses to boot
+(see `affinity_evaluation` above — same dead-config rule). "Not in this gate"
+means "gated the other way", not "ungated".
+
+If you copy the shipped example and blank out
 `[tasks.character_insight_extraction].filter_prompt` expecting the feature to
 just go quiet, it instead refuses to boot — remove the section entirely to
 disable the chain.

--- a/docs/model-config.zh.md
+++ b/docs/model-config.zh.md
@@ -484,7 +484,7 @@ SSE `final` frame 的 `filtered` 字段在客户端收到的是非原始输出�
 | `chat_product_qa` | `pipeline::stream`，通过 `resolve_product_qa()`（PDE `product_qa` 动作的出戏产品问答执行器；任务块缺失或 `filter_prompt` 为空白时关闭；还需要 LLM PDE 已启用） | live（opt-in） |
 | `affinity_evaluation` | `pipeline::post_process`（每轮好感度裁决——五个档位轴加一个 patience 绝对读数，由引擎侧换算成 delta；每个 Reply 轮次后以 fire-and-forget 方式运行；**不接受 `filter_prompt`** —— 该 prompt 由引擎持有，设置该键会拒绝启动——**任何写法都算，包括显式留空**。与这里其它任务不同，空白在这里不等于"关闭"，请直接不写这个键。见 issue #210） | live |
 | `character_insight_extraction` | `pipeline::post_process`（角色链 stage 1 —— 实验特性 —— 针对 AI **角色**的逐轮事实挖掘，是 `insight_extraction` 人类侧挖掘的镜像。持有 prompt，与 `insight_extraction` / `memory_extraction` 共用同一个必填-`filter_prompt` 闸门。这个块是整条链（两个 stage）的总开关——任务块缺失即关闭） | experimental（opt-in） |
-| `character_insight_structuring` | `pipeline::post_process`（角色链 stage 2 —— 实验特性 —— 把 stage 1 挖掘出的事实加上已有的 `character_insights` 行，转成类型化的十列对象。**仅参数，不接受 `filter_prompt`** —— 它的 prompt 写在 `prompt.rs` 里。注意与 `affinity_evaluation` 的差别：这个键上没有 boot 闸门，写了不会拒绝启动，而是被静默忽略的死配置。块缺失时 stage 2 会退回到 stage 1 的模型/预算，绝不退到全局默认） | experimental（opt-in） |
+| `character_insight_structuring` | `pipeline::post_process`（角色链 stage 2 —— 实验特性 —— 把 stage 1 挖掘出的事实加上已有的 `character_insights` 行，转成类型化的十列对象。**仅参数，不接受 `filter_prompt`** —— 它的 prompt 写在 `prompt.rs` 里，必须与它要填的 `character_insights` 列保持同步，所以设置该键会拒绝启动，**任何写法都算，包括显式留空**——与 `affinity_evaluation` 同样处理。块缺失时 stage 2 会退回到 stage 1 的模型/预算，绝不退到全局默认） | experimental（opt-in） |
 | `memory_extraction` | dreaming sweeper（会话结束时进行 memory 整合；任务块缺失时关闭） | live（opt-in） |
 | `chat_input_filter` | `pipeline::stream`（用户输入改写 filter；由 `[tasks.chat_companion]` 上的 `input_filter` 和此任务块共同激活；默认关闭） | live（opt-in） |
 | `chat_voice` | `pipeline::voice::run_voice_turn`，由 `routes::voice`（`POST /comp/voice/{session_id}/turn/stream`）经 `resolve_voice()` 到达（语音通道的伴侣回复；`filter_prompt` 为空白**不会**关闭该任务——会回退到内置 directive；任务块缺失时关闭） | live（opt-in） |
@@ -823,8 +823,12 @@ stage 1，见上文"任务名"一节）都由各自 `[tasks.*_extraction]` **章
   `insight_extraction`；dreaming sweeper 保持不生效；角色链两个 stage 都不会跑）。
 
 `character_insight_structuring`（角色链 stage 2）**故意不在这个闸门里**——
-与上面三个任务不同，它根本不接受 `filter_prompt`（它的 prompt 写死在
-`prompt.rs` 里，不可配置），所以没有可校验的东西。如果照抄示例配置、把
+因为这个闸门要求必须有 prompt，而 stage 2 必须没有。它被反方向的闸门管着：
+它的 prompt 写死在 `prompt.rs` 里，所以给它设置 `filter_prompt` 会拒绝启动
+（见上面的 `affinity_evaluation`，同一条死配置规则）。「不在这个闸门里」
+是「被另一个闸门管着」，不是「没人管」。
+
+如果照抄示例配置、把
 `[tasks.character_insight_extraction].filter_prompt` 清空，指望功能安静关掉，
 结果会是拒绝启动——要关闭整条链，删掉整个 section。
 

--- a/docs/superpowers/specs/2026-08-15-character-insights-design.md
+++ b/docs/superpowers/specs/2026-08-15-character-insights-design.md
@@ -407,7 +407,14 @@ without a prompt (and a test asserts it stays that way). Consequently:
   `"character_insight_structuring"`.
 - `validate_extraction_prompts` gains **only** `character_insight_extraction`:
   present-with-blank-`filter_prompt` refuses boot, absent means the feature is
-  off. The stage-2 block has no prompt to validate.
+  off. The stage-2 block has no prompt to require.
+- `validate_structuring_prompt_unset` gates stage 2 in the **opposite**
+  direction: a `filter_prompt` set there refuses boot, in any shape including
+  blank. *(Added as a follow-up after the initial merge — the first cut left
+  the key as silently-ignored dead config, which is exactly what
+  `validate_affinity_prompt_unset` and `validate_tier_blocks` exist to
+  prevent. Two gates rather than one because they enforce opposite things: one
+  requires the key, the other forbids it.)*
 
 **The stage-1 block is the entire on/off switch.** No new flag, no new env var:
 `resolve_character_insight_extract()` returning `None` skips the whole chain

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -506,7 +506,11 @@ content 表达规则：第三人称、以「角色」开头；保留原始信息
 
 # Stage 2 of the character chain: turns stage-1 facts into the ten-column
 # object. NO filter_prompt here — that prompt is built in the engine
-# (prompt.rs) and is not configurable, the same shape as affinity_evaluation.
+# (prompt.rs) and is not configurable, the same shape as affinity_evaluation:
+# setting the key REFUSES TO BOOT (in any shape, blank included) rather than
+# being silently ignored, because it has to stay in lockstep with the
+# character_insights columns it fills. To change what gets extracted, edit
+# [tasks.character_insight_extraction].filter_prompt above.
 # Delete this block and stage 2 runs on the extraction block's parameters.
 [tasks.character_insight_structuring]
 model = "anthropic/claude-haiku-4.5"


### PR DESCRIPTION
## Summary

Follow-up to #266, closing the open question that PR left behind:
`[tasks.character_insight_structuring].filter_prompt` parsed fine and was never
read. Setting it now refuses to boot, matching how this config already treats
every other piece of dead config.

## Why this is a gate rather than a resolver

`resolve_structuring` returns a `ResolvedModel`, which has no `filter_prompt`
field at all — so a value set there produced no prompt change, no warning, and
no error. That is the silent no-op `validate_affinity_prompt_unset` (#210) and
`validate_tier_blocks` (#215) exist to refuse.

The stage-2 prompt is engine-owned for a concrete reason, not just consistency:
the ten-column schema it asks the model to emit is the same schema
`project_columns` reads back. If the two drift apart, every unrecognised key is
silently dropped on projection — so the symptom is columns that quietly stop
filling, not an error anyone can see. To change what the chain extracts, the
configurable surface is `[tasks.character_insight_extraction].filter_prompt`,
and the error message says so.

## Shape and blank handling

Rejected in **every** shape, blank included. Blank leniency ("commented out" ⇒
built-in default) exists for keys that are actually read; here it would
reproduce the exact silence this removes. Variant shapes (array/table) are
caught too — the gate asks only whether the key exists, which is why it sits
beside the affinity gate and ahead of `validate_prompt_variants`: a
table-shaped value gets the accurate "engine-owned" message instead of the
generic variant one.

Everything else on the block — `model`, `fallback`, `temperature`,
`max_tokens`, sampling, `reasoning` — stays configurable. Those are the reason
the block exists separately from stage 1 in the first place.

## Why not fold it into the affinity gate

Two short checks with different rationales, and this codebase prefers three
similar sites to a premature abstraction — the human chain's
`insight_structuring`, when that split lands, is the third site and the moment
to unify.

*Correction from review:* my first version of this argument leaned on semver —
`validate_affinity_prompt_unset` is public API in a released crate
(`eros-engine-llm` 1.2.1) and 1.3.0 is a minor bump, so it cannot be renamed or
removed. That is true but not the whole picture: a private shared helper behind
two public wrappers would have unified the bodies without touching the public
surface. I did not take it because the public surface is two methods either
way, so the only thing it buys is deduplicating ~8 lines at the second site.
Worth stating plainly, though: making this method public does add another API
that a future unification cannot remove in a minor release either.

## Also in here

- An existing test named `boot_gate_covers_character_extraction_but_not_structuring`
  still asserts something true, but its name invited the reading "stage 2 is
  ungated". It now also asserts the new gate and says plainly that **"not in
  this gate" means "gated the other way"** — one gate requires the key, the
  other forbids it.
- Docs corrected in both languages. The text merged in #266 said no gate
  existed on this key, which was accurate then and is wrong now; the
  "Enabling / disabling extraction" section now explains the opposite-direction
  gating rather than implying stage 2 is unvalidated.
- Spec §5.4 records the addition and why it was missed in the first cut.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 1362 passed, 0 failed (8 new)
- [x] `cargo run -p eros-engine-server -- print-openapi` — no snapshot drift
      (no API surface change)

New tests: key absent boots; task absent boots; key set refuses; blank refuses;
variant-shaped refuses; a prompt on the *extraction* block does not cross-fire;
the shipped `examples/model_config.toml` passes the new gate; and an ordering
regression pinning this gate ahead of `validate_prompt_variants`.

## Review

Reviewed with codex against the inlined diff — no correctness defects. Gate
bypass, cross-fire, ordering, upgrade behaviour, test discrimination and
English/Chinese doc parity all came back clean. Two non-defect notes, both
acted on: the ordering property had no test (added in `13c1ba9` — nothing
failed if someone reordered the gates in `main`), and the semver reasoning
above was incomplete (corrected in place).

One accepted consequence worth stating explicitly: **an existing deployment
that has this key set will stop booting after upgrading.** That is the point —
it was silently doing nothing before — and the error names the key, why it is
refused, what to remove, and which key to use instead.

## Checklist

- [x] CLA signed via cla-assistant.io
- [x] Conventional Commits format on commits
- [ ] DCO sign-off (`git commit -s`) — commit is GPG-signed (`-S`, verified) but
      carries no `Signed-off-by` trailer, matching the existing history on `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
