### PR TITLE
feat: chat-queue infrastructure for stream-on-queue (PR A)

### DIFF
--- a/crates/eros-engine-server/src/pipeline/chat_queue.rs
+++ b/crates/eros-engine-server/src/pipeline/chat_queue.rs
@@ -124,6 +124,16 @@ pub(crate) async fn drain_once(
 /// role='system_error', the role the old async path once produced.
 const FAILURE_NOTICE: &str = "AI 回复失败，请稍后再试";
 
+/// Who is settling decides what a failure means (spec §6): the worker ladder
+/// retries up to max_attempts; a handler-driven stream turn gets exactly one
+/// attempt — its user saw the Error frame and will resend, so a background
+/// retry would race that resend into a double reply.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SettleMode {
+    Ladder,
+    TerminalOnFailure,
+}
+
 async fn process_turn(state: AppState, turn: ClaimedTurn) {
     let cfg = state.config.chat_queue.clone();
     let outcome =
@@ -131,7 +141,7 @@ async fn process_turn(state: AppState, turn: ClaimedTurn) {
             Ok(o) => o,
             Err(_) => TurnOutcome::Failure("generation timeout".into()),
         };
-    settle_turn(&state, &turn, outcome).await;
+    settle_turn(&state, &turn, outcome, SettleMode::Ladder).await;
     // This session may have a next stacked turn — wake the loop now rather
     // than waiting out a tick.
     state.chat_queue_notify.notify_one();
@@ -143,13 +153,20 @@ async fn process_turn(state: AppState, turn: ClaimedTurn) {
 /// marking that turn `failed` would pair a served reply with a spurious
 /// `system_error` row. A guard error falls through to the failure path — the
 /// pre-fix behavior.
-pub(crate) async fn settle_turn(state: &AppState, turn: &ClaimedTurn, outcome: TurnOutcome) {
+pub(crate) async fn settle_turn(
+    state: &AppState,
+    turn: &ClaimedTurn,
+    outcome: TurnOutcome,
+    mode: SettleMode,
+) {
     let cfg = &state.config.chat_queue;
     let repo = ChatQueueRepo { pool: &state.pool };
     let res = match outcome {
         TurnOutcome::Success => repo.mark_done(turn.queue_id).await,
         TurnOutcome::Failure(msg) => {
-            if turn.attempts >= cfg.max_attempts {
+            let terminal =
+                mode == SettleMode::TerminalOnFailure || turn.attempts >= cfg.max_attempts;
+            if terminal {
                 if matches!(
                     turn_already_served(state, turn.user_message_id).await,
                     Ok(true)
@@ -898,6 +915,7 @@ data: [DONE]\n\n";
             &state,
             &turn,
             TurnOutcome::Failure("generation timeout".into()),
+            SettleMode::Ladder,
         )
         .await;
 
@@ -923,7 +941,13 @@ data: [DONE]\n\n";
     async fn terminal_failure_without_reply_goes_failed_with_one_notice(pool: PgPool) {
         let (state, turn) = seed_final_attempt_turn(&pool).await;
 
-        settle_turn(&state, &turn, TurnOutcome::Failure("upstream 500".into())).await;
+        settle_turn(
+            &state,
+            &turn,
+            TurnOutcome::Failure("upstream 500".into()),
+            SettleMode::Ladder,
+        )
+        .await;
 
         let (status, last_error): (String, Option<String>) =
             sqlx::query_as("SELECT status, last_error FROM engine.chat_turn_queue WHERE id = $1")
@@ -1079,5 +1103,98 @@ data: [DONE]\n\n";
             assistant > 0 || ghosted,
             "the turn must complete (reply or ghost) with nobody listening"
         );
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn terminal_mode_fails_a_first_attempt_failure(pool: PgPool) {
+        let (state, mut turn) = seed_final_attempt_turn(&pool).await;
+        turn.attempts = 1; // far below max — the mode, not the ladder, decides
+
+        settle_turn(
+            &state,
+            &turn,
+            TurnOutcome::Failure("upstream 500".into()),
+            SettleMode::TerminalOnFailure,
+        )
+        .await;
+
+        let status: String =
+            sqlx::query_scalar("SELECT status FROM engine.chat_turn_queue WHERE id = $1")
+                .bind(turn.queue_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(status, "failed", "stream turns get exactly one attempt");
+        let notices: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM engine.chat_messages \
+             WHERE session_id = $1 AND role = 'system_error'",
+        )
+        .bind(turn.session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(notices, 1);
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn ladder_mode_still_releases_a_first_attempt_failure(pool: PgPool) {
+        let (state, mut turn) = seed_final_attempt_turn(&pool).await;
+        turn.attempts = 1;
+
+        settle_turn(
+            &state,
+            &turn,
+            TurnOutcome::Failure("upstream 500".into()),
+            SettleMode::Ladder,
+        )
+        .await;
+
+        let status: String =
+            sqlx::query_scalar("SELECT status FROM engine.chat_turn_queue WHERE id = $1")
+                .bind(turn.queue_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(status, "pending", "the worker ladder still retries");
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn terminal_mode_respects_the_served_guard(pool: PgPool) {
+        let (state, mut turn) = seed_final_attempt_turn(&pool).await;
+        turn.attempts = 1;
+        sqlx::query(
+            "INSERT INTO engine.chat_messages (session_id, role, content, user_message_id) \
+             VALUES ($1, 'assistant', 'already served', $2)",
+        )
+        .bind(turn.session_id)
+        .bind(turn.user_message_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        settle_turn(
+            &state,
+            &turn,
+            TurnOutcome::Failure("generation timeout".into()),
+            SettleMode::TerminalOnFailure,
+        )
+        .await;
+
+        let status: String =
+            sqlx::query_scalar("SELECT status FROM engine.chat_turn_queue WHERE id = $1")
+                .bind(turn.queue_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(status, "done");
+        let notices: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM engine.chat_messages \
+             WHERE session_id = $1 AND role = 'system_error'",
+        )
+        .bind(turn.session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(notices, 0);
     }
 }

--- a/crates/eros-engine-server/src/pipeline/chat_queue.rs
+++ b/crates/eros-engine-server/src/pipeline/chat_queue.rs
@@ -1047,8 +1047,16 @@ data: [DONE]\n\n";
             frames.push(f);
         }
         // The PDE ghost arm (stream.rs ActionType::Ghost) yields Meta → Done →
-        // final, same as a reply — so BOTH branches produce a Done and the
-        // assertion below must not be conditional on which one PDE picked.
+        // final, same as a reply — so BOTH branches produce a Meta and a Done
+        // and the assertions below must not be conditional on which one PDE
+        // picked. Asserting both frame kinds pins "every frame is forwarded",
+        // not just the tally-relevant ones.
+        assert!(
+            frames
+                .iter()
+                .any(|f| matches!(f, ProtocolFrame::Meta { .. })),
+            "the turn's Meta frame must reach the tap; got {frames:?}"
+        );
         assert!(
             frames.iter().any(|f| matches!(f, ProtocolFrame::Done { .. })),
             "every completed turn (reply or ghost) surfaces its Done through the tap; got {frames:?}"

--- a/crates/eros-engine-server/src/pipeline/chat_queue.rs
+++ b/crates/eros-engine-server/src/pipeline/chat_queue.rs
@@ -127,7 +127,7 @@ const FAILURE_NOTICE: &str = "AI 回复失败，请稍后再试";
 async fn process_turn(state: AppState, turn: ClaimedTurn) {
     let cfg = state.config.chat_queue.clone();
     let outcome =
-        match tokio::time::timeout(cfg.generation_timeout, drive_turn(&state, &turn)).await {
+        match tokio::time::timeout(cfg.generation_timeout, drive_turn(&state, &turn, None)).await {
             Ok(o) => o,
             Err(_) => TurnOutcome::Failure("generation timeout".into()),
         };
@@ -192,7 +192,11 @@ async fn turn_already_served(state: &AppState, user_message_id: Uuid) -> Result<
 /// Rebuild the turn from the queue row + message row and drive `run_stream`
 /// to exhaustion, discarding frames. Persistence, PDE, filters, ghosting and
 /// post-process all live inside the generator already (spec §6 Execution).
-async fn drive_turn(state: &AppState, turn: &ClaimedTurn) -> TurnOutcome {
+async fn drive_turn(
+    state: &AppState,
+    turn: &ClaimedTurn,
+    tap: Option<tokio::sync::mpsc::UnboundedSender<ProtocolFrame>>,
+) -> TurnOutcome {
     let chat_repo = ChatRepo { pool: &state.pool };
 
     // Replay guard. `run_stream` has none of its own — the stream path's guard
@@ -297,10 +301,15 @@ async fn drive_turn(state: &AppState, turn: &ClaimedTurn) -> TurnOutcome {
     let mut done_frames = 0usize;
     let mut last_error: Option<String> = None;
     while let Some(frame) = stream.next().await {
-        match frame {
+        match &frame {
             ProtocolFrame::Done { .. } => done_frames += 1,
-            ProtocolFrame::Error { message, .. } => last_error = Some(message),
+            ProtocolFrame::Error { message, .. } => last_error = Some(message.clone()),
             _ => {}
+        }
+        // The tap is an observer: a dropped receiver (client gone) must
+        // never stop or slow the drive (spec §3).
+        if let Some(tx) = &tap {
+            let _ = tx.send(frame);
         }
     }
     classify_outcome(done_frames, last_error)
@@ -933,5 +942,142 @@ data: [DONE]\n\n";
         .await
         .unwrap();
         assert_eq!(notices, vec![FAILURE_NOTICE.to_string()]);
+    }
+
+    /// Happy-path mock + session + enqueued turn, ready to drive. Returns the
+    /// MockServer too — dropping it would kill the mock endpoint mid-drive.
+    async fn seed_driveable_turn(
+        pool: &PgPool,
+        client_msg_id: &str,
+    ) -> (crate::state::AppState, MockServer, Uuid) {
+        let mock = MockServer::start().await;
+        let body = "\
+data: {\"choices\":[{\"delta\":{\"content\":\"hello\"}}]}\n\n\
+data: {\"choices\":[{\"delta\":{\"content\":\" back\"}}],\"usage\":{\"prompt_tokens\":2,\"completion_tokens\":2,\"total_tokens\":4},\"id\":\"gen-q\",\"model\":\"primary\"}\n\n\
+data: [DONE]\n\n";
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(pool, user_id).await;
+        let session_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_sessions (user_id, instance_id) \
+             VALUES ($1, $2) RETURNING id",
+        )
+        .bind(user_id)
+        .bind(instance_id)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+        let repo = ChatQueueRepo { pool };
+        let EnqueueOutcome::Queued {
+            user_message_id, ..
+        } = repo
+            .enqueue_user_message(
+                session_id,
+                "hi",
+                client_msg_id,
+                "user",
+                None,
+                user_id,
+                &serde_json::json!({}),
+                20,
+            )
+            .await
+            .unwrap()
+        else {
+            panic!("expected Queued");
+        };
+        (state, mock, user_message_id)
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn drive_tap_receives_the_frame_stream(pool: PgPool) {
+        let (state, _mock, user_message_id) =
+            seed_driveable_turn(&pool, "01JW00000000000000000000T1").await;
+        let repo = ChatQueueRepo { pool: &pool };
+        let turn = repo.claim_next().await.unwrap().unwrap();
+
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let outcome = drive_turn(&state, &turn, Some(tx)).await;
+        assert!(matches!(outcome, TurnOutcome::Success));
+
+        let mut frames = Vec::new();
+        while let Ok(f) = rx.try_recv() {
+            frames.push(f);
+        }
+        // Same PDE tolerance as drain_once_serves_an_enqueued_turn: a reply
+        // turn must surface its Done through the tap; a ghosted turn has no
+        // Done to surface.
+        let assistant: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM engine.chat_messages \
+             WHERE user_message_id = $1 AND role = 'assistant'",
+        )
+        .bind(user_message_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        if assistant > 0 {
+            assert!(
+                frames
+                    .iter()
+                    .any(|f| matches!(f, ProtocolFrame::Done { .. })),
+                "a served reply's Done frame must reach the tap; got {frames:?}"
+            );
+        } else {
+            let ghosted: bool =
+                sqlx::query_scalar("SELECT ghost_decision FROM engine.chat_messages WHERE id = $1")
+                    .bind(user_message_id)
+                    .fetch_one(&pool)
+                    .await
+                    .unwrap();
+            assert!(ghosted, "no reply and no ghost — the drive lost the turn");
+        }
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn drive_survives_a_dropped_tap(pool: PgPool) {
+        let (state, _mock, user_message_id) =
+            seed_driveable_turn(&pool, "01JW00000000000000000000T2").await;
+        let repo = ChatQueueRepo { pool: &pool };
+        let turn = repo.claim_next().await.unwrap().unwrap();
+
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<ProtocolFrame>();
+        drop(rx); // client disconnected before the first frame
+        let outcome = drive_turn(&state, &turn, Some(tx)).await;
+        assert!(
+            matches!(outcome, TurnOutcome::Success),
+            "a dead tap must not stop the drive"
+        );
+        let assistant: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM engine.chat_messages \
+             WHERE user_message_id = $1 AND role = 'assistant'",
+        )
+        .bind(user_message_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let ghosted: bool =
+            sqlx::query_scalar("SELECT ghost_decision FROM engine.chat_messages WHERE id = $1")
+                .bind(user_message_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert!(
+            assistant > 0 || ghosted,
+            "the turn must complete (reply or ghost) with nobody listening"
+        );
     }
 }

--- a/crates/eros-engine-server/src/pipeline/chat_queue.rs
+++ b/crates/eros-engine-server/src/pipeline/chat_queue.rs
@@ -152,7 +152,9 @@ async fn process_turn(state: AppState, turn: ClaimedTurn) {
 /// reply that persisted moments earlier (its Done frame never tallied), and
 /// marking that turn `failed` would pair a served reply with a spurious
 /// `system_error` row. A guard error falls through to the failure path — the
-/// pre-fix behavior.
+/// pre-fix behavior. The `mode` decides what a Failure means: `Ladder`
+/// retries until `max_attempts`, `TerminalOnFailure` goes terminal on the
+/// first failure (spec §6).
 pub(crate) async fn settle_turn(
     state: &AppState,
     turn: &ClaimedTurn,
@@ -207,8 +209,10 @@ async fn turn_already_served(state: &AppState, user_message_id: Uuid) -> Result<
 }
 
 /// Rebuild the turn from the queue row + message row and drive `run_stream`
-/// to exhaustion, discarding frames. Persistence, PDE, filters, ghosting and
-/// post-process all live inside the generator already (spec §6 Execution).
+/// to exhaustion, forwarding every frame to the optional tap (frames are
+/// discarded when no tap is attached). Persistence, PDE, filters, ghosting
+/// and post-process all live inside the generator already (spec §6
+/// Execution).
 async fn drive_turn(
     state: &AppState,
     turn: &ClaimedTurn,
@@ -1029,7 +1033,7 @@ data: [DONE]\n\n";
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
     async fn drive_tap_receives_the_frame_stream(pool: PgPool) {
-        let (state, _mock, user_message_id) =
+        let (state, _mock, _user_message_id) =
             seed_driveable_turn(&pool, "01JW00000000000000000000T1").await;
         let repo = ChatQueueRepo { pool: &pool };
         let turn = repo.claim_next().await.unwrap().unwrap();
@@ -1042,33 +1046,13 @@ data: [DONE]\n\n";
         while let Ok(f) = rx.try_recv() {
             frames.push(f);
         }
-        // Same PDE tolerance as drain_once_serves_an_enqueued_turn: a reply
-        // turn must surface its Done through the tap; a ghosted turn has no
-        // Done to surface.
-        let assistant: i64 = sqlx::query_scalar(
-            "SELECT count(*) FROM engine.chat_messages \
-             WHERE user_message_id = $1 AND role = 'assistant'",
-        )
-        .bind(user_message_id)
-        .fetch_one(&pool)
-        .await
-        .unwrap();
-        if assistant > 0 {
-            assert!(
-                frames
-                    .iter()
-                    .any(|f| matches!(f, ProtocolFrame::Done { .. })),
-                "a served reply's Done frame must reach the tap; got {frames:?}"
-            );
-        } else {
-            let ghosted: bool =
-                sqlx::query_scalar("SELECT ghost_decision FROM engine.chat_messages WHERE id = $1")
-                    .bind(user_message_id)
-                    .fetch_one(&pool)
-                    .await
-                    .unwrap();
-            assert!(ghosted, "no reply and no ghost — the drive lost the turn");
-        }
+        // The PDE ghost arm (stream.rs ActionType::Ghost) yields Meta → Done →
+        // final, same as a reply — so BOTH branches produce a Done and the
+        // assertion below must not be conditional on which one PDE picked.
+        assert!(
+            frames.iter().any(|f| matches!(f, ProtocolFrame::Done { .. })),
+            "every completed turn (reply or ghost) surfaces its Done through the tap; got {frames:?}"
+        );
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/crates/eros-engine-store/src/chat_queue.rs
+++ b/crates/eros-engine-store/src/chat_queue.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use sqlx::PgPool;
 use uuid::Uuid;
 
-use crate::chat::{upsert_user_message_in_tx, UpsertUserOutcome};
+use crate::chat::{upsert_user_message_in_tx, ChatMessage, UpsertUserOutcome};
 
 pub struct ChatQueueRepo<'a> {
     pub pool: &'a PgPool,
@@ -31,6 +31,25 @@ pub enum EnqueueOutcome {
         user_message_id: Uuid,
     },
     DepthExceeded,
+}
+
+/// Outcome of a born-claimed (stream-path) enqueue. Mirrors
+/// `UpsertUserOutcome` so the stream handler keeps its existing replay /
+/// duplicate responses; only `Inserted` grows a queue row (spec §4).
+#[derive(Debug)]
+pub enum ClaimedEnqueueOutcome {
+    Claimed {
+        user_message_id: Uuid,
+        queue_id: Uuid,
+    },
+    Replay {
+        user_message_id: Uuid,
+        ghost: bool,
+        assistant_chain: Vec<ChatMessage>,
+    },
+    DuplicateInProgress {
+        user_message_id: Uuid,
+    },
 }
 
 impl<'a> ChatQueueRepo<'a> {
@@ -103,6 +122,66 @@ impl<'a> ChatQueueRepo<'a> {
                     // mid-flight on the STREAM path — same "being handled" answer.
                     _ => EnqueueOutcome::AlreadyQueued { user_message_id },
                 })
+            }
+        }
+    }
+
+    /// Stream-path enqueue: user row + a BORN-CLAIMED queue row in one
+    /// transaction (spec §4). The row never passes through `pending` — the
+    /// caller drives it directly and it is invisible to `claim_next` while
+    /// live, but its `claimed` status still blocks the session's async turns
+    /// (one-way serialization, spec §5). No depth cap: the stream path has
+    /// its own per-user slot cap.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn enqueue_user_message_claimed(
+        &self,
+        session_id: Uuid,
+        content: &str,
+        client_msg_id: &str,
+        role: &str,
+        metadata: Option<&serde_json::Value>,
+        user_id: Uuid,
+        params: &serde_json::Value,
+    ) -> Result<ClaimedEnqueueOutcome, sqlx::Error> {
+        let mut tx = self.pool.begin().await?;
+        let outcome =
+            upsert_user_message_in_tx(&mut tx, session_id, content, client_msg_id, role, metadata)
+                .await?;
+        match outcome {
+            UpsertUserOutcome::Inserted { message_id } => {
+                let queue_id: Uuid = sqlx::query_scalar(
+                    "INSERT INTO engine.chat_turn_queue \
+                         (session_id, user_message_id, user_id, params, \
+                          status, claimed_at, attempts) \
+                     VALUES ($1, $2, $3, $4, 'claimed', now(), 1) RETURNING id",
+                )
+                .bind(session_id)
+                .bind(message_id)
+                .bind(user_id)
+                .bind(params)
+                .fetch_one(&mut *tx)
+                .await?;
+                tx.commit().await?;
+                Ok(ClaimedEnqueueOutcome::Claimed {
+                    user_message_id: message_id,
+                    queue_id,
+                })
+            }
+            UpsertUserOutcome::Replay {
+                user_message_id,
+                ghost,
+                assistant_chain,
+            } => {
+                tx.commit().await?;
+                Ok(ClaimedEnqueueOutcome::Replay {
+                    user_message_id,
+                    ghost,
+                    assistant_chain,
+                })
+            }
+            UpsertUserOutcome::DuplicateInProgress { user_message_id } => {
+                tx.commit().await?;
+                Ok(ClaimedEnqueueOutcome::DuplicateInProgress { user_message_id })
             }
         }
     }
@@ -767,5 +846,170 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(notice, "出错了");
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn enqueue_claimed_inserts_a_claimed_row_and_blocks_only_its_session(pool: PgPool) {
+        let (user_a, session_a) = seed_session(&pool).await;
+        let (user_b, session_b) = seed_session(&pool).await;
+        let repo = ChatQueueRepo { pool: &pool };
+
+        let ClaimedEnqueueOutcome::Claimed {
+            user_message_id,
+            queue_id,
+        } = repo
+            .enqueue_user_message_claimed(
+                session_a,
+                "hi",
+                "01JW00000000000000000000CL",
+                "user",
+                None,
+                user_a,
+                &serde_json::json!({"tier": "warm"}),
+            )
+            .await
+            .unwrap()
+        else {
+            panic!("expected Claimed");
+        };
+        let (status, attempts, claimed_at, params): (
+            String,
+            i32,
+            Option<chrono::DateTime<chrono::Utc>>,
+            Option<serde_json::Value>,
+        ) = sqlx::query_as(
+            "SELECT status, attempts, claimed_at, params \
+                 FROM engine.chat_turn_queue WHERE id = $1",
+        )
+        .bind(queue_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(status, "claimed", "born claimed — never pending");
+        assert_eq!(attempts, 1, "the handler's own drive is attempt #1");
+        assert!(claimed_at.is_some());
+        assert_eq!(params, Some(serde_json::json!({"tier": "warm"})));
+        let mid_check: Uuid =
+            sqlx::query_scalar("SELECT user_message_id FROM engine.chat_turn_queue WHERE id = $1")
+                .bind(queue_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(mid_check, user_message_id);
+
+        // One-way serialization (spec §4/§5): the claimed row blocks claim_next
+        // for ITS session's pending rows, and no other session.
+        seed_queued(
+            &pool,
+            session_a,
+            user_a,
+            "queued behind the stream turn",
+            10,
+        )
+        .await;
+        seed_queued(&pool, session_b, user_b, "other session", 5).await;
+        let t = repo
+            .claim_next()
+            .await
+            .unwrap()
+            .expect("session B is claimable");
+        assert_eq!(t.session_id, session_b);
+        assert!(
+            repo.claim_next().await.unwrap().is_none(),
+            "session A blocked by the born-claimed row; B already in flight"
+        );
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn enqueue_claimed_replays_an_answered_message(pool: PgPool) {
+        let (user_id, session_id) = seed_session(&pool).await;
+        let repo = ChatQueueRepo { pool: &pool };
+        let mid: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_messages (session_id, role, content, client_msg_id) \
+             VALUES ($1, 'user', 'hello', '01JW00000000000000000000RP') RETURNING id",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO engine.chat_messages (session_id, role, content, user_message_id) \
+             VALUES ($1, 'assistant', 'hi there', $2)",
+        )
+        .bind(session_id)
+        .bind(mid)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let ClaimedEnqueueOutcome::Replay {
+            user_message_id,
+            ghost,
+            assistant_chain,
+        } = repo
+            .enqueue_user_message_claimed(
+                session_id,
+                "hello",
+                "01JW00000000000000000000RP",
+                "user",
+                None,
+                user_id,
+                &serde_json::json!({}),
+            )
+            .await
+            .unwrap()
+        else {
+            panic!("expected Replay");
+        };
+        assert_eq!(user_message_id, mid);
+        assert!(!ghost);
+        assert_eq!(assistant_chain.len(), 1);
+        let rows: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM engine.chat_turn_queue WHERE user_message_id = $1",
+        )
+        .bind(mid)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(rows, 0, "a replay creates no queue row");
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn enqueue_claimed_reports_duplicate_in_progress(pool: PgPool) {
+        let (user_id, session_id) = seed_session(&pool).await;
+        let repo = ChatQueueRepo { pool: &pool };
+        let mid: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_messages (session_id, role, content, client_msg_id) \
+             VALUES ($1, 'user', 'hello', '01JW00000000000000000000DP') RETURNING id",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        let ClaimedEnqueueOutcome::DuplicateInProgress { user_message_id } = repo
+            .enqueue_user_message_claimed(
+                session_id,
+                "hello",
+                "01JW00000000000000000000DP",
+                "user",
+                None,
+                user_id,
+                &serde_json::json!({}),
+            )
+            .await
+            .unwrap()
+        else {
+            panic!("expected DuplicateInProgress");
+        };
+        assert_eq!(user_message_id, mid);
+        let rows: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM engine.chat_turn_queue WHERE user_message_id = $1",
+        )
+        .bind(mid)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(rows, 0);
     }
 }

--- a/docs/superpowers/specs/2026-08-21-stream-on-queue-design.md
+++ b/docs/superpowers/specs/2026-08-21-stream-on-queue-design.md
@@ -1,0 +1,148 @@
+# Stream-on-Queue: unifying the stream endpoint onto the chat-queue infrastructure
+
+**Date:** 2026-08-21
+**Status:** Approved
+**Prereq:** the v2 async chat endpoint (PR #286, spec `2026-08-20-async-chat-endpoint-design.md`)
+
+## 1. Goal and background
+
+Today the SSE stream endpoint (`POST /comp/chat/{session_id}/message/stream`) moves the
+`run_stream` generator into the SSE response body. When the client disconnects mid-turn,
+axum drops the body, the generator is cancelled mid-flight, and **nothing persists** — the
+user's message sits in history with no reply, no failure signal, and no recovery path.
+
+PR #286 built a queue + worker that drives the same generator to completion detached from
+any connection. This change reuses that infrastructure so that a stream turn survives its
+connection: the generation always runs to completion and settles its queue row; the SSE
+stream becomes a *tap* on the generation rather than its owner.
+
+One generation pipeline, two front doors:
+
+- **Async endpoint** — pure producer; the worker drives everything.
+- **Stream endpoint** — enqueues the same way, drives its own turn in a detached task,
+  and streams frames to the client for as long as the client stays.
+
+## 2. Scope and non-goals
+
+In scope: the chat stream endpoint's execution model, the shared drive/settle machinery
+it needs, and the store support for born-claimed queue rows.
+
+Non-goals:
+
+- **No client-visible contract change.** Frame format, status codes (including the 409
+  duplicate semantics), the per-user 3-concurrent-streams cap, and latency are preserved
+  bit-for-bit on the happy path.
+- **No long-poll / getHistory endpoint.** Post-disconnect pickup is the downstream
+  consumer's concern (e.g. Postgres change feeds).
+- **The voice turn endpoint is untouched.**
+- **No runtime feature flag.** Rollback is redeploying the previous image.
+
+## 3. Execution model: ownership moves to a detached task
+
+The stream handler, after its existing pre-flight (validation, session ownership, image
+capability, idempotent user-row upsert):
+
+1. Persists the user row **and** a queue row in the same transaction (§4).
+2. Spawns a **detached tokio task** that owns the generator: it drives `run_stream` to
+   exhaustion, tallies Done/Error frames exactly like the worker path, and settles the
+   queue row (§6).
+3. Builds the SSE body from a subscription to the task's **frame tap** — an
+   `mpsc::unbounded` channel the drive task forwards every frame into. Send errors
+   (receiver dropped) are ignored.
+
+Disconnect is therefore a non-event for the generation: the SSE body drops its receiver,
+the drive task keeps running, the reply persists, and the queue row settles. The drive is
+never backpressured by a slow or dead client (unbounded channel; frame volume per turn is
+small — tokens plus a handful of control frames).
+
+Ghosting, PDE, filters, and post-process all live inside `run_stream` already and need no
+changes; they now simply always run to completion.
+
+## 4. Queue row semantics for stream turns
+
+- **Born claimed.** The stream enqueue inserts the queue row with `status = 'claimed'`,
+  `claimed_at = now()`, `attempts = 1`, in the same transaction as the user row. It never
+  passes through `pending` and is never eligible for `claim_next` while the handler's
+  drive is live.
+- **Bypasses the in-flight guard.** The handler drives its own row directly; it does not
+  consult the per-session single-in-flight rule. Two rapid stream sends on one session run
+  concurrently — today's behavior, preserved deliberately. Serialization remains available
+  as a future ratchet (the mechanism exists; the gate is simply not applied here).
+- **One-way serialization holds.** `claim_next`'s `NOT EXISTS (status = 'claimed')` guard
+  sees stream-owned claimed rows, so async turns queue up behind a live stream turn on the
+  same session. The reverse is intentionally not enforced.
+- **Params are serialized** into the row exactly as the async endpoint does
+  (`QueuedTurnParams`), because crash recovery (§7) rebuilds the turn from the row.
+- **Depth cap:** the pending cap does not gate stream enqueues (their rows are born
+  claimed, and the stream path has its own per-user stream cap). A live stream turn does
+  count toward the session's `pending + claimed` total that gates *async* enqueues; that
+  is correct — the session genuinely has a turn in flight.
+- **Idempotency unchanged:** the existing upsert outcomes keep their stream-path
+  responses (replay → replayed reply, duplicate-in-progress → 409). Only the `Inserted`
+  outcome creates a queue row.
+
+## 5. Concurrency semantics (decided)
+
+| Situation | Behavior |
+|---|---|
+| Two stream sends, same session | Parallel generation — today's behavior, unchanged |
+| Async turn in flight, stream send arrives | Stream runs immediately (bypasses guard) |
+| Stream turn in flight, async send arrives | Async enqueues; worker waits for the stream row to settle |
+
+Rationale: "behave exactly as today when the connection holds" was the design constraint;
+per-session strictness for stream is a gate we can add later without new mechanism.
+
+## 6. Terminal semantics: they follow the driver
+
+| Driver | On generation failure | Rationale |
+|---|---|---|
+| Handler task (normal path) | **Single attempt.** Terminal immediately: `failed` + the `system_error` chat row (atomic, via the existing `mark_failed_with_notice`) | A connected user saw the Error frame and will resend — a background retry would race that resend into a double reply. A disconnected user gets the `system_error` row as their failure signal instead of a silent black hole. |
+| Worker (crash recovery only, §7) | The async ladder, unchanged (release/retry up to `CHAT_QUEUE_MAX_ATTEMPTS`, then terminal) | By then no client is attached; the turn is indistinguishable from an async turn. |
+
+Success and ghost outcomes classify exactly as the worker path (`classify_outcome`): any
+Done ⇒ done; zero Done + zero Error ⇒ ghost ⇒ done.
+
+`settle_turn` grows a terminal-on-failure mode (parameter, not a fork of the ladder
+code). The served-guard re-check before going terminal applies to both modes.
+
+## 7. Crash recovery (process death mid-turn)
+
+Free, by construction: a killed process leaves the stream row `claimed`; the reaper
+collects it after `CHAT_QUEUE_GEN_TIMEOUT_SECS + CHAT_QUEUE_CLAIM_STALE_SECS`; the row
+goes `pending`; the worker claims it and blind-drives it from its params. The existing
+replay guard prevents double replies if the reply had already persisted before the crash.
+Worst-case recovery latency at defaults is ~10 minutes, same as the async path.
+
+## 8. Unchanged surface
+
+SSE frame contract and keepalives; the 409 duplicate-in-progress response; the per-user
+stream slot cap; the ghost/PDE/post-process pipeline; the async endpoint's behavior in
+every regard (PR A must show zero async-path behavior change); the voice endpoint; all
+`CHAT_QUEUE_*` knobs and their meanings.
+
+## 9. Delivery: two serial PRs
+
+**PR A — infrastructure (no behavior change):**
+- `drive_turn` accepts an optional frame tap (forwards every frame; drives to exhaustion
+  regardless of tap liveness).
+- `settle_turn` grows the terminal-on-failure mode.
+- Store: `enqueue_user_message_claimed` (born-claimed variant sharing the transaction
+  shape and idempotency handling of `enqueue_user_message`).
+- Tests: tap receives the frame sequence; tap dropped mid-stream does not stop the drive;
+  terminal-on-failure settles `failed` + one `system_error` row on first failure;
+  born-claimed rows block `claim_next` for the session; async e2e suite untouched and
+  green.
+
+**PR B — stream endpoint rewire:**
+- Stream handler: queue row joins the pre-flight transaction; drive spawns detached; SSE
+  body subscribes to the tap.
+- Tests: happy path streams the same frame sequence as before (regression lock);
+  disconnect e2e — drop the SSE receiver mid-generation, assert the reply persists and
+  the row settles `done`; failure e2e — terminal `failed` + `system_error` row, no retry;
+  duplicate 409 regression lock.
+- Docs: api-reference (stream section gains the disconnect-continuation note) and
+  deploying (queue section mentions stream turns riding the table), each with their
+  `.zh.md` mirrors; llm-audit/prompt-traits unaffected (already widened);
+  `.env.example` unchanged.
+
+Each PR: branch off dev → PR → codex review → CI green → squash-merge, one at a time.

--- a/docs/superpowers/specs/2026-08-21-stream-on-queue-design.md
+++ b/docs/superpowers/specs/2026-08-21-stream-on-queue-design.md
@@ -45,7 +45,10 @@ capability, idempotent user-row upsert):
 1. Persists the user row **and** a queue row in the same transaction (§4).
 2. Spawns a **detached tokio task** that owns the generator: it drives `run_stream` to
    exhaustion, tallies Done/Error frames exactly like the worker path, and settles the
-   queue row (§6).
+   queue row (§6). The detached task wraps its drive in `tokio::time::timeout` with
+   `CHAT_QUEUE_GEN_TIMEOUT_SECS`, exactly as the worker's `process_turn` does: the reap
+   threshold's arithmetic (§7) assumes every drive is bounded by the generation timeout,
+   and an unbounded handler drive could be reaped and re-driven while still running.
 3. Builds the SSE body from a subscription to the task's **frame tap** — an
    `mpsc::unbounded` channel the drive task forwards every frame into. Send errors
    (receiver dropped) are ignored.
@@ -116,9 +119,12 @@ Worst-case recovery latency at defaults is ~10 minutes, same as the async path.
 ## 8. Unchanged surface
 
 SSE frame contract and keepalives; the 409 duplicate-in-progress response; the per-user
-stream slot cap; the ghost/PDE/post-process pipeline; the async endpoint's behavior in
-every regard (PR A must show zero async-path behavior change); the voice endpoint; all
-`CHAT_QUEUE_*` knobs and their meanings.
+stream slot cap — with one qualification: the `StreamSlotGuard` moves from the SSE body
+into the detached drive task, so the cap keeps bounding three concurrent *generations* per
+user (not merely three connections); a client that disconnects and immediately resends
+still holds its old slot until the background drive settles; the ghost/PDE/post-process
+pipeline; the async endpoint's behavior in every regard (PR A must show zero async-path
+behavior change); the voice endpoint; all `CHAT_QUEUE_*` knobs and their meanings.
 
 ## 9. Delivery: two serial PRs
 
@@ -144,5 +150,16 @@ every regard (PR A must show zero async-path behavior change); the voice endpoin
   deploying (queue section mentions stream turns riding the table), each with their
   `.zh.md` mirrors; llm-audit/prompt-traits unaffected (already widened);
   `.env.example` unchanged.
+- Extract the drive-to-exhaustion loop (frame tally + tap forward + `classify_outcome`)
+  out of `drive_turn` into a shared function that accepts a prebuilt
+  `PersistedUserMessage` and a prefetched `CompanionPersona`; the worker's `drive_turn`
+  keeps its rebuild-from-row path and calls the shared loop, the stream handler calls it
+  directly with what the request already resolved — zero added DB round trips on the hot
+  path. The tap parameter migrates to the shared function.
+- Move `StreamSlotGuard` into the detached drive task (see §8).
+- Known async-path answer change, deliberate: once stream turns have queue rows, a
+  replayed `client_msg_id` for a terminally-failed stream turn answers `failed` where it
+  previously answered `already_queued`; also update the store comment 'no queue row means
+  the turn is mid-flight on the STREAM path' which becomes false.
 
 Each PR: branch off dev → PR → codex review → CI green → squash-merge, one at a time.


### PR DESCRIPTION
## Summary

Infrastructure for unifying the SSE stream endpoint onto the chat-queue machinery from #286 — PR A of two. **Zero behavior change**: nothing calls the new pieces yet; the async path is untouched (proven by the untouched async test suite and an algebraically equivalent settle ladder). PR B will rewire the stream handler onto these so a disconnected client no longer cancels the generation mid-flight.

Design doc: `docs/superpowers/specs/2026-08-21-stream-on-queue-design.md` (spec §9 "PR A" is this branch's exact scope).

## What's new

- **`ChatQueueRepo::enqueue_user_message_claimed`** — user row + a *born-claimed* queue row (`status='claimed', claimed_at=now(), attempts=1`) in one transaction. Mirrors the upsert's replay/duplicate idempotency outcomes (`ClaimedEnqueueOutcome`); only `Inserted` creates a queue row. Born-claimed rows are invisible to `claim_next` but block the session's async turns via the existing in-flight guard — one-way serialization per spec §5.
- **Frame tap on `drive_turn`** — optional `mpsc::UnboundedSender<ProtocolFrame>`; every frame is tallied then forwarded. The tap is a pure observer: send errors ignored, a dropped receiver never stops or slows the drive.
- **`SettleMode` on `settle_turn`** — `Ladder` (existing retry behavior, byte-for-byte) or `TerminalOnFailure` (first failure settles `failed` + the atomic `system_error` notice; the served-guard re-check applies in both modes).

## Testing

- 6 new integration tests against real Postgres + wiremock: born-claimed semantics and one-way `claim_next` blocking, replay/duplicate passthrough with zero queue rows, tap frame delivery (unconditional `Done` assertion across both PDE branches, re-run 5x), dead-tap resilience, terminal-vs-ladder mode split, terminal-mode served guard.
- Full workspace green; clippy `-D warnings` clean; OpenAPI diff empty (no routes in this PR — by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
