### PR TITLE
feat: soft-delete a relationship's sessions

### DIFF
--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -640,6 +640,54 @@
         ]
       }
     },
+    "/comp/instance/{instance_id}/sessions": {
+      "delete": {
+        "tags": [
+          "companion"
+        ],
+        "summary": "Soft-delete every session this user holds with one persona instance.",
+        "description": "The conversation stops being visible and stops being resumable, and the\nrelationship state — affinity, relationship-layer memories, character\ninsights — is deleted so the next conversation starts genuinely cold. The\ntranscript in `chat_messages` is NOT deleted: it is evidence, and the audit\ntables that reference a session by id finally point at something readable.\n\nKeyed by instance because the instance is the unit of a relationship;\narchiving one session and leaving its siblings resumable would not give the\ncaller the fresh start it asked for. Every channel goes, voice included.\n\nIdempotent: a second call returns 200 with `archived_sessions: 0`.\n\nThere is no restore endpoint by design. Reviving a session is an operator\naction and `UPDATE engine.chat_sessions SET archived = false WHERE id = …`\nis the whole of it; the relationship state stays gone.",
+        "operationId": "archive_instance_sessions",
+        "parameters": [
+          {
+            "name": "instance_id",
+            "in": "path",
+            "description": "Persona instance id owned by the JWT user",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ArchiveSessionsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "missing or invalid bearer"
+          },
+          "403": {
+            "description": "instance is not owned by the JWT user"
+          },
+          "404": {
+            "description": "no such instance"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
     "/comp/user/{user_id}/profile": {
       "get": {
         "tags": [
@@ -1299,6 +1347,24 @@
           "warmth": {
             "type": "number",
             "format": "double"
+          }
+        }
+      },
+      "ArchiveSessionsResponse": {
+        "type": "object",
+        "required": [
+          "instance_id",
+          "archived_sessions"
+        ],
+        "properties": {
+          "archived_sessions": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Sessions flipped by THIS call. A repeat call reports 0."
+          },
+          "instance_id": {
+            "type": "string",
+            "format": "uuid"
           }
         }
       },

--- a/crates/eros-engine-server/src/pipeline/dreaming.rs
+++ b/crates/eros-engine-server/src/pipeline/dreaming.rs
@@ -123,6 +123,7 @@ async fn scan_and_classify(
          WHERE id IN ( \
              SELECT id FROM engine.chat_sessions \
              WHERE classified_at IS NULL \
+               AND NOT archived \
                AND last_active_at < $1 \
                AND (classification_claimed_at IS NULL \
                     OR classification_claimed_at < $2) \
@@ -421,6 +422,55 @@ fn collapse_spaces(s: &str) -> String {
 mod tests {
     use super::*;
     use crate::routes::companion::testutil::seed_persona_instance;
+
+    /// An archived session must never be claimed. The sweep writes its
+    /// extraction into companion_memories and human_insights, so a claimable
+    /// archived session would spend a model call regrowing exactly the rows
+    /// the archive endpoint just deleted.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn sweeper_skips_archived_sessions(pool: sqlx::PgPool) {
+        let state = crate::routes::companion::test_state(pool.clone());
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
+
+        // Idle for two hours and never classified — eligible on every count
+        // except `archived`.
+        let session_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_sessions (user_id, instance_id, last_active_at, archived) \
+             VALUES ($1, $2, now() - interval '2 hours', true) RETURNING id",
+        )
+        .bind(user_id)
+        .bind(instance_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO engine.chat_messages (session_id, role, content) VALUES \
+             ($1,'user','我住在上海'), ($1,'assistant','上海不错')",
+        )
+        .bind(session_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let processed = scan_and_classify(
+            &state,
+            std::time::Duration::from_secs(1800),
+            std::time::Duration::from_secs(600),
+        )
+        .await
+        .expect("sweep ok");
+        assert_eq!(processed, 0, "archived session must not be swept");
+
+        let claimed_at: Option<chrono::DateTime<Utc>> = sqlx::query_scalar(
+            "SELECT classification_claimed_at FROM engine.chat_sessions WHERE id = $1",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert!(claimed_at.is_none(), "archived session must not be claimed");
+    }
 
     #[test]
     fn parse_memory_candidates_handles_clean_json() {

--- a/crates/eros-engine-server/src/pipeline/post_process.rs
+++ b/crates/eros-engine-server/src/pipeline/post_process.rs
@@ -19,7 +19,6 @@
 use uuid::Uuid;
 
 use eros_engine_core::types::{ActionPlan, ActionType, Event};
-use eros_engine_llm::embedding::EmbeddingRouter;
 use eros_engine_llm::model_config::ModelConfig;
 use eros_engine_llm::openrouter::{ChatMessage, ChatRequest, OpenRouterClient};
 use eros_engine_store::affinity::AffinityRepo;
@@ -60,6 +59,25 @@ fn client_id_from_event(event: &Event) -> Option<String> {
     super::handlers::audit_from_event(event).and_then(|a| a.user.clone())
 }
 
+/// True when the session is still live. `get_session` filters `NOT archived`
+/// (migration 0052), so an archived session — or a read that errors, or an id
+/// that never existed — reads back as "not live" here; all three fail closed
+/// rather than risk a write landing for a session the caller can no longer see.
+///
+/// Called twice per turn: once at the top of `run`, which skips the LLM and
+/// embedding calls entirely once a session is already archived when the task
+/// starts; and again immediately before each of the three writes those calls
+/// feed, which narrows (but — see spec §9 — does not close) the window where
+/// the archive endpoint commits *during* those calls.
+async fn session_still_live(state: &AppState, session_id: Uuid) -> bool {
+    ChatRepo { pool: &state.pool }
+        .get_session(session_id)
+        .await
+        .ok()
+        .flatten()
+        .is_some()
+}
+
 /// Spawned by `pipeline::run`. Owned `state` so the future is `'static`.
 pub async fn run(
     state: AppState,
@@ -70,17 +88,9 @@ pub async fn run(
     plan: ActionPlan,
     produced: Vec<ProducedMessage>,
 ) {
-    // The archive endpoint can land between the turn and this detached task. An
-    // archived session resolves to None (migration 0052), and continuing would
-    // rewrite the three tables that endpoint just deleted — putting a
-    // companion_affinity row back, pointing at a session every read route now 404s.
-    let session_still_live = ChatRepo { pool: &state.pool }
-        .get_session(session_id)
-        .await
-        .ok()
-        .flatten()
-        .is_some();
-    if !session_still_live {
+    // The archive endpoint can land between the turn and this detached task —
+    // this is the entry half of the check documented on `session_still_live`.
+    if !session_still_live(&state, session_id).await {
         return;
     }
 
@@ -258,6 +268,15 @@ async fn persist_affinity(
     levels: eros_engine_core::affinity::EndpointLevelReads,
     eval_failures: &[eros_engine_llm::failure::AttemptFailure],
 ) {
+    // Recheck: the affinity evaluator's LLM call (or a sibling post_process
+    // future) may have run long enough for the archive endpoint to commit
+    // while this task was inside it. Without this, `load_or_create` below
+    // would put a `companion_affinity` row right back for a session every
+    // read route now 404s.
+    if !session_still_live(state, session_id).await {
+        return;
+    }
+
     let repo = AffinityRepo { pool: &state.pool };
 
     // Demo sessions get boosted positive raw scores so meters move within the
@@ -368,7 +387,7 @@ async fn write_turn(
     let rel_content = relationship_memory_content(user_msg);
     if let Err(e) = embed_and_upsert(
         &repo,
-        &state.embed,
+        state,
         MemoryLayer::Relationship,
         session_id,
         user_id,
@@ -384,7 +403,7 @@ async fn write_turn(
     if !user_msg.trim().is_empty() {
         if let Err(e) = embed_and_upsert(
             &repo,
-            &state.embed,
+            state,
             MemoryLayer::Profile,
             session_id,
             user_id,
@@ -400,7 +419,7 @@ async fn write_turn(
 
 async fn embed_and_upsert(
     repo: &MemoryRepo<'_>,
-    embed: &EmbeddingRouter,
+    state: &AppState,
     layer: MemoryLayer,
     session_id: Uuid,
     user_id: Uuid,
@@ -410,10 +429,19 @@ async fn embed_and_upsert(
     if content.trim().is_empty() {
         return Ok(());
     }
-    let embedding = embed
+    let embedding = state
+        .embed
         .embed_document(content)
         .await
         .map_err(|e| format!("embed failed: {e}"))?;
+    // Recheck: the embedding call above may have run long enough for the
+    // archive endpoint to commit while this task was inside it. Without this,
+    // the upsert below would put a `companion_memories` row right back for a
+    // session the archive just deleted it from. A silent no-op, not a
+    // failure — same as the entry guard.
+    if !session_still_live(state, session_id).await {
+        return Ok(());
+    }
     // category=None: this writer dumps raw turns. The classifier extraction
     // step (future) will write its own rows with category populated.
     repo.upsert(
@@ -1210,6 +1238,15 @@ async fn extract_character_insights(
         .await;
     }
     if structured.as_object().is_none_or(|o| o.is_empty()) {
+        return;
+    }
+
+    // Recheck: the two character-chain LLM calls above (extraction, then
+    // structuring) may together have run long enough for the archive endpoint
+    // to commit while this task was inside them. Without this, the apply
+    // below would put a `character_insights` row right back for an instance
+    // the archive just deleted it from.
+    if !session_still_live(state, session_id).await {
         return;
     }
 
@@ -2714,7 +2751,19 @@ mod tests {
             .mount(&mock)
             .await;
 
-        let instance_id = seed_persona_instance(&pool, uuid::Uuid::new_v4()).await;
+        let user_id = uuid::Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
+        // A real, unarchived session — extract_character_insights' pre-write
+        // recheck (Fix 1) reads session liveness through it, same as the
+        // production caller always passes one from the live pipeline.
+        let session_id: uuid::Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(user_id)
+        .bind(instance_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
         let mut state = crate::routes::companion::test_state(pool.clone());
         // Two DISTINCT blocks with two DISTINCT, non-prefix model ids (neither
         // is a substring of the other), so the audit rows AND the mock match
@@ -2737,7 +2786,7 @@ mod tests {
 
         extract_character_insights(
             &state,
-            uuid::Uuid::new_v4(),
+            session_id,
             instance_id,
             uuid::Uuid::new_v4(),
             "你今天在忙什么",
@@ -2892,18 +2941,26 @@ mod tests {
         assert_eq!(stages[0].0, "extraction");
     }
 
-    /// Pins the Fix 2 guard: the archive endpoint can land between a turn and
-    /// this detached task, and `run` must notice before doing any work. The
-    /// state built by `test_state` has no wiremock behind it — `write_turn`'s
-    /// embedding call and the affinity evaluator both point at real hosts —
-    /// so if the guard were missing, or placed after the point where any of
-    /// those calls fire, this test would hang or fail on a real network
-    /// attempt instead of completing. A non-empty user message and produced
-    /// text are used deliberately, so every future inside `run` has
-    /// something to act on if the guard does not stop it first.
+    /// Pins the entry guard: the archive endpoint can land between a turn and
+    /// this detached task, and `run` must notice before doing any work.
+    ///
+    /// Proves it by wiring `state.openrouter` and `state.embed` to a single
+    /// wiremock server carrying one `expect(0)` mock — verified when `mock`
+    /// drops at the end of this test, which panics the test if even one model
+    /// or embedding call went out. That is a stronger claim than the table
+    /// assertions below can make on their own: if the guard were missing, or
+    /// moved below the model/embedding calls, `run`'s fail-open error
+    /// handling would absorb the resulting request errors and still leave the
+    /// three tables empty, so the old version of this test — table counts
+    /// only — would keep passing even though the guard had stopped guarding
+    /// anything. A non-empty user message and produced text are used
+    /// deliberately, so every future inside `run` has something to act on if
+    /// the guard does not stop it first.
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
     async fn run_is_a_noop_on_an_archived_session(pool: sqlx::PgPool) {
         use eros_engine_store::session_archive::SessionArchiveRepo;
+        use wiremock::matchers::any;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
 
         let user_id = Uuid::new_v4();
         let instance_id = seed_persona_instance(&pool, user_id).await;
@@ -2921,7 +2978,37 @@ mod tests {
             .await
             .unwrap();
 
-        let state = crate::routes::companion::test_state(pool.clone());
+        // One server, one catch-all mock, zero allowed hits — backs BOTH
+        // clients so a call from any of `run`'s four futures (the affinity
+        // evaluator, the two insight chains, or the memory embed) is caught
+        // the same way.
+        let mock = MockServer::start().await;
+        Mock::given(any())
+            .respond_with(ResponseTemplate::new(200))
+            .expect(0)
+            .mount(&mock)
+            .await;
+
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "k".into(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+        let embed_cfg = eros_engine_llm::model_config::ModelConfig::from_toml_str(&format!(
+            "[providers.mockembed]\nembeddings = \"{}/v1/embeddings\"\n\
+             [tasks.embedding]\nmodel = \"mock-embed@mockembed\"\n",
+            mock.uri()
+        ))
+        .expect("embedding provider config parses");
+        state.embed = std::sync::Arc::new(
+            eros_engine_llm::embedding::EmbeddingRouter::from_config_with(&embed_cfg, |k| {
+                (k == "MOCKEMBED_API_KEY").then(|| "test-key".to_string())
+            })
+            .expect("mock embedding router builds"),
+        );
+
         let event = Event::UserMessage {
             content: "还记得我们上次聊到的事吗".into(),
             message_id: Uuid::new_v4(),
@@ -2996,6 +3083,231 @@ mod tests {
         assert_eq!(
             insights, 0,
             "the guard must stop character insight extraction from writing a row"
+        );
+    }
+
+    // ─── Fix 1's pre-write recheck ──────────────────────────────────
+    //
+    // The three tests below call `persist_affinity` / `write_turn` /
+    // `extract_character_insights` DIRECTLY rather than through `run`, so
+    // `run`'s entry guard never executes at all — it is the recheck inside
+    // each of these functions, and only that recheck, that can make the
+    // assertions below pass. This is the distinction the entry-guard test
+    // above cannot make on its own: there, the session is already archived
+    // before `run` is even called, so the entry guard alone accounts for
+    // every empty table and the recheck code paths are never reached.
+
+    /// Pins `persist_affinity`'s recheck. No `run`, no entry guard in the call
+    /// path — this proves the function's own gate, not the one at the top of
+    /// `run`.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn persist_affinity_recheck_stops_the_write_on_an_archived_session(pool: sqlx::PgPool) {
+        use eros_engine_store::session_archive::SessionArchiveRepo;
+
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
+        let session_id = sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(user_id)
+        .bind(instance_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        SessionArchiveRepo { pool: &pool }
+            .archive_relationship(user_id, instance_id)
+            .await
+            .unwrap();
+
+        let state = crate::routes::companion::test_state(pool.clone());
+        persist_affinity(
+            &state,
+            session_id,
+            user_id,
+            instance_id,
+            ActionType::ReplyText,
+            eros_engine_core::affinity::AxisGrades::default(),
+            eros_engine_core::affinity::AffinityDeltas::default(),
+            serde_json::json!({}),
+            None,
+            eros_engine_core::affinity::EndpointLevelReads::default(),
+            &[],
+        )
+        .await;
+
+        let affinity: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM engine.companion_affinity WHERE instance_id = $1",
+        )
+        .bind(instance_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            affinity, 0,
+            "persist_affinity's own recheck must stop load_or_create from recreating the row"
+        );
+    }
+
+    /// Pins `embed_and_upsert`'s recheck (called from `write_turn`). The
+    /// embed call is served a real response — if it errored instead, the
+    /// write would be skipped for the wrong reason (a transport error, not
+    /// the recheck), which is exactly the "passes anyway" failure mode Fix 2
+    /// called out. No `run`, no entry guard in the call path.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn write_turn_recheck_stops_the_write_on_an_archived_session(pool: sqlx::PgPool) {
+        use eros_engine_store::session_archive::SessionArchiveRepo;
+        use wiremock::matchers::path as wm_path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
+        let session_id = sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(user_id)
+        .bind(instance_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        SessionArchiveRepo { pool: &pool }
+            .archive_relationship(user_id, instance_id)
+            .await
+            .unwrap();
+
+        let embed_server = MockServer::start().await;
+        Mock::given(wm_path("/v1/embeddings"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": [ { "embedding": vec![0.1_f32; 512] } ]
+            })))
+            .mount(&embed_server)
+            .await;
+        let embed_cfg = eros_engine_llm::model_config::ModelConfig::from_toml_str(&format!(
+            "[providers.mockembed]\nembeddings = \"{}/v1/embeddings\"\n\
+             [tasks.embedding]\nmodel = \"mock-embed@mockembed\"\n",
+            embed_server.uri()
+        ))
+        .expect("embedding provider config parses");
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.embed = std::sync::Arc::new(
+            eros_engine_llm::embedding::EmbeddingRouter::from_config_with(&embed_cfg, |k| {
+                (k == "MOCKEMBED_API_KEY").then(|| "test-key".to_string())
+            })
+            .expect("mock embedding router builds"),
+        );
+
+        write_turn(
+            &state,
+            session_id,
+            user_id,
+            instance_id,
+            "还记得我们上次聊到的事吗",
+        )
+        .await;
+
+        let memories: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM engine.companion_memories WHERE user_id = $1 AND instance_id = $2",
+        )
+        .bind(user_id)
+        .bind(instance_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            memories, 0,
+            "write_turn's own recheck must stop the embed response from being upserted"
+        );
+    }
+
+    /// Pins `extract_character_insights`'s recheck. Both chain stages are
+    /// served real responses, same reasoning as the memory test above: the
+    /// write must be skipped because of the recheck, not because a call
+    /// failed first. No `run`, no entry guard in the call path.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn character_insights_recheck_stops_the_write_on_an_archived_session(pool: sqlx::PgPool) {
+        use eros_engine_store::session_archive::SessionArchiveRepo;
+        use wiremock::matchers::{body_string_contains, method, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        let facts_body = serde_json::json!({
+            "id": "gen-ch-facts", "model": "ch/stage-one",
+            "usage": {"total_tokens": 2},
+            "choices": [{"message": {"content":
+                "{\"facts\":[\"角色说她今天在公司加班到十点\"],\"details\":[]}"}}],
+        });
+        Mock::given(method("POST"))
+            .and(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("char-facts-sentinel"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(facts_body))
+            .mount(&mock)
+            .await;
+        let struct_body = serde_json::json!({
+            "id": "gen-ch-struct", "model": "ch/stage-two",
+            "usage": {"total_tokens": 3},
+            "choices": [{"message": {"content": "{\"location\":\"公司\"}"}}],
+        });
+        Mock::given(method("POST"))
+            .and(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("character_insights schema"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(struct_body))
+            .mount(&mock)
+            .await;
+
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
+        let session_id = sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(user_id)
+        .bind(instance_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        SessionArchiveRepo { pool: &pool }
+            .archive_relationship(user_id, instance_id)
+            .await
+            .unwrap();
+
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = std::sync::Arc::new(
+            eros_engine_llm::model_config::ModelConfig::from_toml_str(
+                "[tasks.character_insight_extraction]\nmodel=\"ch/stage-one\"\n\
+                 filter_prompt=\"char-facts-sentinel\"\n\n\
+                 [tasks.character_insight_structuring]\nmodel=\"ch/stage-two\"\n",
+            )
+            .unwrap(),
+        );
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "k".into(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+
+        extract_character_insights(
+            &state,
+            session_id,
+            instance_id,
+            Uuid::new_v4(),
+            "你今天在忙什么",
+            "还在公司，加班到十点",
+            None,
+        )
+        .await;
+
+        let profiles: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM engine.character_insights WHERE instance_id = $1",
+        )
+        .bind(instance_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            profiles, 0,
+            "extract_character_insights' own recheck must stop apply_extraction from writing the profile"
         );
     }
 }

--- a/crates/eros-engine-server/src/pipeline/post_process.rs
+++ b/crates/eros-engine-server/src/pipeline/post_process.rs
@@ -70,6 +70,20 @@ pub async fn run(
     plan: ActionPlan,
     produced: Vec<ProducedMessage>,
 ) {
+    // The archive endpoint can land between the turn and this detached task. An
+    // archived session resolves to None (migration 0052), and continuing would
+    // rewrite the three tables that endpoint just deleted — putting a
+    // companion_affinity row back, pointing at a session every read route now 404s.
+    let session_still_live = ChatRepo { pool: &state.pool }
+        .get_session(session_id)
+        .await
+        .ok()
+        .flatten()
+        .is_some();
+    if !session_still_live {
+        return;
+    }
+
     let user_msg = match &event {
         Event::UserMessage { content, .. } => content.clone(),
         _ => String::new(),
@@ -2876,5 +2890,112 @@ mod tests {
             "a failed load must abort before structuring; got {stages:?}"
         );
         assert_eq!(stages[0].0, "extraction");
+    }
+
+    /// Pins the Fix 2 guard: the archive endpoint can land between a turn and
+    /// this detached task, and `run` must notice before doing any work. The
+    /// state built by `test_state` has no wiremock behind it — `write_turn`'s
+    /// embedding call and the affinity evaluator both point at real hosts —
+    /// so if the guard were missing, or placed after the point where any of
+    /// those calls fire, this test would hang or fail on a real network
+    /// attempt instead of completing. A non-empty user message and produced
+    /// text are used deliberately, so every future inside `run` has
+    /// something to act on if the guard does not stop it first.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn run_is_a_noop_on_an_archived_session(pool: sqlx::PgPool) {
+        use eros_engine_store::session_archive::SessionArchiveRepo;
+
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
+        let session_id = sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(user_id)
+        .bind(instance_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        SessionArchiveRepo { pool: &pool }
+            .archive_relationship(user_id, instance_id)
+            .await
+            .unwrap();
+
+        let state = crate::routes::companion::test_state(pool.clone());
+        let event = Event::UserMessage {
+            content: "还记得我们上次聊到的事吗".into(),
+            message_id: Uuid::new_v4(),
+            prompt_traits: Vec::new(),
+            audit: None,
+            tier: None,
+            memory_scope: Default::default(),
+            affinity_scope: Default::default(),
+            tips_amount_usd: None,
+            history_anchor: Default::default(),
+        };
+        let plan = ActionPlan {
+            action_type: ActionType::ReplyText,
+            reply_style: eros_engine_core::types::ReplyStyle::Neutral,
+            affinity_deltas: Default::default(),
+            energy_cost: 0.0,
+            context_hints: Vec::new(),
+            reply_tone: None,
+            image_caption: None,
+            image_ref: eros_engine_core::types::ImageRef::Face,
+            aspect_ratio: None,
+        };
+        let produced = vec![ProducedMessage {
+            message_id: Uuid::new_v4(),
+            full_text: "记得呀".into(),
+            action: ActionType::ReplyText,
+        }];
+
+        run(
+            state,
+            session_id,
+            user_id,
+            instance_id,
+            event,
+            plan,
+            produced,
+        )
+        .await;
+
+        let affinity: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM engine.companion_affinity WHERE instance_id = $1",
+        )
+        .bind(instance_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            affinity, 0,
+            "the guard must stop persist_affinity from recreating the row"
+        );
+
+        let memories: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM engine.companion_memories WHERE user_id = $1 AND instance_id = $2",
+        )
+        .bind(user_id)
+        .bind(instance_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            memories, 0,
+            "the guard must stop write_turn from regrowing relationship memory"
+        );
+
+        let insights: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM engine.character_insights WHERE instance_id = $1",
+        )
+        .bind(instance_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            insights, 0,
+            "the guard must stop character insight extraction from writing a row"
+        );
     }
 }

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -143,6 +143,13 @@ pub struct ListSessionsResponse {
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct ArchiveSessionsResponse {
+    pub instance_id: Uuid,
+    /// Sessions flipped by THIS call. A repeat call reports 0.
+    pub archived_sessions: i64,
+}
+
+#[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct ProfileResponse {
     pub user_id: Uuid,
     pub city: Option<String>,
@@ -839,6 +846,62 @@ async fn get_character_profile(
     Ok(Json(CharacterProfileResponse::from_row(instance_id, row)))
 }
 
+/// Soft-delete every session this user holds with one persona instance.
+///
+/// The conversation stops being visible and stops being resumable, and the
+/// relationship state — affinity, relationship-layer memories, character
+/// insights — is deleted so the next conversation starts genuinely cold. The
+/// transcript in `chat_messages` is NOT deleted: it is evidence, and the audit
+/// tables that reference a session by id finally point at something readable.
+///
+/// Keyed by instance because the instance is the unit of a relationship;
+/// archiving one session and leaving its siblings resumable would not give the
+/// caller the fresh start it asked for. Every channel goes, voice included.
+///
+/// Idempotent: a second call returns 200 with `archived_sessions: 0`.
+///
+/// There is no restore endpoint by design. Reviving a session is an operator
+/// action and `UPDATE engine.chat_sessions SET archived = false WHERE id = …`
+/// is the whole of it; the relationship state stays gone.
+#[utoipa::path(
+    delete,
+    path = "/comp/instance/{instance_id}/sessions",
+    tag = "companion",
+    params(("instance_id" = Uuid, Path, description = "Persona instance id owned by the JWT user")),
+    responses(
+        (status = 200, body = ArchiveSessionsResponse),
+        (status = 401, description = "missing or invalid bearer"),
+        (status = 403, description = "instance is not owned by the JWT user"),
+        (status = 404, description = "no such instance")
+    ),
+    security(("bearer" = []))
+)]
+async fn archive_instance_sessions(
+    State(state): State<AppState>,
+    Path(instance_id): Path<Uuid>,
+    Extension(AuthUser(jwt_user)): Extension<AuthUser>,
+) -> Result<Json<ArchiveSessionsResponse>, AppError> {
+    // Ownership is read through the instance, not compared against the path —
+    // same shape as `get_character_profile`. Unlike that route this ignores
+    // `status`: see `PersonaRepo::instance_owner`.
+    let owner = PersonaRepo { pool: &state.pool }
+        .instance_owner(instance_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("no such instance".into()))?;
+    if owner != jwt_user {
+        return Err(AppError::Forbidden("not your data".into()));
+    }
+
+    let archived = eros_engine_store::session_archive::SessionArchiveRepo { pool: &state.pool }
+        .archive_relationship(jwt_user, instance_id)
+        .await?;
+
+    Ok(Json(ArchiveSessionsResponse {
+        instance_id,
+        archived_sessions: archived as i64,
+    }))
+}
+
 // ─── Router ─────────────────────────────────────────────────────────
 
 pub fn router() -> OpenApiRouter<AppState> {
@@ -848,6 +911,7 @@ pub fn router() -> OpenApiRouter<AppState> {
         .routes(routes!(list_sessions))
         .routes(routes!(get_profile))
         .routes(routes!(get_character_profile))
+        .routes(routes!(archive_instance_sessions))
 }
 
 // ────────────────────────────────────────────────────────────────────
@@ -1971,5 +2035,150 @@ mod tests {
         assert!(body["location"].is_null());
         assert_eq!(body["likes"], serde_json::json!([]));
         assert!(body["updated_at"].is_null(), "no row yet ⇒ null stamp");
+    }
+
+    fn archive_request(instance_id: Uuid, jwt: &str) -> Request<Body> {
+        Request::builder()
+            .method("DELETE")
+            .uri(format!("/comp/instance/{instance_id}/sessions"))
+            .header(header::AUTHORIZATION, format!("Bearer {jwt}"))
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn archive_sessions_hides_history_and_is_idempotent(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Nova").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+        let jwt = mint_test_jwt(user_id);
+        let mut router = build_router(test_state(pool.clone()));
+
+        let (status, body) = send_request(&mut router, archive_request(instance_id, &jwt)).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["archived_sessions"], 1);
+        assert_eq!(body["instance_id"], instance_id.to_string());
+
+        // Every read surface now behaves as if the session never existed.
+        let (status, _) = send_request(
+            &mut router,
+            Request::builder()
+                .uri(format!("/comp/chat/{session_id}/history"))
+                .header(header::AUTHORIZATION, format!("Bearer {jwt}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_FOUND, "archived history is 404");
+
+        let (status, _) = send_request(
+            &mut router,
+            Request::builder()
+                .uri(format!("/bff/v1/comp/affinity/{session_id}"))
+                .header(header::AUTHORIZATION, format!("Bearer {jwt}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_FOUND, "archived affinity is 404");
+
+        let (_, body) = send_request(
+            &mut router,
+            Request::builder()
+                .uri(format!("/comp/chat/{user_id}/sessions"))
+                .header(header::AUTHORIZATION, format!("Bearer {jwt}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(body["sessions"].as_array().unwrap().len(), 0);
+
+        // Repeat call: nothing left to flip, still 200.
+        let (status, body) = send_request(&mut router, archive_request(instance_id, &jwt)).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["archived_sessions"], 0);
+    }
+
+    /// The point of deleting the relationship state: the user comes back to a
+    /// new session, not a resurrected one.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn chat_start_after_archive_returns_a_new_session(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Nova").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let old_session = seed_session(&pool, user_id, instance_id).await;
+        let jwt = mint_test_jwt(user_id);
+        let mut router = build_router(test_state(pool.clone()));
+
+        send_request(&mut router, archive_request(instance_id, &jwt)).await;
+
+        let (status, body) = send_request(
+            &mut router,
+            Request::builder()
+                .method("POST")
+                .uri("/comp/chat/start")
+                .header(header::AUTHORIZATION, format!("Bearer {jwt}"))
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    json!({ "instance_id": instance_id.to_string() }).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_ne!(
+            body["session_id"].as_str().unwrap(),
+            old_session.to_string(),
+            "must not resume the archived session"
+        );
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn archive_sessions_rejects_a_foreign_or_unknown_instance(pool: PgPool) {
+        let owner = Uuid::new_v4();
+        let intruder = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Nova").await;
+        let instance_id = seed_instance(&pool, genome_id, owner).await;
+        let mut router = build_router(test_state(pool.clone()));
+
+        let (status, _) = send_request(
+            &mut router,
+            archive_request(instance_id, &mint_test_jwt(intruder)),
+        )
+        .await;
+        assert_eq!(status, StatusCode::FORBIDDEN);
+
+        let (status, _) = send_request(
+            &mut router,
+            archive_request(Uuid::new_v4(), &mint_test_jwt(owner)),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+    }
+
+    /// A client may archive the conversations of a relationship it has already
+    /// marked dormant, so ownership is read WITHOUT the status filter that
+    /// load_instance_gate applies.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn archive_sessions_works_on_a_dormant_instance(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Nova").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        seed_session(&pool, user_id, instance_id).await;
+        sqlx::query("UPDATE engine.persona_instances SET status = 'archived' WHERE id = $1")
+            .bind(instance_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let mut router = build_router(test_state(pool.clone()));
+        let (status, body) = send_request(
+            &mut router,
+            archive_request(instance_id, &mint_test_jwt(user_id)),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["archived_sessions"], 1);
     }
 }

--- a/crates/eros-engine-store/migrations/0052_chat_sessions_archived.sql
+++ b/crates/eros-engine-store/migrations/0052_chat_sessions_archived.sql
@@ -1,0 +1,28 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+--
+-- Session soft-delete (docs/superpowers/specs/2026-08-18-session-soft-delete-design.md).
+--
+-- A client that wants "clear this conversation and start over" previously had
+-- only DELETE, and chat_sessions has three ON DELETE CASCADE children — so the
+-- transcript went with it. This column separates the two: the conversation
+-- stops being visible and stops being resumable, and the rows stay.
+--
+-- Boolean, not a status enum: a session is visible or it is not, and there is
+-- no third state to name. (Contrast persona_instances.status, which carries a
+-- genuine active/archived distinction over ownership.)
+--
+-- No index. The only hot path is resume, which reaches its candidates through
+-- idx_chat_sessions_user_instance_channel and lands on a single-digit number of
+-- rows; filtering NOT archived on the heap from there costs nothing worth an
+-- index. Archived rows are read only by hand-written SQL.
+--
+-- No backfill. Sessions destroyed by earlier hard deletes are gone.
+--
+-- Reviving one session (operator action; deliberately NOT an endpoint):
+--   UPDATE engine.chat_sessions SET archived = false WHERE id = '<session-uuid>';
+-- The transcript comes back. Affinity, relationship-layer memories and
+-- character insights do not — the archive endpoint deletes those on purpose, so
+-- a revived session resumes with a cold relationship.
+
+ALTER TABLE engine.chat_sessions
+    ADD COLUMN archived BOOLEAN NOT NULL DEFAULT false;

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -139,12 +139,16 @@ impl<'a> ChatRepo<'a> {
         .await
     }
 
-    /// Look up a session by id.
+    /// Look up a session by id. Archived sessions do not resolve — soft-delete
+    /// makes a session non-existent to the API, and every entry-point guard
+    /// reaches its session through here.
     pub async fn get_session(&self, session_id: Uuid) -> Result<Option<ChatSession>, sqlx::Error> {
-        sqlx::query_as::<_, ChatSession>("SELECT * FROM engine.chat_sessions WHERE id = $1")
-            .bind(session_id)
-            .fetch_optional(self.pool)
-            .await
+        sqlx::query_as::<_, ChatSession>(
+            "SELECT * FROM engine.chat_sessions WHERE id = $1 AND NOT archived",
+        )
+        .bind(session_id)
+        .fetch_optional(self.pool)
+        .await
     }
 
     /// Resume the most recent session for a user×instance pair, or create a new one.
@@ -159,7 +163,7 @@ impl<'a> ChatRepo<'a> {
     ) -> Result<ChatSession, sqlx::Error> {
         if let Some(existing) = sqlx::query_as::<_, ChatSession>(
             "SELECT * FROM engine.chat_sessions \
-             WHERE user_id = $1 AND instance_id = $2 \
+             WHERE user_id = $1 AND instance_id = $2 AND NOT archived \
              ORDER BY last_active_at DESC LIMIT 1",
         )
         .bind(user_id)
@@ -192,7 +196,7 @@ impl<'a> ChatRepo<'a> {
             "UPDATE engine.chat_sessions SET last_active_at = now() \
              WHERE id = ( \
                  SELECT id FROM engine.chat_sessions \
-                 WHERE user_id = $1 AND instance_id = $2 AND channel = $3 \
+                 WHERE user_id = $1 AND instance_id = $2 AND channel = $3 AND NOT archived \
                  ORDER BY last_active_at DESC \
                  LIMIT 1 \
              ) \
@@ -355,7 +359,7 @@ impl<'a> ChatRepo<'a> {
     pub async fn list_sessions(&self, user_id: Uuid) -> Result<Vec<ChatSession>, sqlx::Error> {
         sqlx::query_as::<_, ChatSession>(
             "SELECT * FROM engine.chat_sessions \
-             WHERE user_id = $1 \
+             WHERE user_id = $1 AND NOT archived \
              ORDER BY last_active_at DESC",
         )
         .bind(user_id)
@@ -1200,6 +1204,7 @@ impl<'a> ChatRepo<'a> {
         sqlx::query_as::<_, ChatSession>(
             "SELECT * FROM engine.chat_sessions \
              WHERE user_id = $1 AND instance_id = $2 AND channel = 'voice' AND id <> $3 \
+               AND NOT archived \
              ORDER BY last_active_at DESC LIMIT 1",
         )
         .bind(user_id)

--- a/crates/eros-engine-store/src/lib.rs
+++ b/crates/eros-engine-store/src/lib.rs
@@ -12,6 +12,7 @@ pub mod insight;
 pub mod memory;
 pub mod persona;
 pub mod pool;
+pub mod session_archive;
 pub mod story;
 pub mod world;
 pub mod world_town;

--- a/crates/eros-engine-store/src/lib.rs
+++ b/crates/eros-engine-store/src/lib.rs
@@ -610,4 +610,27 @@ mod migration_tests {
             assert_eq!(n, 2, "{table} must have both jsonb columns");
         }
     }
+
+    /// 0052. The column is the entire storage surface of session soft-delete:
+    /// `false` is "visible", and an operator reviving a session sets it back
+    /// with a plain UPDATE. Pinned here because a NULLable or defaultless
+    /// column would make every pre-existing session invisible on deploy.
+    #[sqlx::test(migrations = "./migrations")]
+    async fn migration_0052_chat_sessions_archived_column(pool: PgPool) {
+        let (is_nullable, column_default): (String, Option<String>) = sqlx::query_as(
+            "SELECT is_nullable, column_default FROM information_schema.columns \
+             WHERE table_schema = 'engine' AND table_name = 'chat_sessions' \
+               AND column_name = 'archived'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("chat_sessions.archived must exist");
+
+        assert_eq!(is_nullable, "NO", "archived must be NOT NULL");
+        assert_eq!(
+            column_default.as_deref(),
+            Some("false"),
+            "archived must default to false so existing sessions stay visible"
+        );
+    }
 }

--- a/crates/eros-engine-store/src/persona.rs
+++ b/crates/eros-engine-store/src/persona.rs
@@ -176,6 +176,17 @@ impl<'a> PersonaRepo<'a> {
         .await
     }
 
+    /// The instance's owner, whatever its `status`. Deliberately unlike
+    /// `load_instance_gate`, which filters `status = 'active'`: a client may
+    /// archive the conversations of a relationship it has already marked
+    /// dormant, and that call must not 404 on a technicality.
+    pub async fn instance_owner(&self, instance_id: Uuid) -> Result<Option<Uuid>, sqlx::Error> {
+        sqlx::query_scalar("SELECT owner_uid FROM engine.persona_instances WHERE id = $1")
+            .bind(instance_id)
+            .fetch_optional(self.pool)
+            .await
+    }
+
     /// Upsert a persona genome by `name`. New row → INSERT, returns
     /// `(uuid, true)`. Existing row → UPDATE in place (id stable, content
     /// refreshed), returns `(uuid, false)`. Used by `seed-personas` so

--- a/crates/eros-engine-store/src/session_archive.rs
+++ b/crates/eros-engine-store/src/session_archive.rs
@@ -48,6 +48,14 @@ impl<'a> SessionArchiveRepo<'a> {
     /// gets the same treatment as `character_insights` above without taking
     /// the rest of the row's life facts with it.
     ///
+    /// The `character_insights` delete and the `persona_story_insights` update
+    /// are both keyed on `instance_id` alone, unlike the two `user_id +
+    /// instance_id` deletes above them. That's safe: `persona_instances.owner_uid`
+    /// is never updated anywhere in this workspace (only ever set once, at
+    /// INSERT), so the instance identifies its owner for the entire life of the
+    /// row and there is no window in which `instance_id` alone could resolve to
+    /// the wrong relationship.
+    ///
     /// `persona_instances.status` is deliberately not written: the user still
     /// owns the persona, and ownership is the client's business.
     pub async fn archive_relationship(

--- a/crates/eros-engine-store/src/session_archive.rs
+++ b/crates/eros-engine-store/src/session_archive.rs
@@ -40,6 +40,14 @@ impl<'a> SessionArchiveRepo<'a> {
     /// foreign key and are untouched; with the transcript now surviving too,
     /// those records still point at something readable.
     ///
+    /// `persona_story_insights.digest` is cleared, not the row: the row's
+    /// other columns (`occupation`, `city`, `life_rhythm`, ...) are the
+    /// persona's own typed life base, live only in this one row, and deleting
+    /// it would take them with it. `digest` is the one column that is instead
+    /// conversation-derived and re-injected into every later reply, so it
+    /// gets the same treatment as `character_insights` above without taking
+    /// the rest of the row's life facts with it.
+    ///
     /// `persona_instances.status` is deliberately not written: the user still
     /// owns the persona, and ownership is the client's business.
     pub async fn archive_relationship(
@@ -78,6 +86,20 @@ impl<'a> SessionArchiveRepo<'a> {
         .await?;
 
         sqlx::query("DELETE FROM engine.character_insights WHERE instance_id = $1")
+            .bind(instance_id)
+            .execute(&mut *tx)
+            .await?;
+
+        // UPDATE, not DELETE: this row also carries the persona's own typed
+        // life base (occupation, city, ...), which lives only here — deleting
+        // the row would take those with it. Only `digest` is this
+        // relationship's record: it is conversation-derived and injected into
+        // every subsequent reply, the same property that justifies deleting
+        // character_insights above. Clearing it is enough on its own:
+        // fetch_stories_context returns early on a blank digest before it
+        // ever reads persona_story_memories, so the episode recall built up
+        // during this relationship stops being injected too.
+        sqlx::query("UPDATE engine.persona_story_insights SET digest = '' WHERE instance_id = $1")
             .bind(instance_id)
             .execute(&mut *tx)
             .await?;
@@ -443,6 +465,93 @@ mod tests {
             !is_archived,
             "create_or_resume must produce a fresh, unarchived session"
         );
+    }
+
+    /// The story digest is instance-keyed and injected into every subsequent
+    /// reply, so it survives the archive the same way `character_insights`
+    /// used to — clearing it is the fifth statement. `persona_story_events`
+    /// and `persona_story_memories` are the persona's own life, not this
+    /// relationship's record, so they must survive; that pair is the
+    /// assertion that catches someone later "tidying" the UPDATE into a
+    /// DELETE.
+    #[sqlx::test(migrations = "./migrations")]
+    async fn clears_the_story_digest_but_keeps_the_persona_life(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
+        seed_relationship(&pool, user_id, instance_id).await;
+
+        sqlx::query(
+            "INSERT INTO engine.persona_story_insights \
+                 (instance_id, owner_uid, occupation, digest) \
+             VALUES ($1, $2, 'barista', 'opened a coffee shop this week')",
+        )
+        .bind(instance_id)
+        .bind(user_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let event_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_story_events \
+                 (owner_uid, instance_id, category, content, story_date) \
+             VALUES ($1, $2, 'life', 'the espresso machine broke on opening day', CURRENT_DATE) \
+             RETURNING id",
+        )
+        .bind(user_id)
+        .bind(instance_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        let zeros = format!("[{}]", vec!["0"; 512].join(","));
+        sqlx::query(
+            "INSERT INTO engine.persona_story_memories \
+                 (owner_uid, instance_id, event_id, content, embedding, story_date) \
+             VALUES ($1, $2, $3, 'the espresso machine broke on opening day', $4::vector, CURRENT_DATE)",
+        )
+        .bind(user_id)
+        .bind(instance_id)
+        .bind(event_id)
+        .bind(&zeros)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        SessionArchiveRepo { pool: &pool }
+            .archive_relationship(user_id, instance_id)
+            .await
+            .unwrap();
+
+        let (digest, occupation): (String, Option<String>) = sqlx::query_as(
+            "SELECT digest, occupation FROM engine.persona_story_insights \
+             WHERE instance_id = $1",
+        )
+        .bind(instance_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(digest, "", "story digest must be cleared");
+        assert_eq!(
+            occupation.as_deref(),
+            Some("barista"),
+            "retained scalar insight columns must survive"
+        );
+
+        let events = count(
+            &pool,
+            "SELECT count(*) FROM engine.persona_story_events WHERE instance_id = $1",
+            instance_id,
+        )
+        .await;
+        assert_eq!(events, 1, "the persona's life-progression log must survive");
+
+        let memories = count(
+            &pool,
+            "SELECT count(*) FROM engine.persona_story_memories WHERE instance_id = $1",
+            instance_id,
+        )
+        .await;
+        assert_eq!(memories, 1, "the story recall mirror must survive");
     }
 
     /// The session list is a read surface like any other.

--- a/crates/eros-engine-store/src/session_archive.rs
+++ b/crates/eros-engine-store/src/session_archive.rs
@@ -1,0 +1,313 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Soft-deleting a relationship's sessions.
+//!
+//! A client asking to clear a conversation wants two things that the schema
+//! used to fuse into one `DELETE`: the conversation should stop being visible
+//! and resumable, and the relationship state should reset so a fresh start is
+//! genuinely fresh. Only the second requires destroying rows.
+//!
+//! See docs/superpowers/specs/2026-08-18-session-soft-delete-design.md.
+
+use sqlx::PgPool;
+use uuid::Uuid;
+
+pub struct SessionArchiveRepo<'a> {
+    pub pool: &'a PgPool,
+}
+
+impl<'a> SessionArchiveRepo<'a> {
+    /// Archive every session this user holds with this persona instance, and
+    /// delete the relationship state that would otherwise carry into the next
+    /// conversation. Returns the number of sessions flipped by THIS call, so a
+    /// repeat call reports 0 rather than re-reporting the first call's work.
+    ///
+    /// Every channel is archived, voice included: the unit is the
+    /// relationship, not one client's view of it.
+    ///
+    /// Memories are deleted by `(user_id, instance_id)` rather than by session
+    /// id because `MemoryRepo::search` retrieves on exactly that key — deleting
+    /// by session would leave a row retrievable that the caller believed gone.
+    /// The same predicate is what spares the profile layer: those rows carry
+    /// `instance_id IS NULL`, and `instance_id = $2` never matches NULL. They
+    /// are cross-persona facts about the user and ending one relationship must
+    /// not erase them.
+    ///
+    /// `companion_affinity_events` goes with its parent through the existing
+    /// ON DELETE CASCADE — accepted, not worked around. The audit tables an
+    /// operator needs (`companion_decision_events`, `llm_attempt_audit`,
+    /// `chat_vision_events`, `chat_images_events`) hold `session_id` without a
+    /// foreign key and are untouched; with the transcript now surviving too,
+    /// those records finally point at something readable.
+    ///
+    /// `persona_instances.status` is deliberately not written: the user still
+    /// owns the persona, and ownership is the client's business.
+    pub async fn archive_relationship(
+        &self,
+        user_id: Uuid,
+        instance_id: Uuid,
+    ) -> Result<u64, sqlx::Error> {
+        let mut tx = self.pool.begin().await?;
+
+        let archived = sqlx::query(
+            "UPDATE engine.chat_sessions SET archived = true \
+             WHERE user_id = $1 AND instance_id = $2 AND NOT archived",
+        )
+        .bind(user_id)
+        .bind(instance_id)
+        .execute(&mut *tx)
+        .await?
+        .rows_affected();
+
+        sqlx::query(
+            "DELETE FROM engine.companion_memories \
+             WHERE user_id = $1 AND instance_id = $2",
+        )
+        .bind(user_id)
+        .bind(instance_id)
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            "DELETE FROM engine.companion_affinity \
+             WHERE user_id = $1 AND instance_id = $2",
+        )
+        .bind(user_id)
+        .bind(instance_id)
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query("DELETE FROM engine.character_insights WHERE instance_id = $1")
+            .bind(instance_id)
+            .execute(&mut *tx)
+            .await?;
+
+        tx.commit().await?;
+        Ok(archived)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SessionArchiveRepo;
+    use crate::testutil::seed_persona_instance;
+    use sqlx::PgPool;
+    use uuid::Uuid;
+
+    /// Persist one session with one message, an affinity row, one
+    /// relationship-layer memory and one profile-layer memory.
+    async fn seed_relationship(pool: &PgPool, user_id: Uuid, instance_id: Uuid) -> Uuid {
+        let session_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_sessions (user_id, instance_id) \
+             VALUES ($1, $2) RETURNING id",
+        )
+        .bind(user_id)
+        .bind(instance_id)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "INSERT INTO engine.chat_messages (session_id, role, content) \
+             VALUES ($1, 'user', 'hello')",
+        )
+        .bind(session_id)
+        .execute(pool)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "INSERT INTO engine.companion_affinity (session_id, user_id, instance_id) \
+             VALUES ($1, $2, $3)",
+        )
+        .bind(session_id)
+        .bind(user_id)
+        .bind(instance_id)
+        .execute(pool)
+        .await
+        .unwrap();
+
+        // Relationship layer (instance-scoped) and profile layer (instance_id
+        // NULL, cross-persona). Both hang off this session by FK.
+        let zeros = format!("[{}]", vec!["0"; 512].join(","));
+        sqlx::query(
+            "INSERT INTO engine.companion_memories \
+                 (session_id, user_id, instance_id, content, embedding) \
+             VALUES ($1, $2, $3, 'she likes jazz', $4::vector), \
+                    ($1, $2, NULL,  'user is a vet', $4::vector)",
+        )
+        .bind(session_id)
+        .bind(user_id)
+        .bind(instance_id)
+        .bind(&zeros)
+        .execute(pool)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "INSERT INTO engine.character_insights (instance_id, location) \
+             VALUES ($1, 'the office')",
+        )
+        .bind(instance_id)
+        .execute(pool)
+        .await
+        .unwrap();
+
+        session_id
+    }
+
+    async fn count(pool: &PgPool, sql: &str, id: Uuid) -> i64 {
+        sqlx::query_scalar(sql)
+            .bind(id)
+            .fetch_one(pool)
+            .await
+            .unwrap()
+    }
+
+    /// The transcript is evidence: archiving flips a flag and leaves every
+    /// chat_messages row where it is.
+    #[sqlx::test(migrations = "./migrations")]
+    async fn archives_sessions_and_keeps_the_transcript(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
+        let session_id = seed_relationship(&pool, user_id, instance_id).await;
+
+        let n = SessionArchiveRepo { pool: &pool }
+            .archive_relationship(user_id, instance_id)
+            .await
+            .unwrap();
+        assert_eq!(n, 1, "one session flipped");
+
+        let archived: bool =
+            sqlx::query_scalar("SELECT archived FROM engine.chat_sessions WHERE id = $1")
+                .bind(session_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert!(archived);
+
+        let messages = count(
+            &pool,
+            "SELECT count(*) FROM engine.chat_messages WHERE session_id = $1",
+            session_id,
+        )
+        .await;
+        assert_eq!(messages, 1, "transcript must survive the archive");
+    }
+
+    /// Relationship state is deleted so the next conversation starts cold —
+    /// but the profile layer is a fact about the user, shared with every other
+    /// companion, and must not be collateral.
+    #[sqlx::test(migrations = "./migrations")]
+    async fn deletes_relationship_state_but_spares_the_profile_layer(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
+        seed_relationship(&pool, user_id, instance_id).await;
+
+        SessionArchiveRepo { pool: &pool }
+            .archive_relationship(user_id, instance_id)
+            .await
+            .unwrap();
+
+        let affinity = count(
+            &pool,
+            "SELECT count(*) FROM engine.companion_affinity WHERE instance_id = $1",
+            instance_id,
+        )
+        .await;
+        assert_eq!(affinity, 0, "affinity is deleted");
+
+        let relationship_memories = count(
+            &pool,
+            "SELECT count(*) FROM engine.companion_memories WHERE instance_id = $1",
+            instance_id,
+        )
+        .await;
+        assert_eq!(
+            relationship_memories, 0,
+            "relationship-layer memories are deleted"
+        );
+
+        let profile_memories = count(
+            &pool,
+            "SELECT count(*) FROM engine.companion_memories \
+             WHERE user_id = $1 AND instance_id IS NULL",
+            user_id,
+        )
+        .await;
+        assert_eq!(profile_memories, 1, "profile-layer memories must survive");
+
+        let insights = count(
+            &pool,
+            "SELECT count(*) FROM engine.character_insights WHERE instance_id = $1",
+            instance_id,
+        )
+        .await;
+        assert_eq!(insights, 0, "character insights are deleted");
+    }
+
+    /// Every channel goes, and a second call is a no-op that still succeeds.
+    #[sqlx::test(migrations = "./migrations")]
+    async fn archives_every_channel_and_is_idempotent(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
+        seed_relationship(&pool, user_id, instance_id).await;
+        sqlx::query(
+            "INSERT INTO engine.chat_sessions (user_id, instance_id, channel) \
+             VALUES ($1, $2, 'voice')",
+        )
+        .bind(user_id)
+        .bind(instance_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let repo = SessionArchiveRepo { pool: &pool };
+        assert_eq!(
+            repo.archive_relationship(user_id, instance_id)
+                .await
+                .unwrap(),
+            2,
+            "text and voice sessions both archived"
+        );
+        assert_eq!(
+            repo.archive_relationship(user_id, instance_id)
+                .await
+                .unwrap(),
+            0,
+            "second call finds nothing left to flip"
+        );
+    }
+
+    /// Another user's relationship with the same instance is untouched — the
+    /// predicate is (user_id, instance_id), not instance_id alone.
+    #[sqlx::test(migrations = "./migrations")]
+    async fn leaves_another_users_sessions_alone(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let other = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
+        seed_relationship(&pool, user_id, instance_id).await;
+        let other_session: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_sessions (user_id, instance_id) \
+             VALUES ($1, $2) RETURNING id",
+        )
+        .bind(other)
+        .bind(instance_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        SessionArchiveRepo { pool: &pool }
+            .archive_relationship(user_id, instance_id)
+            .await
+            .unwrap();
+
+        let archived: bool =
+            sqlx::query_scalar("SELECT archived FROM engine.chat_sessions WHERE id = $1")
+                .bind(other_session)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert!(!archived, "another user's session must stay visible");
+    }
+}

--- a/crates/eros-engine-store/src/session_archive.rs
+++ b/crates/eros-engine-store/src/session_archive.rs
@@ -90,6 +90,7 @@ impl<'a> SessionArchiveRepo<'a> {
 #[cfg(test)]
 mod tests {
     use super::SessionArchiveRepo;
+    use crate::chat::ChatRepo;
     use crate::testutil::seed_persona_instance;
     use sqlx::PgPool;
     use uuid::Uuid;
@@ -309,5 +310,97 @@ mod tests {
                 .await
                 .unwrap();
         assert!(!archived, "another user's session must stay visible");
+    }
+
+    /// The API-facing choke point. Every entry-point guard resolves a session
+    /// through get_session, so this one predicate is what turns history,
+    /// affinity, chat stream and voice turn into 404 for an archived session.
+    #[sqlx::test(migrations = "./migrations")]
+    async fn get_session_hides_archived_sessions(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
+        let session_id = seed_relationship(&pool, user_id, instance_id).await;
+        let chat = ChatRepo { pool: &pool };
+
+        assert!(chat.get_session(session_id).await.unwrap().is_some());
+
+        SessionArchiveRepo { pool: &pool }
+            .archive_relationship(user_id, instance_id)
+            .await
+            .unwrap();
+
+        assert!(
+            chat.get_session(session_id).await.unwrap().is_none(),
+            "archived session must not resolve"
+        );
+
+        // Revival is an operator UPDATE, and it is the whole restore story.
+        sqlx::query("UPDATE engine.chat_sessions SET archived = false WHERE id = $1")
+            .bind(session_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+        assert!(
+            chat.get_session(session_id).await.unwrap().is_some(),
+            "un-archiving must bring the session back"
+        );
+    }
+
+    /// The critical one: without this predicate the next chat/start reanimates
+    /// the archived session and the user gets their deleted conversation back
+    /// with a blank relationship.
+    #[sqlx::test(migrations = "./migrations")]
+    async fn resume_never_returns_an_archived_session(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
+        seed_relationship(&pool, user_id, instance_id).await;
+        let chat = ChatRepo { pool: &pool };
+
+        SessionArchiveRepo { pool: &pool }
+            .archive_relationship(user_id, instance_id)
+            .await
+            .unwrap();
+
+        assert!(
+            chat.resume_latest_session(user_id, instance_id, "text")
+                .await
+                .unwrap()
+                .is_none(),
+            "resume must fall through to creating a new session"
+        );
+        // `ChatSession` carries no `archived` field and none should be added —
+        // nothing in Rust reads it — so assert against the column directly.
+        let resumed = chat.create_or_resume(user_id, instance_id).await.unwrap();
+        let is_archived: bool =
+            sqlx::query_scalar("SELECT archived FROM engine.chat_sessions WHERE id = $1")
+                .bind(resumed.id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert!(
+            !is_archived,
+            "create_or_resume must produce a fresh, unarchived session"
+        );
+    }
+
+    /// The session list is a read surface like any other.
+    #[sqlx::test(migrations = "./migrations")]
+    async fn list_sessions_hides_archived_sessions(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
+        seed_relationship(&pool, user_id, instance_id).await;
+        let chat = ChatRepo { pool: &pool };
+
+        assert_eq!(chat.list_sessions(user_id).await.unwrap().len(), 1);
+
+        SessionArchiveRepo { pool: &pool }
+            .archive_relationship(user_id, instance_id)
+            .await
+            .unwrap();
+
+        assert!(
+            chat.list_sessions(user_id).await.unwrap().is_empty(),
+            "archived sessions must not appear in the list"
+        );
     }
 }

--- a/crates/eros-engine-store/src/session_archive.rs
+++ b/crates/eros-engine-store/src/session_archive.rs
@@ -35,10 +35,10 @@ impl<'a> SessionArchiveRepo<'a> {
     ///
     /// `companion_affinity_events` goes with its parent through the existing
     /// ON DELETE CASCADE — accepted, not worked around. The audit tables an
-    /// operator needs (`companion_decision_events`, `llm_attempt_audit`,
+    /// operator needs (`companion_decision_events`, `character_insights_events`,
     /// `chat_vision_events`, `chat_images_events`) hold `session_id` without a
     /// foreign key and are untouched; with the transcript now surviving too,
-    /// those records finally point at something readable.
+    /// those records still point at something readable.
     ///
     /// `persona_instances.status` is deliberately not written: the user still
     /// owns the persona, and ownership is the client's business.
@@ -310,6 +310,68 @@ mod tests {
                 .await
                 .unwrap();
         assert!(!archived, "another user's session must stay visible");
+    }
+
+    /// The other half of the predicate: `(user_id, instance_id)`, not
+    /// `user_id` alone. Without `AND instance_id = $2` on the
+    /// `companion_memories` delete, archiving one relationship would erase
+    /// every relationship-layer memory the user holds with every companion —
+    /// and `leaves_another_users_sessions_alone` above would not catch it,
+    /// since that test only varies `user_id`.
+    #[sqlx::test(migrations = "./migrations")]
+    async fn leaves_the_same_users_other_instance_alone(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let instance_a = seed_persona_instance(&pool, user_id).await;
+        let instance_b = seed_persona_instance(&pool, user_id).await;
+        seed_relationship(&pool, user_id, instance_a).await;
+        let session_b = seed_relationship(&pool, user_id, instance_b).await;
+
+        SessionArchiveRepo { pool: &pool }
+            .archive_relationship(user_id, instance_a)
+            .await
+            .unwrap();
+
+        let archived: bool =
+            sqlx::query_scalar("SELECT archived FROM engine.chat_sessions WHERE id = $1")
+                .bind(session_b)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert!(
+            !archived,
+            "the other instance's session must stay unarchived"
+        );
+
+        assert_eq!(
+            count(
+                &pool,
+                "SELECT count(*) FROM engine.companion_memories WHERE instance_id = $1",
+                instance_b,
+            )
+            .await,
+            1,
+            "the other instance's relationship-layer memory must survive"
+        );
+        assert_eq!(
+            count(
+                &pool,
+                "SELECT count(*) FROM engine.companion_affinity WHERE instance_id = $1",
+                instance_b,
+            )
+            .await,
+            1,
+            "the other instance's affinity row must survive"
+        );
+        assert_eq!(
+            count(
+                &pool,
+                "SELECT count(*) FROM engine.character_insights WHERE instance_id = $1",
+                instance_b,
+            )
+            .await,
+            1,
+            "the other instance's character insight row must survive"
+        );
     }
 
     /// The API-facing choke point. Every entry-point guard resolves a session

--- a/crates/eros-engine-store/src/story.rs
+++ b/crates/eros-engine-store/src/story.rs
@@ -170,6 +170,7 @@ impl<'a> StoryRepo<'a> {
                        SELECT 1 FROM engine.chat_sessions cs \
                        WHERE cs.user_id = psi.owner_uid \
                          AND cs.instance_id = psi.instance_id \
+                         AND NOT cs.archived \
                          AND cs.last_active_at > $3) \
                  ORDER BY psi.last_run_at ASC NULLS FIRST \
                  LIMIT $4 \
@@ -304,7 +305,7 @@ impl<'a> StoryRepo<'a> {
         let rows: Vec<(Uuid, String, String)> = sqlx::query_as(
             "SELECT cm.session_id, cm.role, cm.content \
              FROM engine.chat_messages cm \
-             JOIN engine.chat_sessions cs ON cs.id = cm.session_id \
+             JOIN engine.chat_sessions cs ON cs.id = cm.session_id AND NOT cs.archived \
              WHERE cs.user_id = $1 AND cs.instance_id = $2 \
                AND cm.sent_at > now() - make_interval(days => $3) \
                AND cm.truncated = FALSE \
@@ -353,7 +354,7 @@ impl<'a> StoryRepo<'a> {
             "SELECT ca.warmth, ca.trust, ca.intrigue, ca.intimacy, ca.patience, ca.tension, \
                     ca.bond, ca.chemistry \
              FROM engine.companion_affinity ca \
-             JOIN engine.chat_sessions cs ON cs.id = ca.session_id \
+             JOIN engine.chat_sessions cs ON cs.id = ca.session_id AND NOT cs.archived \
              WHERE ca.user_id = $1 AND ca.instance_id = $2 \
              ORDER BY cs.last_active_at DESC LIMIT 1",
         )

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -878,6 +878,31 @@ The flat, typed `character_insights` row for one relationship (`persona_instance
 
 `updated_at: null` means this instance has no `character_insights` row yet — the character extraction chain has not produced a result — and every other field is `null`/`[]` in that response, same convention as the human profile above. Results are database-only: nothing here is read back into any chat prompt.
 
+### `DELETE /comp/instance/{instance_id}/sessions`
+
+Soft-delete every session this user holds with one persona instance. The instance's `owner_uid` MUST match the JWT's user_id; otherwise 403. An unknown instance is 404 — unlike the profile route above, a dormant (`status <> 'active'`) instance is accepted, because a client may clear the conversations of a relationship it has already marked over.
+
+```json
+{
+  "instance_id": "8a1f0c2e-4b6d-4f8a-9c31-2d5e7f0a1b3c",
+  "archived_sessions": 2
+}
+```
+
+`archived_sessions` counts the sessions flipped by *this* call, so a repeat call returns `200` with `0`. Every channel is archived, voice included — the unit is the relationship, not one client's view of it.
+
+**What is deleted:** `companion_affinity` (and its events, by cascade), the relationship layer of `companion_memories`, and `character_insights` — the state that would otherwise carry into the next conversation. **What is not:** `chat_messages`. The transcript stays, so the audit tables that reference a session by id (`companion_decision_events`, `chat_vision_events`, `chat_images_events`, `llm_attempt_audit`) still point at something readable. The profile layer of `companion_memories` (`instance_id IS NULL`) also stays — those are cross-persona facts about the user.
+
+Afterwards the sessions are invisible everywhere: history, affinity, the session list, the chat and voice turn routes all return 404 or omit them, and `POST /comp/chat/start` creates a new session rather than resuming an archived one.
+
+There is no restore endpoint by design. Reviving one session is an operator action:
+
+```sql
+UPDATE engine.chat_sessions SET archived = false WHERE id = '<session-uuid>';
+```
+
+The transcript comes back; the relationship state does not. See [2026-08-18-session-soft-delete-design.md](superpowers/specs/2026-08-18-session-soft-delete-design.md).
+
 > **Tips replaced gift events.** The standalone gift routes
 > (`POST /comp/chat/{session_id}/event/gift`, `GET /comp/chat/{session_id}/gifts`)
 > were removed. A tip is now part of a normal stream turn — set

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -891,7 +891,7 @@ Soft-delete every session this user holds with one persona instance. The instanc
 
 `archived_sessions` counts the sessions flipped by *this* call, so a repeat call returns `200` with `0`. Every channel is archived, voice included — the unit is the relationship, not one client's view of it.
 
-**What is deleted:** `companion_affinity` (and its events, by cascade), the relationship layer of `companion_memories`, and `character_insights` — the state that would otherwise carry into the next conversation. **What is not:** `chat_messages`. The transcript stays, so the audit tables that reference a session by id (`companion_decision_events`, `chat_vision_events`, `chat_images_events`, `llm_attempt_audit`) still point at something readable. The profile layer of `companion_memories` (`instance_id IS NULL`) also stays — those are cross-persona facts about the user.
+**What is deleted:** `companion_affinity` (and its events, by cascade), the relationship layer of `companion_memories`, and `character_insights` — the state that would otherwise carry into the next conversation. **What is not:** `chat_messages`. The transcript stays, so the audit tables that reference a session by id (`companion_decision_events`, `character_insights_events`, `chat_vision_events`, `chat_images_events`) still point at something readable. The profile layer of `companion_memories` (`instance_id IS NULL`) also stays — those are cross-persona facts about the user.
 
 Afterwards the sessions are invisible everywhere: history, affinity, the session list, the chat and voice turn routes all return 404 or omit them, and `POST /comp/chat/start` creates a new session rather than resuming an archived one.
 

--- a/docs/api-reference.zh.md
+++ b/docs/api-reference.zh.md
@@ -771,6 +771,31 @@ curl -N -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/js
 
 `updated_at` 为 `null` 表示这个 instance 还没有 `character_insights` 行——角色抽取链还没跑出结果——这时其余字段也都是 `null`/`[]`，和上面人类画像同一套约定。结果只落库：这里的任何内容都不会被读回任何 chat prompt。
 
+### `DELETE /comp/instance/{instance_id}/sessions`
+
+软删除这个用户与某个 persona instance 之间的全部 session。该 instance 的 `owner_uid` **必须**等于 JWT 的 user_id；否则 403。未知 instance 返回 404 —— 与上面的画像路由不同，已休眠（`status <> 'active'`）的 instance 是接受的：客户端可能先标记关系结束、再来清对话。
+
+```json
+{
+  "instance_id": "8a1f0c2e-4b6d-4f8a-9c31-2d5e7f0a1b3c",
+  "archived_sessions": 2
+}
+```
+
+`archived_sessions` 只算**这一次调用**翻掉的 session 数，所以重复调用返回 `200` 加 `0`。所有 channel 一起归档，语音也在内 —— 单位是这段关系，不是某一个客户端看到的那部分。
+
+**会删掉的：** `companion_affinity`（连同它的 events，走 cascade）、`companion_memories` 的关系层、`character_insights` —— 这些留着会渗进下一段对话。**不会删的：** `chat_messages`。聊天记录留着，所以那些按 session id 引用的审计表（`companion_decision_events`、`chat_vision_events`、`chat_images_events`、`llm_attempt_audit`）终于指得到可读的东西。`companion_memories` 的画像层（`instance_id IS NULL`）也留着 —— 那是关于这个用户的跨角色事实。
+
+调用之后这些 session 在各处都不可见：history、affinity、session 列表、chat 与语音 turn 路由要么 404 要么直接不返回，`POST /comp/chat/start` 会新建 session 而不是恢复已归档的那个。
+
+刻意不提供恢复端点。复活单个 session 是运维动作：
+
+```sql
+UPDATE engine.chat_sessions SET archived = false WHERE id = '<session-uuid>';
+```
+
+聊天记录回来，关系状态不回来。详见 [2026-08-18-session-soft-delete-design.md](superpowers/specs/2026-08-18-session-soft-delete-design.md)。
+
 > **打赏取代了礼物事件。** 独立的礼物路由
 > （`POST /comp/chat/{session_id}/event/gift`、`GET /comp/chat/{session_id}/gifts`）
 > 已移除。打赏现在是普通 stream 轮的一部分 —— 在

--- a/docs/api-reference.zh.md
+++ b/docs/api-reference.zh.md
@@ -784,7 +784,7 @@ curl -N -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/js
 
 `archived_sessions` 只算**这一次调用**翻掉的 session 数，所以重复调用返回 `200` 加 `0`。所有 channel 一起归档，语音也在内 —— 单位是这段关系，不是某一个客户端看到的那部分。
 
-**会删掉的：** `companion_affinity`（连同它的 events，走 cascade）、`companion_memories` 的关系层、`character_insights` —— 这些留着会渗进下一段对话。**不会删的：** `chat_messages`。聊天记录留着，所以那些按 session id 引用的审计表（`companion_decision_events`、`chat_vision_events`、`chat_images_events`、`llm_attempt_audit`）终于指得到可读的东西。`companion_memories` 的画像层（`instance_id IS NULL`）也留着 —— 那是关于这个用户的跨角色事实。
+**会删掉的：** `companion_affinity`（连同它的 events，走 cascade）、`companion_memories` 的关系层、`character_insights` —— 这些留着会渗进下一段对话。**不会删的：** `chat_messages`。聊天记录留着，所以那些按 session id 引用的审计表（`companion_decision_events`、`character_insights_events`、`chat_vision_events`、`chat_images_events`）仍然指得到可读的东西。`companion_memories` 的画像层（`instance_id IS NULL`）也留着 —— 那是关于这个用户的跨角色事实。
 
 调用之后这些 session 在各处都不可见：history、affinity、session 列表、chat 与语音 turn 路由要么 404 要么直接不返回，`POST /comp/chat/start` 会新建 session 而不是恢复已归档的那个。
 

--- a/docs/superpowers/specs/2026-08-18-session-soft-delete-design.md
+++ b/docs/superpowers/specs/2026-08-18-session-soft-delete-design.md
@@ -169,7 +169,7 @@ a single predicate turns all of these into `404`:
 | `POST /comp/chat/{sid}/message/stream` | direct call |
 | `POST /comp/voice/{sid}/turn/stream` | direct call |
 
-**Five queries do their own session lookup and need the predicate added:**
+**Six queries do their own session lookup and need the predicate added:**
 
 1. `resume_latest_session` — the critical one. Without it the next
    `chat/start` reanimates the archived session and the user gets their deleted
@@ -179,6 +179,12 @@ a single predicate turns all of these into `404`:
 4. `latest_sibling_voice_session`
 5. `story.rs` — the three joins onto `chat_sessions` that feed world stories,
    so archived material stops being harvested.
+6. The dreaming sweeper's claim query in `pipeline/dreaming.rs`. Second in
+   importance only to resume, and for the same reason: it selects idle sessions
+   with `classified_at IS NULL`, extracts memories from them, and writes the
+   result into `companion_memories` and `human_insights`. An archived session
+   left claimable would spend a model call regrowing exactly the memory rows
+   this endpoint just deleted.
 
 **`bff_list_affinities` needs no change.** It is driven by
 `companion_affinity`, whose rows this endpoint deletes; an absent row is an
@@ -192,6 +198,8 @@ absent list entry.
 - `chat/start` after archiving returns a **new** session id, not the archived one.
 - History, affinity and stream routes return `404` for an archived session.
 - Voice-channel sessions are archived alongside text ones.
+- The dreaming sweeper's claim query skips archived sessions, so no memory row
+  regrows after an archive.
 - Another user's instance → `403`; unknown instance → `404`; repeat call →
   `200` with `archived_sessions: 0`.
 - `UPDATE … SET archived = false` makes history readable again.

--- a/docs/superpowers/specs/2026-08-18-session-soft-delete-design.md
+++ b/docs/superpowers/specs/2026-08-18-session-soft-delete-design.md
@@ -105,7 +105,7 @@ mark.
 
 ## 5. The archive action
 
-One transaction, four statements:
+One transaction, five statements:
 
 ```sql
 UPDATE engine.chat_sessions SET archived = true
@@ -118,6 +118,8 @@ DELETE FROM engine.companion_affinity
  WHERE user_id = $1 AND instance_id = $2;
 
 DELETE FROM engine.character_insights WHERE instance_id = $2;
+
+UPDATE engine.persona_story_insights SET digest = '' WHERE instance_id = $2;
 ```
 
 **Sessions on every channel are archived**, voice included. The unit is the
@@ -155,6 +157,27 @@ the hard delete and carries the persona's memory of the relationship — where t
 user lives, what they do, the current situation between them — straight into the
 next conversation. Leaving it contradicts the reason affinity and memories are
 deleted at all.
+
+**`persona_story_insights.digest` is cleared, not the row.** It is
+instance-keyed and conversation-derived, and it is injected into the prompt of
+every subsequent reply — the same description that justifies deleting
+`character_insights` above, so leaving it means a "fresh start" still carries a
+narrative shaped by the conversation the user just cleared. The row itself is
+not deleted: with `digest` excepted, its columns (`city`, `occupation`,
+`life_rhythm`, and the rest) are the persona's own typed life base and live
+only in this one row — erasing them because one user cleared one chat would be
+its own bug. (`persona_story_events` and `persona_story_memories` FK to
+`persona_instances` directly, not to this row, so they are unaffected by the
+UPDATE-vs-DELETE choice either way; they are excluded from this cut for the
+same reason as the surviving columns — they are the persona's own life, not
+this relationship's record.) Clearing `digest` alone is sufficient:
+`fetch_stories_context` returns early on a blank
+digest before it ever calls `search_story_memories`, so the episode recall
+stops being injected along with it, without a second statement against
+`persona_story_memories`. It also does not silently regrow — `claim_due`'s
+`EXISTS` already carries `AND NOT cs.archived`, so the story director will not
+revisit this instance until the user starts a genuinely new conversation, at
+which point regenerating from new material is correct.
 
 **`persona_instances.status` is not touched.** The user still owns the persona
 and can start a new conversation immediately; `chat/start` will create a fresh
@@ -203,6 +226,9 @@ absent list entry.
 - Archiving leaves `chat_messages` row count unchanged; `companion_affinity`,
   relationship-layer `companion_memories` and `character_insights` go to zero.
 - Profile-layer memories (`instance_id IS NULL`) survive.
+- Archiving clears `persona_story_insights.digest` to `''` but leaves the row,
+  a retained scalar column, and its `persona_story_events` /
+  `persona_story_memories` rows untouched.
 - `chat/start` after archiving returns a **new** session id, not the archived one.
 - History, affinity and stream routes return `404` for an archived session.
 - Voice-channel sessions are archived alongside text ones.
@@ -244,8 +270,8 @@ new binary serves traffic, because the read filter references a column
   the archive commits can still land its write afterward. The residual window
   is one statement wide. Closing it fully would mean taking a lock across the
   whole post-turn pipeline, which costs more than the defect it would prevent.
-- **Clearing the `persona_story_*` layer.** The story digest is instance-keyed
-  and injected into every subsequent reply, so it survives the archive and
-  carries a narrative shaped by the deleted conversation into the fresh
-  session. Whether to clear it is a real design question, deliberately left
-  open here rather than overlooked.
+- **Touching `persona_story_events`, `persona_story_memories`, or the scalar
+  columns on `persona_story_insights`.** §5 clears `digest` because it is this
+  relationship's record; the rest of that row and both of those tables are the
+  persona's own life narrative, not a per-relationship record, and erasing a
+  persona's life because one user cleared one chat would be its own bug.

--- a/docs/superpowers/specs/2026-08-18-session-soft-delete-design.md
+++ b/docs/superpowers/specs/2026-08-18-session-soft-delete-design.md
@@ -1,0 +1,219 @@
+# Soft-deleting a relationship's sessions — Design
+
+- **Date:** 2026-08-18
+- **Status:** Approved
+- **Type:** Engine change — one schema migration (one boolean column), one new
+  endpoint, an `archived` filter on every session read.
+- **Owner:** enriquephl (sole dev)
+- **Target:** `eros-engine` 1.4.0 proposed — additive endpoint plus a read-visibility
+  change on existing routes. The release number and its timing are the owner's
+  call, not this document's.
+
+## 1. Motivation
+
+The engine has never offered a way to delete a conversation, so downstream
+clients delete rows themselves. The verb available to them is `DELETE`, and
+`engine.chat_sessions` has three `ON DELETE CASCADE` children — `chat_messages`,
+`companion_affinity` (which cascades on to `companion_affinity_events`), and
+`companion_memories`. A client that wants "start over with this companion" gets
+the whole cascade, because that is the only thing the schema will do for it.
+
+Three consequences, all bad:
+
+**Chat history is destroyed permanently.** The user asked to clear a
+conversation, not to erase the record. There is no recovery path — the rows are
+gone.
+
+**Audit rows survive their subject.** `companion_decision_events`,
+`chat_vision_events` and `chat_images_events` all carry `session_id` as a plain
+UUID with no foreign key, so they outlive the delete. An operator inspecting an
+image-generation record can find the session id and nothing it points at.
+
+**The engine never learns it happened.** The semantics of "delete a
+conversation" are currently decided by which foreign keys happen to exist, in a
+client the engine cannot see. That is a rule with no owner.
+
+What the client actually wants is narrower than what it gets: the conversation
+should stop being visible and stop being resumable, and the relationship state
+should reset so a fresh start is genuinely fresh. Neither of those requires
+destroying the transcript.
+
+## 2. Design principles applied
+
+1. The transcript is evidence and is never deleted by an API call. Visibility is
+   a flag; the rows stay.
+2. Relationship state — affinity, relationship-layer memory, character insights —
+   *is* deleted, because leaving it would contaminate the next conversation.
+   Requirement, not oversight.
+3. `archived` is a boolean, not a status enum. A session is visible or it is
+   not; there is no third state to name.
+4. No restore endpoint. Reviving a session is an operator action, and `UPDATE`
+   is the whole of it.
+5. The engine does not touch ownership. `persona_instances.status` and the
+   client's own ownership tables are the client's business.
+
+## 3. The endpoint
+
+```
+DELETE /comp/instance/{instance_id}/sessions
+→ 200 { "instance_id": "…", "archived_sessions": 3 }
+```
+
+Keyed by instance, matching `GET /comp/instance/{instance_id}/profile`. The
+instance is the unit of a relationship: one user, one persona, however many
+sessions across however many channels. Archiving one session and leaving its
+siblings resumable would not give the caller the fresh start it asked for.
+
+- Auth: the existing bearer-JWT layer. The instance's `owner_uid` must equal the
+  JWT `sub` — mismatch is `403`, unknown instance is `404`. Ownership is read
+  through the instance rather than compared against a path parameter, the same
+  way `get_character_profile` does it.
+- Idempotent. A second call finds nothing left to archive and returns
+  `archived_sessions: 0` with `200`.
+- `archived_sessions` counts sessions flipped by *this* call.
+
+### Reviving a session
+
+Deliberately not an endpoint. An operator runs:
+
+```sql
+UPDATE engine.chat_sessions SET archived = false WHERE id = '…';
+```
+
+That restores the session and its transcript. Affinity, relationship-layer
+memories and character insights are gone and do not come back — the revived
+session resumes with a cold relationship. This is the documented and intended
+outcome, not a limitation: those rows were deleted precisely so the next
+conversation would not inherit them.
+
+## 4. Schema
+
+Migration `0052_chat_sessions_archived.sql`:
+
+```sql
+ALTER TABLE engine.chat_sessions
+    ADD COLUMN archived BOOLEAN NOT NULL DEFAULT false;
+```
+
+**No index.** The only hot path is resume, which reaches its rows through
+`idx_chat_sessions_user_instance_channel` and lands on a single-digit number of
+candidates; filtering `NOT archived` on the heap from there costs nothing worth
+an index. Archived rows are read only by hand-written SQL.
+
+**No backfill.** Sessions destroyed by earlier hard deletes are gone. Nothing to
+mark.
+
+## 5. The archive action
+
+One transaction, four statements:
+
+```sql
+UPDATE engine.chat_sessions SET archived = true
+ WHERE user_id = $1 AND instance_id = $2 AND NOT archived;
+
+DELETE FROM engine.companion_memories
+ WHERE user_id = $1 AND instance_id = $2;
+
+DELETE FROM engine.companion_affinity
+ WHERE user_id = $1 AND instance_id = $2;
+
+DELETE FROM engine.character_insights WHERE instance_id = $2;
+```
+
+**Sessions on every channel are archived**, voice included. The unit is the
+relationship, not one client's view of it.
+
+**Memories are deleted by `(user_id, instance_id)`, not by session id.**
+`MemoryRepo::search` retrieves on exactly that key, so the delete key has to
+match the read key — deleting by session id would leave a row retrievable that
+the caller believed gone. The same predicate is what protects the profile layer:
+profile memories carry `instance_id IS NULL`, and `instance_id = $2` never
+matches NULL. Those rows are cross-persona facts about the user, shared with
+every companion; ending one relationship must not erase them. Today's hard
+delete does erase them, via the `session_id` cascade. That is a data-loss bug
+this design fixes by construction.
+
+**`companion_affinity_events` goes with its parent** through the existing
+`ON DELETE CASCADE`. Accepted, not worked around: those events are the ledger of
+a relationship that no longer exists. The audit surface an operator needs —
+`companion_decision_events`, `llm_attempt_audit`, `chat_vision_events`,
+`chat_images_events` — holds `session_id` without a foreign key and is untouched
+by any of this. Combined with the transcript now surviving, an operator
+inspecting an image-generation record can finally read the conversation around
+it. That is the point of the change.
+
+**`character_insights` is deleted.** It is instance-keyed, so today it survives
+the hard delete and carries the persona's memory of the relationship — where the
+user lives, what they do, the current situation between them — straight into the
+next conversation. Leaving it contradicts the reason affinity and memories are
+deleted at all.
+
+**`persona_instances.status` is not touched.** The user still owns the persona
+and can start a new conversation immediately; `chat/start` will create a fresh
+session because no unarchived one remains.
+
+## 6. Read visibility
+
+An archived session does not exist as far as the API is concerned.
+
+**One choke point covers most of it.** `ChatRepo::get_session` gains
+`AND NOT archived`. Every entry-point guard resolves the session through it, so
+a single predicate turns all of these into `404`:
+
+| Route | Path to `get_session` |
+|---|---|
+| `GET /comp/chat/{sid}/history` | `require_session_for_user` |
+| `GET /bff/v1/comp/chat/{sid}/history` | `require_session_for_user` |
+| `GET /bff/v1/comp/affinity/{sid}` | `require_session_for_user` |
+| `GET /bff/v1/comp/affinity/{sid}/event` | `require_session_for_user` |
+| `POST /comp/chat/{sid}/message/stream` | direct call |
+| `POST /comp/voice/{sid}/turn/stream` | direct call |
+
+**Five queries do their own session lookup and need the predicate added:**
+
+1. `resume_latest_session` — the critical one. Without it the next
+   `chat/start` reanimates the archived session and the user gets their deleted
+   conversation back with a blank relationship.
+2. `create_or_resume`
+3. `list_sessions` (`GET /comp/chat/{user_id}/sessions`)
+4. `latest_sibling_voice_session`
+5. `story.rs` — the three joins onto `chat_sessions` that feed world stories,
+   so archived material stops being harvested.
+
+**`bff_list_affinities` needs no change.** It is driven by
+`companion_affinity`, whose rows this endpoint deletes; an absent row is an
+absent list entry.
+
+## 7. Testing
+
+- Archiving leaves `chat_messages` row count unchanged; `companion_affinity`,
+  relationship-layer `companion_memories` and `character_insights` go to zero.
+- Profile-layer memories (`instance_id IS NULL`) survive.
+- `chat/start` after archiving returns a **new** session id, not the archived one.
+- History, affinity and stream routes return `404` for an archived session.
+- Voice-channel sessions are archived alongside text ones.
+- Another user's instance → `403`; unknown instance → `404`; repeat call →
+  `200` with `archived_sessions: 0`.
+- `UPDATE … SET archived = false` makes history readable again.
+
+## 8. Downstream
+
+Not delivered by this spec, and the feature does not hold in production without
+it. A client that reads `engine.chat_sessions` directly — through a privileged
+SQL function, say, to build a chat list — must add `AND NOT archived` to those
+reads. The engine cannot enforce visibility on a query it never sees. Any client
+that currently hard-deletes sessions replaces that with a call to this endpoint.
+
+## 9. Not doing
+
+- **A restore endpoint.** §3 covers why.
+- **Preserving `companion_affinity_events`.** Keeping them past their parent row
+  means a nullable `affinity_id` or a redundant `session_id` column, and an
+  orphan state for every reader to handle. §5 covers why the audit story does
+  not need it.
+- **Zeroing the affinity row instead of deleting it.** Reusing the row makes
+  "delete and start over" into "same ledger, continued," which is the shape that
+  caused the tier-oscillation problem this codebase already has a note about.
+- **A `status` enum on `chat_sessions`.** There is one distinction to draw.
+- **Touching `human_insights`.** User-level, cross-persona, same reasoning as the
+  profile memory layer.

--- a/docs/superpowers/specs/2026-08-18-session-soft-delete-design.md
+++ b/docs/superpowers/specs/2026-08-18-session-soft-delete-design.md
@@ -136,11 +136,19 @@ this design fixes by construction.
 **`companion_affinity_events` goes with its parent** through the existing
 `ON DELETE CASCADE`. Accepted, not worked around: those events are the ledger of
 a relationship that no longer exists. The audit surface an operator needs —
-`companion_decision_events`, `llm_attempt_audit`, `chat_vision_events`,
+`companion_decision_events`, `character_insights_events`, `chat_vision_events`,
 `chat_images_events` — holds `session_id` without a foreign key and is untouched
 by any of this. Combined with the transcript now surviving, an operator
 inspecting an image-generation record can finally read the conversation around
 it. That is the point of the change.
+
+Since migration `0050`, `companion_affinity_events` also carries the
+`llm_attempts` / `gateway_errors` columns, so the cascade takes the
+affinity-eval slice of the per-attempt LLM failure audit with it — every failed
+attempt record for that relationship's affinity evals is gone along with the
+row it hung off. Accepted for the same reason the events themselves are: the
+attempts belong to a relationship that no longer exists. The chat-turn slice of
+that audit survives on `chat_messages`, which is never deleted.
 
 **`character_insights` is deleted.** It is instance-keyed, so today it survives
 the hard delete and carries the persona's memory of the relationship — where the
@@ -212,6 +220,11 @@ SQL function, say, to build a chat list — must add `AND NOT archived` to those
 reads. The engine cannot enforce visibility on a query it never sees. Any client
 that currently hard-deletes sessions replaces that with a call to this endpoint.
 
+Migrations run through an explicit `migrate` subcommand, not at boot, so
+deploy order is a real constraint: migration `0052` must be applied before the
+new binary serves traffic, because the read filter references a column
+(`archived`) that does not exist until then.
+
 ## 9. Not doing
 
 - **A restore endpoint.** §3 covers why.
@@ -225,3 +238,14 @@ that currently hard-deletes sessions replaces that with a call to this endpoint.
 - **A `status` enum on `chat_sessions`.** There is one distinction to draw.
 - **Touching `human_insights`.** User-level, cross-persona, same reasoning as the
   profile memory layer.
+- **Closing the `post_process` race entirely.** The guard added at the top of
+  `post_process::run` closes the window between an archive and a *new*
+  detached task; a turn's post-processing that is already past that check when
+  the archive commits can still land its write afterward. The residual window
+  is one statement wide. Closing it fully would mean taking a lock across the
+  whole post-turn pipeline, which costs more than the defect it would prevent.
+- **Clearing the `persona_story_*` layer.** The story digest is instance-keyed
+  and injected into every subsequent reply, so it survives the archive and
+  carries a narrative shaped by the deleted conversation into the fresh
+  session. Whether to clear it is a real design question, deliberately left
+  open here rather than overlooked.

--- a/docs/superpowers/specs/2026-08-18-session-soft-delete-design.md
+++ b/docs/superpowers/specs/2026-08-18-session-soft-delete-design.md
@@ -249,7 +249,14 @@ that currently hard-deletes sessions replaces that with a call to this endpoint.
 Migrations run through an explicit `migrate` subcommand, not at boot, so
 deploy order is a real constraint: migration `0052` must be applied before the
 new binary serves traffic, because the read filter references a column
-(`archived`) that does not exist until then.
+(`archived`) that does not exist until then — and the order isn't merely a
+preference, it's the only direction that works: migration-first is safe
+because `ChatSession` derives `sqlx::FromRow`, whose generated code fetches
+each declared field by column name and simply never looks up one it doesn't
+know about, so the previous binary's `SELECT *` against the post-migration
+table decodes fine; binary-first is not safe, because the new binary's read
+filter (`AND NOT archived`) names a column the table doesn't have yet and
+every session read fails until the migration runs.
 
 ## 9. Not doing
 
@@ -264,12 +271,26 @@ new binary serves traffic, because the read filter references a column
 - **A `status` enum on `chat_sessions`.** There is one distinction to draw.
 - **Touching `human_insights`.** User-level, cross-persona, same reasoning as the
   profile memory layer.
-- **Closing the `post_process` race entirely.** The guard added at the top of
+- **Closing the `post_process` race entirely.** The guard at the top of
   `post_process::run` closes the window between an archive and a *new*
-  detached task; a turn's post-processing that is already past that check when
-  the archive commits can still land its write afterward. The residual window
-  is one statement wide. Closing it fully would mean taking a lock across the
-  whole post-turn pipeline, which costs more than the defect it would prevent.
+  detached task, but the model and embedding calls that follow it — the
+  affinity evaluator, the two-stage character-insight chain, the memory
+  embedding calls — can each run long enough for the archive to commit while
+  the task is inside them. So the check runs a second time, immediately
+  before each of the three writes those calls feed
+  (`companion_affinity`, `companion_memories`, `character_insights`), right
+  after its own model call returns. That narrows the window from the whole
+  model-call phase down to the gap between the recheck and the write it
+  guards — it does not close it. Closing it fully would mean taking a lock
+  across the whole post-turn pipeline, which costs more than the defect it
+  would prevent.
+
+  Separately: an in-flight chat or voice turn that resolved its session
+  *before* the archive committed can still append to `chat_messages` and bump
+  `last_active_at` on the now-archived row after the archive lands. That is
+  harmless by construction — the transcript is preserved by design regardless,
+  and `last_active_at` on a row no read route can return changes nothing a
+  reader can see.
 - **Touching `persona_story_events`, `persona_story_memories`, or the scalar
   columns on `persona_story_insights`.** §5 clears `digest` because it is this
   relationship's record; the rest of that row and both of those tables are the


### PR DESCRIPTION
Adds `DELETE /comp/instance/{instance_id}/sessions`, so a client can end a
conversation without hard-deleting the transcript.

Spec: [`docs/superpowers/specs/2026-08-18-session-soft-delete-design.md`](docs/superpowers/specs/2026-08-18-session-soft-delete-design.md)

## Why

The engine has never offered a way to delete a conversation, so clients delete
rows themselves. The only verb available is `DELETE`, and `engine.chat_sessions`
has three `ON DELETE CASCADE` children — so "start over with this companion"
takes the transcript with it, permanently, and leaves `companion_decision_events`
/ `chat_vision_events` / `chat_images_events` pointing at a session id that
resolves to nothing.

What a client actually wants is narrower: the conversation should stop being
visible and resumable, and the relationship state should reset. Neither requires
destroying the transcript.

## What it does

- **Migration 0052** adds `engine.chat_sessions.archived BOOLEAN NOT NULL DEFAULT false`.
  No index (resume already lands on a handful of rows through
  `idx_chat_sessions_user_instance_channel`), no backfill.
- **One transaction** flips the flag for every session of that user × instance —
  voice included — then deletes `companion_affinity`, the relationship layer of
  `companion_memories`, and `character_insights`, and blanks
  `persona_story_insights.digest`. All of that is state that would otherwise
  carry into the next conversation.
- **`chat_messages` is never deleted.** Neither is the profile layer of
  `companion_memories` (`instance_id IS NULL`) — those are cross-persona facts
  about the user, and today's client-side hard delete erases them via the
  `session_id` cascade. Fixed here by construction.
- **Ten session reads gain `AND NOT archived`.** `ChatRepo::get_session` is the
  choke point every entry-point guard resolves through, so history, affinity, the
  chat stream and the voice turn all become `404` from one predicate. `resume`,
  `list_sessions`, the sibling-voice lookup, three `story.rs` joins, the dreaming
  sweeper's claim query and the detached `post_process` task each carry their own.
- **No restore endpoint**, by design. Reviving one session is an operator
  `UPDATE engine.chat_sessions SET archived = false WHERE id = '…'`; the
  transcript comes back, the relationship state stays gone.

## Notes for review

- `PersonaRepo::instance_owner` deliberately does **not** filter
  `status = 'active'`, unlike the neighbouring `load_instance_gate` — a client may
  clear the conversations of a relationship it has already marked over.
- `companion_affinity_events` goes with its parent by cascade. Since migration
  0050 that also takes the affinity-eval slice of the per-attempt LLM failure
  audit. Accepted and stated in spec §5 rather than worked around; the chat-turn
  slice survives on `chat_messages`.
- The `post_process` guard narrows, but does not close, the race where a turn's
  detached post-processing lands after the archive commits. Residual window is one
  statement wide — recorded in spec §9.
- Migration 0052 must be applied before the new binary serves traffic: the read
  filter references a column that does not exist until then.
- Downstream work is out of scope and named in spec §8 — a client that reads
  `engine.chat_sessions` through its own privileged SQL must add `AND NOT archived`
  to those reads.

## Verification

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
`cargo test --workspace` (1445 passed / 0 failed), and the OpenAPI snapshot drift
check all pass at HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)