### PR TITLE
feat(server): recoverable image_request payload for offline consumers

### DIFF
--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -549,6 +549,64 @@
         ]
       }
     },
+    "/comp/chat/{session_id}/messages/{message_id}/image-request": {
+      "get": {
+        "tags": [
+          "companion"
+        ],
+        "summary": "The delegated `image_request` payload for one persisted image turn.",
+        "description": "The SSE frame is wire-only: an async turn, or a stream client that\ndisconnected before the frame fired, never receives it. This endpoint\nrecovers the same payload from what the turn persisted — `metadata.image`\non the assistant row plus the composed prompt on its `chat_images_events`\naudit row. 404 when the message is not an image turn, or when the compose\nevent was never recorded (the audit write is fail-open) — in that case\nthe prompt is genuinely unrecoverable and the consumer should treat the\nturn as text-only.",
+        "operationId": "get_image_request_payload",
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "description": "Chat session id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "message_id",
+            "in": "path",
+            "description": "Assistant image-turn message id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImageRequestPayloadResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "missing or invalid bearer"
+          },
+          "403": {
+            "description": "not your session"
+          },
+          "404": {
+            "description": "session/message not found, not an image turn, or prompt unavailable"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
     "/comp/chat/{session_id}/read": {
       "post": {
         "tags": [
@@ -2265,6 +2323,36 @@
               "string",
               "null"
             ]
+          }
+        }
+      },
+      "ImageRequestPayloadResponse": {
+        "type": "object",
+        "description": "The recoverable `image_request` payload (same fields as the SSE frame,\nminus the frame discriminator).",
+        "required": [
+          "message_id",
+          "composed_prompt"
+        ],
+        "properties": {
+          "aspect_ratio": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "composed_prompt": {
+            "type": "string",
+            "description": "Base64 (STANDARD) of the UTF-8 composed prompt — identical encoding\nto the SSE frame's `composed_prompt`."
+          },
+          "image_ref": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "`\"face\"` | `\"previous\"`. Absent on rows persisted before the marker\ncarried it."
+          },
+          "message_id": {
+            "type": "string"
           }
         }
       },

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -191,9 +191,14 @@ fn build_image_request_frame(
 /// 2026-08-02; absence = no successful compose this turn — raw skip,
 /// fail-open, or task not configured). Also stores `compose_event_id`, the
 /// `chat_images_events` row id — the pointer that makes the audit table
-/// reachable from a message (spec 2026-08-14). Deliberately NOT stored: the
-/// composed wire prompt (the consumer's job), url, or success/failure of the
-/// draw. Pure.
+/// reachable from a message (spec 2026-08-14) — and `image_ref`
+/// (`face`|`previous`), so the full `image_request` payload stays
+/// recoverable via `GET .../messages/{id}/image-request` for consumers that
+/// were not on the wire when the frame fired (async turns, disconnected
+/// streams). Deliberately NOT stored: the composed wire prompt (it lives on
+/// the compose event — one authoritative home), url, or success/failure of
+/// the draw. Pure.
+#[allow(clippy::too_many_arguments)]
 fn build_delegated_image_marker(
     subject: &str,
     caption: Option<&str>,
@@ -202,8 +207,10 @@ fn build_delegated_image_marker(
     compose_model: Option<&str>,
     compose_generation_id: Option<&str>,
     compose_event_id: Option<Uuid>,
+    image_ref: eros_engine_core::types::ImageRef,
 ) -> serde_json::Value {
     let mut m = serde_json::json!({ "prompt": subject });
+    m["image_ref"] = serde_json::to_value(image_ref).expect("ImageRef serializes");
     if let Some(c) = caption.filter(|s| !s.trim().is_empty()) {
         m["caption"] = serde_json::Value::String(c.to_string());
     }
@@ -4554,6 +4561,7 @@ pub fn run_stream(
                         img.compose_model.as_deref(),
                         img.compose_generation_id.as_deref(),
                         img.compose_event_id,
+                        plan.image_ref,
                     );
                     image_only_caption = img.caption.clone();
                     let row = eros_engine_store::chat::AssistantInsert {
@@ -5099,6 +5107,7 @@ pub fn run_stream(
                             img.compose_model.as_deref(),
                             img.compose_generation_id.as_deref(),
                             img.compose_event_id,
+                            plan.image_ref,
                         );
                         if let Err(e) = chat_repo
                             .merge_assistant_image_meta(user_msg.session_id, msg_uuid, &marker)
@@ -5617,15 +5626,26 @@ mod tests {
             None,
             None,
             None,
+            eros_engine_core::types::ImageRef::Previous,
         );
         assert_eq!(m["prompt"], "on a rooftop");
         assert_eq!(m["caption"], "在天台");
         assert_eq!(m["aspect_ratio"], "3:4");
+        assert_eq!(m["image_ref"], "previous");
     }
 
     #[test]
     fn delegated_image_marker_omits_absent_caption() {
-        let m = build_delegated_image_marker("on a rooftop", None, None, None, None, None, None);
+        let m = build_delegated_image_marker(
+            "on a rooftop",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            eros_engine_core::types::ImageRef::Face,
+        );
         assert_eq!(m["prompt"], "on a rooftop");
         assert!(
             m.get("caption").is_none(),
@@ -17019,13 +17039,15 @@ data: [DONE]\n\n"
             None,
             None,
             None,
+            eros_engine_core::types::ImageRef::Face,
         );
         assert_eq!(marker["prompt"], "beach at sunset");
         assert_eq!(marker["aspect_ratio"], "3:4");
+        assert_eq!(marker["image_ref"], "face");
         assert_eq!(
             marker.as_object().unwrap().len(),
-            2,
-            "marker must be minimal"
+            3,
+            "marker must be minimal: prompt + aspect + image_ref"
         );
         // The §5 regression guard: transcript still annotates it as a prior
         // image. With no caption, that annotation is the bare marker — the
@@ -17039,9 +17061,18 @@ data: [DONE]\n\n"
         );
         assert_ne!(line.trim(), "", "image turn must not be a blank line");
 
-        // No aspect => still a valid one-key marker that annotates (bare, same reason).
-        let m2 = build_delegated_image_marker("a portrait", None, None, None, None, None, None);
-        assert_eq!(m2.as_object().unwrap().len(), 1);
+        // No aspect => prompt + image_ref only; still annotates (bare, same reason).
+        let m2 = build_delegated_image_marker(
+            "a portrait",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            eros_engine_core::types::ImageRef::Face,
+        );
+        assert_eq!(m2.as_object().unwrap().len(), 2);
         let w2 = serde_json::json!({ "image": m2 });
         assert_eq!(
             assistant_transcript_line("", Some(&w2)),
@@ -17061,13 +17092,14 @@ data: [DONE]\n\n"
             Some("served/model"),
             Some("gen-xyz"),
             None,
+            eros_engine_core::types::ImageRef::Face,
         );
         assert_eq!(m["prompt"], "beach at sunset");
         assert_eq!(m["aspect_ratio"], "3:4");
         assert_eq!(m["compose_variant"], "b");
         assert_eq!(m["compose_model"], "served/model");
         assert_eq!(m["compose_generation_id"], "gen-xyz");
-        assert_eq!(m.as_object().unwrap().len(), 5);
+        assert_eq!(m.as_object().unwrap().len(), 6);
 
         // No generation id from the provider → key absent, not null.
         let m2 = build_delegated_image_marker(
@@ -17078,6 +17110,7 @@ data: [DONE]\n\n"
             Some("served/model"),
             None,
             None,
+            eros_engine_core::types::ImageRef::Face,
         );
         assert_eq!(m2["compose_model"], "served/model");
         assert!(m2
@@ -17088,8 +17121,8 @@ data: [DONE]\n\n"
         assert!(m2.as_object().unwrap().get("compose_variant").is_none());
         assert_eq!(
             m2.as_object().unwrap().len(),
-            2,
-            "prompt + compose_model only"
+            3,
+            "prompt + image_ref + compose_model only"
         );
     }
 

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -829,7 +829,7 @@ async fn get_image_request_payload(
             AppError::NotFound("prompt unavailable (compose event was never recorded)".into())
         })?;
     let prompt = eros_engine_store::image_events::ImageComposeEventRepo { pool: &state.pool }
-        .composed_prompt(compose_event_id)
+        .composed_prompt_in_session(compose_event_id, session_id)
         .await?
         .ok_or_else(|| AppError::NotFound("prompt unavailable".into()))?;
     use base64::Engine as _;
@@ -2574,6 +2574,92 @@ mod tests {
         )
         .await;
         assert_eq!(status, StatusCode::NOT_FOUND, "no such message");
+
+        // Malformed compose_event_id in the marker (corrupt metadata).
+        let seed_with_marker = |marker: serde_json::Value| {
+            let pool = pool.clone();
+            async move {
+                sqlx::query_scalar::<_, Uuid>(
+                    "INSERT INTO engine.chat_messages \
+                         (session_id, role, content, assistant_action_type, metadata) \
+                     VALUES ($1, 'assistant', '', 'reply', \
+                             jsonb_build_object('image', $2::jsonb)) \
+                     RETURNING id",
+                )
+                .bind(session_id)
+                .bind(serde_json::to_string(&marker).unwrap())
+                .fetch_one(&pool)
+                .await
+                .unwrap()
+            }
+        };
+        let malformed =
+            seed_with_marker(serde_json::json!({"prompt": "p", "compose_event_id": "not-a-uuid"}))
+                .await;
+        let (status, _) = send_request(
+            &mut router,
+            image_request_request(session_id, malformed, &jwt),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_FOUND, "malformed event id");
+
+        // Dangling compose_event_id (event row never landed / was purged).
+        let dangling = seed_with_marker(
+            serde_json::json!({"prompt": "p", "compose_event_id": Uuid::new_v4().to_string()}),
+        )
+        .await;
+        let (status, _) = send_request(
+            &mut router,
+            image_request_request(session_id, dangling, &jwt),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_FOUND, "dangling event id");
+
+        // Event row exists but composed_prompt is NULL (standalone-endpoint
+        // exhausted shape).
+        let null_event: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_images_events \
+                 (source, user_id, session_id, status, inputs, attempts) \
+             VALUES ('chat_reply_image', $1, $2, 'exhausted', '{}', 1) RETURNING id",
+        )
+        .bind(user_id)
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let null_prompt = seed_with_marker(
+            serde_json::json!({"prompt": "p", "compose_event_id": null_event.to_string()}),
+        )
+        .await;
+        let (status, _) = send_request(
+            &mut router,
+            image_request_request(session_id, null_prompt, &jwt),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_FOUND, "NULL composed_prompt");
+
+        // A marker pointing at ANOTHER session's compose event must not leak
+        // that session's prompt — the event lookup is session-scoped.
+        let other_genome = seed_genome(&pool, "Vega").await;
+        let other_instance = seed_instance(&pool, other_genome, user_id).await;
+        let other_session = seed_session(&pool, user_id, other_instance).await;
+        let foreign_event: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_images_events \
+                 (source, user_id, session_id, status, inputs, composed_prompt, attempts) \
+             VALUES ('chat_reply_image', $1, $2, 'ok', '{}', 'secret prompt', 1) RETURNING id",
+        )
+        .bind(user_id)
+        .bind(other_session)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let cross = seed_with_marker(
+            serde_json::json!({"prompt": "p", "compose_event_id": foreign_event.to_string()}),
+        )
+        .await;
+        let (status, _) =
+            send_request(&mut router, image_request_request(session_id, cross, &jwt)).await;
+        assert_eq!(status, StatusCode::NOT_FOUND, "cross-session event pointer");
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -761,6 +761,92 @@ async fn get_history(
     }))
 }
 
