### PR TITLE
docs: correct the self-reinforcement citation in the echo-cancellation spec

### DIFF
--- a/docs/superpowers/specs/2026-08-19-chat-echo-cancellation-design.md
+++ b/docs/superpowers/specs/2026-08-19-chat-echo-cancellation-design.md
@@ -103,14 +103,21 @@ Applying the rule in §4 retroactively to all 5,051 user turns: **675 turns
 The production numbers match what the literature says is a property of the
 model class rather than of any particular model.
 
+*Learning to Break the Loop: Analyzing and Mitigating Repetitions for Neural
+Text Generation* (NeurIPS 2022, [arXiv:2206.02369](https://arxiv.org/abs/2206.02369))
+identifies the **self-reinforcement effect**: the more times a sentence is
+repeated in the context, the higher the probability of continuing to generate
+that sentence. Sentences with a higher initial probability have a stronger
+effect, which is why a given model's own pet phrase is the one that catches
+first.
+
 *Repetition In Repetition Out: Towards Understanding Neural Text Degeneration
-from the Data Perspective* (NeurIPS 2023, [arXiv:2310.10226](https://arxiv.org/html/2310.10226))
-evaluates encoder-decoder Transformers, decoder-only Transformers, and LSTMs.
-All models trained by MLE exhibit severe repetition, with no clear indication
-that any architecture suffers less. The same work identifies the
-**self-reinforcement effect**: sentence-level repetition is self-reinforcing —
-the more times a sentence appears in the context, the higher the probability of
-emitting it again.
+from the Data Perspective* (NeurIPS 2023, [arXiv:2310.10226](https://arxiv.org/abs/2310.10226))
+traces that effect and the competing explanations — high-inflow words, the
+likelihood objective — back to a single cause: repetition in the training data.
+Penalizing it stays critical at larger model sizes and after instruction
+tuning, which is what makes this a property of the model class rather than
+something a model swap fixes.
 
 The mechanism is the ordinary autoregressive one ([Raschka, *Why LLMs get stuck
 in repetition loops*](https://sebastianraschka.com/faq/docs/repetition-loops-generation.html)):


### PR DESCRIPTION
`§3.2 Literature` of the echo-cancellation design spec attributed the
**self-reinforcement effect** to the wrong paper, and credited that paper with a
cross-architecture finding it does not contain.

## What was wrong

> *Repetition In Repetition Out …* (NeurIPS 2023, arXiv:2310.10226) evaluates
> encoder-decoder Transformers, decoder-only Transformers, and LSTMs. All models
> trained by MLE exhibit severe repetition … The same work identifies the
> **self-reinforcement effect**.

Neither claim is that paper's. Its abstract argues from the **data perspective**:
degeneration correlates with repetition in the training data, dropping attention
to repetitive training words mitigates it, and prior explanations — high-inflow
words, the likelihood objective, *the self-reinforcement phenomenon* — reduce to
that one cause. It names self-reinforcement as someone else's result, and the
architecture comparison does not appear in the paper at all (`LSTM`,
`encoder-decoder`, `decoder-only` each occur zero times in the full text).

## What it says now

**[arXiv:2206.02369](https://arxiv.org/abs/2206.02369)** — Xu et al., *Learning
to Break the Loop*, NeurIPS 2022 — becomes the primary citation. Its abstract
states the load-bearing claim verbatim:

> The sentence-level repetitions have a self-reinforcement effect: the more times
> a sentence is repeated in the context, the higher the probability of continuing
> to generate that sentence

plus a corollary that matches what §3.1 measured: sentences with a higher initial
probability reinforce more strongly — which is why the phrase that catches is a
given model's own pet phrase.

**[arXiv:2310.10226](https://arxiv.org/abs/2310.10226)** stays as the second
citation, saying what it actually says. It is what supports "a property of the
model class rather than of any particular model": the cause sits in the training
data of every MLE-trained model, and penalizing it stays critical at larger model
sizes and after instruction tuning. A model swap does not fix it.

The unsourced cross-architecture sentence is dropped rather than re-sourced.
§3.1's own measurement — seven of seven production models, no zeroes, a 27×
spread — already carries that point on stronger evidence than a citation would.

Both links also move from `arxiv.org/html/…` to `arxiv.org/abs/…`.

## Scope

Documentation only — one section of one spec. No code, no behaviour, no
interface. The same error was published in two other places and both are already
corrected in place: the v1.4.1 release notes and the #280 PR body.
