### PR TITLE
feat: user_message_id on companion_affinity_events and the BFF delta

### DIFF
--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -1876,6 +1876,14 @@
           },
           "state_after": {
             "description": "Post-turn absolute state — axes, both line scores, both tiers, both\njudge levels. Absent on rows written before migration 0049.\n\nTakes the place of client-side accumulation: with this, a consumer\nadopts the authoritative absolute value every turn instead of adding\ndeltas to a running total. It is a WRITE-TIME snapshot, so after an\nabsence only `GET /bff/v1/comp/affinity/{sid}` is correct — that one\nrefreshes the derived endpoints at read."
+          },
+          "user_message_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "The user message (`chat_messages.id`) that drove this turn, for\nattaching the delta to a specific message. Absent on `proactive` /\n`time_decay` events and on rows written before migration 0056."
           }
         }
       },

--- a/crates/eros-engine-server/src/pipeline/post_process.rs
+++ b/crates/eros-engine-server/src/pipeline/post_process.rs
@@ -99,9 +99,13 @@ pub async fn run(
         return;
     }
 
-    let user_msg = match &event {
-        Event::UserMessage { content, .. } => content.clone(),
-        _ => String::new(),
+    let (user_msg, user_message_id) = match &event {
+        Event::UserMessage {
+            content,
+            message_id,
+            ..
+        } => (content.clone(), Some(*message_id)),
+        _ => (String::new(), None),
     };
     // As of 4.0 the request's affinity scope is read-side only (prompt
     // injection gating); nothing in the write path consumes it any more.
@@ -225,6 +229,7 @@ pub async fn run(
             affinity_meta,
             levels,
             &eval_failures,
+            user_message_id,
         )
         .await;
     };