+/// The recoverable `image_request` payload (same fields as the SSE frame,
+/// minus the frame discriminator).
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct ImageRequestPayloadResponse {
+    #[schema(value_type = String)]
+    pub message_id: Uuid,
+    /// Base64 (STANDARD) of the UTF-8 composed prompt — identical encoding
+    /// to the SSE frame's `composed_prompt`.
+    pub composed_prompt: String,
+    /// `"face"` | `"previous"`. Absent on rows persisted before the marker
+    /// carried it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub image_ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub aspect_ratio: Option<String>,
+}
+
+/// The delegated `image_request` payload for one persisted image turn.
+///
+/// The SSE frame is wire-only: an async turn, or a stream client that
+/// disconnected before the frame fired, never receives it. This endpoint
+/// recovers the same payload from what the turn persisted — `metadata.image`
+/// on the assistant row plus the composed prompt on its `chat_images_events`
+/// audit row. 404 when the message is not an image turn, or when the compose
+/// event was never recorded (the audit write is fail-open) — in that case
+/// the prompt is genuinely unrecoverable and the consumer should treat the
+/// turn as text-only.
+#[utoipa::path(
+    get,
+    path = "/comp/chat/{session_id}/messages/{message_id}/image-request",
+    tag = "companion",
+    params(
+        ("session_id" = Uuid, Path, description = "Chat session id"),
+        ("message_id" = Uuid, Path, description = "Assistant image-turn message id")
+    ),
+    responses(
+        (status = 200, body = ImageRequestPayloadResponse),
+        (status = 401, description = "missing or invalid bearer"),
+        (status = 403, description = "not your session"),
+        (status = 404, description = "session/message not found, not an image turn, or prompt unavailable")
+    ),
+    security(("bearer" = []))
+)]
+async fn get_image_request_payload(
+    State(state): State<AppState>,
+    Path((session_id, message_id)): Path<(Uuid, Uuid)>,
+    Extension(AuthUser(user_id)): Extension<AuthUser>,
+) -> Result<Json<ImageRequestPayloadResponse>, AppError> {
+    require_session_for_user(&state, session_id, user_id).await?;
+    let chat_repo = ChatRepo { pool: &state.pool };
+    let msg = chat_repo
+        .message_by_id_in_session(session_id, message_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("no such message".into()))?;
+    let image = msg
+        .metadata
+        .as_ref()
+        .and_then(|m| m.get("image"))
+        .cloned()
+        .ok_or_else(|| AppError::NotFound("not an image turn".into()))?;
+    let compose_event_id = image
+        .get("compose_event_id")
+        .and_then(|v| v.as_str())
+        .and_then(|s| Uuid::parse_str(s).ok())
+        .ok_or_else(|| {
+            AppError::NotFound("prompt unavailable (compose event was never recorded)".into())
+        })?;
+    let prompt = eros_engine_store::image_events::ImageComposeEventRepo { pool: &state.pool }
+        .composed_prompt(compose_event_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("prompt unavailable".into()))?;
+    use base64::Engine as _;
+    Ok(Json(ImageRequestPayloadResponse {
+        message_id,
+        composed_prompt: base64::engine::general_purpose::STANDARD.encode(prompt.as_bytes()),
+        image_ref: image
+            .get("image_ref")
+            .and_then(|v| v.as_str())
+            .map(str::to_owned),
+        aspect_ratio: image
+            .get("aspect_ratio")
+            .and_then(|v| v.as_str())
+            .map(str::to_owned),
+    }))
+}
+
 /// All sessions for the JWT user. The `{user_id}` path parameter MUST
 /// match the JWT's user_id; mismatch returns 403.
 #[utoipa::path(
