### PR TITLE
chore(release): v1.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,7 +531,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "eros-engine-core"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "chrono",
  "serde",
@@ -541,7 +541,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-llm"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-server"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-store"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "1.4.0"
+version = "1.4.1"
 edition = "2021"
 license = "AGPL-3.0-only"
 repository = "https://github.com/etherfunlab/eros-engine"

--- a/README.ja.md
+++ b/README.ja.md
@@ -69,14 +69,14 @@ eros-engine-llm   = "1.0"   # optional: model and embedding clients
 各 `v*` タグについて、複数アーキテクチャ対応のイメージを GitHub Container Registry へ公開しています。
 
 ```bash
-docker pull ghcr.io/etherfunlab/eros-engine:1.4.0
+docker pull ghcr.io/etherfunlab/eros-engine:1.4.1
 # Or follow the latest tagged release
 docker pull ghcr.io/etherfunlab/eros-engine:latest
 ```
 
 ```bash
 docker run --rm -p 8080:8080 --env-file .env \
-  ghcr.io/etherfunlab/eros-engine:1.4.0 serve
+  ghcr.io/etherfunlab/eros-engine:1.4.1 serve
 ```
 
 Postgres と `.env` は利用者側で用意してください。同じ `docker/Dockerfile` を任意のコンテナ環境へ配備できます。詳細は [Deploying](docs/deploying.md) を参照してください。

--- a/README.md
+++ b/README.md
@@ -69,14 +69,14 @@ eros-engine-llm   = "1.0"   # optional: model and embedding clients
 Multi-architecture images are published to GitHub Container Registry for every `v*` tag:
 
 ```bash
-docker pull ghcr.io/etherfunlab/eros-engine:1.4.0
+docker pull ghcr.io/etherfunlab/eros-engine:1.4.1
 # Or follow the latest tagged release
 docker pull ghcr.io/etherfunlab/eros-engine:latest
 ```
 
 ```bash
 docker run --rm -p 8080:8080 --env-file .env \
-  ghcr.io/etherfunlab/eros-engine:1.4.0 serve
+  ghcr.io/etherfunlab/eros-engine:1.4.1 serve
 ```
 
 Bring your own Postgres and `.env`; the same `docker/Dockerfile` can be deployed to any container host. See [Deploying](docs/deploying.md).

--- a/README.zh.md
+++ b/README.zh.md
@@ -69,14 +69,14 @@ eros-engine-llm   = "1.0"   # optional: model and embedding clients
 每个 `v*` tag 都会向 GitHub Container Registry 发布多架构镜像：
 
 ```bash
-docker pull ghcr.io/etherfunlab/eros-engine:1.4.0
+docker pull ghcr.io/etherfunlab/eros-engine:1.4.1
 # Or follow the latest tagged release
 docker pull ghcr.io/etherfunlab/eros-engine:latest
 ```
 
 ```bash
 docker run --rm -p 8080:8080 --env-file .env \
-  ghcr.io/etherfunlab/eros-engine:1.4.0 serve
+  ghcr.io/etherfunlab/eros-engine:1.4.1 serve
 ```
 
 你需要自行提供 Postgres 和 `.env`；同一个 `docker/Dockerfile` 可部署到任意容器托管平台。详见[部署](docs/deploying.zh.md)。

--- a/crates/eros-engine-llm/Cargo.toml
+++ b/crates/eros-engine-llm/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "openrouter", "voyage", "embeddings", "llm"]
 categories = ["api-bindings"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "1.4.0" }
+eros-engine-core = { path = "../eros-engine-core", version = "1.4.1" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/eros-engine-server/Cargo.toml
+++ b/crates/eros-engine-server/Cargo.toml
@@ -13,9 +13,9 @@ name = "eros-engine"
 path = "src/main.rs"
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "1.4.0" }
-eros-engine-llm  = { path = "../eros-engine-llm", version = "1.4.0" }
-eros-engine-store = { path = "../eros-engine-store", version = "1.4.0" }
+eros-engine-core = { path = "../eros-engine-core", version = "1.4.1" }
+eros-engine-llm  = { path = "../eros-engine-llm", version = "1.4.1" }
+eros-engine-store = { path = "../eros-engine-store", version = "1.4.1" }
 axum = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0-only",
       "identifier": "AGPL-3.0-only"
     },
-    "version": "1.4.0"
+    "version": "1.4.1"
   },
   "servers": [
     {

--- a/crates/eros-engine-store/Cargo.toml
+++ b/crates/eros-engine-store/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "memory", "pgvector", "postgres", "sqlx"]
 categories = ["database"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "1.4.0" }
+eros-engine-core = { path = "../eros-engine-core", version = "1.4.1" }
 sqlx = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
Version bump only — no behaviour change in this commit.

| | |
|---|---|
| 6 version strings | workspace `Cargo.toml`, plus the inter-crate `version =` pins in llm / store / server |
| 3 READMEs | the two `ghcr.io/etherfunlab/eros-engine:` docker lines in each of `README.md` / `.zh.md` / `.ja.md` |
| openapi snapshot | regenerated — `info.version` comes from `CARGO_PKG_VERSION`, so it moves with the bump |

Historical `v1.4.0` references in `docs/` are left alone; they name the release a
behaviour landed in, not the current version.

## What v1.4.1 carries

- **#280** echo cancellation for injected history — within the messages one text turn injects, any non-empty string occurring more than once is dropped in all of its occurrences, except the current turn's own user message. Off via `CHAT_ECHO_CANCELLATION_DISABLED`; unset means it runs.
- **#281** neutral photo marker — the marker folded into the model's own history is a possessive noun phrase (`[你的照片：…]`) rather than a sentence about sending.
- **#282** iron rules govern words, not surface shape — format constraints moved to the regex filter, turn-count quotas became ordinal, ⓪ no longer fixes a relationship distance the affinity tiers already inject. 12 numbered rules to 7.
- **#279** read receipts via `chat_messages.read_at`.

No migration. The only API surface change is the additive `read_at` field from #279.

`fmt --check` clean · `clippy --workspace --all-targets -- -D warnings` clean ·
`test --workspace` 1464 passed / 0 failed · openapi snapshot regenerated.