### PR TITLE
chore(dev): reopen 1.3.1-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,7 +531,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "eros-engine-core"
-version = "1.3.0"
+version = "1.3.1-dev"
 dependencies = [
  "chrono",
  "serde",
@@ -541,7 +541,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-llm"
-version = "1.3.0"
+version = "1.3.1-dev"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-server"
-version = "1.3.0"
+version = "1.3.1-dev"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-store"
-version = "1.3.0"
+version = "1.3.1-dev"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "1.3.0"
+version = "1.3.1-dev"
 edition = "2021"
 license = "AGPL-3.0-only"
 repository = "https://github.com/etherfunlab/eros-engine"

--- a/crates/eros-engine-llm/Cargo.toml
+++ b/crates/eros-engine-llm/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "openrouter", "voyage", "embeddings", "llm"]
 categories = ["api-bindings"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "1.3.0" }
+eros-engine-core = { path = "../eros-engine-core", version = "1.3.1-dev" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/eros-engine-server/Cargo.toml
+++ b/crates/eros-engine-server/Cargo.toml
@@ -13,9 +13,9 @@ name = "eros-engine"
 path = "src/main.rs"
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "1.3.0" }
-eros-engine-llm  = { path = "../eros-engine-llm", version = "1.3.0" }
-eros-engine-store = { path = "../eros-engine-store", version = "1.3.0" }
+eros-engine-core = { path = "../eros-engine-core", version = "1.3.1-dev" }
+eros-engine-llm  = { path = "../eros-engine-llm", version = "1.3.1-dev" }
+eros-engine-store = { path = "../eros-engine-store", version = "1.3.1-dev" }
 axum = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0-only",
       "identifier": "AGPL-3.0-only"
     },
-    "version": "1.3.0"
+    "version": "1.3.1-dev"
   },
   "servers": [
     {

--- a/crates/eros-engine-store/Cargo.toml
+++ b/crates/eros-engine-store/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "memory", "pgvector", "postgres", "sqlx"]
 categories = ["database"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "1.3.0" }
+eros-engine-core = { path = "../eros-engine-core", version = "1.3.1-dev" }
 sqlx = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
Post-release version reopen: `1.3.0` → `1.3.1-dev` across the workspace + path-dep pins, `Cargo.lock`, `openapi.json`. README docker-pull lines stay at the released `1.3.0`.