@@ -980,6 +1066,7 @@ pub fn router() -> OpenApiRouter<AppState> {
     OpenApiRouter::new()
         .routes(routes!(start_chat))
         .routes(routes!(get_history))
+        .routes(routes!(get_image_request_payload))
         .routes(routes!(list_sessions))
         .routes(routes!(get_profile))
         .routes(routes!(get_character_profile))
@@ -2355,5 +2442,154 @@ mod tests {
             .unwrap();
         let (status, _) = send_request(&mut router, mark_read_request(session_id, &jwt)).await;
         assert_eq!(status, StatusCode::NOT_FOUND, "an archived session is gone");
+    }
+
+    /// Seed one assistant image-turn row plus (optionally) its compose event,
+    /// returning (message_id, compose_event_id).
+    async fn seed_image_turn(
+        pool: &PgPool,
+        session_id: Uuid,
+        user_id: Uuid,
+        composed_prompt: Option<&str>,
+    ) -> (Uuid, Option<Uuid>) {
+        let event_id = match composed_prompt {
+            Some(p) => Some(
+                sqlx::query_scalar::<_, Uuid>(
+                    "INSERT INTO engine.chat_images_events \
+                         (source, user_id, session_id, status, inputs, \
+                          composed_prompt, attempts) \
+                     VALUES ('chat_reply_image', $1, $2, 'ok', '{}', $3, 1) \
+                     RETURNING id",
+                )
+                .bind(user_id)
+                .bind(session_id)
+                .bind(p)
+                .fetch_one(pool)
+                .await
+                .unwrap(),
+            ),
+            None => None,
+        };
+        let mut marker = serde_json::json!({
+            "prompt": "on a rooftop at dusk",
+            "aspect_ratio": "3:4",
+            "image_ref": "previous",
+        });
+        if let Some(id) = event_id {
+            marker["compose_event_id"] = serde_json::Value::String(id.to_string());
+        }
+        // Persisted action type is 'reply' even for image turns (the wire
+        // FrameActionType is separate; CHECK in migration 0012 allows only
+        // reply/gift_reaction) — mirrors run_stream's own AssistantInsert.
+        let message_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_messages \
+                 (session_id, role, content, assistant_action_type, metadata) \
+             VALUES ($1, 'assistant', '', 'reply', jsonb_build_object('image', $2::jsonb)) \
+             RETURNING id",
+        )
+        .bind(session_id)
+        .bind(serde_json::to_string(&marker).unwrap())
+        .fetch_one(pool)
+        .await
+        .unwrap();
+        (message_id, event_id)
+    }
+
+    fn image_request_request(session_id: Uuid, message_id: Uuid, jwt: &str) -> Request<Body> {
+        Request::builder()
+            .uri(format!(
+                "/comp/chat/{session_id}/messages/{message_id}/image-request"
+            ))
+            .header(header::AUTHORIZATION, format!("Bearer {jwt}"))
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn image_request_returns_the_frame_payload(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Nova").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+        let prompt = "写实照片，面部参照，黄昏天台";
+        let (message_id, _) = seed_image_turn(&pool, session_id, user_id, Some(prompt)).await;
+        let mut router = build_router(test_state(pool.clone()));
+
+        let (status, body) = send_request(
+            &mut router,
+            image_request_request(session_id, message_id, &mint_test_jwt(user_id)),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["message_id"], message_id.to_string());
+        // Same encoding as the SSE frame: STANDARD base64 of the UTF-8 prompt.
+        use base64::Engine as _;
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(body["composed_prompt"].as_str().unwrap())
+            .unwrap();
+        assert_eq!(std::str::from_utf8(&decoded).unwrap(), prompt);
+        assert_eq!(body["image_ref"], "previous");
+        assert_eq!(body["aspect_ratio"], "3:4");
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn image_request_404s_on_non_image_turns_and_missing_events(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Nova").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+        let jwt = mint_test_jwt(user_id);
+        let mut router = build_router(test_state(pool.clone()));
+
+        // A plain text assistant row is not an image turn.
+        let text_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_messages (session_id, role, content) \
+             VALUES ($1, 'assistant', 'hello') RETURNING id",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let (status, _) = send_request(
+            &mut router,
+            image_request_request(session_id, text_id, &jwt),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_FOUND, "not an image turn");
+
+        // An image turn whose compose event was never recorded (fail-open
+        // audit write) has no retrievable prompt.
+        let (orphan_id, _) = seed_image_turn(&pool, session_id, user_id, None).await;
+        let (status, _) = send_request(
+            &mut router,
+            image_request_request(session_id, orphan_id, &jwt),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_FOUND, "prompt unavailable");
+
+        // Unknown message id.
+        let (status, _) = send_request(
+            &mut router,
+            image_request_request(session_id, Uuid::new_v4(), &jwt),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_FOUND, "no such message");
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn image_request_enforces_session_ownership(pool: PgPool) {
+        let owner = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Nova").await;
+        let instance_id = seed_instance(&pool, genome_id, owner).await;
+        let session_id = seed_session(&pool, owner, instance_id).await;
+        let (message_id, _) = seed_image_turn(&pool, session_id, owner, Some("p")).await;
+        let mut router = build_router(test_state(pool.clone()));
+
+        let (status, _) = send_request(
+            &mut router,
+            image_request_request(session_id, message_id, &mint_test_jwt(Uuid::new_v4())),
+        )
+        .await;
+        assert_eq!(status, StatusCode::FORBIDDEN, "not your session");
     }
 }

--- a/crates/eros-engine-store/src/image_events.rs
+++ b/crates/eros-engine-store/src/image_events.rs
@@ -48,6 +48,20 @@ pub struct ImageComposeEventRepo<'a> {
 }
 
 impl ImageComposeEventRepo<'_> {