@@ -295,6 +300,7 @@ async fn persist_affinity(
     meta: Option<eros_engine_store::OpenRouterCallMeta>,
     levels: eros_engine_core::affinity::EndpointLevelReads,
     eval_failures: &[eros_engine_llm::failure::AttemptFailure],
+    user_message_id: Option<Uuid>,
 ) {
     // Recheck: the affinity evaluator's LLM call (or a sibling post_process
     // future) may have run long enough for the archive endpoint to commit
@@ -336,7 +342,7 @@ async fn persist_affinity(
 
     match action {
         ActionType::Ghost => {
-            if let Err(e) = repo.record_ghost(&mut affinity).await {
+            if let Err(e) = repo.record_ghost(&mut affinity, user_message_id).await {
                 tracing::warn!("affinity record_ghost failed: {e}");
             }
         }
@@ -372,6 +378,7 @@ async fn persist_affinity(
                     levels,
                     llm_attempts,
                     gateway_errors,
+                    user_message_id,
                 )
                 .await
             {
@@ -1839,6 +1846,20 @@ mod tests {
         .unwrap()
     }
 
+    /// A `role='user'` row for the turn under test. Since migration 0056 the
+    /// affinity event FK-references it, so a `run()` test that asserts on
+    /// affinity rows must seed it and pass its id in the `Event`.
+    async fn seed_user_message(pool: &sqlx::PgPool, session_id: Uuid) -> Uuid {
+        sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO engine.chat_messages (session_id, role, content) \
+             VALUES ($1, 'user', 'seed') RETURNING id",
+        )
+        .bind(session_id)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+    }
+
     /// Mock OpenRouter that replies with the first entry whose
     /// `prompt_substring` appears anywhere in the outbound request, and
     /// records each request's wire `task` name, in order.
@@ -3112,13 +3133,14 @@ mod tests {
         .fetch_one(&pool)
         .await
         .unwrap();
+        let umid = seed_user_message(&pool, session_id).await;
 
         // "hi" is short enough to trip both the PDE's short-message rule delta
         // (a patience penalty) AND `eval_skip_reason`'s `short_user_msg` gate,
         // so the LLM affinity eval never fires while the rule delta still does.
         let event = Event::UserMessage {
             content: "hi".into(),
-            message_id: Uuid::new_v4(),
+            message_id: umid,
             prompt_traits: Vec::new(),
             audit: None,
             tier: None,
@@ -3165,8 +3187,8 @@ mod tests {
         )
         .await;
 
-        let rows: Vec<(String, serde_json::Value)> = sqlx::query_as(
-            "SELECT e.event_type, e.context \
+        let rows: Vec<(String, serde_json::Value, Option<Uuid>)> = sqlx::query_as(
+            "SELECT e.event_type, e.context, e.user_message_id \
              FROM engine.companion_affinity_events e \
              JOIN engine.companion_affinity a ON a.id = e.affinity_id \
              WHERE a.session_id = $1",
@@ -3194,6 +3216,11 @@ mod tests {
             "the LLM affinity eval must still be skipped (the guaranteed-neutral \
              half of the contract); context: {:?}",
             rows[0].1
+        );
+        assert_eq!(
+            rows[0].2,
+            Some(umid),
+            "the event must point at the user message that drove the turn"
         );
 
         // 4.0: patience is a derived endpoint. A skipped eval holds the
@@ -3255,6 +3282,7 @@ mod tests {
             .load_or_create(session_id, user_id, instance_id)
             .await
             .unwrap();
+        let umid = seed_user_message(&pool, session_id).await;
 
         let mut state = crate::routes::companion::test_state(pool.clone());
         state.model_config = std::sync::Arc::new(
@@ -3273,7 +3301,7 @@ mod tests {
 
         let event = Event::UserMessage {
             content: "我今天过得还不错，你呢".into(),
-            message_id: Uuid::new_v4(),
+            message_id: umid,
             prompt_traits: Vec::new(),
             audit: None,
             tier: None,
@@ -3384,6 +3412,7 @@ mod tests {
             .load_or_create(session_id, user_id, instance_id)
             .await
             .unwrap();
+        let umid = seed_user_message(&pool, session_id).await;
 
         let mut state = crate::routes::companion::test_state(pool.clone());
         state.model_config = std::sync::Arc::new(
@@ -3402,7 +3431,7 @@ mod tests {
 
         let event = Event::UserMessage {
             content: "我今天过得还不错，你呢".into(),
-            message_id: Uuid::new_v4(),
+            message_id: umid,
             prompt_traits: Vec::new(),
             audit: None,
             tier: None,
@@ -3517,6 +3546,7 @@ mod tests {
                 patience: Some(3),
             },
             &[],
+            None,
         )
         .await;
 
@@ -4053,6 +4083,7 @@ mod tests {
             None,
             eros_engine_core::affinity::EndpointLevelReads::default(),
             &[],
+            None,
         )
         .await;
 

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -4156,7 +4156,10 @@ pub fn run_stream(
                 if let Err(e) = chat_repo.mark_user_message_ghosted(user_msg.user_message_id).await {
                     tracing::warn!("stream: ghost mark failed: {e}");
                 }
-                if let Err(e) = affinity_repo.record_ghost(&mut affinity).await {
+                if let Err(e) = affinity_repo
+                    .record_ghost(&mut affinity, Some(user_msg.user_message_id))
+                    .await
+                {
                     tracing::warn!("stream: record_ghost failed: {e}");
                 }
                 yield ProtocolFrame::Meta {
@@ -12428,6 +12431,21 @@ data: [DONE]\n\n";
             judge_sent.contains("pde/judge") && judge_sent.contains("[亲密度]"),
             "the single call must be the PDE judge (carries build_pde_ctx); got {judge_sent}",
         );
+
+        // The ghost event points at the user row that drove the turn. The
+        // ghost arm writes it inline (not spawned), so it is committed by
+        // the time the stream has been collected.
+        let ghost_umid: Option<Uuid> = sqlx::query_scalar(
+            "SELECT e.user_message_id \
+             FROM engine.companion_affinity_events e \
+             JOIN engine.companion_affinity a ON a.id = e.affinity_id \
+             WHERE a.session_id = $1 AND e.event_type = 'ghost'",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(ghost_umid, Some(umid));
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/crates/eros-engine-server/src/routes/bff/affinity.rs
+++ b/crates/eros-engine-server/src/routes/bff/affinity.rs
@@ -49,6 +49,11 @@ pub struct BffAffinityDelta {
     /// refreshes the derived endpoints at read.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub state_after: Option<serde_json::Value>,
+    /// The user message (`chat_messages.id`) that drove this turn, for
+    /// attaching the delta to a specific message. Absent on `proactive` /
+    /// `time_decay` events and on rows written before migration 0056.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_message_id: Option<Uuid>,
     pub created_at: DateTime<Utc>,
 }
 
@@ -152,6 +157,7 @@ async fn bff_get_affinity_delta(
             effective_deltas_computed,
             label_changes,
             state_after: r.state_after,
+            user_message_id: r.user_message_id,
             created_at: r.created_at,
         })
     });
@@ -445,6 +451,77 @@ mod tests {
             .header(header::AUTHORIZATION, format!("Bearer {token}"))
             .body(Body::empty())
             .unwrap()
+    }
+
+    async fn seed_user_message(pool: &PgPool, session_id: Uuid) -> Uuid {
+        sqlx::query_scalar(
+            "INSERT INTO engine.chat_messages (session_id, role, content) \
+             VALUES ($1, 'user', 'seed') RETURNING id",
+        )
+        .bind(session_id)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+    }
+
+    /// Like `seed_event`, with the 0056 turn pointer set.
+    async fn seed_event_for_message(
+        pool: &PgPool,
+        affinity_id: Uuid,
+        user_message_id: Uuid,
+        secs_ago: i64,
+    ) -> Uuid {
+        sqlx::query_scalar(
+            "INSERT INTO engine.companion_affinity_events \
+               (affinity_id, event_type, deltas, effective_deltas, user_message_id, created_at) \
+             VALUES ($1, 'message', '{}'::jsonb, $2, $3, now() - make_interval(secs => $4)) \
+             RETURNING id",
+        )
+        .bind(affinity_id)
+        .bind(json!({ "warmth": 0.05 }))
+        .bind(user_message_id)
+        .bind(secs_ago as f64)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn bff_affinity_delta_echoes_user_message_id(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+        let aid = seed_affinity(&pool, session_id, user_id, instance_id).await;
+        let umid = seed_user_message(&pool, session_id).await;
+        seed_event_for_message(&pool, aid, umid, 10).await;
+
+        let state = test_state(pool);
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+        let (status, body) = send_request(&mut app, req(&token, session_id)).await;
+        assert_eq!(status, StatusCode::OK, "body={body}");
+        assert_eq!(body["event"]["user_message_id"], json!(umid.to_string()));
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn bff_affinity_delta_omits_user_message_id_when_null(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+        let aid = seed_affinity(&pool, session_id, user_id, instance_id).await;
+        seed_event(&pool, aid, "message", 0.05, 10).await; // pre-0056-shaped row
+
+        let state = test_state(pool);
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+        let (status, body) = send_request(&mut app, req(&token, session_id)).await;
+        assert_eq!(status, StatusCode::OK, "body={body}");
+        assert!(
+            body["event"].get("user_message_id").is_none(),
+            "key must be absent, not null: {body}"
+        );
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/crates/eros-engine-store/migrations/0056_affinity_event_user_message.sql
+++ b/crates/eros-engine-store/migrations/0056_affinity_event_user_message.sql
@@ -1,0 +1,25 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+--
+-- Which turn an affinity event belongs to.
+--
+-- Points at the USER message that drove the turn: a turn has exactly one,
+-- while it may have zero (ghost) or several (burst) assistant messages.
+-- Assistant rows already reference it via chat_messages.user_message_id, so
+-- "all replies for this event" is a join, not a second column.
+--
+-- A real FK, unlike the other audit tables: this table already cascades away
+-- with its session through affinity_id, so "the trail outlives the row" never
+-- held here. SET NULL (not CASCADE) so a message deleted on its own blanks
+-- the pointer instead of erasing the event.
+--
+-- NULL on proactive / time_decay rows and on every row written before this
+-- migration. No backfill: a timestamp-proximity guess is what this column
+-- exists to replace.
+
+ALTER TABLE engine.companion_affinity_events
+    ADD COLUMN user_message_id UUID NULL
+        REFERENCES engine.chat_messages(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_affinity_events_user_message
+    ON engine.companion_affinity_events (user_message_id)
+    WHERE user_message_id IS NOT NULL;

--- a/crates/eros-engine-store/src/affinity.rs
+++ b/crates/eros-engine-store/src/affinity.rs
@@ -137,6 +137,9 @@ pub struct AffinityEventRow {
     pub state_before: Option<serde_json::Value>,
     /// Post-turn state (migration 0049). NULL on pre-4.1 rows.
     pub state_after: Option<serde_json::Value>,
+    /// The user message that drove this turn (migration 0056). NULL on
+    /// `proactive` / `time_decay` rows and on rows written before 0056.
+    pub user_message_id: Option<Uuid>,
     pub created_at: DateTime<Utc>,
 }
 
@@ -285,7 +288,7 @@ impl<'a> AffinityRepo<'a> {
         event_type: Option<&str>,
     ) -> Result<Vec<AffinityEventRow>, sqlx::Error> {
         sqlx::query_as::<_, AffinityEventRow>(
-            "SELECT e.id, e.event_type, e.deltas, e.effective_deltas, e.label_changes, e.effective_line_deltas, e.state_before, e.state_after, e.created_at \
+            "SELECT e.id, e.event_type, e.deltas, e.effective_deltas, e.label_changes, e.effective_line_deltas, e.state_before, e.state_after, e.user_message_id, e.created_at \
              FROM engine.companion_affinity_events e \
              JOIN engine.companion_affinity a ON a.id = e.affinity_id \
              WHERE a.session_id = $1 \
@@ -310,7 +313,7 @@ impl<'a> AffinityRepo<'a> {
         session_id: Uuid,
     ) -> Result<Option<AffinityEventRow>, sqlx::Error> {
         sqlx::query_as::<_, AffinityEventRow>(
-            "SELECT e.id, e.event_type, e.deltas, e.effective_deltas, e.label_changes, e.effective_line_deltas, e.state_before, e.state_after, e.created_at \
+            "SELECT e.id, e.event_type, e.deltas, e.effective_deltas, e.label_changes, e.effective_line_deltas, e.state_before, e.state_after, e.user_message_id, e.created_at \
              FROM engine.companion_affinity_events e \
              JOIN engine.companion_affinity a ON a.id = e.affinity_id \
              WHERE a.session_id = $1 \
@@ -383,6 +386,9 @@ impl<'a> AffinityRepo<'a> {
     /// `levels`: the judge's absolute endpoint reads. A `Some` overwrites the
     /// stored level; a `None` (omitted field / skipped eval) holds it. The
     /// endpoint values themselves are recomputed either way.
+    ///
+    /// `user_message_id`: the user message that drove the turn; `None` for
+    /// proactive / time-decay writes.
     #[allow(clippy::too_many_arguments)] // each arg is a distinct persist concern
     pub async fn persist_with_event(
         &self,
@@ -397,6 +403,7 @@ impl<'a> AffinityRepo<'a> {
         levels: EndpointLevelReads,
         llm_attempts: Option<serde_json::Value>,
         gateway_errors: Option<serde_json::Value>,
+        user_message_id: Option<Uuid>,
     ) -> Result<(), sqlx::Error> {
         let mut tx = self.pool.begin().await?;
 
@@ -578,8 +585,8 @@ impl<'a> AffinityRepo<'a> {
             "INSERT INTO engine.companion_affinity_events \
                (affinity_id, event_type, deltas, effective_deltas, label_changes, effective_line_deltas, context, \
                 state_before, state_after, model, usage, generation_id, \
-                llm_attempts, gateway_errors) \
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)",
+                llm_attempts, gateway_errors, user_message_id) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)",
         )
         .bind(current.id)
         .bind(event_type)
@@ -595,6 +602,7 @@ impl<'a> AffinityRepo<'a> {
         .bind(meta.and_then(|m| m.generation_id.clone()))
         .bind(llm_attempts)
         .bind(gateway_errors)
+        .bind(user_message_id)
         .execute(&mut *tx)
         .await?;
 
@@ -617,7 +625,11 @@ impl<'a> AffinityRepo<'a> {
     /// audit row that never existed in the table, and the next turn, reading
     /// the row under lock, would show the relationship jumping back up with no
     /// event to explain it. Both snapshots come off the row.
-    pub async fn record_ghost(&self, affinity: &mut Affinity) -> Result<(), sqlx::Error> {
+    pub async fn record_ghost(
+        &self,
+        affinity: &mut Affinity,
+        user_message_id: Option<Uuid>,
+    ) -> Result<(), sqlx::Error> {
         let mut tx = self.pool.begin().await?;
 
         let before = sqlx::query_as::<_, AffinityRow>(
@@ -649,14 +661,15 @@ impl<'a> AffinityRepo<'a> {
         sqlx::query(
             "INSERT INTO engine.companion_affinity_events \
                (affinity_id, event_type, deltas, effective_deltas, effective_line_deltas, context, \
-                state_before, state_after) \
-             VALUES ($1, 'ghost', '{}'::jsonb, $2, $3, '{}'::jsonb, $4, $5)",
+                state_before, state_after, user_message_id) \
+             VALUES ($1, 'ghost', '{}'::jsonb, $2, $3, '{}'::jsonb, $4, $5, $6)",
         )
         .bind(affinity.id)
         .bind(zero)
         .bind(zero_line)
         .bind(state_snapshot(&before))
         .bind(state_snapshot(&after))
+        .bind(user_message_id)
         .execute(&mut *tx)
         .await?;
 
@@ -691,6 +704,7 @@ mod tests {
             serde_json::json!({}),
             None,
             EndpointLevelReads::default(),
+            None,
             None,
             None,
         )
@@ -852,6 +866,7 @@ mod tests {
                 EndpointLevelReads::default(),
                 None,
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -909,6 +924,7 @@ mod tests {
             EndpointLevelReads::default(),
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -959,6 +975,7 @@ mod tests {
                 ctx,
                 None,
                 EndpointLevelReads::default(),
+                None,
                 None,
                 None,
             )
@@ -1035,6 +1052,7 @@ mod tests {
             EndpointLevelReads::default(),
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -1072,8 +1090,8 @@ mod tests {
         assert_eq!(a.ghost_streak, 0);
         assert_eq!(a.total_ghosts, 0);
 
-        repo.record_ghost(&mut a).await.unwrap();
-        repo.record_ghost(&mut a).await.unwrap();
+        repo.record_ghost(&mut a, None).await.unwrap();
+        repo.record_ghost(&mut a, None).await.unwrap();
 
         let reloaded = repo.load(session_id).await.unwrap().unwrap();
         assert_eq!(reloaded.ghost_streak, 2);
@@ -1107,6 +1125,7 @@ mod tests {
             serde_json::json!({}),
             None,
             EndpointLevelReads::default(),
+            None,
             None,
             None,
         )
@@ -1166,6 +1185,7 @@ mod tests {
             EndpointLevelReads::default(),
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -1195,6 +1215,7 @@ mod tests {
             serde_json::json!({}),
             None,
             EndpointLevelReads::default(),
+            None,
             None,
             None,
         )
@@ -1257,6 +1278,7 @@ mod tests {
                     EndpointLevelReads::default(),
                     None,
                     None,
+                    None,
                 )
                 .await
                 .unwrap();
@@ -1314,6 +1336,7 @@ mod tests {
                 EndpointLevelReads::default(),
                 None,
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -1369,6 +1392,7 @@ mod tests {
             serde_json::json!({ "affinity_reason": "他坦白了" }),
             None,
             EndpointLevelReads::default(),
+            None,
             None,
             None,
         )
@@ -1440,7 +1464,7 @@ mod tests {
             .load_or_create(session_id, user_id, instance_id)
             .await
             .unwrap();
-        repo.record_ghost(&mut a).await.unwrap();
+        repo.record_ghost(&mut a, None).await.unwrap();
 
         let eff: Option<serde_json::Value> = sqlx::query_scalar(
             "SELECT effective_deltas FROM engine.companion_affinity_events \
@@ -1493,6 +1517,7 @@ mod tests {
                 EndpointLevelReads::default(),
                 None,
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -1513,6 +1538,7 @@ mod tests {
                 serde_json::json!({}),
                 None,
                 EndpointLevelReads::default(),
+                None,
                 None,
                 None,
             )
@@ -1976,7 +2002,7 @@ mod tests {
             "precondition: 30 days must cool the in-memory copy below the row"
         );
 
-        repo.record_ghost(&mut in_memory).await.unwrap();
+        repo.record_ghost(&mut in_memory, None).await.unwrap();
 
         let (before, after): (serde_json::Value, serde_json::Value) = sqlx::query_as(
             "SELECT state_before, state_after FROM engine.companion_affinity_events \
@@ -2144,6 +2170,7 @@ mod tests {
             serde_json::json!({}),
             None,
             levels,
+            None,
             None,
             None,
         )
@@ -2319,6 +2346,7 @@ mod tests {
             EndpointLevelReads::default(),
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -2415,7 +2443,7 @@ mod tests {
             .load_or_create(session_id, user_id, instance_id)
             .await
             .unwrap();
-        repo.record_ghost(&mut a).await.unwrap();
+        repo.record_ghost(&mut a, None).await.unwrap();
 
         let (before, after): (Option<serde_json::Value>, Option<serde_json::Value>) =
             sqlx::query_as(
@@ -2435,5 +2463,154 @@ mod tests {
             assert_eq!(before.get(k), after.get(k), "a ghost moves no axis ({k})");
         }
         assert_ne!(before.get("total_ghosts"), after.get("total_ghosts"));
+    }
+
+    /// Read the newest event's `user_message_id` for a session straight from
+    /// the table, so these tests don't depend on the row struct being right.
+    async fn newest_event_user_message_id(pool: &PgPool, session_id: Uuid) -> Option<Uuid> {
+        sqlx::query_scalar::<_, Option<Uuid>>(
+            "SELECT e.user_message_id \
+             FROM engine.companion_affinity_events e \
+             JOIN engine.companion_affinity a ON a.id = e.affinity_id \
+             WHERE a.session_id = $1 \
+             ORDER BY e.created_at DESC, e.id DESC LIMIT 1",
+        )
+        .bind(session_id)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn persist_with_event_stores_user_message_id(pool: PgPool) {
+        let repo = AffinityRepo { pool: &pool };
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
+        let session_id = make_session(&pool, user_id, instance_id).await;
+        let umid = insert_cutoff_msg(&pool, session_id).await;
+        let mut a = repo
+            .load_or_create(session_id, user_id, instance_id)
+            .await
+            .unwrap();
+
+        repo.persist_with_event(
+            &mut a,
+            &AxisGrades::default(),
+            &AffinityDeltas::default(),
+            1.0,
+            &AffinityTuning::default(),
+            "message",
+            serde_json::json!({}),
+            None,
+            EndpointLevelReads::default(),
+            None,
+            None,
+            Some(umid),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            newest_event_user_message_id(&pool, session_id).await,
+            Some(umid)
+        );
+        // The row struct carries it too, on both readers.
+        let latest = repo.latest_turn_event(session_id).await.unwrap().unwrap();
+        assert_eq!(latest.user_message_id, Some(umid));
+        let listed = repo.list_events(session_id, 10, 0, None).await.unwrap();
+        assert_eq!(listed[0].user_message_id, Some(umid));
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn persist_with_event_none_reads_back_null(pool: PgPool) {
+        let repo = AffinityRepo { pool: &pool };
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
+        let session_id = make_session(&pool, user_id, instance_id).await;
+        let mut a = repo
+            .load_or_create(session_id, user_id, instance_id)
+            .await
+            .unwrap();
+
+        persist_rule(&repo, &mut a, AffinityDeltas::default()).await;
+
+        assert_eq!(newest_event_user_message_id(&pool, session_id).await, None);
+        let latest = repo.latest_turn_event(session_id).await.unwrap().unwrap();
+        assert_eq!(latest.user_message_id, None);
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn record_ghost_stores_user_message_id(pool: PgPool) {
+        let repo = AffinityRepo { pool: &pool };
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
+        let session_id = make_session(&pool, user_id, instance_id).await;
+        let umid = insert_cutoff_msg(&pool, session_id).await;
+        let mut a = repo
+            .load_or_create(session_id, user_id, instance_id)
+            .await
+            .unwrap();
+
+        repo.record_ghost(&mut a, Some(umid)).await.unwrap();
+
+        assert_eq!(
+            newest_event_user_message_id(&pool, session_id).await,
+            Some(umid)
+        );
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn user_message_id_is_a_real_foreign_key(pool: PgPool) {
+        let repo = AffinityRepo { pool: &pool };
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
+        let session_id = make_session(&pool, user_id, instance_id).await;
+        let mut a = repo
+            .load_or_create(session_id, user_id, instance_id)
+            .await
+            .unwrap();
+
+        // An id that is not a chat_messages row must be rejected by the DB,
+        // not silently stored — proves the FK exists, not just the column.
+        let err = repo
+            .record_ghost(&mut a, Some(Uuid::new_v4()))
+            .await
+            .expect_err("unknown message id must violate the FK");
+        let db_err = err.as_database_error().expect("a database error");
+        assert!(
+            db_err.is_foreign_key_violation(),
+            "expected a foreign-key violation, got {db_err:?}"
+        );
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn deleting_the_message_nulls_the_pointer_and_keeps_the_event(pool: PgPool) {
+        let repo = AffinityRepo { pool: &pool };
+        let user_id = Uuid::new_v4();
+        let instance_id = seed_persona_instance(&pool, user_id).await;
+        let session_id = make_session(&pool, user_id, instance_id).await;
+        let umid = insert_cutoff_msg(&pool, session_id).await;
+        let mut a = repo
+            .load_or_create(session_id, user_id, instance_id)
+            .await
+            .unwrap();
+        repo.record_ghost(&mut a, Some(umid)).await.unwrap();
+
+        sqlx::query("DELETE FROM engine.chat_messages WHERE id = $1")
+            .bind(umid)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        // SET NULL, not CASCADE: the event survives, the pointer is blanked.
+        let n: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM engine.companion_affinity_events WHERE affinity_id = $1",
+        )
+        .bind(a.id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(n, 1, "event row must survive the message delete");
+        assert_eq!(newest_event_user_message_id(&pool, session_id).await, None);
     }
 }

--- a/docs/affinity-model.md
+++ b/docs/affinity-model.md
@@ -416,6 +416,11 @@ Each delta turn appends one row to `engine.companion_affinity_events`:
   `boost_warmth`/`boost_patience` (the B values in force), `decay_factor`,
   and `units` (the per-line units in force). `cross_penalty_assessed` joins
   them whenever a turn was taxed.
+- `user_message_id` — the user message that drove the turn (migration
+  `0056`). A real FK to `chat_messages`, `ON DELETE SET NULL`. `NULL` on
+  `proactive` / `time_decay` rows and on rows written before the migration;
+  nothing is backfilled. Assistant rows point at the same message through
+  `chat_messages.user_message_id`, so the replies for an event are a join.
 
 ### Per-turn label changes
 

--- a/docs/affinity-model.zh.md
+++ b/docs/affinity-model.zh.md
@@ -345,6 +345,10 @@ NULL DEFAULT 2`，范围检查 `1..=3`）——权威判官档位——并用档
   `warmth_grade`/`patience_grade`（仅本轮实际读到时）、
   `boost_warmth`/`boost_patience`（当轮生效的 B 值）、`decay_factor`、
   `units`（当轮生效的按线单位）。被收税的回合另有 `cross_penalty_assessed`。
+- `user_message_id` —— 驱动本轮的用户消息（migration `0056`）。对 `chat_messages`
+  的真外键，`ON DELETE SET NULL`。`proactive` / `time_decay` 行以及迁移前写入的行为
+  `NULL`，不回填。assistant 行经 `chat_messages.user_message_id` 指向同一条消息，
+  所以一个事件对应的回复用 join 取。
 
 ### 逐回合标签变动
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1256,6 +1256,7 @@ Query parameters (both optional):
       "ghost_streak": 0, "total_ghosts": 2,
       "updated_at": "2026-08-17T14:02:11.412Z"
     },
+    "user_message_id": "…",
     "created_at": "…"
   }
 }
@@ -1279,6 +1280,10 @@ reports all-zero `effective_deltas`.
   instead of adding deltas to a running total. It is a **write-time**
   snapshot — after an absence only `GET /bff/v1/comp/affinity/{session_id}`
   is correct, because that route refreshes the derived endpoints at read.
+- `user_message_id` — the user message (`chat_messages.id`) that drove this
+  turn; attach the delta to that message or to its replies
+  (`chat_messages.user_message_id`). Absent on `proactive` / `time_decay`
+  events and on rows written before migration `0056`.
 
 ### `GET /bff/v1/comp/affinity/{session_id}`
 

--- a/docs/api-reference.zh.md
+++ b/docs/api-reference.zh.md
@@ -1110,6 +1110,7 @@ canonical `/comp/*` 路由永遠不會為了遷就前端而被改形狀——而
       "ghost_streak": 0, "total_ghosts": 2,
       "updated_at": "2026-08-17T14:02:11.412Z"
     },
+    "user_message_id": "…",
     "created_at": "…"
   }
 }
@@ -1127,6 +1128,9 @@ time-decay），或最近一次事件早于 affinity migration `0014`。`event_t
   值，而不是把 delta 加到本地 running total 上。它是**写入时**的快照——隔了一段
   时间之后只有 `GET /bff/v1/comp/affinity/{session_id}` 是对的，那条路由会在读
   的时候重算衍生端点。
+- `user_message_id` —— 驱动本轮的用户消息（`chat_messages.id`）；把 delta 挂到这条消息
+  或它的回复（`chat_messages.user_message_id`）上。`proactive` / `time_decay` 事件
+  以及 migration `0056` 之前写入的行没有这个键。
 
 ### `GET /bff/v1/comp/affinity/{session_id}`
 

--- a/docs/superpowers/specs/2026-08-22-affinity-event-user-message-id-design.md
+++ b/docs/superpowers/specs/2026-08-22-affinity-event-user-message-id-design.md
@@ -1,0 +1,152 @@
+# `companion_affinity_events.user_message_id` — Design
+
+- **Date:** 2026-08-22
+- **Status:** Approved, not yet implemented
+- **Type:** Additive column on a live audit table + one new field on a BFF DTO
+- **Owner:** enriquephl (sole dev)
+- **Target:** `eros-engine` 1.6.x, one PR to `dev`
+- **Depends on:** nothing. Independent of
+  [2026-08-22-image-edit-endpoint-design.md](2026-08-22-image-edit-endpoint-design.md);
+  the two take migration numbers in merge order.
+
+## 1. Problem
+
+`engine.companion_affinity_events` records one row per turn but nothing on the
+row says *which* turn. The only link is `affinity_id → companion_affinity →
+session_id`, so a consumer wanting "the delta this message caused" has to match
+`created_at` against `chat_messages.created_at` — a guess, not a fact. Every
+sibling audit table (`companion_decision_events`, `*_insights_events`,
+`chat_vision_events`) already carries a message reference; this one is the
+outlier.
+
+## 2. Which message
+
+**The user message that drove the turn.** Not the assistant message(s):
+
+- A turn has exactly one user message. It may have zero assistant messages
+  (`ghost`) or several (a burst), so an assistant-side key is either absent or
+  a lossy "last one".
+- `message` / `ghost` / `gift` turns all have a user message.
+- Assistant rows already point back at it via
+  `chat_messages.user_message_id`, so "all replies for this event" is
+  `WHERE user_message_id = event.user_message_id` — a join, not a second column.
+
+`proactive` and `time_decay` rows have no user message and store `NULL`.
+
+The column is named **`user_message_id`**, not `message_id`: it holds the same
+fact as `chat_messages.user_message_id` and `chat_turn_queue.user_message_id`
+and takes the same name. The generic `message_id` on the insight tables names a
+different fact (the assistant message that was mined).
+
+## 3. Schema — migration `0056_affinity_event_user_message.sql`
+
+```sql
+ALTER TABLE engine.companion_affinity_events
+    ADD COLUMN user_message_id UUID NULL
+        REFERENCES engine.chat_messages(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_affinity_events_user_message
+    ON engine.companion_affinity_events (user_message_id)
+    WHERE user_message_id IS NOT NULL;
+```
+
+**A real foreign key, deliberately.** The audit-table convention in this
+codebase is "no FK — the trail must outlive the row it describes". That
+argument never held for this table: it already cascades away with its session
+through `affinity_id → companion_affinity(session_id) ON DELETE CASCADE`, which
+`session_archive.rs` documents as accepted. Adding an FK therefore removes
+nothing that exists today. `ON DELETE SET NULL` rather than `CASCADE` so that a
+message deleted on its own (migration 0027 did that once for legacy gift rows)
+blanks the pointer instead of erasing the event.
+
+The write order makes the FK safe: the user row is inserted before the turn
+starts, and both affinity writers run strictly after it (`post_process::run` is
+spawned after the `final` frame; the ghost path writes after
+`mark_user_message_ghosted`).
+
+**No backfill.** Rows written before the migration stay `NULL`. A backfill by
+timestamp proximity would write a guess into a column whose whole point is to
+replace one.
+
+No lockdown block: the table's `REVOKE` / RLS from migration 0013 covers new
+columns.
+
+## 4. Writers — `crates/eros-engine-store/src/affinity.rs`
+
+Both event writers gain one parameter, `user_message_id: Option<Uuid>`, bound
+as a new column in their INSERTs:
+
+- `AffinityRepo::persist_with_event(...)` — already carries
+  `#[allow(clippy::too_many_arguments)]`; one more positional argument, no
+  insert struct introduced for it.
+- `AffinityRepo::record_ghost(&mut Affinity, user_message_id: Option<Uuid>)`.
+
+Call sites:
+
+| Site | Value |
+|---|---|
+| `pipeline/post_process.rs::persist_affinity` (→ `persist_with_event`, and the `Ghost` arm's `record_ghost`) | `Some(message_id)` from `Event::UserMessage { message_id, .. }`; `None` for any other `Event` variant |
+| `pipeline/stream.rs` ghost arm (`record_ghost`, next to `mark_user_message_ghosted`) | `Some(user_msg.user_message_id)` |
+| store tests that call either writer | `None` unless the test is about this column |
+
+`persist_affinity` gains a `user_message_id: Option<Uuid>` parameter threaded
+from `run()`, which destructures `message_id` out of the event alongside
+`content`. `proactive` reaches `persist_with_event` through the same function
+with whatever `run()` was given — in practice `None`, since proactive turns do
+not arrive as `Event::UserMessage`.
+
+Nothing moves into `context`. The column is the authority; the JSON blob does
+not get a copy.
+
+## 5. Reader — the BFF delta endpoint
+
+The column is useless to a downstream that may not read `engine.*` tables
+unless an endpoint carries it, so:
+
+- `AffinityEventRow` gains `pub user_message_id: Option<Uuid>`; the two SELECTs
+  that build it (`list_events`, `latest_turn_event`) add the column.
+- `BffAffinityDelta` (`GET /bff/v1/comp/affinity/{session_id}/event`) gains
+  `user_message_id: Option<Uuid>`, `skip_serializing_if = "Option::is_none"` —
+  the same key-presence contract as its other nullable fields. Absent on
+  pre-migration rows.
+
+Additive only. No new endpoint, no v2 twin: the v2 convention says a v2 form
+appears only when behaviour changes, and this is a new key on a v1 response.
+
+## 6. Not in scope
+
+- Backfill (§3).
+- An assistant-side column. Derivable by join (§2).
+- Exposing `user_message_id` on `list_events` consumers other than the BFF
+  delta (there are none in the server today).
+- Any change to `context`, `event_type`, or the CHECK constraint.
+
+## 7. Testing
+
+**Store (`sqlx::test`):**
+
+- `persist_with_event` with `Some(id)` round-trips through `latest_turn_event`
+  and `list_events`; with `None` reads back `NULL`.
+- `record_ghost` with `Some(id)` stores it.
+- An id not present in `chat_messages` fails the INSERT (proves the FK exists,
+  not just the column).
+- Deleting the referenced message leaves the event row with `NULL` (proves
+  `SET NULL`, not `CASCADE`).
+
+**Pipeline (`sqlx::test`, mocked OpenRouter, mirroring the existing affinity
+post-process tests):**
+
+- A `message` turn's event row carries the driving user message id.
+- A `ghost` turn's row carries it (stream arm).
+
+**Server:**
+
+- The BFF delta endpoint echoes `user_message_id` on a seeded row that has one
+  and omits the key on a seeded row that does not.
+
+**Docs:** `docs/affinity-model.md` + `.zh.md` "Event rows" section lists the
+column; `docs/api-reference.md` + `.zh.md` BFF delta section documents the
+key. OpenAPI regenerated.
+
+**Pre-PR gate:** `cargo fmt --check`, `cargo clippy`, `cargo test`, OpenAPI
+regeneration check.

--- a/docs/superpowers/specs/2026-08-22-image-edit-endpoint-design.md
+++ b/docs/superpowers/specs/2026-08-22-image-edit-endpoint-design.md
@@ -1,0 +1,329 @@
+# `POST /v2/comp/session/{session_id}/message/{message_id}/image/edit` — Design
+
+- **Date:** 2026-08-22
+- **Status:** Approved, not yet implemented
+- **Type:** One new v2 action endpoint, one new config task, one CHECK widening
+  on an audit table
+- **Owner:** enriquephl (sole dev)
+- **Target:** `eros-engine` 1.6.x, one PR to `dev`
+- **Convention:** [2026-08-22-user-insights-and-api-v2-design.md](2026-08-22-user-insights-and-api-v2-design.md) §4
+- **Independent of:** [2026-08-22-affinity-event-user-message-id-design.md](2026-08-22-affinity-event-user-message-id-design.md);
+  the two take migration numbers in merge order.
+
+## 1. What this is
+
+A consumer holds a picture the character sent (an assistant message with
+`metadata.image`) and wants a variation of it: "换套衣服", "换个角度",
+"晚上的版本". Today there is no way to ask the engine for that — the standalone
+composer (`POST /persona/{instance_id}/image/compose`) knows nothing about the
+source picture, and the chat turn's `image.force` flag composes from the
+conversation, not from an instruction.
+
+This endpoint takes an edit instruction against one source image turn, runs the
+composer with the source's subject as context, and **forces a `reply_image`
+turn**: a new image-only assistant message is persisted and its `image_request`
+payload is returned synchronously. The engine composes; the consumer draws —
+the delegation contract is unchanged.
+
+It is the thing the removed engine draw endpoint (`POST
+/comp/chat/{session_id}/image/stream`, gone in #203) was reaching for, brought
+back in the delegate-only shape.
+
+## 2. Contract
+
+### 2.1 Path
+
+```
+POST /v2/comp/session/{session_id}/message/{message_id}/image/edit
+```
+
+Per the v2 grammar: `session/{session_id}` then `message/{message_id}` are
+entity segments sharing a stem with their parameter; `image` is the resource;
+`edit` is the verb leaf. `chat` does not appear. Both ids are `chat_*` UUIDs,
+the same type the v1 recovery endpoint takes — `{message_id}` is the value
+`ChatHistoryEntry.id` / `BffHistoryEntry.id` carries.
+
+`session_id` stays in the path even though a message id is globally unique:
+ownership is settled on the session (`require_session_for_user`), the message
+is then loaded *inside* that session (`message_by_id_in_session`), and that is
+the same two-step every session-keyed route performs. A message-only path would
+need a new ownership resolver for one endpoint.
+
+### 2.2 Request
+
+```rust
+#[derive(Deserialize, ToSchema)]
+pub struct ImageEditRequest {
+    /// The edit, in the user's words. Required, non-empty after trim.
+    pub instruction: String,
+    /// Same presets as the chat path. Default `realistic`. Pass the style the
+    /// source was drawn with — the engine does not record it on the message.
+    #[serde(default)] pub style: Option<StyleKey>,
+    /// Same allow-list as the chat path. Default: the source marker's
+    /// `aspect_ratio`; absent there too ⇒ unspecified, as on the chat path.
+    #[serde(default)] pub aspect_ratio: Option<String>,
+    /// `[tasks.chat_image_edit_compose].filter_prompt` variant, same selection
+    /// rules as `image.prompt_variant` on the chat path.
+    #[serde(default)] pub prompt_variant: Option<String>,
+}
+```
+
+`instruction`, not `prompt`: in this codebase `prompt` is the composer's output
+subject (`metadata.image.prompt`) and the wire string is `composed_prompt`. A
+third meaning on the request body would make the docs unreadable.
+
+### 2.3 Status ladder, in evaluation order
+
+| Status | Condition | Body |
+|---|---|---|
+| 401 | missing / invalid bearer | — |
+| 404 | session unknown or archived | `session not found` |
+| 403 | session not owned by the JWT user | `not your session` |
+| 404 | no such message in this session | `no such message` |
+| **409** | message exists but has no `metadata.image` | `not an image turn` |
+| 422 | `instruction` blank, `aspect_ratio` off the allow-list | validation message |
+| 501 | no composer configured (§3.1) | `image prompt composer not configured` |
+| 502 | composer chain exhausted | `image prompt composer failed` |
+| 200 | — | `ImageEditResponse` |
+
+**409, not 404, for "not an image turn".** The message *was* found; what is
+wrong is its state relative to the action, which is what Conflict means. The
+v1 recovery endpoint answers 404 for the same condition, and that stays frozen
+— v1 is a read, where "the thing you asked for does not exist" is defensible;
+this is an action on a resource that does exist.
+
+Nothing is persisted on any non-200 path except the `exhausted` audit row on
+502 (§3.4). A 502 leaves no assistant message: there is **no portrait
+fallback** here. The chat path falls back to a plain portrait because a turn
+that promised a picture must ship one; an edit that ignores its instruction is
+worse than an error, and the consumer can simply retry.
+
+### 2.4 Response
+
+```rust
+#[derive(Serialize, ToSchema)]
+pub struct ImageEditResponse {
+    /// The new assistant message (`chat_messages.id`).
+    pub message_id: Uuid,
+    /// The source image turn this is an edit of.
+    pub edit_of: Uuid,
+    /// base64(STANDARD) of the UTF-8 wire prompt — the same encoding as the
+    /// `image_request` frame and the recovery endpoint, so a consumer feeds it
+    /// to the draw path it already has.
+    pub composed_prompt: String,
+    /// Always `"previous"` on an edit turn; see §3.3.
+    pub image_ref: String,
+    pub aspect_ratio: Option<String>,
+    /// The composer's caption for the new picture; `null` when it gave none.
+    pub caption: Option<String>,
+}
+```
+
+A new struct. `ImageRequestPayloadResponse` is the v1 recovery endpoint's type
+and stays exactly as shipped; `ComposeResponse` is the standalone composer's
+and carries no message id.
+
+## 3. Behaviour
+
+### 3.1 Config — `[tasks.chat_image_edit_compose]`
+
+A new task block, the same shape as `chat_image_prompt_compose`: `model`,
+`fallback`, `retry_depth`, `temperature`, `max_tokens`, `reasoning`, sampling
+knobs, and a `filter_prompt` accepting the same three shapes (plain / indexed /
+keyed) selected by `prompt_variant`. The built-in default is a new
+`DEFAULT_EDIT_PROMPT` constant next to `DEFAULT_COMPOSE_PROMPT`.
+
+Resolution, `resolve_image_edit_compose(variant) -> Option<ResolvedImagePromptCompose>`
+(the existing resolved type; nothing in it is compose-specific):
+
+| `chat_image_edit_compose` | `chat_image_prompt_compose` | Result |
+|---|---|---|
+| present | any | the edit block's chain and params; its `filter_prompt` if set, else `DEFAULT_EDIT_PROMPT` |
+| absent | present | the **compose** block's chain and params, `compose_prompt = DEFAULT_EDIT_PROMPT`, `variant_key = None` |
+| absent | absent | `None` → 501 |
+
+The compose block is the gate — an operator who enabled image turns gets edits
+with no further config, on the same models, with the engine prompt. The edit
+block exists so the prompt and the model can be tuned separately once there is
+a reading to tune against (the `image_edit` audit rows, §3.4).
+
+Housekeeping that comes with a new task: `KNOWN_CHAT_TASKS` gains
+`chat_image_edit_compose`; the wire `task` on the composer call is
+`chat_image_edit_compose`, so `[[providers.*.body]]` rules and
+`log_openrouter_usage` distinguish it from chat composes; the
+model-config validator applies the same `filter_prompt` variant checks as the
+compose block. `examples/model_config.toml` ships the block commented out,
+directly under the compose block, with the fallback rule in its comment.
+
+`DEFAULT_EDIT_PROMPT` says: you are given the character's appearance, the
+picture they previously sent (its subject and caption), and the partner's
+requested change; return the same two-field JSON — `prompt` describing the
+**new** picture, preserving everything about the original the change does not
+touch, applying the change fully and without softening; `caption` one short
+in-language line. The no-sanitising clause is copied from the compose prompt
+verbatim — content policy is the provider's and the consumer's, not this step's.
+
+### 3.2 The composer call
+
+The chain walk in `run_image_prompt_compose` is reused; the function is
+refactored to take the rendered user payload and the wire task name instead of
+rendering the five chat slots itself (the chat path passes what it renders
+today — no behaviour change there). The edit payload is a new pure renderer:
+
+```
+[人物外观]
+{persona meta "appearance"}
+
+[原图]
+{source metadata.image.prompt}
+{source metadata.image.caption, when present}
+
+[修改要求]
+{instruction}
+
+[风格]
+{style}
+
+[画幅]
+{aspect_ratio or （未指定）}
+```
+
+The source's **subject** feeds the composer, not its stored wire prompt:
+`chat_images_events.composed_prompt` already contains the style preset and the
+appearance, both of which the payload carries in their own slots. An empty
+subject (a source drawn through the portrait fallback) renders `（无）` and the
+composer works from appearance plus instruction — still a valid edit.
+
+Output parsing (`parse_compose_reply`) and assembly
+(`compose_image_prompt(style, persona, subject)`) are the existing functions.
+
+### 3.3 Persistence
+
+In this order, on the success path:
+
+1. **Audit row** in `engine.chat_images_events`, `source = 'image_edit'`,
+   `session_id` / `instance_id` / `user_id` set, `inputs =
+   {appearance, source_subject, source_caption, instruction, style,
+   aspect_ratio, source_message_id}`. The row is written the moment the
+   composer returns, via the existing `record_compose_event`, and its id is
+   stamped on the marker below — the same direction the chat path uses.
+2. **Assistant row** via `ChatRepo::insert_assistant_batch` (which also bumps
+   the session's `last_active_at`):
+   - `id` — a fresh ULID cast to UUID, like every streamed assistant row.
+   - `content = ""`, `assistant_action_type = 'reply'` — identical to the chat
+     path's image-only row.
+   - **`user_message_id` = the source message's `user_message_id`.** The edit
+     belongs to the turn the source picture answered; there is no new user
+     message. `NULL` if the source has none.
+   - `metadata.image` — the usual marker from `build_delegated_image_marker`
+     (subject, caption, aspect, compose trio, `compose_event_id`,
+     `image_ref`), plus one new key **`edit_of`** = the source message id.
+     The builder gains an `edit_of: Option<Uuid>` parameter, written only when
+     present; chat-path markers are byte-identical to today.
+   - `image_ref = "previous"`. On an edit turn "previous" means the `edit_of`
+     image, not "whatever the consumer drew last" — the consumer holds both
+     ids in the response. No new `ImageRef` variant: that enum is on the wire
+     in `image_request` frames and a new value would break every consumer's
+     match.
+
+Nothing else runs. No PDE verdict, no affinity event, no insight or memory
+extraction, no ghost-streak change, no queue claim. The new row is not a
+`ProducedMessage`; it is a picture, not a reply to anything new.
+
+Because it is an ordinary assistant row with `metadata.image`, everything that
+reads such rows works on it for free: history shows `image: true`, the v1
+recovery endpoint returns its `composed_prompt`, and its caption enters the
+transcript so the character later "remembers" having sent the edited picture.
+
+### 3.4 Audit
+
+Migration `0057_chat_images_events_image_edit.sql` widens the `source` CHECK
+to add `'image_edit'`. `inputs` for that source carries the seven keys in
+§3.3, not the chat composer's five — `inputs` is free-form JSONB and the
+`source` column says which shape to expect. `docs/llm-audit.md` documents both.
+
+A 502 writes one `exhausted` row with `attempts` / `last_failure` / the failure
+list, `composed_prompt = NULL` — the same as the standalone composer's 502.
+
+`chat_images_events WHERE source = 'image_edit'` grouped by `status` and by day
+is the reading for this feature: how often edits are requested, how often the
+composer refuses or fails, and on which models.
+
+### 3.5 Concurrency and cost
+
+- A chat turn may be in flight on the session while an edit lands. The edit
+  row interleaves wherever its `created_at` falls. Accepted — the voice and
+  chat pipelines already write to one session concurrently, and the edit row
+  carries no state the in-flight turn reads.
+- One composer call per request, no per-user cap. Every call is audited
+  (§3.4). Default-open; the gate gets ratcheted if the reading says so.
+
+## 4. Implementation shape
+
+- `crates/eros-engine-server/src/routes/image_edit.rs` — DTOs, handler,
+  `router()`; merged (not nested) into both `router()` and
+  `router_for_openapi()` in `routes/mod.rs`, like `insight.rs`.
+- `pipeline/stream.rs` — `run_image_prompt_compose` takes `(payload, task)`;
+  new `compose_edit_payload(...)` and `compose_edit_inputs_json(...)` pure
+  functions; `build_delegated_image_marker` gains `edit_of`.
+- `crates/eros-engine-llm/src/model_config.rs` — `DEFAULT_EDIT_PROMPT`,
+  `resolve_image_edit_compose`, `KNOWN_CHAT_TASKS` entry, validator case.
+- `crates/eros-engine-store/migrations/0057_…` — CHECK widening.
+- `examples/model_config.toml` — the commented block.
+- `docs/api-reference.md` + `.zh.md` — new v2 section after the async-turn
+  entry, with the 409 rule and the `image_ref = previous` meaning;
+  `docs/llm-audit.md` + `.zh.md` — the new `source` and `inputs` shape.
+- `openapi.json` regenerated.
+
+## 5. Not in scope
+
+- Image-to-image on the engine side, reference-image URLs, or any drawing. The
+  consumer draws; it already holds the source image it chose to edit.
+- An SSE mode. One composer call, one JSON response; the standalone composer's
+  streaming mode exists for long-form prompts on a path with no message to
+  persist, which is not this.
+- Editing a message that is not an image turn (409), or "edit the latest
+  picture" without a message id.
+- Recording the edit instruction as a user message. The instruction is an
+  input to a picture, not a thing the user said to the character; it is kept
+  on the audit row's `inputs`.
+- A new `ImageRef` variant (§3.3).
+- Any change to `/persona/{instance_id}/image/compose` or to the v1 recovery
+  endpoint.
+
+## 6. Testing
+
+**Pure:**
+
+- `compose_edit_payload` renders all five slots, the caption line only when
+  present, `（无）` for an empty subject.
+- `resolve_image_edit_compose`: the edit block's model when present; the
+  **compose block's model specifically** with `DEFAULT_EDIT_PROMPT` when
+  absent; `None` when both are absent. An unknown variant key falls back to
+  the built-in prompt.
+- `DEFAULT_EDIT_PROMPT` is non-empty and names both output fields (guards a
+  broken-constant edit).
+- The shipped example config parses with the new task present.
+
+**Server (`sqlx::test`, mocked OpenRouter, mirroring the recovery-endpoint
+tests):**
+
+- The full ladder: 403 foreign session, 404 unknown session, 404 unknown
+  message, **409** on a text message, 422 blank instruction, 501 with no
+  composer task, 502 on chain exhaustion.
+- 502 writes exactly one `image_edit` / `exhausted` audit row and **no**
+  assistant row.
+- Success: response fields; a new assistant row exists with `content = ""`,
+  `user_message_id` equal to the source's, `metadata.image.edit_of` equal to
+  the source id, `image_ref = "previous"`, and a `compose_event_id` that
+  resolves to an `image_edit` / `ok` audit row whose `inputs.instruction` is
+  the request's; the wire `task` on the mocked call is
+  `chat_image_edit_compose`.
+- Follow-through: `GET /comp/chat/{sid}/history` flags the new row
+  `image: true`, and the v1 recovery endpoint returns the same
+  `composed_prompt` for the new `message_id`.
+- Editing an edit: a second call with the first result's `message_id` as the
+  source succeeds and points `edit_of` at it.
+
+**Pre-PR gate:** `cargo fmt --check`, `cargo clippy`, `cargo test`, OpenAPI
+regeneration check.


### PR DESCRIPTION
## What

`engine.companion_affinity_events` gains `user_message_id` — the user message that drove the turn — and the BFF affinity delta endpoint echoes it.

Spec: `docs/superpowers/specs/2026-08-22-affinity-event-user-message-id-design.md`

- **Migration `0056`**: `user_message_id UUID NULL REFERENCES engine.chat_messages(id) ON DELETE SET NULL` + partial index `idx_affinity_events_user_message`. A real FK, unlike the other audit tables: this table already cascades with its session via `affinity_id`, so "the trail outlives the row" never applied here. No backfill — pre-migration rows stay `NULL`.
- **Writers**: `AffinityRepo::persist_with_event` / `record_ghost` take a trailing `Option<Uuid>`. `message` / `gift` / `ghost` turns pass the turn's user message (`Event::UserMessage.message_id` in `post_process::run`; `user_msg.user_message_id` on the stream ghost arm). Anything else stores `NULL`.
- **Reader**: `AffinityEventRow.user_message_id`; `GET /bff/v1/comp/affinity/{session_id}/event` → `event.user_message_id`, key absent when none. Additive only.
- Docs (`affinity-model`, `api-reference`, en + zh) and `openapi.json` regenerated.

Why the user message and not the assistant one: a turn has exactly one user message, while it may have zero (`ghost`) or several (burst) assistant messages; replies for an event are `chat_messages WHERE user_message_id = event.user_message_id`.

## Notes

- This branch also carries `docs/superpowers/specs/2026-08-22-image-edit-endpoint-design.md` (the next feature's spec) — `dev` is PR-only, so it rides here rather than being pushed directly. No code for it in this PR.
- `proactive` rows are documented as never carrying the pointer. `persist_affinity` would pass through whatever `run()` was handed, but no production path spawns `post_process` for a proactive turn today, so no such row is ever written. Spec §4 records this.
- `fffb96a` (store) alone does not build the server crate; `65910d0` completes the arity change. Don't bisect across the first one.

## Tests

- Store: round-trip on both readers, `None` → `NULL`, ghost carries it, FK violation on an unknown id, `DELETE` of the message → `SET NULL` with the event surviving.
- Pipeline: a `message` turn's event row carries the driving user message; the stream ghost turn's row carries it. Existing `run()` tests now seed the user row (the FK would otherwise fail the INSERT silently under the fail-open writer).
- BFF: key echoed when set; key absent (not `null`) when not.
- Gate: `cargo fmt --check` / `clippy -D warnings` / `cargo test --workspace` / OpenAPI drift — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
