### PR TITLE
feat(server): image-turn discovery in chat history

### DIFF
--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -1788,6 +1788,10 @@
             "format": "uuid",
             "description": "Stable message id — the `engine.chat_messages` row primary key (UUID)."
           },
+          "image": {
+            "type": "boolean",
+            "description": "Present (always `true`) only on assistant rows whose turn delegated an\nimage to the consumer (`metadata.image` marker recorded) — key-presence\ncontract like `read_at`. Recover the payload via\n`GET /comp/chat/{session_id}/messages/{message_id}/image-request`; a 404\nthere on a flagged row means the composed prompt was never recorded\n(fail-open audit) — genuinely unrecoverable. Spec:\ndocs/superpowers/specs/2026-08-21-image-turn-discovery-design.md."
+          },
           "read_at": {
             "type": [
               "string",
@@ -2024,6 +2028,7 @@
       "ChatHistoryEntry": {
         "type": "object",
         "required": [
+          "id",
           "role",
           "content",
           "sent_at",
@@ -2042,6 +2047,15 @@
           },
           "extracted_facts": {
             "type": "object"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Stable message id — the `engine.chat_messages` row primary key (UUID).\nFeeds `GET /comp/chat/{session_id}/messages/{message_id}/image-request`\nwhen rehydrating an image turn."
+          },
+          "image": {
+            "type": "boolean",
+            "description": "Present (always `true`) only on assistant rows whose turn delegated an\nimage to the consumer (`metadata.image` marker recorded) — key-presence\ncontract like `read_at`. Recover the payload via the `image-request`\nendpoint; a 404 there on a flagged row means the composed prompt was\nnever recorded (fail-open audit) — genuinely unrecoverable."
           },
           "read_at": {
             "type": [

--- a/crates/eros-engine-server/src/pipeline/voice.rs
+++ b/crates/eros-engine-server/src/pipeline/voice.rs
@@ -974,6 +974,7 @@ mod tests {
             tips_amount_usd: None,
             channel: None,
             read_at: None,
+            image: false,
         }
     }
 

--- a/crates/eros-engine-server/src/routes/bff/companion.rs
+++ b/crates/eros-engine-server/src/routes/bff/companion.rs
@@ -18,7 +18,9 @@ use eros_engine_store::chat::ChatRepo;
 use crate::auth::middleware::AuthUser;
 use crate::error::AppError;
 use crate::routes::companion::resolve_or_create_session;
-use crate::routes::companion::{require_session_for_user, HistoryQuery, StartChatRequest};
+use crate::routes::companion::{
+    is_false, require_session_for_user, HistoryQuery, StartChatRequest,
+};
 use crate::state::AppState;
 
 // ─── DTOs ───────────────────────────────────────────────────────────
@@ -55,6 +57,15 @@ pub struct BffHistoryEntry {
     /// answer (excluded from companion context). Omitted for normal turns.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub channel: Option<String>,
+    /// Present (always `true`) only on assistant rows whose turn delegated an
+    /// image to the consumer (`metadata.image` marker recorded) — key-presence
+    /// contract like `read_at`. Recover the payload via
+    /// `GET /comp/chat/{session_id}/messages/{message_id}/image-request`; a 404
+    /// there on a flagged row means the composed prompt was never recorded
+    /// (fail-open audit) — genuinely unrecoverable. Spec:
+    /// docs/superpowers/specs/2026-08-21-image-turn-discovery-design.md.
+    #[serde(skip_serializing_if = "is_false")]
+    pub image: bool,
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
@@ -158,6 +169,7 @@ async fn bff_get_history(
             tips_amount_usd: r.tips_amount_usd,
             channel: r.channel,
             read_at: r.read_at,
+            image: r.image,
         })
         .collect();
     let total = messages.len();
@@ -216,6 +228,7 @@ async fn bff_start_chat(
                 tips_amount_usd: r.tips_amount_usd,
                 channel: r.channel,
                 read_at: r.read_at,
+                image: r.image,
             })
             .collect()
     };
@@ -551,6 +564,94 @@ mod tests {
         assert_eq!(history[0]["role"], "user");
         assert_eq!(history[0]["content"], "hello");
         assert_eq!(history[1]["role"], "assistant");
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn bff_history_flags_image_turns(pool: PgPool) {
+        // `image: true` is present only on rows carrying the `metadata.image`
+        // marker — the discovery half of the image-request recovery endpoint
+        // (spec 2026-08-21-image-turn-discovery-design.md). Every other row
+        // omits the key rather than sending false; a NULL metadata column
+        // must decode as omitted, not error.
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+        sqlx::query(
+            "INSERT INTO engine.chat_messages \
+                 (session_id, role, content, assistant_action_type, metadata, sent_at) \
+             VALUES ($1, 'user', 'draw yourself', NULL, NULL, now() - interval '2 seconds'), \
+                    ($1, 'assistant', 'sure', 'reply', NULL, now() - interval '1 second'), \
+                    ($1, 'assistant', '', 'reply', \
+                     '{\"image\": {\"prompt\": \"dusk\", \"image_ref\": \"previous\"}}', now())",
+        )
+        .bind(session_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let state = test_state(pool);
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        let (status, body) =
+            send_request(&mut app, bff_history_request(&token, session_id, "")).await;
+        assert_eq!(status, StatusCode::OK, "got body: {body}");
+        let messages = body["messages"].as_array().unwrap();
+        assert_eq!(messages.len(), 3);
+        assert!(
+            messages[0].get("image").is_none(),
+            "user row omits the key rather than sending false: {}",
+            messages[0]
+        );
+        assert!(
+            messages[1].get("image").is_none(),
+            "plain assistant row omits the key: {}",
+            messages[1]
+        );
+        assert_eq!(messages[2]["image"], json!(true), "image turn is flagged");
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn bff_start_bundle_flags_image_turns(pool: PgPool) {
+        // The cold-mount start bundle serializes history through the same DTO
+        // and must inherit the flag — it is the path a cold mount actually
+        // uses (spec 2026-08-21-image-turn-discovery-design.md §3).
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+        sqlx::query(
+            "INSERT INTO engine.chat_messages \
+                 (session_id, role, content, assistant_action_type, metadata, sent_at) \
+             VALUES ($1, 'assistant', 'sure', 'reply', NULL, now() - interval '1 second'), \
+                    ($1, 'assistant', '', 'reply', \
+                     '{\"image\": {\"prompt\": \"dusk\", \"image_ref\": \"previous\"}}', now())",
+        )
+        .bind(session_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let state = test_state(pool);
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        let (status, body) = send_request(
+            &mut app,
+            bff_start_request(&token, json!({ "genome_id": genome_id })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "got body: {body}");
+        assert_eq!(body["session_id"], json!(session_id.to_string()));
+        let history = body["history"].as_array().expect("history array");
+        assert_eq!(history.len(), 2);
+        assert!(
+            history[0].get("image").is_none(),
+            "plain assistant row omits the key: {}",
+            history[0]
+        );
+        assert_eq!(history[1]["image"], json!(true), "image turn is flagged");
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -106,8 +106,16 @@ pub struct HistoryQuery {
     pub offset: Option<i64>,
 }
 
+pub(crate) fn is_false(b: &bool) -> bool {
+    !*b
+}
+
 #[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct ChatHistoryEntry {
+    /// Stable message id — the `engine.chat_messages` row primary key (UUID).
+    /// Feeds `GET /comp/chat/{session_id}/messages/{message_id}/image-request`
+    /// when rehydrating an image turn.
+    pub id: Uuid,
     pub role: String,
     pub content: String,
     pub sent_at: DateTime<Utc>,
@@ -127,6 +135,13 @@ pub struct ChatHistoryEntry {
     /// "no receipt", never as "not yet read".
     #[serde(skip_serializing_if = "Option::is_none")]
     pub read_at: Option<DateTime<Utc>>,
+    /// Present (always `true`) only on assistant rows whose turn delegated an
+    /// image to the consumer (`metadata.image` marker recorded) — key-presence
+    /// contract like `read_at`. Recover the payload via the `image-request`
+    /// endpoint; a 404 there on a flagged row means the composed prompt was
+    /// never recorded (fail-open audit) — genuinely unrecoverable.
+    #[serde(skip_serializing_if = "is_false")]
+    pub image: bool,
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
@@ -741,6 +756,8 @@ async fn get_history(
     let entries: Vec<ChatHistoryEntry> = rows
         .into_iter()
         .map(|m| ChatHistoryEntry {
+            id: m.id,
+            image: m.metadata.as_ref().and_then(|md| md.get("image")).is_some(),
             role: m.role,
             content: m.content,
             sent_at: m.sent_at,
@@ -2414,6 +2431,65 @@ mod tests {
         let (status, body) = send_request(&mut router, mark_read_request(session_id, &jwt)).await;
         assert_eq!(status, StatusCode::OK);
         assert_eq!(body["marked"], 0, "a repeat call reports no transitions");
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn history_carries_id_and_image_flag(pool: PgPool) {
+        // Discovery half of the image-request endpoint (spec
+        // 2026-08-21-image-turn-discovery-design.md): every entry is
+        // addressable by its row id, and image turns are flagged so a
+        // rehydrating client knows which ids to feed the recovery endpoint.
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Nova").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+        let user_row: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_messages (session_id, role, content, sent_at) \
+             VALUES ($1, 'user', 'draw yourself', now() - interval '2 seconds') RETURNING id",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let plain_row: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_messages (session_id, role, content, sent_at) \
+             VALUES ($1, 'assistant', 'sure', now() - interval '1 second') RETURNING id",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let (image_row, _) =
+            seed_image_turn(&pool, session_id, user_id, Some("dusk rooftop")).await;
+        let jwt = mint_test_jwt(user_id);
+        let mut router = build_router(test_state(pool.clone()));
+
+        let (status, body) = send_request(
+            &mut router,
+            Request::builder()
+                .uri(format!("/comp/chat/{session_id}/history"))
+                .header(header::AUTHORIZATION, format!("Bearer {jwt}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let messages = body["messages"].as_array().unwrap();
+        assert_eq!(messages.len(), 3);
+        for (m, id) in messages.iter().zip([user_row, plain_row, image_row]) {
+            assert_eq!(m["id"], id.to_string(), "entries echo their row id: {m}");
+        }
+        assert!(
+            messages[0].get("image").is_none(),
+            "user row omits the key rather than sending false: {}",
+            messages[0]
+        );
+        assert!(
+            messages[1].get("image").is_none(),
+            "plain assistant row omits the key: {}",
+            messages[1]
+        );
+        assert_eq!(messages[2]["image"], true, "image turn is flagged");
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -108,6 +108,11 @@ pub struct ChatMessageSlim {
     /// Read receipt (migration 0053). See `ChatMessage::read_at`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub read_at: Option<DateTime<Utc>>,
+    /// `true` iff the row's `metadata.image` marker is present — the turn
+    /// delegated an image to the consumer. Projected as
+    /// `(metadata->'image' IS NOT NULL)` so the slim query stays slim.
+    /// Spec: docs/superpowers/specs/2026-08-21-image-turn-discovery-design.md.
+    pub image: bool,
 }
 
 pub struct ChatRepo<'a> {
@@ -369,7 +374,8 @@ impl<'a> ChatRepo<'a> {
         let mut rows = sqlx::query_as::<_, ChatMessageSlim>(
             "SELECT id, role, content, sent_at, client_msg_id, \
                     (metadata->>'tips_amount_usd')::float8 AS tips_amount_usd, \
-                    channel, read_at \
+                    channel, read_at, \
+                    (metadata->'image' IS NOT NULL) AS image \
              FROM engine.chat_messages \
              WHERE session_id = $1 \
              ORDER BY sent_at DESC \

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -518,21 +518,34 @@ Paginated message history, newest first. `limit` defaults to 20 (capped at 50).
 {
   "session_id": "…",
   "messages": [
-    { "role": "assistant", "content": "Bishop.", "sent_at": "…", "read_at": "…" },
-    { "role": "user",      "content": "hi…",     "sent_at": "…", "read_at": "…" },
-    { "role": "assistant", "content": "…", "sent_at": "…", "channel": "product_qa" }
+    { "id": "…", "role": "assistant", "content": "Bishop.", "sent_at": "…", "read_at": "…" },
+    { "id": "…", "role": "user",      "content": "hi…",     "sent_at": "…", "read_at": "…" },
+    { "id": "…", "role": "assistant", "content": "…", "sent_at": "…", "channel": "product_qa" },
+    { "id": "…", "role": "assistant", "content": "",  "sent_at": "…", "image": true }
   ],
-  "total": 3
+  "total": 4
 }
 ```
 
-`role` ∈ `user | assistant | gift_user | system_error`. `gift_user` is a tip
+`id` is the stable message id (the `engine.chat_messages` row key) — it is
+what the `image-request` route below takes. `role` ∈
+`user | assistant | gift_user | system_error`. `gift_user` is a tip
 turn (sent via `tips_amount_usd` on the stream route, above). Each entry also
 carries an optional `channel` field — `"product_qa"` marks an
 out-of-character product answer (excluded from companion context/memory,
 same as its live-stream `action_type`); the field is omitted for normal
 turns. `read_at` is a read receipt and is **omitted entirely while unread** —
 see the route below.
+
+`image: true` is present only on assistant rows whose turn delegated an image
+to the consumer; every other row omits the key (never `false`). It is the
+discovery half of the `image-request` route: feed the flagged entry's `id` to
+that route instead of probing every assistant message. A `404` from that
+route **on a flagged row** means the composed prompt was never recorded —
+genuinely unrecoverable; surface it as such rather than silently dropping
+the image. The flag also tells a rehydrating client that a turn promised an
+image (the `image_request` SSE frame is the turn's last frame and wire-only —
+a disconnect before it fires would otherwise be undetectable from history).
 
 ### `GET /comp/chat/{session_id}/messages/{message_id}/image-request`
 
@@ -547,7 +560,9 @@ ownership checks are the same as `history`.
 
 Fields mirror the SSE frame: `composed_prompt` is base64(`STANDARD`) of the
 UTF-8 wire prompt; `image_ref` may be absent on rows persisted before the
-marker carried it. `404` when the message is not an image turn — or when the
+marker carried it. **Absent `image_ref` means unknown, not `face`** — a
+consumer that defaults it to `face` will redraw a `previous`-ref turn against
+the wrong reference image. `404` when the message is not an image turn — or when the
 turn's compose event was never recorded (the audit write is fail-open); in
 that case the prompt is genuinely unrecoverable and the consumer should
 treat the turn as text-only.
@@ -1125,7 +1140,12 @@ and `read_at`, the read receipt described under `POST /comp/chat/{session_id}/re
 (omitted while unread). `id` is the
 `chat_messages` row primary key (UUID); `client_msg_id` is the id the FE
 sent during streaming (`null` for rows that never carried one, e.g.
-assistant turns). Same auth, ownership check, and
+assistant turns). `image: true` marks an assistant row whose turn delegated
+an image (omitted on every other row, never `false`) — the same key-presence
+contract and `image-request` discovery semantics as the canonical history
+route above, including the "404 on a flagged row = unrecoverable" reading.
+The `POST /bff/v1/comp/chat/start` bundle serializes history through this
+same entry shape and therefore carries the flag too. Same auth, ownership check, and
 `limit ∈ [1, 50]` clamp as the canonical history route. **Intentional
 divergence:** the default `limit` is 50 (the canonical route defaults to 20),
 because the BFF exists for a cold mount that wants a full backscroll in one
@@ -1137,9 +1157,10 @@ round-trip.
   "messages": [
     { "id": "3cc06c53-…", "client_msg_id": "c_abc", "role": "user",      "content": "alpha", "sent_at": "…", "read_at": "…" },
     { "id": "9f2e7a10-…", "client_msg_id": null,    "role": "assistant", "content": "beta",  "sent_at": "…", "read_at": "…" },
-    { "id": "a1b2c3d4-…", "client_msg_id": null,    "role": "assistant", "content": "gamma", "sent_at": "…", "channel": "product_qa" }
+    { "id": "a1b2c3d4-…", "client_msg_id": null,    "role": "assistant", "content": "gamma", "sent_at": "…", "channel": "product_qa" },
+    { "id": "b5c6d7e8-…", "client_msg_id": null,    "role": "assistant", "content": "",      "sent_at": "…", "image": true }
   ],
-  "total": 3
+  "total": 4
 }
 ```
 

--- a/docs/api-reference.zh.md
+++ b/docs/api-reference.zh.md
@@ -446,19 +446,28 @@ curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json"
 {
   "session_id": "…",
   "messages": [
-    { "role": "assistant", "content": "Bishop。", "sent_at": "…", "read_at": "…" },
-    { "role": "user",      "content": "嗨…",     "sent_at": "…", "read_at": "…" },
-    { "role": "assistant", "content": "…", "sent_at": "…", "channel": "product_qa" }
+    { "id": "…", "role": "assistant", "content": "Bishop。", "sent_at": "…", "read_at": "…" },
+    { "id": "…", "role": "user",      "content": "嗨…",     "sent_at": "…", "read_at": "…" },
+    { "id": "…", "role": "assistant", "content": "…", "sent_at": "…", "channel": "product_qa" },
+    { "id": "…", "role": "assistant", "content": "",  "sent_at": "…", "image": true }
   ],
-  "total": 3
+  "total": 4
 }
 ```
 
-`role` ∈ `user | assistant | gift_user | system_error`。`gift_user` 是打赏轮
-（通过上面 stream 路由的 `tips_amount_usd` 发起）。每条记录还带一个可选的
+`id` 是稳定的消息 id（`engine.chat_messages` 行主键），下面的 `image-request`
+路由收的就是它。`role` ∈ `user | assistant | gift_user | system_error`。
+`gift_user` 是打赏轮（通过上面 stream 路由的 `tips_amount_usd` 发起）。每条记录还带一个可选的
 `channel` 字段——`"product_qa"` 标记出戏产品问答（排除在伴侣上下文/记忆之
 外，与其在实时流上的 `action_type` 一致）；普通轮次省略该字段。`read_at` 是已读
 回执，**未读时整个键都不出现** —— 见下面这条路由。
+
+`image: true` 只出现在把画图委托给消费方的 assistant 行上；其余行整个键省略
+（不会是 `false`）。它是 `image-request` 路由的发现半边：把带标记那条的 `id`
+喂给该路由即可，不必逐条试探。带标记的行在那条路由拿到 `404`，意味着
+composed prompt 当时就没记下来——真的取不回来了，应当如实呈现，而不是把图
+静默丢掉。这个标记同时让重连的客户端知道某一轮承诺过一张图（`image_request`
+SSE 帧是整轮最后一帧且只走线上——在它发出前断线，光看 history 本来无从察觉）。
 
 ### `GET /comp/chat/{session_id}/messages/{message_id}/image-request`
 
@@ -471,7 +480,8 @@ curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json"
 ```
 
 字段与 SSE 帧一致：`composed_prompt` 是 UTF-8 wire prompt 的 base64（`STANDARD`）；
-`image_ref` 在该键加入前落库的旧行上缺省。消息不是图片轮、或该轮的 compose
+`image_ref` 在该键加入前落库的旧行上缺省。**缺省是「未知」，不是 `face`**——
+把缺省默认成 `face`，会让 `previous` 参照的轮次拿错参考图重画。消息不是图片轮、或该轮的 compose
 事件当时没写成（审计写入是 fail-open）时返回 `404`——后者意味着 prompt 已无从取回，
 消费方应把该轮当纯文本处理。
 
@@ -990,6 +1000,11 @@ canonical `/comp/*` 路由永遠不會為了遷就前端而被改形狀——而
 省略该字段。还有 `read_at`，即 `POST /comp/chat/{session_id}/read` 那节说的
 已读回执，未读时省略。`id` 是 `chat_messages` 行的主鍵（UUID）；
 `client_msg_id` 是前端串流時帶上的 id（沒帶的行為 `null`，例如 assistant 回合）。
+`image: true` 标记把画图委托给消费方的 assistant 行（其余行整个键省略，
+不会是 `false`）——键出现即为真的约定、`image-request` 补取路由的发现语义，
+连同「带标记的行 404 = 真的取不回来」的读法，都与上面 canonical history
+一节相同。`POST /bff/v1/comp/chat/start` 打包的历史走的是同一个条目形状，
+所以同样带这个标记。
 鑒權、ownership 檢查、`limit ∈ [1, 50]` 夾取
 都與 canonical history 路由相同。**刻意差異：** 默認 `limit` 是 50
 （canonical 默認 20），因為 BFF 是為「冷啟動一次拉一整屏 backscroll」設計的。
@@ -1000,9 +1015,10 @@ canonical `/comp/*` 路由永遠不會為了遷就前端而被改形狀——而
   "messages": [
     { "id": "3cc06c53-…", "client_msg_id": "c_abc", "role": "user",      "content": "alpha", "sent_at": "…" },
     { "id": "9f2e7a10-…", "client_msg_id": null,    "role": "assistant", "content": "beta",  "sent_at": "…" },
-    { "id": "a1b2c3d4-…", "client_msg_id": null,    "role": "assistant", "content": "gamma", "sent_at": "…", "channel": "product_qa" }
+    { "id": "a1b2c3d4-…", "client_msg_id": null,    "role": "assistant", "content": "gamma", "sent_at": "…", "channel": "product_qa" },
+    { "id": "b5c6d7e8-…", "client_msg_id": null,    "role": "assistant", "content": "",      "sent_at": "…", "image": true }
   ],
-  "total": 3
+  "total": 4
 }
 ```
 

--- a/docs/superpowers/specs/2026-08-21-image-turn-discovery-design.md
+++ b/docs/superpowers/specs/2026-08-21-image-turn-discovery-design.md
@@ -1,0 +1,123 @@
+# Image-turn discovery in chat history
+
+**Date:** 2026-08-21
+**Status:** Approved
+**Prereq:** the recoverable `image_request` payload endpoint (PR #290)
+
+## 1. Goal and background
+
+PR #290 shipped the payload half of image-turn recovery: `GET
+/comp/chat/{session_id}/messages/{message_id}/image-request` reproduces the wire-only
+`image_request` frame from what the turn persisted. The discovery half is missing
+(raised by a web client on the PR:
+<https://github.com/etherfunlab/eros-engine/pull/290#issuecomment-5364944925>):
+
+- **A client cannot learn which `message_id` to ask about.** `ChatHistoryEntry` carries
+  no image marker, so the only strategy is probing recent assistant messages and reading
+  404 as "not an image turn" — N requests per rehydrate, most of them 404s.
+- **The 404 is overloaded.** "Not an image turn" and "compose event was never recorded"
+  are indistinguishable from outside, and only the second should surface to a user as a
+  genuinely unrecoverable image.
+- **Canonical history rows are not addressable at all.** `ChatHistoryEntry` has no `id`
+  field, so a consumer that rehydrates purely from the canonical route has no
+  `message_id` to feed the recovery endpoint even if it knew which row to pick. Live
+  consumers get ids from the `meta` frame; rehydrating consumers — the entire audience
+  of #290 — get nothing. (The BFF mirror already carries `id`; only the flag is missing
+  there.)
+
+There are **two history surfaces**, and a cold-mounting client uses the BFF one:
+
+- Canonical: `GET /comp/chat/{session_id}/history` → `ChatHistoryEntry`
+  (full-row `ChatRepo::history()`).
+- BFF: `GET /bff/v1/comp/chat/{sid}/history` and the bundled history inside
+  `POST /bff/v1/comp/chat/start` → `BffHistoryEntry`
+  (narrow-projection `ChatRepo::history_slim()`; the slim SELECT does not fetch
+  `metadata`).
+
+Both contracts get the flag, or the consumer that raised the issue never sees it.
+
+This matters beyond bots: since stream-on-queue (#288) a disconnected stream turn still
+completes and persists, but `image_request` is the turn's **last** frame and wire-only. A
+disconnect before it fires leaves a persisted assistant message that promises an image no
+one will ever draw, and the client cannot detect that from history.
+
+## 2. Scope and non-goals
+
+In scope: both history response contracts (canonical + BFF, including the start-bundle
+history), the `history_slim` projection, docs, tests.
+
+Non-goals:
+
+- **No per-session batch endpoint** listing image turns. It adds a route and the client
+  still has to diff the result against its own draw records; a flag on the history call
+  every client already makes is the cheaper cut (free across pagination).
+- **No `action_type` on history.** The persisted `assistant_action_type` is
+  CHECK-constrained to `reply` / `gift_reaction`; the wire action names
+  (`reply_text_image` / `reply_image`) are never persisted. The honest persisted signal
+  for "this turn delegated an image" is `metadata.image` presence — a bool is exactly as
+  much as the store can truthfully answer.
+- **No change to the recovery endpoint or its 404 ladder.** The flag resolves the
+  double-meaning client-side: a 404 on a *flagged* message now unambiguously means the
+  compose event was never recorded (fail-open audit) — genuinely unrecoverable.
+- **No migration, no extra query.** The canonical path is handler-level mapping only
+  (`history()` already selects full rows). The BFF path adds **one projected
+  expression** to the `history_slim` SELECT rather than widening it to full rows —
+  the slim query stays slim.
+
+## 3. Design
+
+The flag everywhere, `id` where it was missing. All values derive from data the
+existing queries already touch.
+
+**Canonical — `ChatHistoryEntry`** gains two fields:
+
+- `id: Uuid` — always present (the `engine.chat_messages` PK, same documentation as
+  `BffHistoryEntry.id`). Makes canonical history rows addressable; closes the
+  discovery → fetch loop entirely within the engine API, and makes the two history
+  contracts symmetric.
+- `image: bool` — serialized **only when `true`** (key-presence contract, matching
+  `read_at` / `channel` on the same DTO). `true` iff the row's `metadata.image` object is
+  present, i.e. the turn delegated an image to the consumer. Doubles as the
+  "show a drawing/pending state on rehydrate" signal. Derived in the handler map from
+  the full row's `metadata`.
+
+**BFF — `ChatMessageSlim` + `BffHistoryEntry`**:
+
+- `history_slim` projects `(metadata->'image' IS NOT NULL) AS image` into a new
+  `ChatMessageSlim.image: bool` (`IS NOT NULL`, not the `?` operator: `metadata` is a
+  nullable column and the flag must decode as `false`, not SQL `NULL`, on rows without
+  metadata).
+- `BffHistoryEntry` gains `image: bool` with the identical skip-if-false key-presence
+  contract, so both routes read identically.
+- `POST /bff/v1/comp/chat/start` bundles history through the same DTO and therefore
+  **inherits the flag** — stated here explicitly because the start bundle is the path a
+  cold mount actually uses.
+
+OpenAPI regenerated. All additions are backwards-compatible (new keys, nothing removed
+or renamed).
+
+## 4. Documentation
+
+`docs/api-reference.md` + `.zh.md`:
+
+- History sections (canonical **and** BFF/start): document `id` and `image`, and the
+  disambiguation rule — *flagged message + 404 from the image-request endpoint = the
+  image is unrecoverable; surface it as such rather than silently dropping it.*
+- Image-request section, one caveat line: `image_ref` is absent on rows persisted before
+  the marker carried it (pre-v1.5.1). **Absent means unknown, not `face`** — a consumer
+  that defaults absent to `face` will redraw a `previous`-ref turn against the wrong
+  reference image.
+
+## 5. Tests
+
+Extend the existing history route tests, covering **all three serving paths** (canonical
+history, BFF history, BFF start bundle):
+
+- Every canonical entry echoes its row `id`.
+- A seeded image turn (assistant row with `metadata.image`, seeded the same way as the
+  #290 endpoint tests) serializes `"image": true` on each path.
+- A plain assistant turn and a user turn omit the `image` key entirely on each path.
+
+## 6. Rollout
+
+Single PR to `dev`. Contract additions only; no config, no migration, no deploy coupling.


### PR DESCRIPTION
## What

The **discovery half** of the #290 image-request recovery endpoint, as raised by a web client in [this PR #290 comment](https://github.com/etherfunlab/eros-engine/pull/290#issuecomment-5364944925). Spec: [`2026-08-21-image-turn-discovery-design.md`](https://github.com/etherfunlab/eros-engine/blob/feat/image-turn-discovery/docs/superpowers/specs/2026-08-21-image-turn-discovery-design.md).

- **`ChatHistoryEntry`** gains `id` (the `engine.chat_messages` row PK — canonical history rows were previously not addressable at all, so a consumer rehydrating purely from the engine API had no `message_id` to feed the recovery endpoint) and `image: true` (key-presence contract like `read_at`; present only on assistant rows carrying the `metadata.image` marker).
- **`BffHistoryEntry`** gains the same `image` flag with the identical contract; the `POST /bff/v1/comp/chat/start` bundle serializes history through the same DTO and inherits it — the path a cold mount actually uses.
- **`history_slim`** projects `(metadata->'image' IS NOT NULL) AS image` into `ChatMessageSlim` (`IS NOT NULL`, not `?`: `metadata` is nullable and the flag must decode `false`, not SQL NULL). The slim query stays slim — **no migration, no extra query**.
- **Docs (en+zh)**: both history sections document `id`/`image` and the disambiguation rule (*flagged row + 404 from image-request = the composed prompt was never recorded — genuinely unrecoverable; surface it as such*); the image-request section gains the `image_ref` caveat — **absent = unknown, NOT `face`** (defaulting to `face` redraws a `previous`-ref turn against the wrong reference).

## Why not action_type / a batch endpoint

Persisted `assistant_action_type` is CHECK-constrained to `reply`/`gift_reaction`; the wire action names are never persisted — a bool is exactly as much as the store can truthfully answer. A batch route adds a route and the client still diffs against its own draw records; the flag rides the history call every client already makes, free across pagination.

## Tests

New coverage on all three serving paths (canonical history, BFF history, BFF start bundle): id echo, `image: true` on a seeded image turn, key omitted (never `false`) on user/plain-assistant rows, NULL-metadata decode. Workspace: 1508 passed, 0 failed. fmt/clippy clean, OpenAPI regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)