+    /// The composed wire prompt recorded on one compose event. `None` when
+    /// the row is gone or the compose never produced a prompt — the write is
+    /// fail-open, so absence is a legal state the caller must surface, not an
+    /// error.
+    pub async fn composed_prompt(&self, event_id: Uuid) -> Result<Option<String>, sqlx::Error> {
+        sqlx::query_scalar::<_, Option<String>>(
+            "SELECT composed_prompt FROM engine.chat_images_events WHERE id = $1",
+        )
+        .bind(event_id)
+        .fetch_optional(self.pool)
+        .await
+        .map(Option::flatten)
+    }
+
     /// Append one audit row and return its id. The caller stamps that id onto
     /// the assistant row (`metadata.image.compose_event_id`) — this table has
     /// no `message_id`, so the returned id IS the linkage.

--- a/crates/eros-engine-store/src/image_events.rs
+++ b/crates/eros-engine-store/src/image_events.rs
@@ -48,15 +48,24 @@ pub struct ImageComposeEventRepo<'a> {
 }
 
 impl ImageComposeEventRepo<'_> {
-    /// The composed wire prompt recorded on one compose event. `None` when
-    /// the row is gone or the compose never produced a prompt — the write is
-    /// fail-open, so absence is a legal state the caller must surface, not an
-    /// error.
-    pub async fn composed_prompt(&self, event_id: Uuid) -> Result<Option<String>, sqlx::Error> {
+    /// The composed wire prompt recorded on one compose event, scoped to the
+    /// session that owns it — the session predicate is the ownership check,
+    /// so a message whose `compose_event_id` points at another session's
+    /// event resolves to `None`, never to someone else's prompt. `None` also
+    /// when the row is gone or the compose never produced a prompt — the
+    /// write is fail-open, so absence is a legal state the caller must
+    /// surface, not an error.
+    pub async fn composed_prompt_in_session(
+        &self,
+        event_id: Uuid,
+        session_id: Uuid,
+    ) -> Result<Option<String>, sqlx::Error> {
         sqlx::query_scalar::<_, Option<String>>(
-            "SELECT composed_prompt FROM engine.chat_images_events WHERE id = $1",
+            "SELECT composed_prompt FROM engine.chat_images_events \
+             WHERE id = $1 AND session_id = $2",
         )
         .bind(event_id)
+        .bind(session_id)
         .fetch_optional(self.pool)
         .await
         .map(Option::flatten)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -432,7 +432,9 @@ succeeded — independent of whether the compose call did — and is the
 reachable link to `engine.chat_images_events`, where the composed **wire**
 prompt actually lives (the `metadata.image` marker never duplicates it); see
 [LLM audit → Image-path event tables](llm-audit.md#image-path-event-tables).
-The reference kind is not recorded.
+The marker also records `image_ref` (`"face"` | `"previous"`), so the full
+`image_request` payload stays recoverable after the fact (absent on rows
+persisted before it was added).
 
 Validation: `force` + `tips_amount_usd` on the same turn → `422`. `force`
 while `[tasks.chat_image_prompt_compose]` is not configured → `422` (the
@@ -467,6 +469,13 @@ data: {"type":"image_request","message_id":"01J...","composed_prompt":"5YaZ5a6e.
 
 The engine never draws and no draw-lifecycle frames exist: the consumer
 receives `image_request` and calls its own image vendor.
+
+The frame itself is wire-only. A consumer that was not connected when it
+fired — an async turn, or a stream client that disconnected mid-turn — can
+recover the same payload afterwards via
+[`GET /comp/chat/{session_id}/messages/{message_id}/image-request`](#get-compchatsession_idmessagesmessage_idimage-request):
+an image turn is recognizable in history by `metadata.image` on the
+assistant row.
 
 ### `POST /v2/comp/chat/{session_id}/message/async`
 
@@ -524,6 +533,24 @@ out-of-character product answer (excluded from companion context/memory,
 same as its live-stream `action_type`); the field is omitted for normal
 turns. `read_at` is a read receipt and is **omitted entirely while unread** —
 see the route below.
+
+### `GET /comp/chat/{session_id}/messages/{message_id}/image-request`
+
+The delegated `image_request` payload for one persisted image turn — the
+recovery path for consumers that never received the SSE frame (async turns;
+stream clients that disconnected before the frame fired). Auth and session
+ownership checks are the same as `history`.
+
+```json
+{ "message_id": "01J…", "composed_prompt": "5YaZ5a6e…", "image_ref": "previous", "aspect_ratio": "3:4" }
+```
+
+Fields mirror the SSE frame: `composed_prompt` is base64(`STANDARD`) of the
+UTF-8 wire prompt; `image_ref` may be absent on rows persisted before the
+marker carried it. `404` when the message is not an image turn — or when the
+turn's compose event was never recorded (the audit write is fail-open); in
+that case the prompt is genuinely unrecoverable and the consumer should
+treat the turn as text-only.
 
 ### `POST /comp/chat/{session_id}/read`
 

--- a/docs/api-reference.zh.md
+++ b/docs/api-reference.zh.md
@@ -373,7 +373,7 @@ curl -N -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/js
 | `aspect_ratio` | `String` | 无 | 允许值：`1:1`、`3:4`、`4:3`、`9:16`、`16:9`；省略时不存在（PDE 计划 → 请求 → 不存在）。非法时返回 `422`。 |
 | `prompt_variant` | `String` | 无 | 选择 `[tasks.chat_image_prompt_compose].filter_prompt` 的一个变体：按下标（`"0"`、`"1"`）或按 key（`"a"`、`"b"`），取决于该任务的配置形态（见 [model-config.zh.md](model-config.zh.md)）。`"raw"` 不带任何特殊含义：只有当该部署把某个变体配置在这个字面量 key 下时才会命中，和其他任意变体名一样。下标/key 没命中——包括未配置的 `"raw"`——都会回退到引擎内置的合成器提示词，绝不报 `422` 或其他错误。该任务未配置，或配置为单一纯字符串提示词时，此字段被忽略。 |
 
-**参考图选择（`image_ref`）。** PDE verdict 带有 `image_ref`（`"face"` \| `"previous"`，默认 `"face"`），并附带在下方的 `image_request` 帧中——聊天流本身不会把它解析成实际 URL。`previous` 且无可用图时回退到 `face` 的规则，以及 `face_ref_url` / `prev_image_url` 参考图 URL，都属于消费方自己调用的图像供应商（引擎没有绘图端点）。持久化的 `metadata.image` 标记记录合成器决定的图片主题、画幅，以及它的 `caption`（合成器随 prompt 一起返回的一句话描述；没有则为 `None`——聊天历史和 judge transcript 只读回 caption，从不读回那段长 prompt），加上——仅当合成器 LLM 调用成功时——审计三元组 `compose_variant`（命中的 `filter_prompt` key/下标，纯字符串或内置提示词时缺省）、`compose_model` 和 `compose_generation_id`。三元组缺失意味着本轮没有成功合成（fail-open 降级，或合成器未配置）。只要审计写入本身成功，就会带一个 `compose_event_id` 指针——不管合成本身有没有成功——它是通往 `engine.chat_images_events` 的可达链接，拼装出的**线上 wire** prompt 实际存在那张表里（`metadata.image` 标记从不重复存它）；详见 [LLM audit → 图片链路事件表](llm-audit.zh.md#图片链路事件表)。不记录参考类型。
+**参考图选择（`image_ref`）。** PDE verdict 带有 `image_ref`（`"face"` \| `"previous"`，默认 `"face"`），并附带在下方的 `image_request` 帧中——聊天流本身不会把它解析成实际 URL。`previous` 且无可用图时回退到 `face` 的规则，以及 `face_ref_url` / `prev_image_url` 参考图 URL，都属于消费方自己调用的图像供应商（引擎没有绘图端点）。持久化的 `metadata.image` 标记记录合成器决定的图片主题、画幅，以及它的 `caption`（合成器随 prompt 一起返回的一句话描述；没有则为 `None`——聊天历史和 judge transcript 只读回 caption，从不读回那段长 prompt），加上——仅当合成器 LLM 调用成功时——审计三元组 `compose_variant`（命中的 `filter_prompt` key/下标，纯字符串或内置提示词时缺省）、`compose_model` 和 `compose_generation_id`。三元组缺失意味着本轮没有成功合成（fail-open 降级，或合成器未配置）。只要审计写入本身成功，就会带一个 `compose_event_id` 指针——不管合成本身有没有成功——它是通往 `engine.chat_images_events` 的可达链接，拼装出的**线上 wire** prompt 实际存在那张表里（`metadata.image` 标记从不重复存它）；详见 [LLM audit → 图片链路事件表](llm-audit.zh.md#图片链路事件表)。标记同时记录 `image_ref`（`"face"` \| `"previous"`），让完整的 `image_request` 载荷事后仍可取回（该键加入之前落库的旧行没有）。
 
 校验：同一轮同时有 `force` 和 `tips_amount_usd` → `422`。`force` 而部署未配置
 `[tasks.chat_image_prompt_compose]` → `422`（合成器是唯一的提示词来源；没有它，
@@ -403,6 +403,11 @@ data: {"type":"image_request","message_id":"01J...","composed_prompt":"5YaZ5a6e.
 - `product_qa`：`meta(action_type=product_qa) → delta* → done → final` — 形状与普通文本回复相同，由独立的模型链（`[tasks.chat_product_qa]`）流式生成，而非 `chat_companion`；落库时带 `channel='product_qa'`，重放时同样报告为 `product_qa`。
 
 引擎从不绘图，也不存在任何绘图生命周期帧：消费方收到 `image_request` 后自行调用图像供应商。
+
+这个帧本身只在线上（wire-only）。发帧时不在场的消费方——异步轮次，或中途断线的
+stream 客户端——事后可通过
+[`GET /comp/chat/{session_id}/messages/{message_id}/image-request`](#get-compchatsession_idmessagesmessage_idimage-request)
+取回同一份载荷；历史里的图片轮以 assistant 行上的 `metadata.image` 为识别标志。
 
 ### `POST /v2/comp/chat/{session_id}/message/async`
 
@@ -454,6 +459,21 @@ curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json"
 `channel` 字段——`"product_qa"` 标记出戏产品问答（排除在伴侣上下文/记忆之
 外，与其在实时流上的 `action_type` 一致）；普通轮次省略该字段。`read_at` 是已读
 回执，**未读时整个键都不出现** —— 见下面这条路由。
+
+### `GET /comp/chat/{session_id}/messages/{message_id}/image-request`
+
+取回一条已落库图片轮的 `image_request` 载荷——给没收到 SSE 帧的消费方
+（异步轮次；帧发出前就断线的 stream 客户端）的补取通道。鉴权与会话归属检查与
+`history` 相同。
+
+```json
+{ "message_id": "01J…", "composed_prompt": "5YaZ5a6e…", "image_ref": "previous", "aspect_ratio": "3:4" }
+```
+
+字段与 SSE 帧一致：`composed_prompt` 是 UTF-8 wire prompt 的 base64（`STANDARD`）；
+`image_ref` 在该键加入前落库的旧行上缺省。消息不是图片轮、或该轮的 compose
+事件当时没写成（审计写入是 fail-open）时返回 `404`——后者意味着 prompt 已无从取回，
+消费方应把该轮当纯文本处理。
 
 ### `POST /comp/chat/{session_id}/read`
 


### PR DESCRIPTION
## Summary

Closes the gap v1.5.0 left for image turns: the `image_request` SSE frame is wire-only, so an **async turn** — or a **stream client that disconnected** before the frame fired — could never obtain the composed prompt (it lives on the `chat_images_events` audit row, and `image_ref` lived nowhere reachable at all).

- **New endpoint** `GET /comp/chat/{session_id}/messages/{message_id}/image-request`: recovers the frame payload (`composed_prompt` base64 + `image_ref` + `aspect_ratio`) from `metadata.image` + the compose event. Same auth/ownership as `history`. `404` when the message isn't an image turn or the compose event was never recorded (fail-open audit write — the prompt is genuinely unrecoverable).
- **`metadata.image` now records `image_ref`** (`face`|`previous`) — previously it existed only in the PDE decision event with no message-reachable key. Absent on pre-existing rows; the response surfaces it as nullable.
- Docs: api-reference (+zh) — endpoint section, frame-section recovery note, and two now-false "reference kind is not recorded" statements corrected.

## Testing

Endpoint e2e ×3 (happy path with base64 round-trip, 404 triple: non-image / missing compose event / unknown id, ownership 403); marker unit tests extended for the new key; 1505/1505 workspace, clippy clean, OpenAPI regenerated (+88 lines, the new path + schema).

## Status

**Deliberately left unmerged** — parked until the downstream bot consumer actually reaches image turns; merge decision then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)