### PR TITLE
feat: v2 image-edit endpoint

### DIFF
--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -2112,14 +2112,22 @@ impl ModelConfig {
             None | Some(PromptSpec::Plain(_)) => None,
             Some(_) => selected.and(variant).map(str::to_string),
         };
-        if selected.is_none()
-            && variant.is_some()
-            && edit_cfg.is_some_and(|c| c.filter_prompt.is_some())
-        {
-            tracing::warn!(
+        match compose_variant_log_event(
+            selected,
+            variant,
+            edit_cfg.is_some_and(|c| c.filter_prompt.is_some()),
+        ) {
+            Some(ComposeVariantLogEvent::Mismatch) => tracing::warn!(
                 variant = ?cap_for_log(variant.unwrap_or_default(), 64),
                 "image-edit: variant not found; using the built-in prompt"
-            );
+            ),
+            Some(ComposeVariantLogEvent::Selected) => {
+                tracing::debug!(
+                    variant = ?cap_for_log(variant.unwrap_or_default(), 64),
+                    "image-edit: variant selected"
+                )
+            }
+            None => {}
         }
         let compose_prompt = selected
             .map(str::trim)

--- a/crates/eros-engine-llm/src/model_config.rs
+++ b/crates/eros-engine-llm/src/model_config.rs
@@ -163,9 +163,10 @@ impl ModelSpec {
 /// `"xxx"` (plain), `["aaa","bbb"]` (index-keyed variants), or
 /// `{ a = "aaa", b = "bbb" }` (string-keyed variants).
 ///
-/// Only `[tasks.chat_image_prompt_compose]` reads variants; every other task —
-/// and every tier block, including the composer's own — must use the plain
-/// shape. Enforced at boot by `ModelConfig::validate_prompt_variants`, because
+/// Only `[tasks.chat_image_prompt_compose]` and `[tasks.chat_image_edit_compose]`
+/// read variants; every other task — and every tier block, including the two
+/// composers' own — must use the plain shape. Enforced at boot by
+/// `ModelConfig::validate_prompt_variants`, because
 /// `TaskConfig` is shared by every `[tasks.*]` section and the type alone
 /// cannot express the restriction.
 ///
@@ -1215,6 +1216,21 @@ You receive the character's appearance, the recent scene, the partner's latest m
 \n\
 Output only the JSON object. No commentary, options, or headings.";
 
+/// Built-in system prompt for `chat_image_edit_compose`, the image-EDIT
+/// composer. Same JSON contract as [`DEFAULT_COMPOSE_PROMPT`] — the difference
+/// is the job: this one revises a picture the character already sent, given the
+/// partner's requested change. Like the compose prompt, it ships in code so a
+/// deployment gets working edits with no prompt of its own.
+const DEFAULT_EDIT_PROMPT: &str = "You revise a picture the character previously sent in a chat, and you return JSON with exactly two fields: \"prompt\" and \"caption\".\n\
+\n\
+You receive the character's appearance, the picture that was sent before (its subject, and the caption the character gave it), the change the partner is asking for, a visual style, and a target aspect ratio, each as a labeled section.\n\
+\n\
+\"prompt\" is the image-generation prompt for the NEW picture: apply the requested change in full, and keep everything the change does not touch — the appearance, the setting, the framing, the mood — as it was. Produce one coherent, detailed, vivid prompt that faithfully preserves the appearance and fits the style and aspect ratio, delivering the full intent and tone of what was asked for. Do not soften, sanitize, downgrade, omit, censor, or refuse any part of it, and do not add safety warnings, disclaimers, or moderation of your own — content policy is the responsibility of the image provider and the downstream consumer, not this step.\n\
+\n\
+\"caption\" is one short line, in the language the conversation is in, saying what the new picture shows — as the character would recall it later. It is read back into the conversation history, so keep it brief and natural; it is not an image-generation prompt and must not repeat the style boilerplate.\n\
+\n\
+Output only the JSON object. No commentary, options, or headings.";
+
 /// Resolved image-prompt composer task (`chat_image_prompt_compose`). Mirrors
 /// `ResolvedVision`. Optional: `resolve_image_prompt_compose` returns `None`
 /// (feature off) only when the task is absent; a present task with no
@@ -2052,6 +2068,81 @@ impl ModelConfig {
             sampling: m.sampling,
         })
     }
+
+    /// Resolved image-EDIT composer (`chat_image_edit_compose`).
+    ///
+    /// Three cases:
+    /// - the edit block is present → its chain, params and `filter_prompt`
+    ///   (variant-selected exactly like the chat composer), falling back to
+    ///   `DEFAULT_EDIT_PROMPT` when it configures none;
+    /// - the edit block is absent but `[tasks.chat_image_prompt_compose]` is
+    ///   present → that block's chain and params with `DEFAULT_EDIT_PROMPT`.
+    ///   The chat composer's own `filter_prompt` is deliberately NOT reused:
+    ///   it is written for composing from conversation context, not for
+    ///   revising a picture, so reading it here would silently do the wrong
+    ///   job. `variant_key` is `None` in this case — nothing was selected.
+    /// - neither → `None`, and the endpoint answers 501.
+    ///
+    /// Enabling image turns therefore enables edits, on the same models, with
+    /// no further configuration; the edit block exists to tune the prompt and
+    /// the chain separately once `chat_images_events` has a reading to tune
+    /// against.
+    pub fn resolve_image_edit_compose(
+        &self,
+        variant: Option<&str>,
+    ) -> Option<ResolvedImagePromptCompose> {
+        const EDIT_TASK: &str = "chat_image_edit_compose";
+        const COMPOSE_TASK: &str = "chat_image_prompt_compose";
+        let variant = variant.map(str::trim).filter(|v| !v.is_empty());
+        // The chain comes from whichever block exists; the prompt only ever
+        // comes from the edit block.
+        let (chain_task, edit_cfg) = match self.tasks.get(EDIT_TASK) {
+            Some(cfg) => (EDIT_TASK, Some(cfg)),
+            None => {
+                if !self.tasks.contains_key(COMPOSE_TASK) {
+                    return None;
+                }
+                (COMPOSE_TASK, None)
+            }
+        };
+        let selected = edit_cfg
+            .and_then(|c| c.filter_prompt.as_ref())
+            .and_then(|s| s.select(variant));
+        let variant_key = match edit_cfg.and_then(|c| c.filter_prompt.as_ref()) {
+            None | Some(PromptSpec::Plain(_)) => None,
+            Some(_) => selected.and(variant).map(str::to_string),
+        };
+        if selected.is_none()
+            && variant.is_some()
+            && edit_cfg.is_some_and(|c| c.filter_prompt.is_some())
+        {
+            tracing::warn!(
+                variant = ?cap_for_log(variant.unwrap_or_default(), 64),
+                "image-edit: variant not found; using the built-in prompt"
+            );
+        }
+        let compose_prompt = selected
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+            .unwrap_or_else(|| DEFAULT_EDIT_PROMPT.to_string());
+        let task_cfg = &self.tasks[chain_task];
+        let retry_depth = task_cfg.retry_depth.unwrap_or(1);
+        let m = self.resolve(chain_task, None);
+        let mut fallback_model = m.fallback_model;
+        fallback_model.truncate(retry_depth as usize);
+        Some(ResolvedImagePromptCompose {
+            model: m.model,
+            fallback_model,
+            temperature: m.temperature,
+            max_tokens: m.max_tokens,
+            compose_prompt,
+            retry_depth,
+            reasoning: task_cfg.reasoning.clone(),
+            variant_key,
+            sampling: m.sampling,
+        })
+    }
 }
 
 /// Cap a string to at most `max_chars` characters before it reaches a log
@@ -2393,9 +2484,10 @@ impl ModelConfig {
     }
 
     /// Boot gate for `filter_prompt` variant shapes. Variants are read by
-    /// `chat_image_prompt_compose` alone, and never from a tier block (the
-    /// composer resolves with `tier = None`), so a variant anywhere else is
-    /// dead config — refuse to boot rather than let it silently no-op.
+    /// `chat_image_prompt_compose` and `chat_image_edit_compose` alone, and
+    /// never from a tier block (both composers resolve with `tier = None`),
+    /// so a variant anywhere else is dead config — refuse to boot rather than
+    /// let it silently no-op.
     ///
     /// Also enforces the structural rules for a variant container: non-empty,
     /// no blank or whitespace-padded keys, no blank values (a padded key like
@@ -2406,16 +2498,20 @@ impl ModelConfig {
     /// deterministic across restarts (`self.tasks` is a `HashMap`).
     pub fn validate_prompt_variants(&self) -> Result<(), String> {
         const COMPOSE_TASK: &str = "chat_image_prompt_compose";
+        const EDIT_TASK: &str = "chat_image_edit_compose";
         let mut names: Vec<&String> = self.tasks.keys().collect();
         names.sort();
         for name in names {
             let task = &self.tasks[name];
             if let Some(spec) = &task.filter_prompt {
-                if !matches!(spec, PromptSpec::Plain(_)) && name != COMPOSE_TASK {
+                if !matches!(spec, PromptSpec::Plain(_))
+                    && name != COMPOSE_TASK
+                    && name != EDIT_TASK
+                {
                     return Err(format!(
                         "[tasks.{name}].filter_prompt uses a variant shape (array/table), but \
-                         only [tasks.{COMPOSE_TASK}] reads variants — eros-engine refuses to \
-                         boot. Use a plain string here."
+                         only [tasks.{COMPOSE_TASK}] and [tasks.{EDIT_TASK}] read variants — \
+                         eros-engine refuses to boot. Use a plain string here."
                     ));
                 }
                 check_variant_shape(name, spec)?;
@@ -2674,6 +2770,7 @@ pub const KNOWN_CHAT_TASKS: &[&str] = &[
     "chat_input_filter",
     "chat_voice",
     "chat_image_prompt_compose",
+    "chat_image_edit_compose",
     "chat_product_qa",
     "pde_decision",
     "insight_extraction",
@@ -3877,6 +3974,17 @@ reasoning = { exclude = true }
                 "google/gemini-3.1-flash-lite".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn committed_example_config_leaves_the_image_edit_task_commented_out() {
+        let text = include_str!("../../../examples/model_config.toml");
+        let cfg = ModelConfig::from_toml_str(text).expect("examples/model_config.toml must parse");
+        // The block ships commented out, like the composer block above it —
+        // this guards against a stray uncomment turning the example into a
+        // config that calls a model nobody asked for.
+        assert!(!cfg.has_task("chat_image_edit_compose"));
+        assert!(cfg.validate_prompt_variants().is_ok());
     }
 
     // Regression: the committed example extraction prompts stay dual-track
@@ -8048,5 +8156,84 @@ output_regex = [ { models = ["x/y"], pattern = '[' } ]
         assert_eq!(r.read.model, "voyage-4-lite");
         assert_eq!(r.write.model, "voyage-4");
         assert!(matches!(r.read.route, EmbedRoute::Voyage));
+    }
+
+    // ─── chat_image_edit_compose ────────────────────────────────────────────
+
+    #[test]
+    fn image_edit_resolver_is_none_when_neither_block_exists() {
+        let cfg = ModelConfig::from_toml_str("[tasks.chat_companion]\nmodel = \"m\"\n").unwrap();
+        assert!(cfg.resolve_image_edit_compose(None).is_none());
+    }
+
+    #[test]
+    fn image_edit_resolver_falls_back_to_the_compose_block_with_the_builtin_edit_prompt() {
+        // No [tasks.chat_image_edit_compose]: the chain comes from the chat
+        // composer's block, but the PROMPT must be the edit prompt — the chat
+        // composer's own filter_prompt is aimed at a different job.
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.chat_image_prompt_compose]\nmodel = \"compose-model\"\nfilter_prompt = \"CHAT COMPOSER PROMPT\"\n",
+        )
+        .unwrap();
+        let r = cfg.resolve_image_edit_compose(None).expect("falls back");
+        assert_eq!(r.model, "compose-model");
+        assert_eq!(r.compose_prompt, DEFAULT_EDIT_PROMPT);
+        assert!(r.variant_key.is_none());
+    }
+
+    #[test]
+    fn image_edit_resolver_prefers_its_own_block() {
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.chat_image_prompt_compose]\nmodel = \"compose-model\"\n\
+             [tasks.chat_image_edit_compose]\nmodel = \"edit-model\"\nfilter_prompt = \"EDIT PROMPT\"\n",
+        )
+        .unwrap();
+        let r = cfg.resolve_image_edit_compose(None).expect("resolves");
+        assert_eq!(r.model, "edit-model");
+        assert_eq!(r.compose_prompt, "EDIT PROMPT");
+    }
+
+    #[test]
+    fn image_edit_resolver_selects_and_reports_the_variant() {
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.chat_image_edit_compose]\nmodel = \"edit-model\"\n\
+             filter_prompt = { a = \"PROMPT A\", b = \"PROMPT B\" }\n",
+        )
+        .unwrap();
+        let r = cfg.resolve_image_edit_compose(Some("b")).expect("resolves");
+        assert_eq!(r.compose_prompt, "PROMPT B");
+        assert_eq!(r.variant_key.as_deref(), Some("b"));
+
+        // An unknown key is never an error — it falls back to the built-in.
+        let miss = cfg
+            .resolve_image_edit_compose(Some("zzz"))
+            .expect("resolves");
+        assert_eq!(miss.compose_prompt, DEFAULT_EDIT_PROMPT);
+        assert!(miss.variant_key.is_none());
+    }
+
+    #[test]
+    fn image_edit_block_may_use_variant_shapes() {
+        // validate_prompt_variants rejects non-Plain filter_prompt on every
+        // task EXCEPT the two composer tasks; without the allowlist entry this
+        // config would refuse to boot.
+        let cfg = ModelConfig::from_toml_str(
+            "[tasks.chat_image_edit_compose]\nmodel = \"m\"\nfilter_prompt = [\"A\", \"B\"]\n",
+        )
+        .unwrap();
+        assert!(cfg.validate_prompt_variants().is_ok());
+    }
+
+    #[test]
+    fn default_edit_prompt_names_both_output_fields() {
+        // Guards a broken-constant edit: the composer's JSON contract is the
+        // whole reason this prompt exists.
+        assert!(DEFAULT_EDIT_PROMPT.contains("\"prompt\""));
+        assert!(DEFAULT_EDIT_PROMPT.contains("\"caption\""));
+    }
+
+    #[test]
+    fn known_chat_tasks_carries_the_image_edit_task() {
+        assert!(KNOWN_CHAT_TASKS.contains(&"chat_image_edit_compose"));
     }
 }

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -1513,6 +1513,89 @@
         ]
       }
     },
+    "/v2/comp/session/{session_id}/message/{message_id}/image/edit": {
+      "post": {
+        "tags": [
+          "companion"
+        ],
+        "summary": "Revise an existing image turn.",
+        "description": "The instruction is an input to a picture, not something the user said to\nthe character: it is recorded on the audit row, never as a chat message.\nThe new assistant row inherits the source's `user_message_id`, so the edit\nbelongs to the turn the original picture answered.",
+        "operationId": "edit_image",
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "description": "Chat session id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "message_id",
+            "in": "path",
+            "description": "The image turn to revise",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImageEditRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImageEditResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "missing or invalid bearer"
+          },
+          "403": {
+            "description": "not your session"
+          },
+          "404": {
+            "description": "session or message not found"
+          },
+          "409": {
+            "description": "the message is not an image turn"
+          },
+          "422": {
+            "description": "blank instruction or unsupported aspect_ratio"
+          },
+          "429": {
+            "description": "per-user in-flight cap reached"
+          },
+          "501": {
+            "description": "no image composer configured on this deployment"
+          },
+          "5XX": {
+            "description": "composer chain exhausted; the provider's own status passes through, same body as the compose endpoint"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
     "/world/town/{user_id}/feed": {
       "get": {
         "tags": [
@@ -2617,6 +2700,79 @@
           "total": {
             "type": "integer",
             "minimum": 0
+          }
+        }
+      },
+      "ImageEditRequest": {
+        "type": "object",
+        "required": [
+          "instruction"
+        ],
+        "properties": {
+          "aspect_ratio": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Same allow-list as the chat path. Defaults to the source turn's\n`aspect_ratio`."
+          },
+          "instruction": {
+            "type": "string",
+            "description": "What to change, in the user's words (\"换套衣服\"). Required, non-blank."
+          },
+          "prompt_variant": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "`[tasks.chat_image_edit_compose].filter_prompt` variant, with the same\nselection rules as the chat path's `image.prompt_variant`."
+          },
+          "style": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Style preset for the new picture. Default `realistic`; pass the style\nthe source was drawn with — the engine does not record it."
+          }
+        }
+      },
+      "ImageEditResponse": {
+        "type": "object",
+        "required": [
+          "message_id",
+          "edit_of",
+          "composed_prompt",
+          "image_ref"
+        ],
+        "properties": {
+          "aspect_ratio": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "caption": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The composer's caption for the new picture."
+          },
+          "composed_prompt": {
+            "type": "string",
+            "description": "Base64 (STANDARD) of the UTF-8 composed prompt — the same encoding as\nthe SSE `image_request` frame, so an existing draw path consumes it\nunchanged."
+          },
+          "edit_of": {
+            "type": "string",
+            "description": "The image turn this revises."
+          },
+          "image_ref": {
+            "type": "string",
+            "description": "Always `\"previous\"`: on an edit turn that means the `edit_of` picture."
+          },
+          "message_id": {
+            "type": "string",
+            "description": "The new assistant message."
           }
         }
       },

--- a/crates/eros-engine-server/src/error.rs
+++ b/crates/eros-engine-server/src/error.rs
@@ -22,6 +22,19 @@ pub enum AppError {
     BadRequest(String),
     #[error("forbidden: {0}")]
     Forbidden(String),
+    /// The resource exists but its state does not permit the action — e.g.
+    /// editing a message that is not an image turn.
+    #[error("conflict: {0}")]
+    Conflict(String),
+    /// A well-formed request whose values are not acceptable.
+    #[error("unprocessable: {0}")]
+    Unprocessable(String),
+    /// A capability the deployment did not configure.
+    #[error("not implemented: {0}")]
+    NotImplemented(String),
+    /// A per-user concurrency cap was reached.
+    #[error("too many requests: {0}")]
+    TooManyRequests(String),
     /// A provider failure surfaced with the provider's own status. Used by the
     /// standalone compose endpoint, whose caller needs "the provider failed my
     /// call" distinguishable from "the engine broke". Scoped to that endpoint:
@@ -117,6 +130,10 @@ impl IntoResponse for AppError {
             AppError::Unauthorized(_) => (StatusCode::UNAUTHORIZED, "unauthorized"),
             AppError::BadRequest(_) => (StatusCode::BAD_REQUEST, "bad_request"),
             AppError::Forbidden(_) => (StatusCode::FORBIDDEN, "forbidden"),
+            AppError::Conflict(_) => (StatusCode::CONFLICT, "conflict"),
+            AppError::Unprocessable(_) => (StatusCode::UNPROCESSABLE_ENTITY, "unprocessable"),
+            AppError::NotImplemented(_) => (StatusCode::NOT_IMPLEMENTED, "not_implemented"),
+            AppError::TooManyRequests(_) => (StatusCode::TOO_MANY_REQUESTS, "too_many_requests"),
             _ => (StatusCode::INTERNAL_SERVER_ERROR, "internal"),
         };
         (

--- a/crates/eros-engine-server/src/main.rs
+++ b/crates/eros-engine-server/src/main.rs
@@ -254,7 +254,8 @@ async fn run_server() -> Result<()> {
     // [tasks.insight_extraction] would otherwise surface as "filter_prompt is
     // unset" (telling an operator who just set it to set it) instead of the
     // accurate "uses a variant shape, but only [tasks.chat_image_prompt_compose]
-    // reads variants" from `validate_prompt_variants`.
+    // and [tasks.chat_image_edit_compose] read variants" from
+    // `validate_prompt_variants`.
     if let Err(msg) = model_config.validate_prompt_variants() {
         anyhow::bail!(msg);
     }

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -197,9 +197,10 @@ fn build_image_request_frame(
 /// were not on the wire when the frame fired (async turns, disconnected
 /// streams). Deliberately NOT stored: the composed wire prompt (it lives on
 /// the compose event — one authoritative home), url, or success/failure of
-/// the draw. Pure.
+/// the draw. `edit_of` is set only by the image-edit endpoint: the message
+/// this picture is a revision of. Absent on ordinary chat image turns. Pure.
 #[allow(clippy::too_many_arguments)]
-fn build_delegated_image_marker(
+pub(crate) fn build_delegated_image_marker(
     subject: &str,
     caption: Option<&str>,
     aspect_ratio: Option<&str>,
@@ -208,6 +209,7 @@ fn build_delegated_image_marker(
     compose_generation_id: Option<&str>,
     compose_event_id: Option<Uuid>,
     image_ref: eros_engine_core::types::ImageRef,
+    edit_of: Option<Uuid>,
 ) -> serde_json::Value {
     let mut m = serde_json::json!({ "prompt": subject });
     m["image_ref"] = serde_json::to_value(image_ref).expect("ImageRef serializes");
@@ -228,6 +230,9 @@ fn build_delegated_image_marker(
     }
     if let Some(id) = compose_event_id {
         m["compose_event_id"] = serde_json::Value::String(id.to_string());
+    }
+    if let Some(id) = edit_of {
+        m["edit_of"] = serde_json::Value::String(id.to_string());
     }
     m
 }
@@ -3128,27 +3133,17 @@ pub(crate) struct ComposeRun {
     pub(crate) failures: Vec<eros_engine_llm::failure::AttemptFailure>,
 }
 
-/// Generate the image prompt (and its caption) via the optional composer LLM.
-/// Walks `[model] + fallback` on transport failure (error/timeout/empty);
-/// returns a `ComposeRun` carrying the parsed prompt/caption plus the audit
-/// trio in `outcome` on first success, or `outcome: None` (caller falls back
-/// to an empty subject — the portrait path) alongside how many models were
-/// attempted and why the last one failed. Never blocks or fails the image
-/// turn. Mirrors `run_input_filter`.
-///
-/// Shared with `routes/persona.rs`: the standalone compose endpoint's
-/// non-stream mode maps an `outcome: None` here to a 502 instead of the chat
-/// path's fail-open (spec 2026-08-03 §3.6 — no portrait fallback there).
-pub(crate) async fn run_image_prompt_compose(
-    state: &AppState,
-    c: &eros_engine_llm::model_config::ResolvedImagePromptCompose,
+/// Render the chat composer's five-slot payload, substituting the placeholders
+/// the prompt expects for empty slots. Extracted from `run_image_prompt_compose`
+/// so that function is only the chain walk and can serve a second composer
+/// (the image-edit endpoint) with a different payload. Pure.
+pub(crate) fn render_compose_payload(
     persona: &eros_engine_core::persona::CompanionPersona,
     recent_scene: &str,
     latest_user_msg: &str,
     aspect_ratio: Option<&str>,
     style: &str,
-) -> ComposeRun {
-    use eros_engine_llm::openrouter::{ChatMessage, ChatRequest};
+) -> String {
     let appearance = crate::prompt::meta_str(persona, "appearance")
         .map(str::trim)
         .filter(|s| !s.is_empty())
@@ -3164,7 +3159,26 @@ pub(crate) async fn run_image_prompt_compose(
         latest_user_msg
     };
     let ar = aspect_ratio.unwrap_or("（未指定）");
-    let user_payload = compose_user_payload(appearance, scene, latest, style, ar);
+    compose_user_payload(appearance, scene, latest, style, ar)
+}
+
+/// Walk `[model] + fallback` for a composer task, named by `task`, on
+/// transport failure (error/timeout/empty); returns a `ComposeRun` carrying
+/// the parsed prompt/caption plus the audit trio in `outcome` on first
+/// success, or `outcome: None` (caller falls back to an empty subject — the
+/// portrait path) alongside how many models were attempted and why the last
+/// one failed. Never blocks or fails the image turn. Mirrors `run_input_filter`.
+///
+/// Shared with `routes/persona.rs`: the standalone compose endpoint's
+/// non-stream mode maps an `outcome: None` here to a 502 instead of the chat
+/// path's fail-open (spec 2026-08-03 §3.6 — no portrait fallback there).
+pub(crate) async fn run_image_prompt_compose(
+    state: &AppState,
+    c: &eros_engine_llm::model_config::ResolvedImagePromptCompose,
+    user_payload: &str,
+    task: &'static str,
+) -> ComposeRun {
+    use eros_engine_llm::openrouter::{ChatMessage, ChatRequest};
     let chain: Vec<String> = std::iter::once(c.model.clone())
         .chain(c.fallback_model.iter().cloned())
         .collect();
@@ -3186,14 +3200,14 @@ pub(crate) async fn run_image_prompt_compose(
                 },
                 ChatMessage {
                     role: "user".into(),
-                    content: user_payload.clone(),
+                    content: user_payload.to_string(),
                 },
             ],
             temperature: c.temperature as f32,
             max_tokens: c.max_tokens,
             sampling: c.sampling,
             reasoning: c.reasoning.clone(),
-            task: Some("chat_image_prompt_compose".into()),
+            task: Some(task.into()),
             ..Default::default()
         };
         let resp = match tokio::time::timeout(FILTER_TIMEOUT, state.openrouter.execute(req)).await {
@@ -3201,9 +3215,7 @@ pub(crate) async fn run_image_prompt_compose(
             Ok(Err(e)) => {
                 tracing::warn!(model = %model_id, error = %e, "image-compose: model error; next");
                 failures.push(eros_engine_llm::failure::AttemptFailure::from_llm_error(
-                    "chat_image_prompt_compose",
-                    model_id,
-                    &e,
+                    task, model_id, &e,
                 ));
                 last_failure = Some(operation_failure_pointer(&failures));
                 // Transport failure: nothing came back, so any identity
@@ -3216,10 +3228,7 @@ pub(crate) async fn run_image_prompt_compose(
             }
             Err(_) => {
                 tracing::warn!(model = %model_id, "image-compose: timeout; next");
-                failures.push(filter_timeout_failure(
-                    "chat_image_prompt_compose",
-                    model_id,
-                ));
+                failures.push(filter_timeout_failure(task, model_id));
                 last_failure = Some(operation_failure_pointer(&failures));
                 last_model = None;
                 last_generation_id = None;
@@ -3227,7 +3236,7 @@ pub(crate) async fn run_image_prompt_compose(
                 continue;
             }
         };
-        super::log_openrouter_usage("chat_image_prompt_compose", None, &resp);
+        super::log_openrouter_usage(task, None, &resp);
         let text = resp.reply.trim().to_string();
         if text.is_empty() {
             tracing::warn!(model = %model_id, "image-compose: empty reply; next");
@@ -3425,11 +3434,14 @@ async fn build_delegated_image_prompt(
             run_image_prompt_compose(
                 state,
                 &c,
-                persona,
-                pde_transcript,
-                latest_user_msg,
-                inputs.aspect_ratio.as_deref(),
-                &style_str,
+                &render_compose_payload(
+                    persona,
+                    pde_transcript,
+                    latest_user_msg,
+                    inputs.aspect_ratio.as_deref(),
+                    &style_str,
+                ),
+                "chat_image_prompt_compose",
             )
             .await
         }
@@ -4565,6 +4577,7 @@ pub fn run_stream(
                         img.compose_generation_id.as_deref(),
                         img.compose_event_id,
                         plan.image_ref,
+                        None,
                     );
                     image_only_caption = img.caption.clone();
                     let row = eros_engine_store::chat::AssistantInsert {
@@ -5111,6 +5124,7 @@ pub fn run_stream(
                             img.compose_generation_id.as_deref(),
                             img.compose_event_id,
                             plan.image_ref,
+                            None,
                         );
                         if let Err(e) = chat_repo
                             .merge_assistant_image_meta(user_msg.session_id, msg_uuid, &marker)
@@ -5630,6 +5644,7 @@ mod tests {
             None,
             None,
             eros_engine_core::types::ImageRef::Previous,
+            None,
         );
         assert_eq!(m["prompt"], "on a rooftop");
         assert_eq!(m["caption"], "在天台");
@@ -5648,6 +5663,7 @@ mod tests {
             None,
             None,
             eros_engine_core::types::ImageRef::Face,
+            None,
         );
         assert_eq!(m["prompt"], "on a rooftop");
         assert!(
@@ -17058,6 +17074,7 @@ data: [DONE]\n\n"
             None,
             None,
             eros_engine_core::types::ImageRef::Face,
+            None,
         );
         assert_eq!(marker["prompt"], "beach at sunset");
         assert_eq!(marker["aspect_ratio"], "3:4");
@@ -17089,6 +17106,7 @@ data: [DONE]\n\n"
             None,
             None,
             eros_engine_core::types::ImageRef::Face,
+            None,
         );
         assert_eq!(m2.as_object().unwrap().len(), 2);
         let w2 = serde_json::json!({ "image": m2 });
@@ -17111,6 +17129,7 @@ data: [DONE]\n\n"
             Some("gen-xyz"),
             None,
             eros_engine_core::types::ImageRef::Face,
+            None,
         );
         assert_eq!(m["prompt"], "beach at sunset");
         assert_eq!(m["aspect_ratio"], "3:4");
@@ -17129,6 +17148,7 @@ data: [DONE]\n\n"
             None,
             None,
             eros_engine_core::types::ImageRef::Face,
+            None,
         );
         assert_eq!(m2["compose_model"], "served/model");
         assert!(m2
@@ -17286,5 +17306,89 @@ data: [DONE]\n\n"
         }
         let read_at = read_at.expect("the turn handed the message to the judge, so it was read");
         assert!(read_at >= sent_at, "read after the row was written");
+    }
+
+    // ── Task 2: render_compose_payload / build_delegated_image_marker(edit_of) ──
+
+    /// Build a `CompanionPersona` with `art_metadata.appearance` set, matching
+    /// the construction pattern from `pde_test_persona` above.
+    fn test_persona_with_appearance(
+        appearance: &str,
+    ) -> eros_engine_core::persona::CompanionPersona {
+        use eros_engine_core::persona::{CompanionPersona, PersonaGenome, PersonaInstance};
+        let iid = uuid::Uuid::new_v4();
+        let gid = uuid::Uuid::new_v4();
+        let oid = uuid::Uuid::new_v4();
+        CompanionPersona {
+            instance_id: iid,
+            genome: PersonaGenome {
+                id: gid,
+                name: "Mia".into(),
+                system_prompt: "You are Mia.".into(),
+                tip_personality: Some("normal".into()),
+                art_metadata: serde_json::json!({ "appearance": appearance }),
+            },
+            instance: PersonaInstance {
+                id: iid,
+                genome_id: gid,
+                owner_uid: oid,
+                status: "active".into(),
+            },
+        }
+    }
+
+    #[test]
+    fn render_compose_payload_fills_empty_slots_with_placeholders() {
+        // Locks the placeholder behaviour that used to live inside
+        // run_image_prompt_compose: the extraction must not change what the
+        // chat path sends.
+        let persona = test_persona_with_appearance("");
+        let out = render_compose_payload(&persona, "  ", "", None, "realistic");
+        assert!(out.contains("[人物外观]\n（无）"), "got {out}");
+        assert!(out.contains("[最近场景]\n（无）"), "got {out}");
+        assert!(out.contains("[对方最新消息]\n（无）"), "got {out}");
+        assert!(out.contains("[画幅]\n（未指定）"), "got {out}");
+        assert!(out.contains("[风格]\nrealistic"), "got {out}");
+    }
+
+    #[test]
+    fn render_compose_payload_passes_real_values_through() {
+        let persona = test_persona_with_appearance("银发红瞳");
+        let out = render_compose_payload(&persona, "在天台", "拍张照", Some("3:4"), "anime");
+        assert!(out.contains("[人物外观]\n银发红瞳"), "got {out}");
+        assert!(out.contains("[最近场景]\n在天台"), "got {out}");
+        assert!(out.contains("[对方最新消息]\n拍张照"), "got {out}");
+        assert!(out.contains("[画幅]\n3:4"), "got {out}");
+    }
+
+    #[test]
+    fn delegated_image_marker_carries_edit_of_only_when_present() {
+        let id = Uuid::new_v4();
+        let with = build_delegated_image_marker(
+            "s",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            eros_engine_core::types::ImageRef::Previous,
+            Some(id),
+        );
+        assert_eq!(with["edit_of"], serde_json::json!(id.to_string()));
+        assert_eq!(with["image_ref"], serde_json::json!("previous"));
+
+        let without = build_delegated_image_marker(
+            "s",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            eros_engine_core::types::ImageRef::Face,
+            None,
+        );
+        assert!(without.get("edit_of").is_none(), "got {without}");
     }
 }

--- a/crates/eros-engine-server/src/routes/image_edit.rs
+++ b/crates/eros-engine-server/src/routes/image_edit.rs
@@ -217,6 +217,61 @@ mod payload_tests {
         let out = compose_edit_payload("银发红瞳", "   ", None, "换套衣服", "anime", "3:4");
         assert!(out.contains("[原图]\n（无）"), "got {out}");
     }
+
+    #[test]
+    fn edit_inputs_json_has_exactly_the_seven_documented_keys() {
+        // A renamed or dropped key on this audit row is a silent contract
+        // break for anyone reading `engine.chat_images_events`; lock the key
+        // SET so it fails here instead of shipping.
+        use eros_engine_core::persona::{CompanionPersona, PersonaGenome, PersonaInstance};
+        let iid = uuid::Uuid::new_v4();
+        let gid = uuid::Uuid::new_v4();
+        let persona = CompanionPersona {
+            instance_id: iid,
+            genome: PersonaGenome {
+                id: gid,
+                name: "Mia".into(),
+                system_prompt: "You are Mia.".into(),
+                tip_personality: Some("normal".into()),
+                art_metadata: serde_json::json!({ "appearance": "银发红瞳" }),
+            },
+            instance: PersonaInstance {
+                id: iid,
+                genome_id: gid,
+                owner_uid: uuid::Uuid::new_v4(),
+                status: "active".into(),
+            },
+        };
+        let value = super::compose_edit_inputs_json(
+            &persona,
+            uuid::Uuid::new_v4(),
+            "在天台看夕阳的少女",
+            Some("在天台看夕阳"),
+            "换套衣服",
+            "anime",
+            Some("3:4"),
+        );
+        let mut keys: Vec<&str> = value
+            .as_object()
+            .expect("object")
+            .keys()
+            .map(String::as_str)
+            .collect();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            vec![
+                "appearance",
+                "aspect_ratio",
+                "instruction",
+                "source_caption",
+                "source_message_id",
+                "source_subject",
+                "style",
+            ],
+            "got {value}"
+        );
+    }
 }
 
 /// Revise an existing image turn.
@@ -664,6 +719,27 @@ mod tests {
                 &token,
                 json!({"instruction": "换套衣服", "aspect_ratio": "7:3"}),
             ),
+        )
+        .await;
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn image_edit_422_when_instruction_exceeds_max_chars(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+        let (_, mid) = seed_image_turn(&pool, session_id).await;
+
+        let state = test_state(pool);
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        let too_long = "换".repeat(MAX_INSTRUCTION_CHARS + 1);
+        let (status, _) = send_request(
+            &mut app,
+            edit_req(session_id, mid, &token, json!({"instruction": too_long})),
         )
         .await;
         assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);

--- a/crates/eros-engine-server/src/routes/image_edit.rs
+++ b/crates/eros-engine-server/src/routes/image_edit.rs
@@ -1,0 +1,952 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! `POST /v2/comp/session/{session_id}/message/{message_id}/image/edit`
+//!
+//! Revise a picture the character already sent: the consumer names the image
+//! turn and says what to change ("换套衣服"), and the engine composes a new
+//! image prompt from that picture's subject and force-emits an image turn for
+//! it. The engine composes; the consumer draws — the delegation contract from
+//! v0.7.1 is unchanged, and the persisted row is an ordinary image turn, so
+//! history discovery and the v1 recovery endpoint work on it unmodified.
+//!
+//! Nothing else about a turn runs here: no PDE verdict, no affinity, no
+//! insight or memory extraction, no queue.
+
+use axum::extract::{Extension, Path, State};
+use axum::Json;
+use base64::Engine as _;
+use serde::{Deserialize, Serialize};
+use ulid::Ulid;
+use utoipa_axum::{router::OpenApiRouter, routes};
+use uuid::Uuid;
+
+use eros_engine_llm::model_config::StyleKey;
+use eros_engine_store::chat::{AssistantInsert, ChatRepo};
+use eros_engine_store::image_events::ImageComposeEventInsert;
+use eros_engine_store::persona::PersonaRepo;
+
+use crate::auth::middleware::AuthUser;
+use crate::error::AppError;
+use crate::pipeline::handlers::compose_image_prompt;
+use crate::pipeline::stream::{
+    build_delegated_image_marker, record_compose_event, run_image_prompt_compose, split_failures,
+};
+use crate::routes::companion::require_session_for_user;
+use crate::routes::companion_stream::aspect_ratio_supported;
+use crate::routes::persona::compose_chain_exhausted;
+use crate::state::AppState;
+
+/// Wire task name; also the config block name.
+const EDIT_TASK: &str = "chat_image_edit_compose";
+/// Same ceiling as the standalone composer's `content`.
+const MAX_INSTRUCTION_CHARS: usize = 4096;
+/// Same per-user in-flight cap as every other LLM entry point.
+const CONCURRENT_STREAMS_PER_USER: u32 = 3;
+
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
+pub struct ImageEditRequest {
+    /// What to change, in the user's words ("换套衣服"). Required, non-blank.
+    pub instruction: String,
+    /// Style preset for the new picture. Default `realistic`; pass the style
+    /// the source was drawn with — the engine does not record it.
+    #[serde(default)]
+    #[schema(value_type = Option<String>)]
+    pub style: Option<StyleKey>,
+    /// Same allow-list as the chat path. Defaults to the source turn's
+    /// `aspect_ratio`.
+    #[serde(default)]
+    pub aspect_ratio: Option<String>,
+    /// `[tasks.chat_image_edit_compose].filter_prompt` variant, with the same
+    /// selection rules as the chat path's `image.prompt_variant`.
+    #[serde(default)]
+    pub prompt_variant: Option<String>,
+}
+
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct ImageEditResponse {
+    /// The new assistant message.
+    #[schema(value_type = String)]
+    pub message_id: Uuid,
+    /// The image turn this revises.
+    #[schema(value_type = String)]
+    pub edit_of: Uuid,
+    /// Base64 (STANDARD) of the UTF-8 composed prompt — the same encoding as
+    /// the SSE `image_request` frame, so an existing draw path consumes it
+    /// unchanged.
+    pub composed_prompt: String,
+    /// Always `"previous"`: on an edit turn that means the `edit_of` picture.
+    pub image_ref: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub aspect_ratio: Option<String>,
+    /// The composer's caption for the new picture.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub caption: Option<String>,
+}
+
+/// The edit composer's payload. Mirrors `compose_user_payload`'s five slots,
+/// with `[原图]` replacing `[最近场景]`/`[对方最新消息]`. Pure.
+pub(crate) fn compose_edit_payload(
+    appearance: &str,
+    source_subject: &str,
+    source_caption: Option<&str>,
+    instruction: &str,
+    style: &str,
+    aspect_ratio: &str,
+) -> String {
+    let subject = source_subject.trim();
+    let mut original = if subject.is_empty() {
+        "（无）".to_string()
+    } else {
+        subject.to_string()
+    };
+    if let Some(c) = source_caption.map(str::trim).filter(|s| !s.is_empty()) {
+        original.push('\n');
+        original.push_str(c);
+    }
+    format!(
+        "[人物外观]\n{appearance}\n\n[原图]\n{original}\n\n[修改要求]\n{instruction}\n\n[风格]\n{style}\n\n[画幅]\n{aspect_ratio}"
+    )
+}
+
+/// `compose_edit_payload` with the persona's appearance and the placeholders
+/// the prompt expects for empty slots — the edit-side twin of
+/// `render_compose_payload`.
+fn render_edit_payload(
+    persona: &eros_engine_core::persona::CompanionPersona,
+    source_subject: &str,
+    source_caption: Option<&str>,
+    instruction: &str,
+    aspect_ratio: Option<&str>,
+    style: &str,
+) -> String {
+    let appearance = crate::prompt::meta_str(persona, "appearance")
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or("（无）");
+    compose_edit_payload(
+        appearance,
+        source_subject,
+        source_caption,
+        instruction,
+        style,
+        aspect_ratio.unwrap_or("（未指定）"),
+    )
+}
+
+/// The audit row's `inputs`: seven keys, engine-supplied, never concatenated.
+/// The `source` column says which shape to expect (the chat composer writes
+/// five).
+fn compose_edit_inputs_json(
+    persona: &eros_engine_core::persona::CompanionPersona,
+    source_message_id: Uuid,
+    source_subject: &str,
+    source_caption: Option<&str>,
+    instruction: &str,
+    style: &str,
+    aspect_ratio: Option<&str>,
+) -> serde_json::Value {
+    serde_json::json!({
+        "appearance": crate::prompt::meta_str(persona, "appearance")
+            .map(str::trim)
+            .unwrap_or(""),
+        "source_message_id": source_message_id.to_string(),
+        "source_subject": source_subject.trim(),
+        "source_caption": source_caption.map(str::trim).unwrap_or(""),
+        "instruction": instruction.trim(),
+        "style": style,
+        "aspect_ratio": aspect_ratio.unwrap_or(""),
+    })
+}
+
+fn validate(req: &ImageEditRequest) -> Result<(), AppError> {
+    if req.instruction.trim().is_empty() {
+        return Err(AppError::Unprocessable(
+            "instruction must not be blank".into(),
+        ));
+    }
+    if req.instruction.chars().count() > MAX_INSTRUCTION_CHARS {
+        return Err(AppError::Unprocessable(
+            "instruction exceeds 4096 chars".into(),
+        ));
+    }
+    if let Some(ar) = req.aspect_ratio.as_deref() {
+        if !aspect_ratio_supported(ar) {
+            return Err(AppError::Unprocessable("unsupported aspect_ratio".into()));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod payload_tests {
+    use super::compose_edit_payload;
+
+    #[test]
+    fn edit_payload_renders_every_slot() {
+        let out = compose_edit_payload(
+            "银发红瞳",
+            "在天台看夕阳的少女",
+            Some("在天台看夕阳"),
+            "换套衣服",
+            "anime",
+            "3:4",
+        );
+        assert!(out.contains("[人物外观]\n银发红瞳"), "got {out}");
+        assert!(
+            out.contains("[原图]\n在天台看夕阳的少女\n在天台看夕阳"),
+            "got {out}"
+        );
+        assert!(out.contains("[修改要求]\n换套衣服"), "got {out}");
+        assert!(out.contains("[风格]\nanime"), "got {out}");
+        assert!(out.contains("[画幅]\n3:4"), "got {out}");
+    }
+
+    #[test]
+    fn edit_payload_omits_the_caption_line_when_absent() {
+        let out = compose_edit_payload("银发红瞳", "少女", None, "换套衣服", "anime", "3:4");
+        assert!(out.contains("[原图]\n少女\n\n[修改要求]"), "got {out}");
+
+        let blank =
+            compose_edit_payload("银发红瞳", "少女", Some("  "), "换套衣服", "anime", "3:4");
+        assert!(blank.contains("[原图]\n少女\n\n[修改要求]"), "got {blank}");
+    }
+
+    #[test]
+    fn edit_payload_placeholders_an_empty_source_subject() {
+        // A source drawn through the portrait fallback has no subject; the
+        // composer still works from appearance plus instruction.
+        let out = compose_edit_payload("银发红瞳", "   ", None, "换套衣服", "anime", "3:4");
+        assert!(out.contains("[原图]\n（无）"), "got {out}");
+    }
+}
+
+/// Revise an existing image turn.
+///
+/// The instruction is an input to a picture, not something the user said to
+/// the character: it is recorded on the audit row, never as a chat message.
+/// The new assistant row inherits the source's `user_message_id`, so the edit
+/// belongs to the turn the original picture answered.
+#[utoipa::path(
+    post,
+    path = "/v2/comp/session/{session_id}/message/{message_id}/image/edit",
+    tag = "companion",
+    params(
+        ("session_id" = Uuid, Path, description = "Chat session id"),
+        ("message_id" = Uuid, Path, description = "The image turn to revise")
+    ),
+    request_body = ImageEditRequest,
+    responses(
+        (status = 200, body = ImageEditResponse),
+        (status = 401, description = "missing or invalid bearer"),
+        (status = 403, description = "not your session"),
+        (status = 404, description = "session or message not found"),
+        (status = 409, description = "the message is not an image turn"),
+        (status = 422, description = "blank instruction or unsupported aspect_ratio"),
+        (status = 429, description = "per-user in-flight cap reached"),
+        (status = 501, description = "no image composer configured on this deployment"),
+        (status = "5XX", description = "composer chain exhausted; the provider's own status \
+            passes through, same body as the compose endpoint")
+    ),
+    security(("bearer" = []))
+)]
+async fn edit_image(
+    State(state): State<AppState>,
+    Path((session_id, message_id)): Path<(Uuid, Uuid)>,
+    Extension(AuthUser(user_id)): Extension<AuthUser>,
+    Json(req): Json<ImageEditRequest>,
+) -> Result<Json<ImageEditResponse>, AppError> {
+    // Ownership and state first, body second: a caller must not learn that
+    // their aspect_ratio was invalid on a session they do not own.
+    let session = require_session_for_user(&state, session_id, user_id).await?;
+    let chat_repo = ChatRepo { pool: &state.pool };
+    let source = chat_repo
+        .message_by_id_in_session(session_id, message_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("no such message".into()))?;
+    let marker = source
+        .metadata
+        .as_ref()
+        .and_then(|m| m.get("image"))
+        .cloned()
+        .ok_or_else(|| AppError::Conflict("not an image turn".into()))?;
+    // The edit belongs to the turn the source answered; a source with no turn
+    // has nothing to attach to. No engine path produces one.
+    let source_user_message_id = source.user_message_id.ok_or_else(|| {
+        AppError::Conflict("source image turn has no originating user message".into())
+    })?;
+    let instance_id = session
+        .instance_id
+        .ok_or_else(|| AppError::Conflict("session has no persona instance".into()))?;
+
+    validate(&req)?;
+
+    if !state.model_config.has_task(EDIT_TASK)
+        && !state.model_config.has_task("chat_image_prompt_compose")
+    {
+        return Err(AppError::NotImplemented(
+            "no image composer is configured on this deployment".into(),
+        ));
+    }
+
+    // Same per-user in-flight pool as chat, voice and the compose endpoint:
+    // this is one more user-triggered LLM call.
+    let _guard = state
+        .stream_slots
+        .try_acquire(user_id, CONCURRENT_STREAMS_PER_USER)
+        .ok_or_else(|| AppError::TooManyRequests("per-user in-flight cap reached".into()))?;
+
+    let persona = PersonaRepo { pool: &state.pool }
+        .load_companion(instance_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("no such instance".into()))?;
+
+    let source_subject = marker
+        .get("prompt")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
+    let source_caption = marker.get("caption").and_then(|v| v.as_str());
+    let aspect_ratio = req.aspect_ratio.clone().or_else(|| {
+        marker
+            .get("aspect_ratio")
+            .and_then(|v| v.as_str())
+            .map(str::to_owned)
+    });
+    let style_key = req.style.unwrap_or_default();
+    let style_str = serde_json::to_value(style_key)
+        .ok()
+        .and_then(|v| v.as_str().map(String::from))
+        .unwrap_or_else(|| "realistic".to_string());
+    let instruction = req.instruction.trim().to_string();
+
+    let resolved = state
+        .model_config
+        .resolve_image_edit_compose(req.prompt_variant.as_deref())
+        .expect("has_task checked above");
+    let run = run_image_prompt_compose(
+        &state,
+        &resolved,
+        &render_edit_payload(
+            &persona,
+            source_subject,
+            source_caption,
+            &instruction,
+            aspect_ratio.as_deref(),
+            &style_str,
+        ),
+        EDIT_TASK,
+    )
+    .await;
+
+    let inputs = compose_edit_inputs_json(
+        &persona,
+        message_id,
+        source_subject,
+        source_caption,
+        &instruction,
+        &style_str,
+        aspect_ratio.as_deref(),
+    );
+    let (llm_attempts, gateway_errors) = split_failures(&run.failures);
+
+    let Some(outcome) = run.outcome else {
+        // No portrait fallback here: an edit that ignored its instruction is
+        // worse than an error, and the caller can retry.
+        record_compose_event(
+            &state.pool,
+            ImageComposeEventInsert {
+                llm_attempts,
+                gateway_errors,
+                source: "image_edit",
+                user_id,
+                instance_id: Some(instance_id),
+                session_id: Some(session_id),
+                status: "exhausted",
+                inputs,
+                subject: None,
+                caption: None,
+                composed_prompt: None,
+                variant: resolved.variant_key.as_deref(),
+                model: run.last_model.as_deref(),
+                usage: run.last_usage.clone(),
+                generation_id: run.last_generation_id.as_deref(),
+                attempts: run.attempts,
+                last_failure: run.last_failure,
+            },
+        )
+        .await;
+        return Err(compose_chain_exhausted(
+            &run.failures,
+            run.last_failure,
+            EDIT_TASK,
+        ));
+    };
+
+    let composed_prompt = compose_image_prompt(style_key, &persona, &outcome.prompt);
+    let compose_event_id = record_compose_event(
+        &state.pool,
+        ImageComposeEventInsert {
+            llm_attempts,
+            gateway_errors,
+            source: "image_edit",
+            user_id,
+            instance_id: Some(instance_id),
+            session_id: Some(session_id),
+            status: "ok",
+            inputs,
+            subject: Some(outcome.prompt.as_str()),
+            caption: outcome.caption.as_deref(),
+            composed_prompt: Some(composed_prompt.as_str()),
+            variant: outcome.variant.as_deref(),
+            model: Some(outcome.model.as_str()),
+            usage: outcome.usage.clone(),
+            generation_id: outcome.generation_id.as_deref(),
+            attempts: run.attempts,
+            last_failure: None,
+        },
+    )
+    .await;
+
+    // ULID-shaped id, like every other assistant row.
+    let new_id: Uuid = Ulid::new().into();
+    let image_marker = build_delegated_image_marker(
+        &outcome.prompt,
+        outcome.caption.as_deref(),
+        aspect_ratio.as_deref(),
+        outcome.variant.as_deref(),
+        Some(outcome.model.as_str()),
+        outcome.generation_id.as_deref(),
+        compose_event_id,
+        eros_engine_core::types::ImageRef::Previous,
+        Some(message_id),
+    );
+    chat_repo
+        .insert_assistant_batch(
+            session_id,
+            source_user_message_id,
+            &[AssistantInsert {
+                id: new_id,
+                content: String::new(),
+                assistant_action_type: "reply".into(),
+                continues_from_message_id: None,
+                truncated: false,
+                model: None,
+                usage: None,
+                generation_id: None,
+                filter_audit: None,
+                metadata: Some(serde_json::json!({ "image": image_marker })),
+                llm_attempts: None,
+                gateway_errors: None,
+            }],
+        )
+        .await?;
+
+    Ok(Json(ImageEditResponse {
+        message_id: new_id,
+        edit_of: message_id,
+        composed_prompt: base64::engine::general_purpose::STANDARD
+            .encode(composed_prompt.as_bytes()),
+        image_ref: "previous".into(),
+        aspect_ratio,
+        caption: outcome.caption,
+    }))
+}
+
+pub fn router() -> OpenApiRouter<AppState> {
+    OpenApiRouter::new().routes(routes!(edit_image))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::{header, Request, StatusCode};
+    use serde_json::json;
+    use sqlx::PgPool;
+    use std::sync::Arc;
+    use uuid::Uuid;
+    use wiremock::matchers::path as wm_path;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::routes::companion::test_state;
+    use crate::routes::companion::testutil::{
+        build_router, mint_test_jwt, seed_genome, seed_instance, seed_session, send_request,
+    };
+
+    /// State with an edit-capable composer pointed at the mock.
+    fn with_composer(mut state: AppState, mock_uri: &str, toml: &str) -> AppState {
+        state.model_config =
+            Arc::new(eros_engine_llm::model_config::ModelConfig::from_toml_str(toml).unwrap());
+        state.openrouter = Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                format!("{mock_uri}/api/v1/chat/completions"),
+            ),
+        );
+        state
+    }
+
+    const EDIT_TASK_TOML: &str = "[tasks.chat_image_edit_compose]\nmodel = \"editor\"\n";
+
+    /// A user row plus an assistant image turn pointing back at it. Returns
+    /// (user_message_id, image_message_id).
+    async fn seed_image_turn(pool: &PgPool, session_id: Uuid) -> (Uuid, Uuid) {
+        let umid: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_messages (session_id, role, content) \
+             VALUES ($1, 'user', '拍张照') RETURNING id",
+        )
+        .bind(session_id)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+        let mid: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_messages \
+               (session_id, role, content, assistant_action_type, user_message_id, metadata) \
+             VALUES ($1, 'assistant', '', 'reply', $2, $3) RETURNING id",
+        )
+        .bind(session_id)
+        .bind(umid)
+        .bind(json!({ "image": {
+            "prompt": "在天台看夕阳的少女",
+            "caption": "在天台看夕阳",
+            "image_ref": "face",
+            "aspect_ratio": "3:4"
+        }}))
+        .fetch_one(pool)
+        .await
+        .unwrap();
+        (umid, mid)
+    }
+
+    async fn seed_text_turn(pool: &PgPool, session_id: Uuid) -> Uuid {
+        sqlx::query_scalar(
+            "INSERT INTO engine.chat_messages (session_id, role, content, assistant_action_type) \
+             VALUES ($1, 'assistant', '在的', 'reply') RETURNING id",
+        )
+        .bind(session_id)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+    }
+
+    async fn mount_editor(mock: &MockServer) {
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "gen-edit",
+                "model": "served/editor",
+                "choices": [{"message": {"content":
+                    r#"{"prompt":"EDITED SUBJECT","caption":"换了条裙子"}"#}}],
+            })))
+            .mount(mock)
+            .await;
+    }
+
+    fn edit_req(
+        session_id: Uuid,
+        message_id: Uuid,
+        jwt: &str,
+        body: serde_json::Value,
+    ) -> Request<Body> {
+        Request::builder()
+            .method("POST")
+            .uri(format!(
+                "/v2/comp/session/{session_id}/message/{message_id}/image/edit"
+            ))
+            .header(header::AUTHORIZATION, format!("Bearer {jwt}"))
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap()
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn image_edit_404_when_session_unknown(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let state = test_state(pool);
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+        let (status, _) = send_request(
+            &mut app,
+            edit_req(
+                Uuid::new_v4(),
+                Uuid::new_v4(),
+                &token,
+                json!({"instruction": "换套衣服"}),
+            ),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn image_edit_403_when_session_not_owned(pool: PgPool) {
+        let owner = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, owner).await;
+        let session_id = seed_session(&pool, owner, instance_id).await;
+        let (_, mid) = seed_image_turn(&pool, session_id).await;
+
+        let state = test_state(pool);
+        let mut app = build_router(state);
+        let token = mint_test_jwt(Uuid::new_v4()); // someone else
+        let (status, _) = send_request(
+            &mut app,
+            edit_req(session_id, mid, &token, json!({"instruction": "换套衣服"})),
+        )
+        .await;
+        assert_eq!(status, StatusCode::FORBIDDEN);
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn image_edit_404_when_message_not_in_session(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+
+        let state = test_state(pool);
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+        let (status, _) = send_request(
+            &mut app,
+            edit_req(
+                session_id,
+                Uuid::new_v4(),
+                &token,
+                json!({"instruction": "换套衣服"}),
+            ),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn image_edit_409_when_not_an_image_turn(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+        let mid = seed_text_turn(&pool, session_id).await;
+
+        let state = test_state(pool);
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+        let (status, body) = send_request(
+            &mut app,
+            edit_req(session_id, mid, &token, json!({"instruction": "换套衣服"})),
+        )
+        .await;
+        // 409, NOT 404: the message was found; its state forbids the action.
+        assert_eq!(status, StatusCode::CONFLICT, "body={body}");
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn image_edit_422_on_blank_instruction_and_bad_aspect_ratio(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+        let (_, mid) = seed_image_turn(&pool, session_id).await;
+
+        let state = test_state(pool);
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        let (status, _) = send_request(
+            &mut app,
+            edit_req(session_id, mid, &token, json!({"instruction": "   "})),
+        )
+        .await;
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+
+        let (status, _) = send_request(
+            &mut app,
+            edit_req(
+                session_id,
+                mid,
+                &token,
+                json!({"instruction": "换套衣服", "aspect_ratio": "7:3"}),
+            ),
+        )
+        .await;
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn image_edit_501_when_no_composer_configured(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+        let (_, mid) = seed_image_turn(&pool, session_id).await;
+
+        // test_state's default model config has neither composer task.
+        let state = test_state(pool);
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+        let (status, _) = send_request(
+            &mut app,
+            edit_req(session_id, mid, &token, json!({"instruction": "换套衣服"})),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_IMPLEMENTED);
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn image_edit_502_writes_an_audit_row_and_no_message(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+        let (_, mid) = seed_image_turn(&pool, session_id).await;
+
+        let mock = MockServer::start().await;
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&mock)
+            .await;
+
+        let state = with_composer(test_state(pool.clone()), &mock.uri(), EDIT_TASK_TOML);
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+        let (status, _) = send_request(
+            &mut app,
+            edit_req(session_id, mid, &token, json!({"instruction": "换套衣服"})),
+        )
+        .await;
+        assert!(status.is_server_error(), "got {status}");
+
+        let (n_events, exhausted): (i64, i64) = sqlx::query_as(
+            "SELECT count(*), count(*) FILTER (WHERE status = 'exhausted') \
+             FROM engine.chat_images_events WHERE source = 'image_edit' AND session_id = $1",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!((n_events, exhausted), (1, 1));
+
+        // No portrait fallback: nothing was persisted as a message.
+        let n_msgs: i64 =
+            sqlx::query_scalar("SELECT count(*) FROM engine.chat_messages WHERE session_id = $1")
+                .bind(session_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(n_msgs, 2, "only the seeded user + image rows may exist");
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn image_edit_success_persists_the_turn_and_returns_the_payload(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+        let (umid, mid) = seed_image_turn(&pool, session_id).await;
+
+        let mock = MockServer::start().await;
+        mount_editor(&mock).await;
+        let state = with_composer(test_state(pool.clone()), &mock.uri(), EDIT_TASK_TOML);
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        let (status, body) = send_request(
+            &mut app,
+            edit_req(session_id, mid, &token, json!({"instruction": "换套衣服"})),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "body={body}");
+        assert_eq!(body["edit_of"], json!(mid.to_string()));
+        assert_eq!(body["image_ref"], json!("previous"));
+        assert_eq!(body["caption"], json!("换了条裙子"));
+        // Inherited from the source marker when the request omits it.
+        assert_eq!(body["aspect_ratio"], json!("3:4"));
+
+        use base64::Engine as _;
+        let decoded = String::from_utf8(
+            base64::engine::general_purpose::STANDARD
+                .decode(body["composed_prompt"].as_str().unwrap())
+                .unwrap(),
+        )
+        .unwrap();
+        assert!(decoded.contains("EDITED SUBJECT"), "got {decoded}");
+
+        let new_id = Uuid::parse_str(body["message_id"].as_str().unwrap()).unwrap();
+        let (content, action, row_umid, metadata): (
+            String,
+            Option<String>,
+            Option<Uuid>,
+            serde_json::Value,
+        ) = sqlx::query_as(
+            "SELECT content, assistant_action_type, user_message_id, metadata \
+                 FROM engine.chat_messages WHERE id = $1",
+        )
+        .bind(new_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(content, "");
+        assert_eq!(action.as_deref(), Some("reply"));
+        assert_eq!(
+            row_umid,
+            Some(umid),
+            "the edit belongs to the source's turn"
+        );
+        assert_eq!(metadata["image"]["edit_of"], json!(mid.to_string()));
+        assert_eq!(metadata["image"]["image_ref"], json!("previous"));
+        assert_eq!(metadata["image"]["prompt"], json!("EDITED SUBJECT"));
+
+        // The audit row is linked and records the instruction.
+        let compose_event_id =
+            Uuid::parse_str(metadata["image"]["compose_event_id"].as_str().unwrap()).unwrap();
+        let (source, status_col, instruction): (String, String, String) = sqlx::query_as(
+            "SELECT source, status, inputs->>'instruction' FROM engine.chat_images_events WHERE id = $1",
+        )
+        .bind(compose_event_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(source, "image_edit");
+        assert_eq!(status_col, "ok");
+        assert_eq!(instruction, "换套衣服");
+
+        // `task` is config routing only and never reaches the wire, so prove
+        // the edit task drove this call by what DID: its model chain and its
+        // built-in edit prompt.
+        let reqs = mock.received_requests().await.unwrap();
+        let sent = String::from_utf8_lossy(&reqs[0].body);
+        assert!(
+            sent.contains("editor"),
+            "the edit block's model must be used: {sent}"
+        );
+        assert!(
+            sent.contains("You revise a picture"),
+            "the built-in EDIT prompt must be the system message: {sent}"
+        );
+        assert!(
+            sent.contains("[修改要求]"),
+            "the edit payload must be sent: {sent}"
+        );
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn image_edit_row_is_discoverable_and_recoverable(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+        let (_, mid) = seed_image_turn(&pool, session_id).await;
+
+        let mock = MockServer::start().await;
+        mount_editor(&mock).await;
+        let state = with_composer(test_state(pool.clone()), &mock.uri(), EDIT_TASK_TOML);
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+        let (_, body) = send_request(
+            &mut app,
+            edit_req(session_id, mid, &token, json!({"instruction": "换套衣服"})),
+        )
+        .await;
+        let new_id = body["message_id"].as_str().unwrap().to_string();
+        let composed = body["composed_prompt"].as_str().unwrap().to_string();
+
+        // History flags it like any other image turn.
+        let (status, hist) = send_request(
+            &mut app,
+            Request::builder()
+                .method("GET")
+                .uri(format!("/comp/chat/{session_id}/history"))
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let entry = hist
+            .as_array()
+            .or_else(|| hist["messages"].as_array())
+            .expect("history array")
+            .iter()
+            .find(|e| e["id"] == json!(new_id))
+            .expect("the edit row must appear in history");
+        assert_eq!(entry["image"], json!(true));
+
+        // And the v1 recovery endpoint returns the same prompt for it.
+        let (status, rec) = send_request(
+            &mut app,
+            Request::builder()
+                .method("GET")
+                .uri(format!(
+                    "/comp/chat/{session_id}/messages/{new_id}/image-request"
+                ))
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "body={rec}");
+        assert_eq!(rec["composed_prompt"], json!(composed));
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn an_edit_can_itself_be_edited(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+        let (_, mid) = seed_image_turn(&pool, session_id).await;
+
+        let mock = MockServer::start().await;
+        mount_editor(&mock).await;
+        let state = with_composer(test_state(pool.clone()), &mock.uri(), EDIT_TASK_TOML);
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        let (_, first) = send_request(
+            &mut app,
+            edit_req(session_id, mid, &token, json!({"instruction": "换套衣服"})),
+        )
+        .await;
+        let first_id = Uuid::parse_str(first["message_id"].as_str().unwrap()).unwrap();
+
+        let (status, second) = send_request(
+            &mut app,
+            edit_req(
+                session_id,
+                first_id,
+                &token,
+                json!({"instruction": "换个角度"}),
+            ),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "body={second}");
+        assert_eq!(second["edit_of"], json!(first_id.to_string()));
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn image_edit_429_when_the_per_user_cap_is_reached(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+        let (_, mid) = seed_image_turn(&pool, session_id).await;
+
+        let mock = MockServer::start().await;
+        mount_editor(&mock).await;
+        let state = with_composer(test_state(pool.clone()), &mock.uri(), EDIT_TASK_TOML);
+        // Hold every slot, exactly as the compose endpoint's 429 test does.
+        let _g: Vec<_> = (0..CONCURRENT_STREAMS_PER_USER)
+            .map(|_| {
+                state
+                    .stream_slots
+                    .try_acquire(user_id, CONCURRENT_STREAMS_PER_USER)
+                    .expect("slot")
+            })
+            .collect();
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+        let (status, _) = send_request(
+            &mut app,
+            edit_req(session_id, mid, &token, json!({"instruction": "换套衣服"})),
+        )
+        .await;
+        assert_eq!(status, StatusCode::TOO_MANY_REQUESTS);
+    }
+}

--- a/crates/eros-engine-server/src/routes/image_edit.rs
+++ b/crates/eros-engine-server/src/routes/image_edit.rs
@@ -540,6 +540,11 @@ mod tests {
     }
 
     const EDIT_TASK_TOML: &str = "[tasks.chat_image_edit_compose]\nmodel = \"editor\"\n";
+    /// No `[tasks.chat_image_edit_compose]` — the config every existing
+    /// deployment is already in. Exercises the fallback branch of
+    /// `resolve_image_edit_compose` and the handler's
+    /// `.expect("has_task checked above")`.
+    const COMPOSE_ONLY_TOML: &str = "[tasks.chat_image_prompt_compose]\nmodel = \"composer\"\n";
 
     /// A user row plus an assistant image turn pointing back at it. Returns
     /// (user_message_id, image_message_id).
@@ -899,6 +904,45 @@ mod tests {
         assert!(
             sent.contains("[修改要求]"),
             "the edit payload must be sent: {sent}"
+        );
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn image_edit_falls_back_to_the_compose_chain_and_the_built_in_edit_prompt(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+        let (_, mid) = seed_image_turn(&pool, session_id).await;
+
+        let mock = MockServer::start().await;
+        mount_editor(&mock).await;
+        // Only [tasks.chat_image_prompt_compose] is configured — no
+        // [tasks.chat_image_edit_compose] block at all.
+        let state = with_composer(test_state(pool.clone()), &mock.uri(), COMPOSE_ONLY_TOML);
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        let (status, body) = send_request(
+            &mut app,
+            edit_req(session_id, mid, &token, json!({"instruction": "换套衣服"})),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "body={body}");
+
+        // The chat composer's chain drove the call (its model is "composer"),
+        // but the built-in EDIT prompt was used — never the chat composer's
+        // own filter_prompt, which is written to compose from conversation
+        // context, not to revise a picture.
+        let reqs = mock.received_requests().await.unwrap();
+        let sent = String::from_utf8_lossy(&reqs[0].body);
+        assert!(
+            sent.contains("composer"),
+            "the compose block's model must drive the fallback chain: {sent}"
+        );
+        assert!(
+            sent.contains("You revise a picture"),
+            "the built-in EDIT prompt must be used, not the chat composer's own prompt: {sent}"
         );
     }
 

--- a/crates/eros-engine-server/src/routes/image_edit.rs
+++ b/crates/eros-engine-server/src/routes/image_edit.rs
@@ -544,7 +544,11 @@ mod tests {
     /// deployment is already in. Exercises the fallback branch of
     /// `resolve_image_edit_compose` and the handler's
     /// `.expect("has_task checked above")`.
-    const COMPOSE_ONLY_TOML: &str = "[tasks.chat_image_prompt_compose]\nmodel = \"composer\"\n";
+    ///
+    /// The compose block carries its own `filter_prompt` so the fallback test
+    /// below has something to prove was NOT used — without it, a handler that
+    /// wrongly reused the chat composer's prompt would still pass.
+    const COMPOSE_ONLY_TOML: &str = "[tasks.chat_image_prompt_compose]\nmodel = \"composer\"\nfilter_prompt = \"CHAT COMPOSER PROMPT MUST NOT BE USED FOR EDITS\"\n";
 
     /// A user row plus an assistant image turn pointing back at it. Returns
     /// (user_message_id, image_message_id).
@@ -943,6 +947,10 @@ mod tests {
         assert!(
             sent.contains("You revise a picture"),
             "the built-in EDIT prompt must be used, not the chat composer's own prompt: {sent}"
+        );
+        assert!(
+            !sent.contains("CHAT COMPOSER PROMPT MUST NOT BE USED FOR EDITS"),
+            "the chat composer's filter_prompt must never reach the edit call: {sent}"
         );
     }
 

--- a/crates/eros-engine-server/src/routes/mod.rs
+++ b/crates/eros-engine-server/src/routes/mod.rs
@@ -21,6 +21,7 @@ pub mod companion_async;
 pub mod companion_stream;
 pub mod dto;
 pub mod health;
+pub mod image_edit;
 pub mod insight;
 pub mod persona;
 pub mod voice;
@@ -43,6 +44,7 @@ pub fn router(state: AppState) -> OpenApiRouter<AppState> {
         .merge(world_town::router())
         .merge(persona::router())
         .merge(insight::router())
+        .merge(image_edit::router())
         .layer(from_fn_with_state(state.clone(), require_auth));
 
     OpenApiRouter::new().merge(health::router()).merge(comp)
@@ -63,6 +65,7 @@ pub fn router_for_openapi() -> OpenApiRouter<AppState> {
         .merge(world_town::router())
         .merge(persona::router())
         .merge(insight::router())
+        .merge(image_edit::router())
 }
 
 /// The generated OpenAPI document as JSON, for tests that assert on the wire

--- a/crates/eros-engine-server/src/routes/persona.rs
+++ b/crates/eros-engine-server/src/routes/persona.rs
@@ -25,8 +25,9 @@ use crate::error::{AppError, StreamPreError};
 use crate::pipeline::handlers::compose_image_prompt;
 use crate::pipeline::stream::{
     compose_inputs_json, compose_user_payload, error_frame_fields_from_last,
-    operation_failure_pointer, parse_compose_reply, record_compose_event, run_image_prompt_compose,
-    split_failures, stream_error_code_for, StreamErrorCode, FILTER_TIMEOUT,
+    operation_failure_pointer, parse_compose_reply, record_compose_event, render_compose_payload,
+    run_image_prompt_compose, split_failures, stream_error_code_for, StreamErrorCode,
+    FILTER_TIMEOUT,
 };
 use crate::routes::companion_stream::aspect_ratio_supported;
 use crate::state::{AppState, StreamSlotGuard};
@@ -176,13 +177,14 @@ fn validate(req: &ComposeRequest) -> Result<(), AppError> {
 /// has no typed failure at all — those calls succeeded and were billed — so it
 /// falls back to the chain-scoped `ChainExhausted`, with the coarse tag folded
 /// into the message.
-fn compose_chain_exhausted(
+pub(crate) fn compose_chain_exhausted(
     failures: &[eros_engine_llm::failure::AttemptFailure],
     last_failure: Option<&str>,
+    task: &'static str,
 ) -> AppError {
     let f = failures.last().cloned().unwrap_or_else(|| {
         eros_engine_llm::failure::AttemptFailure::Gateway(eros_engine_llm::failure::GatewayError {
-            task: "chat_image_prompt_compose".into(),
+            task: task.into(),
             model: None,
             kind: eros_engine_llm::failure::GatewayKind::ChainExhausted,
             message: format!(
@@ -330,11 +332,14 @@ pub async fn compose_image(
     let run = run_image_prompt_compose(
         &state,
         &resolved,
-        &persona,
-        &scene,
-        &content,
-        req.aspect_ratio.as_deref(),
-        &style_str,
+        &render_compose_payload(
+            &persona,
+            &scene,
+            &content,
+            req.aspect_ratio.as_deref(),
+            &style_str,
+        ),
+        "chat_image_prompt_compose",
     )
     .await;
 
@@ -384,7 +389,11 @@ pub async fn compose_image(
             },
         )
         .await;
-        return Err(compose_chain_exhausted(&run.failures, run.last_failure));
+        return Err(compose_chain_exhausted(
+            &run.failures,
+            run.last_failure,
+            "chat_image_prompt_compose",
+        ));
     };
 
     let composed_prompt = compose_image_prompt(style_key, &persona, &outcome.prompt);
@@ -731,7 +740,11 @@ async fn compose_stream(
             },
         )
         .await;
-        return Err(compose_chain_exhausted(&chain_failures, Some(last_failure)));
+        return Err(compose_chain_exhausted(
+            &chain_failures,
+            Some(last_failure),
+            "chat_image_prompt_compose",
+        ));
     };
 
     let frames = async_stream::stream! {

--- a/crates/eros-engine-store/migrations/0057_chat_images_events_image_edit.sql
+++ b/crates/eros-engine-store/migrations/0057_chat_images_events_image_edit.sql
@@ -7,6 +7,15 @@
 -- an edit instruction — so its calls belong in the same table. Its `inputs`
 -- carries seven keys rather than the chat composer's five; `source` says which
 -- shape to expect.
+--
+-- The old CHECK is found by column, not by name or by definition text: 0045
+-- never named it, so there's no fixed name to target, and matching the
+-- definition text (e.g. ILIKE '%source%') would also catch any future CHECK
+-- that merely mentions the word "source" in its expression — and `SELECT ...
+-- INTO` below takes the first match silently rather than erroring on more
+-- than one. Matching con.conkey against `source`'s attnum instead pins the
+-- lookup to "the CHECK whose column set is exactly {source}", which is
+-- unambiguous regardless of constraint name or expression wording.
 
 DO $$
 DECLARE
@@ -16,10 +25,11 @@ BEGIN
     FROM pg_constraint con
     JOIN pg_class rel ON rel.oid = con.conrelid
     JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
+    JOIN pg_attribute att ON att.attrelid = rel.oid AND att.attname = 'source'
     WHERE nsp.nspname = 'engine'
       AND rel.relname = 'chat_images_events'
       AND con.contype = 'c'
-      AND pg_get_constraintdef(con.oid) ILIKE '%source%';
+      AND con.conkey = ARRAY[att.attnum];
     IF cname IS NOT NULL THEN
         EXECUTE format(
             'ALTER TABLE engine.chat_images_events DROP CONSTRAINT %I',

--- a/crates/eros-engine-store/migrations/0057_chat_images_events_image_edit.sql
+++ b/crates/eros-engine-store/migrations/0057_chat_images_events_image_edit.sql
@@ -1,0 +1,37 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+--
+-- `image_edit` joins the composer audit's source vocabulary.
+--
+-- POST /v2/comp/session/{session_id}/message/{message_id}/image/edit runs the
+-- same composer against a different payload — the source picture's subject plus
+-- an edit instruction — so its calls belong in the same table. Its `inputs`
+-- carries seven keys rather than the chat composer's five; `source` says which
+-- shape to expect.
+
+DO $$
+DECLARE
+    cname text;
+BEGIN
+    SELECT con.conname INTO cname
+    FROM pg_constraint con
+    JOIN pg_class rel ON rel.oid = con.conrelid
+    JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
+    WHERE nsp.nspname = 'engine'
+      AND rel.relname = 'chat_images_events'
+      AND con.contype = 'c'
+      AND pg_get_constraintdef(con.oid) ILIKE '%source%';
+    IF cname IS NOT NULL THEN
+        EXECUTE format(
+            'ALTER TABLE engine.chat_images_events DROP CONSTRAINT %I',
+            cname
+        );
+    END IF;
+END $$;
+
+ALTER TABLE engine.chat_images_events
+    ADD CONSTRAINT chat_images_events_source_check
+    CHECK (source IN (
+        'chat_reply_text_image', 'chat_reply_image',
+        'compose_endpoint', 'compose_endpoint_stream',
+        'image_edit'
+    ));

--- a/crates/eros-engine-store/src/image_events.rs
+++ b/crates/eros-engine-store/src/image_events.rs
@@ -369,4 +369,70 @@ mod tests {
         .expect("query relrowsecurity for chat_vision_events");
         assert!(enabled, "RLS must be enabled on engine.chat_vision_events");
     }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn image_edit_is_an_accepted_source(pool: PgPool) {
+        let repo = ImageComposeEventRepo { pool: &pool };
+        let id = repo
+            .record(ImageComposeEventInsert {
+                llm_attempts: None,
+                gateway_errors: None,
+                source: "image_edit",
+                user_id: Uuid::new_v4(),
+                instance_id: Some(Uuid::new_v4()),
+                session_id: Some(Uuid::new_v4()),
+                status: "ok",
+                inputs: serde_json::json!({ "instruction": "换套衣服" }),
+                subject: Some("SUBJECT"),
+                caption: Some("换了条裙子"),
+                composed_prompt: Some("STYLE\n银发红瞳\nSUBJECT"),
+                variant: None,
+                model: Some("m"),
+                usage: None,
+                generation_id: Some("g"),
+                attempts: 1,
+                last_failure: None,
+            })
+            .await
+            .expect("the widened CHECK must accept image_edit");
+
+        let (source, instruction): (String, String) = sqlx::query_as(
+            "SELECT source, inputs->>'instruction' FROM engine.chat_images_events WHERE id = $1",
+        )
+        .bind(id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(source, "image_edit");
+        assert_eq!(instruction, "换套衣服");
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn an_unknown_source_is_still_rejected(pool: PgPool) {
+        // The widening must not have dropped the constraint outright.
+        let repo = ImageComposeEventRepo { pool: &pool };
+        let err = repo
+            .record(ImageComposeEventInsert {
+                llm_attempts: None,
+                gateway_errors: None,
+                source: "not_a_real_source",
+                user_id: Uuid::new_v4(),
+                instance_id: None,
+                session_id: None,
+                status: "ok",
+                inputs: serde_json::json!({}),
+                subject: None,
+                caption: None,
+                composed_prompt: None,
+                variant: None,
+                model: None,
+                usage: None,
+                generation_id: None,
+                attempts: 0,
+                last_failure: None,
+            })
+            .await
+            .expect_err("an unknown source must violate the CHECK");
+        assert!(err.as_database_error().is_some(), "got {err:?}");
+    }
 }

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -567,6 +567,7 @@ insight or memory extraction. The new row inherits the source's
 
 | Status | Meaning |
 |---|---|
+| 401 | missing or invalid bearer |
 | 403 | not your session |
 | 404 | unknown session, or no such message in it |
 | **409** | the message exists but is not an image turn |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -576,6 +576,13 @@ insight or memory extraction. The new row inherits the source's
 | 429 | per-user in-flight cap reached (3, shared with chat/voice/compose) |
 | 5XX | composer chain exhausted — the provider's own status and body, as on the compose endpoint. **No message is persisted**; retry is safe |
 
+A body that fails to deserialize (missing `instruction`, wrong type for
+`style`) or a malformed path UUID is rejected by axum's extractors before any
+of the above, with a framework-shaped plain-text 400/422 — not the
+`{"error", "message"}` shape this endpoint returns. The 422 cases in the table
+above (blank `instruction`, unsupported `aspect_ratio`) are ones the request
+deserialized successfully into, gated after ownership and state as described.
+
 Requires `[tasks.chat_image_edit_compose]` **or** `[tasks.chat_image_prompt_compose]`:
 with only the latter, edits run on the chat composer's chain using the engine's
 built-in edit prompt.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -512,6 +512,73 @@ turn; nothing is coalesced or dropped, only reordered. Worker config
 [Deploying → Operational notes](deploying.md#operational-notes). Design:
 [async chat endpoint spec](superpowers/specs/2026-08-20-async-chat-endpoint-design.md).
 
+### `POST /v2/comp/session/{session_id}/message/{message_id}/image/edit`
+
+Revise a picture the character already sent. `{message_id}` is an image turn —
+a message whose history entry carries `"image": true`. The engine composes a new
+image prompt from that picture's subject plus the instruction, persists a new
+image-only assistant message, and returns its `image_request` payload; the
+consumer draws it, exactly as for a chat image turn.
+
+```json
+{
+  "instruction": "换套衣服",
+  "style": "realistic",
+  "aspect_ratio": "3:4",
+  "prompt_variant": "a"
+}
+```
+
+- `instruction` — required, non-blank, ≤4096 chars. What to change, in the
+  user's words. It is an input to a picture, not a chat message: it is recorded
+  on the audit row and never persisted as conversation.
+- `style` — `realistic` (default) | `semi_realistic` | `anime`. Pass the style
+  the source was drawn with; the engine does not record it on the message.
+- `aspect_ratio` — `1:1` | `3:4` | `4:3` | `9:16` | `16:9`. Defaults to the
+  source turn's.
+- `prompt_variant` — selects a `[tasks.chat_image_edit_compose].filter_prompt`
+  variant, with the same rules as the chat path's `image.prompt_variant`.
+
+```json
+{
+  "message_id": "…",
+  "edit_of": "…",
+  "composed_prompt": "<base64>",
+  "image_ref": "previous",
+  "aspect_ratio": "3:4",
+  "caption": "换了条裙子"
+}
+```
+
+`composed_prompt` is base64(STANDARD) of the UTF-8 wire prompt — the same
+encoding as the SSE `image_request` frame and the recovery endpoint, so an
+existing draw path consumes it unchanged. `image_ref` is always `previous`, and
+on an edit turn that means **the `edit_of` picture**, not whatever the consumer
+drew last.
+
+The new message is an ordinary image turn: it appears in history with
+`"image": true` and its prompt is recoverable via
+`GET /comp/chat/{session_id}/messages/{message_id}/image-request`. Its
+`metadata.image` additionally carries `edit_of`. An edit can itself be edited.
+
+Nothing else about a turn runs: no PDE decision, no affinity movement, no
+insight or memory extraction. The new row inherits the source's
+`user_message_id` — the edit belongs to the turn the original picture answered.
+
+| Status | Meaning |
+|---|---|
+| 403 | not your session |
+| 404 | unknown session, or no such message in it |
+| **409** | the message exists but is not an image turn |
+| 422 | blank `instruction`, or unsupported `aspect_ratio` |
+| 501 | neither `[tasks.chat_image_edit_compose]` nor `[tasks.chat_image_prompt_compose]` is configured |
+| 429 | per-user in-flight cap reached (3, shared with chat/voice/compose) |
+| 5XX | composer chain exhausted — the provider's own status and body, as on the compose endpoint. **No message is persisted**; retry is safe |
+
+Requires `[tasks.chat_image_edit_compose]` **or** `[tasks.chat_image_prompt_compose]`:
+with only the latter, edits run on the chat composer's chain using the engine's
+built-in edit prompt.
+
 ### `GET /comp/chat/{session_id}/history?limit=20&offset=0`
 
 Paginated message history, newest first. `limit` defaults to 20 (capped at 50).

--- a/docs/api-reference.zh.md
+++ b/docs/api-reference.zh.md
@@ -499,6 +499,12 @@ curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json"
 | 429 | 达到每用户并发上限（3，与 chat/voice/compose 共用） |
 | 5XX | 合成链走完仍无输出 —— 透传供应商自己的状态码与响应体，与 compose 端点一致。**不落任何消息**，可安全重试 |
 
+请求体反序列化失败（缺 `instruction`、`style` 类型不对）或路径里的 UUID 格式不对，
+会被 axum 的 extractor 挡在上述判定之前，返回框架自身的纯文本 400/422 ——
+不是本端点的 `{"error", "message"}` 形状。上表里的 422（`instruction` 空白、
+`aspect_ratio` 不支持）是反序列化成功之后，按文中所述顺序、
+排在 ownership 与状态判定之后才触发的。
+
 需要 `[tasks.chat_image_edit_compose]` **或** `[tasks.chat_image_prompt_compose]`：
 只配后者时，编辑走聊天合成器的模型链，用引擎内置的编辑提示词。
 

--- a/docs/api-reference.zh.md
+++ b/docs/api-reference.zh.md
@@ -442,6 +442,65 @@ curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json"
 [部署 → 運維注意事項](deploying.zh.md#運維注意事項)。设计文档：
 [async chat endpoint spec](superpowers/specs/2026-08-20-async-chat-endpoint-design.md)。
 
+### `POST /v2/comp/session/{session_id}/message/{message_id}/image/edit`
+
+改一张角色已经发过的图。`{message_id}` 指向一个图片回合 —— 历史里带
+`"image": true` 的那条消息。引擎用这张图的画面主体加上这条指令合成新的图片
+提示词，落一条新的纯图片 assistant 消息，并返回它的 `image_request` 载荷；
+消费方照常画，与聊天里的图片回合一致。
+
+```json
+{
+  "instruction": "换套衣服",
+  "style": "realistic",
+  "aspect_ratio": "3:4",
+  "prompt_variant": "a"
+}
+```
+
+- `instruction` —— 必填，非空白，≤4096 字。要改什么，用用户自己的话写。
+  它是画图的输入，不是一条聊天消息：只记在审计行上，不落成对话。
+- `style` —— `realistic`（缺省）| `semi_realistic` | `anime`。传原图用的风格；
+  引擎不会把风格记在消息上。
+- `aspect_ratio` —— `1:1` | `3:4` | `4:3` | `9:16` | `16:9`。缺省沿用原图回合的。
+- `prompt_variant` —— 选 `[tasks.chat_image_edit_compose].filter_prompt` 的变体，
+  规则与聊天路径的 `image.prompt_variant` 相同。
+
+```json
+{
+  "message_id": "…",
+  "edit_of": "…",
+  "composed_prompt": "<base64>",
+  "image_ref": "previous",
+  "aspect_ratio": "3:4",
+  "caption": "换了条裙子"
+}
+```
+
+`composed_prompt` 是 UTF-8 提示词的 base64（STANDARD）—— 与 SSE `image_request`
+帧、恢复端点的编码一致，现成的画图链路可直接消费。`image_ref` 恒为 `previous`，
+在编辑回合里它指的是 **`edit_of` 那张图**，不是消费方最后画的那张。
+
+新消息就是一个普通的图片回合：历史里带 `"image": true`，提示词可经
+`GET /comp/chat/{session_id}/messages/{message_id}/image-request` 恢复。它的
+`metadata.image` 另外带一个 `edit_of`。编辑出来的图还可以再编辑。
+
+回合的其余部分一概不跑：不做 PDE 判定、不动好感度、不抽 insight 与记忆。
+新行沿用原图行的 `user_message_id` —— 这次编辑属于原图所回应的那个回合。
+
+| 状态码 | 含义 |
+|---|---|
+| 403 | 不是你的 session |
+| 404 | session 不存在，或该 session 里没有这条消息 |
+| **409** | 消息存在，但不是图片回合 |
+| 422 | `instruction` 空白，或 `aspect_ratio` 不支持 |
+| 501 | `[tasks.chat_image_edit_compose]` 与 `[tasks.chat_image_prompt_compose]` 都没配 |
+| 429 | 达到每用户并发上限（3，与 chat/voice/compose 共用） |
+| 5XX | 合成链走完仍无输出 —— 透传供应商自己的状态码与响应体，与 compose 端点一致。**不落任何消息**，可安全重试 |
+
+需要 `[tasks.chat_image_edit_compose]` **或** `[tasks.chat_image_prompt_compose]`：
+只配后者时，编辑走聊天合成器的模型链，用引擎内置的编辑提示词。
+
 ### `GET /comp/chat/{session_id}/history?limit=20&offset=0`
 
 分頁讀消息歷史，最新在前。`limit` 默认 20（上限 50）。

--- a/docs/api-reference.zh.md
+++ b/docs/api-reference.zh.md
@@ -490,6 +490,7 @@ curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json"
 
 | 状态码 | 含义 |
 |---|---|
+| 401 | bearer 缺失或无效 |
 | 403 | 不是你的 session |
 | 404 | session 不存在，或该 session 里没有这条消息 |
 | **409** | 消息存在，但不是图片回合 |

--- a/docs/llm-audit.md
+++ b/docs/llm-audit.md
@@ -452,6 +452,14 @@ delegated image prompt, or the standalone `POST
 | `gateway_errors` | `JSONB?` | Every hop where our path to the provider broke. NULL when there were none. |
 | `created_at` | `TIMESTAMPTZ` | |
 
+- `image_edit` — `POST /v2/comp/session/{session_id}/message/{message_id}/image/edit`.
+  Its `inputs` carries seven keys rather than the chat composer's five:
+  `appearance`, `source_message_id`, `source_subject`, `source_caption`,
+  `instruction`, `style`, `aspect_ratio`. `source` says which shape to expect.
+  `engine.chat_images_events WHERE source = 'image_edit'` grouped by `status`
+  is the reading for how often edits are asked for and how often the composer
+  refuses.
+
 `status` is deliberately three values: `exhausted` means "no usable compose
 result from this call" for every reason including a mid-stream death on the
 streaming endpoint, and `last_failure` carries the distinction.

--- a/docs/llm-audit.md
+++ b/docs/llm-audit.md
@@ -338,7 +338,7 @@ strictly finer than one would have been: it separates `chat_companion` from
 | `chat_output_filter` | `chat_messages` | assistant |
 | `chat_input_filter` | `chat_messages` | **user** |
 | `chat_vision` | `chat_vision_events` | — |
-| `chat_image_prompt_compose` | `chat_images_events` | — |
+| `chat_image_prompt_compose` / `chat_image_edit_compose` | `chat_images_events` | — |
 | `pde_decision` | `companion_decision_events` | — |
 | `affinity_evaluation` | `companion_affinity_events` | — |
 
@@ -427,13 +427,14 @@ deployment.
 ### `engine.chat_images_events`
 
 One row per image-composer LLM call, from **any** caller — a chat turn's
-delegated image prompt, or the standalone `POST
-/persona/{instance_id}/image/compose` endpoint in either streaming mode.
+delegated image prompt, the standalone `POST
+/persona/{instance_id}/image/compose` endpoint in either streaming mode, or
+`POST /v2/comp/session/{session_id}/message/{message_id}/image/edit`.
 
 | Column | Type | Meaning |
 |---|---|---|
 | `id` | `UUID` | Row id — see linkage below. |
-| `source` | `TEXT` | `chat_reply_text_image` \| `chat_reply_image` \| `compose_endpoint` \| `compose_endpoint_stream`. |
+| `source` | `TEXT` | `chat_reply_text_image` \| `chat_reply_image` \| `compose_endpoint` \| `compose_endpoint_stream` \| `image_edit` (see below). |
 | `user_id` | `UUID` | |
 | `instance_id` | `UUID?` | Persona instance; NULL when the caller has none in scope. |
 | `session_id` | `UUID?` | Chat session; NULL on the standalone endpoint (no session). |
@@ -441,14 +442,14 @@ delegated image prompt, or the standalone `POST
 | `inputs` | `JSONB` | The five composer slots, structured: `{appearance, recent_scene, latest_user_msg, style, aspect_ratio}`. Empty slots are `""`, not the `（无）` placeholder the prompt renders — that substitution is a rendering detail, not an input. `latest_user_msg` differs by `source`: `chat_reply_image` passes the raw `user_msg.content`, while `chat_reply_text_image` passes `effective_user_msg` — the post-input-filter rewrite. Both faithfully record what the composer actually saw on that turn; an operator diffing rows across the two sources should expect the difference, not read it as an inconsistency. |
 | `subject` | `TEXT?` | The composer's own `prompt` field. NULL unless `status = "ok"`. |
 | `caption` | `TEXT?` | NULL when the composer produced none, including the non-JSON fallback reply, where the whole reply becomes `subject` instead. |
-| `composed_prompt` | `TEXT?` | The assembled wire string — style preset + persona appearance + subject, i.e. exactly what the downstream consumer is handed. Stored on **every** row that produced one, including `exhausted` and `not_configured` on the chat path (the portrait fallback still assembles a wire prompt, and this column is then the only record anywhere of what was drawn). NULL only on the standalone endpoint's `exhausted` rows, which fail without assembling anything. |
+| `composed_prompt` | `TEXT?` | The assembled wire string — style preset + persona appearance + subject, i.e. exactly what the downstream consumer is handed. Stored on **every** row that produced one, including `exhausted` and `not_configured` on the chat path (the portrait fallback still assembles a wire prompt, and this column is then the only record anywhere of what was drawn). NULL only on the standalone endpoint's `exhausted` rows and the `image_edit` endpoint's `exhausted` rows — both fail without assembling anything (the edit endpoint has no portrait fallback either). |
 | `variant` | `TEXT?` | The resolved `prompt_variant` key; `"raw"` is an ordinary key, not a skip. |
 | `model` | `TEXT?` | The model that answered, on success. Also populated on `exhausted` whenever the LAST attempt got a response back at all: `empty`/`empty_prompt` on the chat path and the non-stream endpoint (both walk `run_image_prompt_compose`'s shared chain), and on the standalone endpoint's streaming mode also a candidate that streamed metadata (model/generation_id/usage) and then broke — that evidence is retained because the provider answered and may have been billed. NULL when no response ever came back on any path: a break or timeout that captured nothing at all, or `not_configured` (no call was made). **Since v1.4.0 the "did the provider answer?" test lives ENTIRELY in this trio** (`model` / `generation_id` / `usage`); `last_failure` no longer doubles as a second, coarser copy of it, which is why the two labels that used to encode it (`stream_open_failed` / `stream_died_midway`) are gone. |
 | `usage` | `JSONB?` | Full unfiltered OpenRouter usage block, `serde_json::to_value`'d — `OPENROUTER_USAGE_HIDDEN_KEYS` filters the wire copy only, never this. Travels with `model`: populated exactly where `model` is. |
 | `generation_id` | `TEXT?` | Travels with `model`. |
 | `attempts` | `SMALLINT` | Models actually called off `[primary, ...fallback]`; `0` for `not_configured`. |
 | `last_failure` | `TEXT?` | Why the last attempt failed; NULL when `status = "ok"` or `"not_configured"` (no attempt was made, so there is nothing to have failed). Values: `empty` \| `empty_prompt` \| `upstream_error` \| `gateway_error`. A free column, not a CHECK — the vocabulary grows as new failure modes get labeled. The first two are **content verdicts**: the call succeeded and was billed, its output was just unusable. The last two are **pointer values** naming which of the two columns below holds the per-hop detail; since v1.4.0 they replace `model_error` / `timeout` and the streaming mode's `stream_open_failed` / `stream_died_midway` — each of those covered a provider status AND a local timeout under one label, so all four are retired and the column now reads the same whichever endpoint wrote the row (see [Failed attempts](#failed-attempts-llm_attempts--gateway_errors)). **`empty` is also reachable in streaming mode**, not just the chain-walk paths — a candidate that never opens (no content chunk) but whose stream ends normally reports `empty`, same label as the chain-walk's content-level blank-reply arm, because both mean the same thing: the provider answered and may have been billed. |
-| `llm_attempts` | `JSONB?` | Every hop where the provider answered with a failure, `task = "chat_image_prompt_compose"`. NULL when there were none — see [Failed attempts](#failed-attempts-llm_attempts--gateway_errors). |
+| `llm_attempts` | `JSONB?` | Every hop where the provider answered with a failure. `task = "chat_image_prompt_compose"` on every row except `source = "image_edit"`, where it is `"chat_image_edit_compose"` — even when the edit ran on the compose task's fallback chain, see [Model config → image-EDIT composer](model-config.md#taskschat_image_edit_compose--image-edit-composer-optional). NULL when there were none — see [Failed attempts](#failed-attempts-llm_attempts--gateway_errors). |
 | `gateway_errors` | `JSONB?` | Every hop where our path to the provider broke. NULL when there were none. |
 | `created_at` | `TIMESTAMPTZ` | |
 

--- a/docs/llm-audit.zh.md
+++ b/docs/llm-audit.zh.md
@@ -299,7 +299,7 @@ Venice 用 `429 MODEL_OVERLOADED` 和 `503 MODEL_AT_CAPACITY`，下一家又会�
 | `chat_output_filter` | `chat_messages` | assistant |
 | `chat_input_filter` | `chat_messages` | **user** |
 | `chat_vision` | `chat_vision_events` | — |
-| `chat_image_prompt_compose` | `chat_images_events` | — |
+| `chat_image_prompt_compose` / `chat_image_edit_compose` | `chat_images_events` | — |
 | `pde_decision` | `companion_decision_events` | — |
 | `affinity_evaluation` | `companion_affinity_events` | — |
 
@@ -375,13 +375,14 @@ wire 上报的任务名是 `insight_structuring`——但它落到的审计行�
 ### `engine.chat_images_events`
 
 每次图片合成器 LLM 调用一行，来自**任意** caller——聊天轮次里委托的图片
-prompt，或者独立端点 `POST /persona/{instance_id}/image/compose` 的任一种
-流式模式。
+prompt、独立端点 `POST /persona/{instance_id}/image/compose` 的任一种
+流式模式，或者
+`POST /v2/comp/session/{session_id}/message/{message_id}/image/edit`。
 
 | 列 | 类型 | 含义 |
 |---|---|---|
 | `id` | `UUID` | 行 id——见下面的关联关系。 |
-| `source` | `TEXT` | `chat_reply_text_image` \| `chat_reply_image` \| `compose_endpoint` \| `compose_endpoint_stream`。 |
+| `source` | `TEXT` | `chat_reply_text_image` \| `chat_reply_image` \| `compose_endpoint` \| `compose_endpoint_stream` \| `image_edit`（见下文）。 |
 | `user_id` | `UUID` | |
 | `instance_id` | `UUID?` | 角色实例；caller 没有实例上下文时为 NULL。 |
 | `session_id` | `UUID?` | 聊天 session；独立端点没有 session，恒为 NULL。 |
@@ -389,14 +390,14 @@ prompt，或者独立端点 `POST /persona/{instance_id}/image/compose` 的任�
 | `inputs` | `JSONB` | 合成器的五个槽位，结构化保存：`{appearance, recent_scene, latest_user_msg, style, aspect_ratio}`。空槽位记为 `""`，不是 prompt 渲染时用的 `（无）` 占位符——那个替换是渲染细节，不是输入本身。`latest_user_msg` 按 `source` 不同而不同：`chat_reply_image` 传的是原始的 `user_msg.content`，而 `chat_reply_text_image` 传的是 `effective_user_msg`——input filter 改写之后的版本。两者都如实记录了合成器那一轮实际看到的内容；跨这两个 source 比对行的运维应该预期这个差异，不要当成不一致。 |
 | `subject` | `TEXT?` | 合成器自己的 `prompt` 字段。`status = "ok"` 之外恒为 NULL。 |
 | `caption` | `TEXT?` | 合成器没写 caption 时为 NULL，包括非 JSON 回退的情形——此时整段回复变成 `subject`。 |
-| `composed_prompt` | `TEXT?` | 拼装出的线上 wire 字符串——style 预设 + 角色外观 + subject，也就是下游消费方实际拿到的那个字符串。**每一行只要产出过它就会保存**，包括聊天路径上的 `exhausted` 和 `not_configured`（肖像回退仍会拼出一个 wire prompt，这一列就是唯一记录了当时画的到底是什么的地方）；只有独立端点的 `exhausted` 行是 NULL——它失败时根本没拼装任何东西。 |
+| `composed_prompt` | `TEXT?` | 拼装出的线上 wire 字符串——style 预设 + 角色外观 + subject，也就是下游消费方实际拿到的那个字符串。**每一行只要产出过它就会保存**，包括聊天路径上的 `exhausted` 和 `not_configured`（肖像回退仍会拼出一个 wire prompt，这一列就是唯一记录了当时画的到底是什么的地方）；只有独立端点的 `exhausted` 行和 `image_edit` 端点的 `exhausted` 行是 NULL——两者失败时都没拼装任何东西（编辑端点同样没有肖像回退）。 |
 | `variant` | `TEXT?` | 解析出的 `prompt_variant` key；`"raw"` 是普通 key，不是跳过标记。 |
 | `model` | `TEXT?` | 成功时是应答的模型。`exhausted` 时也可能有值——只要最后一次尝试确实拿到过应答：聊天路径和非流式端点共用的 `empty`/`empty_prompt`（都走 `run_image_prompt_compose` 那一套共享的链路遍历），以及独立端点流式模式下先流出 metadata（model/generation_id/usage）、之后才断掉的候选——那份证据会被保留，因为 provider 应答了，可能已经计费。只有在任意路径上完全没有应答回来时才是 NULL：什么都没捕获到就断掉或超时，或者 `not_configured`（压根没发起调用）。**自 v1.4.0 起，「provider 到底有没有应答」这条判据完全由这三列**（`model` / `generation_id` / `usage`）承担；`last_failure` 不再兼任它的粗粒度副本，这也正是当初用来编码它的两个标签（`stream_open_failed` / `stream_died_midway`）被取消的原因。 |
 | `usage` | `JSONB?` | 完整未过滤的 OpenRouter usage 块，`serde_json::to_value` 出来的——`OPENROUTER_USAGE_HIDDEN_KEYS` 只过滤 wire 上那份回显，从不影响这里。与 `model` 同步：`model` 有值的地方它才有值。 |
 | `generation_id` | `TEXT?` | 与 `model` 同步。 |
 | `attempts` | `SMALLINT` | 实际调用了 `[primary, ...fallback]` 里多少个模型；`not_configured` 时为 `0`。 |
 | `last_failure` | `TEXT?` | 最后一次尝试为什么失败；`status = "ok"` 或 `"not_configured"`（压根没发起尝试，也就无所谓失败）时为 NULL。取值：`empty` \| `empty_prompt` \| `upstream_error` \| `gateway_error`。自由文本列，不是 CHECK——这个词表会随新失败模式的出现而增长。前两个是**内容裁决**：调用成功了也计费了，只是产出不可用。后两个是**指针值**，指明下面两列中哪一列存着逐 hop 的细节；自 v1.4.0 起它们取代了 `model_error` / `timeout` 以及流式模式的 `stream_open_failed` / `stream_died_midway`——那四个标签里每一个都同时覆盖了 provider 状态和本地超时，所以一并退役，这一列现在无论由哪个端点写入读起来都一样（见[失败的尝试](#失败的尝试llm_attempts--gateway_errors)）。**`empty` 在流式模式下也能出现**，不止链路遍历那两条路径——一个候选压根没开流（没有内容块），但流本身正常结束，也记 `empty`，跟链路遍历里内容层面「空回复」那一支同名，因为两者说的是同一件事：provider 应答了，可能已经计费。 |
-| `llm_attempts` | `JSONB?` | provider 应答了但报了失败的每一个 hop，`task = "chat_image_prompt_compose"`。一个都没有时为 NULL——见[失败的尝试](#失败的尝试llm_attempts--gateway_errors)。 |
+| `llm_attempts` | `JSONB?` | provider 应答了但报了失败的每一个 hop。除 `source = "image_edit"` 外都是 `task = "chat_image_prompt_compose"`；`image_edit` 行恒为 `"chat_image_edit_compose"`——即便这次编辑实际走的是合成任务的回退链，见[模型配置 → 图片-EDIT 合成器](model-config.zh.md#taskschat_image_edit_compose--图片-edit-合成器可选)。一个都没有时为 NULL——见[失败的尝试](#失败的尝试llm_attempts--gateway_errors)。 |
 | `gateway_errors` | `JSONB?` | 我们通往 provider 的路断掉的每一个 hop。一个都没有时为 NULL。 |
 | `created_at` | `TIMESTAMPTZ` | |
 

--- a/docs/llm-audit.zh.md
+++ b/docs/llm-audit.zh.md
@@ -400,6 +400,13 @@ prompt，或者独立端点 `POST /persona/{instance_id}/image/compose` 的任�
 | `gateway_errors` | `JSONB?` | 我们通往 provider 的路断掉的每一个 hop。一个都没有时为 NULL。 |
 | `created_at` | `TIMESTAMPTZ` | |
 
+- `image_edit` —— `POST /v2/comp/session/{session_id}/message/{message_id}/image/edit`。
+  它的 `inputs` 是七个键，不是聊天合成器的五个：`appearance`、`source_message_id`、
+  `source_subject`、`source_caption`、`instruction`、`style`、`aspect_ratio`。
+  看 `source` 就知道该按哪种形状读。按 `status` 分组查
+  `engine.chat_images_events WHERE source = 'image_edit'`，就是「编辑被用得多不多、
+  合成器多久拒一次」的读数。
+
 `status` 刻意只有三个值：`exhausted` 表示「这次调用没产出可用的合成结果」，
 涵盖包括流式端点中途死掉在内的所有原因，具体区分交给 `last_failure`。
 

--- a/docs/model-config.md
+++ b/docs/model-config.md
@@ -551,6 +551,7 @@ input filter has no triggers, timing, or tiers).
 | `chat_output_filter` | `pipeline::stream` via `resolve_output_filter()` (optional second-pass rewrite of the chat reply before delivery) | live |
 | `pde_decision` | `pipeline::stream` (opt-in LLM judge via `run_pde_decision`, called from `run_stream`; rules engine used when `filter_prompt` is absent or the LLM call fails) | live (opt-in) |
 | `chat_image_prompt_compose` | `pipeline::stream` (image-prompt composer; **required for image turns** — the PDE judge writes no seed, so without this task the engine reports 可发图=否 and downgrades image actions. Generates the prompt from turn context and returns JSON `{prompt, caption}`; `caption` is persisted to `metadata.image.caption` and is what history-facing renders read) | live (required for images) |
+| `chat_image_edit_compose` | `routes::image_edit` via `resolve_image_edit_compose()` (image-EDIT composer for `POST /v2/comp/session/{session_id}/message/{message_id}/image/edit`; revises a picture the character already sent from an instruction. **Optional even for the endpoint** — with this block absent the endpoint runs on `[tasks.chat_image_prompt_compose]`'s chain and parameters with the engine's built-in edit prompt; with both blocks absent the endpoint answers 501) | live (optional) |
 | `chat_vision` | `pipeline::stream` via `resolve_vision()` (vision pre-stage: describes an `image_url` attachment into JSON before the reply prompt; off when task block absent or `filter_prompt` blank) | live (opt-in) |
 | `chat_product_qa` | `pipeline::stream` via `resolve_product_qa()` (out-of-character product-QA executor for the PDE `product_qa` action; off when task block absent or `filter_prompt` blank; also requires the LLM PDE) | live (opt-in) |
 | `affinity_evaluation` | `pipeline::post_process` (per-turn affinity verdict — four graded line axes plus two absolute 1..3 endpoint levels, converted engine-side; runs after each Reply turn, fire-and-forget; **takes no `filter_prompt`** — the prompt is engine-owned and setting the key refuses to boot — **in any form, an explicit blank included**. Unlike every other task here, blank does not mean "off", so omit the key entirely. See issue #210) | live |
@@ -572,6 +573,7 @@ A `[tasks.<name>]` entry is only meaningful if the engine actually calls `model_
 - `crates/eros-engine-server/src/pipeline/handlers.rs` → `chat_companion`, `chat_output_filter`
 - `crates/eros-engine-server/src/pipeline/post_process.rs` → `insight_extraction`, `insight_structuring`, `affinity_evaluation`, `character_insight_extraction`, `character_insight_structuring`, `user_insight_extraction`, `user_insight_structuring`
 - `crates/eros-engine-server/src/pipeline/stream.rs` → `pde_decision` via `run_pde_decision` inside `run_stream` (only when `filter_prompt` is set); `chat_image_prompt_compose` via `resolve_image_prompt_compose()` (image-prompt composer, required for image turns, resolved lazily only on image turns); `chat_vision` via `resolve_vision()` (vision pre-stage, opt-in); `chat_product_qa` via `resolve_product_qa()` (product-QA executor, opt-in); `chat_input_filter` via `resolve_input_filter()` (input rewrite, opt-in); `memory_extraction` via the dreaming sweeper
+- `crates/eros-engine-server/src/routes/image_edit.rs` → `chat_image_edit_compose` via `resolve_image_edit_compose()` (image-EDIT composer, resolved on every request to the edit endpoint; falls back to `[tasks.chat_image_prompt_compose]`'s chain when the edit block is absent — see below)
 
 `embedding` doesn't go through the generic `resolve()` path above — it has
 its own resolver, `ModelConfig::resolve_embedding()`, called once at boot
@@ -728,9 +730,10 @@ image-model provider and the downstream deployment, not this step. A
 non-blank `filter_prompt` overrides it (and must honor the JSON contract
 above); a blank/absent one falls back to it.
 
-**Variants.** This is the **only** task whose `filter_prompt` accepts more than a
-plain string. The consumer picks one per chat turn via `image.prompt_variant` on
-the send-message body. Three shapes:
+**Variants.** This task's `filter_prompt` accepts more than a plain string (so
+does `[tasks.chat_image_edit_compose]`'s — see below). The consumer picks one
+per chat turn via `image.prompt_variant` on the send-message body. Three
+shapes:
 
 ```toml
 filter_prompt = "…"                       # one prompt; prompt_variant is ignored
@@ -769,8 +772,9 @@ index or key — `"raw"` included, if unconfigured — falls back to the built-i
 prompt above like any other miss, never an error. `raw` is not reserved: a
 table key literally named `raw` boots fine.
 
-Variants are honored on this task only. An array/table `filter_prompt` on any
-other task refuses to boot rather than sit there unreachable. This task's own
+Variants are honored on this task and `[tasks.chat_image_edit_compose]` only.
+An array/table `filter_prompt` on any other task refuses to boot rather than
+sit there unreachable. This task's own
 `[tasks.chat_image_prompt_compose.tiers.*]` blocks refuse to boot in **any**
 shape — the composer always resolves with no tier, so the whole block is
 unreachable (see "Tier blocks are limited to two tasks" above).
@@ -813,6 +817,37 @@ tables](llm-audit.md#image-path-event-tables). Specs:
 (`metadata.image` keys above) and
 `docs/superpowers/specs/2026-08-14-image-audit-events-design.md`
 (`chat_images_events`).
+
+### `[tasks.chat_image_edit_compose]` — image-EDIT composer (optional)
+
+Powers `POST
+/v2/comp/session/{session_id}/message/{message_id}/image/edit` (see
+[api-reference.md](api-reference.md)): the consumer names an existing image
+turn and an instruction ("换套衣服"), and this task composes a new image
+prompt from that picture's subject plus the instruction. Same shape as
+`[tasks.chat_image_prompt_compose]` above (`model`, `fallback`,
+`retry_depth`, `temperature`, `max_tokens`, `reasoning`, sampling knobs), and
+`filter_prompt` is likewise **optional** and accepts the same three shapes
+(plain / array-by-index / table-by-key), selected per request via
+`prompt_variant` on the edit body.
+
+**This block is optional even for the endpoint.** With it absent, the
+endpoint runs on `[tasks.chat_image_prompt_compose]`'s chain and parameters,
+using the engine's built-in edit prompt instead of the chat composer's own
+`filter_prompt` (which is written to compose from conversation context, not
+to revise a picture) — so configuring image turns is already enough to get
+edits, with no further config. With **both** blocks absent, the endpoint
+answers 501. Configure this block to give edits their own model or their own
+prompt.
+
+Because the fallback path resolves through `[tasks.chat_image_prompt_compose]`
+itself (`resolve("chat_image_prompt_compose", None)`), it advances that
+task's round-robin `model` cursor exactly like a chat image compose call
+does — heavy edit traffic on a deployment with no edit block shifts which
+model the *next chat image compose* lands on.
+
+Call site: `crates/eros-engine-server/src/routes/image_edit.rs` via
+`resolve_image_edit_compose()` in `model_config.rs`.
 
 ### `[tasks.chat_vision]` — image input (vision pre-stage, opt-in)
 
@@ -1111,7 +1146,7 @@ After the primary is selected, any occurrence of that exact id is removed from t
 
 After deduplication the chain is truncated to `retry_depth` entries — a call tries the primary, then at most `retry_depth` fallbacks; anything past the truncation point is never tried. `retry_depth` is settable task-level, and per tier on the two tier-aware tasks (tier > task default).
 
-The default differs by task. The generic `resolve()` uses `2` (primary + 2 fallbacks — so `chat_companion` tries at most 3 models per streaming chat burst); the single-purpose tasks (`chat_output_filter`, `chat_input_filter`, `chat_vision`, `pde_decision`, `chat_product_qa`, `chat_image_prompt_compose`) use `1` (primary + first fallback).
+The default differs by task. The generic `resolve()` uses `2` (primary + 2 fallbacks — so `chat_companion` tries at most 3 models per streaming chat burst); the single-purpose tasks (`chat_output_filter`, `chat_input_filter`, `chat_vision`, `pde_decision`, `chat_product_qa`, `chat_image_prompt_compose`, `chat_image_edit_compose`) use `1` (primary + first fallback).
 
 ## Stability commitments
 

--- a/docs/model-config.zh.md
+++ b/docs/model-config.zh.md
@@ -490,6 +490,7 @@ SSE `final` frame 的 `filtered` 字段在客户端收到的是非原始输出�
 | `chat_output_filter` | `pipeline::stream`，通过 `resolve_output_filter()`（交付前对 chat 回复进行可选的二次改写） | live |
 | `pde_decision` | `pipeline::stream`（通过 `run_pde_decision` 实现的 opt-in LLM 判断器，由 `run_stream` 调用；缺少 `filter_prompt` 或 LLM 调用失败时使用规则引擎） | live（opt-in） |
 | `chat_image_prompt_compose` | `pipeline::stream`（出图 prompt 合成器；**图片轮次必需** —— PDE judge 不再写种子，未配置该任务时引擎报 可发图=否 并把图片动作降级为纯文本。它从当轮上下文生成 prompt，返回 JSON `{prompt, caption}`；`caption` 落到 `metadata.image.caption`，是聊天历史与 judge transcript 实际读取的字段） | live（图片必需） |
+| `chat_image_edit_compose` | `routes::image_edit`，通过 `resolve_image_edit_compose()`（`POST /v2/comp/session/{session_id}/message/{message_id}/image/edit` 的图片-EDIT 合成器；根据一条指令改写角色已发过的图。**即便对该端点本身也是可选的**——块缺失时端点走 `[tasks.chat_image_prompt_compose]` 的模型链与参数，配上引擎内置的编辑 prompt；两块都缺失时端点回 501） | live（可选） |
 | `chat_vision` | `pipeline::stream`，通过 `resolve_vision()`（视觉预处理阶段：在 reply prompt 前将 `image_url` 附件描述为 JSON；任务块缺失或 `filter_prompt` 为空白时关闭） | live（opt-in） |
 | `chat_product_qa` | `pipeline::stream`，通过 `resolve_product_qa()`（PDE `product_qa` 动作的出戏产品问答执行器；任务块缺失或 `filter_prompt` 为空白时关闭；还需要 LLM PDE 已启用） | live（opt-in） |
 | `affinity_evaluation` | `pipeline::post_process`（每轮好感度裁决——四个档位线轴加 warmth/patience 两个 1..3 绝对档，由引擎侧换算；每个 Reply 轮次后以 fire-and-forget 方式运行；**不接受 `filter_prompt`** —— 该 prompt 由引擎持有，设置该键会拒绝启动——**任何写法都算，包括显式留空**。与这里其它任务不同，空白在这里不等于"关闭"，请直接不写这个键。见 issue #210） | live |
@@ -511,6 +512,7 @@ SSE `final` frame 的 `filtered` 字段在客户端收到的是非原始输出�
 - `crates/eros-engine-server/src/pipeline/handlers.rs` → `chat_companion`、`chat_output_filter`
 - `crates/eros-engine-server/src/pipeline/post_process.rs` → `insight_extraction`、`insight_structuring`、`affinity_evaluation`、`character_insight_extraction`、`character_insight_structuring`、`user_insight_extraction`、`user_insight_structuring`
 - `crates/eros-engine-server/src/pipeline/stream.rs` → `pde_decision`，通过 `run_stream` 内的 `run_pde_decision`（仅当设置了 `filter_prompt`）；`chat_image_prompt_compose`，通过 `resolve_image_prompt_compose()`（出图 prompt 合成器，图片轮次必需，仅在图片轮次按需解析）；`chat_vision`，通过 `resolve_vision()`（视觉预处理阶段，opt-in）；`chat_product_qa`，通过 `resolve_product_qa()`（产品问答执行器，opt-in）；`chat_input_filter`，通过 `resolve_input_filter()`（输入改写，opt-in）；`memory_extraction`，通过 dreaming sweeper
+- `crates/eros-engine-server/src/routes/image_edit.rs` → `chat_image_edit_compose`，通过 `resolve_image_edit_compose()`（图片-EDIT 合成器，编辑端点每次请求都会解析；编辑块缺失时回退到 `[tasks.chat_image_prompt_compose]` 的模型链——详见下文）
 
 `embedding` 不走上面这条通用 `resolve()` 路径——它有自己的解析器
 `ModelConfig::resolve_embedding()`，在 `main.rs` 启动时调用一次来构建
@@ -624,7 +626,7 @@ max_tokens   = 700
 
 **内置默认提示词。** 不同于其他每个任务（提示词必须来自配置），合成器自带一个通用、**不含产品身份**的内置默认。它**从上下文生成** prompt 和 caption——人格外观、最近场景、对方最新消息、style、宽高比——**不**软化、不降级、不审查、不拒绝，也不自带内容审核层——审核交给画图模型供应商和下游部署，不在这一步。非空 `filter_prompt` 覆盖它（且必须遵守上面的 JSON 契约）；空白/缺失则回退到它。
 
-**变体（variants）。** 这是**唯一**一个 `filter_prompt` 接受纯字符串以外形态的任务。前端在每个 chat 轮次通过发消息请求体上的 `image.prompt_variant` 挑一个。三种形态：
+**变体（variants）。** 这个任务的 `filter_prompt` 接受纯字符串以外的形态（`[tasks.chat_image_edit_compose]` 的也接受，见下文）。前端在每个 chat 轮次通过发消息请求体上的 `image.prompt_variant` 挑一个。三种形态：
 
 ```toml
 filter_prompt = "…"                       # 单一提示词；prompt_variant 被忽略
@@ -649,13 +651,39 @@ b = """
 
 `prompt_variant = "raw"` 不带任何特殊含义。它和其他任意变体名一样，只有当该部署把某个变体配置在这个字面量 key 下（不论大小写）时才会命中；下标/key 没命中——包括未配置的 `"raw"`——都会像其他任何 miss 一样回退到上面的内置提示词，绝不报错。`raw` 不再是保留字：表里出现字面量为 `raw` 的 key 可以正常启动。
 
-变体只在这一个任务上生效。任何其他任务的数组/表形态 `filter_prompt` 都会拒绝启动，而不是留在那里永远选不到。本任务自己的 `[tasks.chat_image_prompt_compose.tiers.*]` 块则**不论写什么**都会拒绝启动——合成器解析时永远不走 tier，整个块都不可达（见上方"tier 块只对两个任务生效"）。
+变体只在这一个任务和 `[tasks.chat_image_edit_compose]` 上生效。任何其他任务的数组/表形态 `filter_prompt` 都会拒绝启动，而不是留在那里永远选不到。本任务自己的 `[tasks.chat_image_prompt_compose.tiers.*]` 块则**不论写什么**都会拒绝启动——合成器解析时永远不走 tier，整个块都不可达（见上方"tier 块只对两个任务生效"）。
 
 调用点：`crates/eros-engine-server/src/pipeline/stream.rs`，通过 `model_config.rs` 中的 `resolve_image_prompt_compose()`。
 
 **审计。** 一次成功的合成器调用——包括上面提到的"非 JSON 回退路径"，它同样算作成功——会向图片轮次的 `chat_messages.metadata.image` 写入三个键：`compose_variant`（命中了 `filter_prompt` 的哪个 key/下标；纯字符串或内置提示词时缺失；按调用方传入的值记录（已 trim），不做归一化——例如索引形态里 `"01"` 命中下标 1，审计时仍记为 `"01"`）、`compose_model`（实际应答的模型），以及 `compose_generation_id`。只有当合成器调用本身失败（fail-open 降级）或该任务未配置时，三者才会缺失——语义与 affinity 审计三元组的 NULL 语义一致（`raw` 已不带特殊含义，因此不再是这里的独立情形）。合成器的 `caption` 单独持久化为 `metadata.image.caption`：只要回复解析为带非空 `caption` 字段的 JSON 就会被设置，否则为 `None`——包括"成功但非 JSON"的回复，此时整段回复变成 `prompt`，没有 caption。`metadata.image.prompt`——合成器的 `prompt` 字段，也就是真正的出图主体——**会**持久化在每个图片轮次上；它正是 `build_delegated_image_marker` 写入、与上面审计三元组同行的那个字段。
 
 **每一次合成器调用——不论成功失败、不论来自哪个调用方——都会另外落一行到 `engine.chat_images_events`**（迁移 0045）：完整的 usage 块、拼装出的 wire prompt（`composed_prompt`——style 预设 + 人格外观 + subject，也就是图像供应商实际会收到的那个字符串）、链路遍历的事实（`attempts` / `last_failure`），以及合成器当时看到的五个原始输入。`metadata.image.compose_event_id` 指向那一行——反向查找走 assistant 行 → `compose_event_id` → `chat_images_events`，绝不是反过来。用量/费用和拼装出的 wire prompt **不会**重复写进 `chat_messages.metadata.image` 本身；要对账，要么 join `compose_event_id` 去查审计表，要么拿 generation id 去供应商日志里对。详见 [LLM audit → 图片链路事件表](llm-audit.zh.md#图片链路事件表)。设计文档：`docs/superpowers/specs/2026-08-02-image-compose-audit-design.md`（上面 `metadata.image` 的键）与 `docs/superpowers/specs/2026-08-14-image-audit-events-design.md`（`chat_images_events`）。
+
+### `[tasks.chat_image_edit_compose]` — 图片-EDIT 合成器（可选）
+
+为 `POST /v2/comp/session/{session_id}/message/{message_id}/image/edit`
+供电（见 [api-reference.zh.md](api-reference.zh.md)）：前端指定一个已存在的
+图片回合和一条指令（"换套衣服"），这个任务从那张图的画面主体加上指令合成
+新的图片 prompt。结构与上面的 `[tasks.chat_image_prompt_compose]` 相同
+（`model`、`fallback`、`retry_depth`、`temperature`、`max_tokens`、
+`reasoning`、采样旋钮），`filter_prompt` 同样是**可选**的，接受同样的三种
+形态（纯字符串 / 按下标 / 按 key），通过编辑请求体上的 `prompt_variant`
+逐次选择。
+
+**即便对该端点本身，这个块也是可选的。** 块缺失时，端点走
+`[tasks.chat_image_prompt_compose]` 的模型链与参数，用引擎内置的编辑
+prompt，而不是聊天合成器自己的 `filter_prompt`（那个是为从对话上下文生成
+图片写的，不是为改一张既有图片写的）——所以配置好图片轮次就已经足够拿到
+编辑能力，不需要额外配置。**两个块都缺失**时端点回 501。要给编辑单独配
+模型或单独调 prompt，就配这个块。
+
+因为回退路径是通过 `[tasks.chat_image_prompt_compose]` 本身解析的
+（`resolve("chat_image_prompt_compose", None)`），它会像一次真正的聊天出图
+合成调用一样，推进该任务的 `model` round-robin 游标——没配编辑块的部署上，
+编辑流量会影响**下一次聊天出图合成**落到哪个模型上。
+
+调用点：`crates/eros-engine-server/src/routes/image_edit.rs`，通过
+`model_config.rs` 中的 `resolve_image_edit_compose()`。
 
 ### `[tasks.chat_vision]` — 图片输入（视觉预处理阶段，opt-in）
 
@@ -915,7 +943,7 @@ model = { "x-ai/grok-4.20" = 0.8, "z-ai/glm-4.7-flash" = 0.2 }  # weighted rando
 
 去重之后，链会被截断到 `retry_depth` 条——每次调用先试 primary，再最多试 `retry_depth` 个 fallback，截断点之后的条目永远不会被尝试。`retry_depth` 可在任务级设置，在两个 tier 感知任务上还可按 tier 覆盖（tier > 任务默认块）。
 
-默认值按任务不同。通用 `resolve()` 用 `2`（primary + 2 个 fallback——所以 `chat_companion` 每轮流式聊天 burst 最多试 3 个模型）；单一用途任务（`chat_output_filter`、`chat_input_filter`、`chat_vision`、`pde_decision`、`chat_product_qa`、`chat_image_prompt_compose`）用 `1`（primary + 第一个 fallback）。
+默认值按任务不同。通用 `resolve()` 用 `2`（primary + 2 个 fallback——所以 `chat_companion` 每轮流式聊天 burst 最多试 3 个模型）；单一用途任务（`chat_output_filter`、`chat_input_filter`、`chat_vision`、`pde_decision`、`chat_product_qa`、`chat_image_prompt_compose`、`chat_image_edit_compose`）用 `1`（primary + 第一个 fallback）。
 
 ## 稳定性承诺
 

--- a/docs/superpowers/specs/2026-08-22-image-edit-endpoint-design.md
+++ b/docs/superpowers/specs/2026-08-22-image-edit-endpoint-design.md
@@ -81,9 +81,11 @@ third meaning on the request body would make the docs unreadable.
 | 403 | session not owned by the JWT user | `not your session` |
 | 404 | no such message in this session | `no such message` |
 | **409** | message exists but has no `metadata.image` | `not an image turn` |
+| 409 | the source image turn has no originating user message, or the session has no persona instance | (unreachable on every engine-written path; the edit has nothing to attach to) |
 | 422 | `instruction` blank, `aspect_ratio` off the allow-list | validation message |
 | 501 | no composer configured (§3.1) | `image prompt composer not configured` |
-| 502 | composer chain exhausted | `image prompt composer failed` |
+| 429 | per-user in-flight cap reached (`CONCURRENT_STREAMS_PER_USER`, shared with chat/voice/compose) | `per-user in-flight cap reached` |
+| 5XX | composer chain exhausted | `image prompt composer failed` |
 | 200 | — | `ImageEditResponse` |
 
 **409, not 404, for "not an image turn".** The message *was* found; what is
@@ -113,8 +115,11 @@ pub struct ImageEditResponse {
     pub composed_prompt: String,
     /// Always `"previous"` on an edit turn; see §3.3.
     pub image_ref: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub aspect_ratio: Option<String>,
-    /// The composer's caption for the new picture; `null` when it gave none.
+    /// The composer's caption for the new picture; the field is omitted
+    /// entirely (not `null`) when it gave none.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
 }
 ```
@@ -255,17 +260,24 @@ composer refuses or fails, and on which models.
   row interleaves wherever its `created_at` falls. Accepted — the voice and
   chat pipelines already write to one session concurrently, and the edit row
   carries no state the in-flight turn reads.
-- One composer call per request, no per-user cap. Every call is audited
-  (§3.4). Default-open; the gate gets ratcheted if the reading says so.
+- One composer call per request, guarded by the same per-user in-flight cap as
+  chat, voice and the standalone composer (`CONCURRENT_STREAMS_PER_USER`, 429
+  over cap). Not a new gate: it is the throttle every user-triggered LLM entry
+  point already carries, and omitting it would have made this the only
+  unbounded one. Every call is audited (§3.4).
 
 ## 4. Implementation shape
 
 - `crates/eros-engine-server/src/routes/image_edit.rs` — DTOs, handler,
   `router()`; merged (not nested) into both `router()` and
   `router_for_openapi()` in `routes/mod.rs`, like `insight.rs`.
-- `pipeline/stream.rs` — `run_image_prompt_compose` takes `(payload, task)`;
-  new `compose_edit_payload(...)` and `compose_edit_inputs_json(...)` pure
-  functions; `build_delegated_image_marker` gains `edit_of`.
+- `pipeline/stream.rs` — the shared refactor only: `render_compose_payload`,
+  the parameterized `run_image_prompt_compose`, and `build_delegated_image_marker`
+  gaining `edit_of`. The edit-specific renderers (`compose_edit_payload`,
+  `render_edit_payload`, `compose_edit_inputs_json`) live in
+  `routes/image_edit.rs` instead, alongside the handler that is their only
+  caller — `stream.rs` is already the workspace's largest file, and a
+  single-caller function does not earn a place in it.
 - `crates/eros-engine-llm/src/model_config.rs` — `DEFAULT_EDIT_PROMPT`,
   `resolve_image_edit_compose`, `KNOWN_CHAT_TASKS` entry, validator case.
 - `crates/eros-engine-store/migrations/0057_…` — CHECK widening.

--- a/docs/superpowers/specs/2026-08-22-image-edit-endpoint-design.md
+++ b/docs/superpowers/specs/2026-08-22-image-edit-endpoint-design.md
@@ -95,10 +95,10 @@ v1 recovery endpoint answers 404 for the same condition, and that stays frozen
 this is an action on a resource that does exist.
 
 Nothing is persisted on any non-200 path except the `exhausted` audit row on
-502 (§3.4). A 502 leaves no assistant message: there is **no portrait
-fallback** here. The chat path falls back to a plain portrait because a turn
-that promised a picture must ship one; an edit that ignores its instruction is
-worse than an error, and the consumer can simply retry.
+chain exhaustion (§3.4). An exhausted chain leaves no assistant message: there
+is **no portrait fallback** here. The chat path falls back to a plain portrait
+because a turn that promised a picture must ship one; an edit that ignores its
+instruction is worse than an error, and the consumer can simply retry.
 
 ### 2.4 Response
 
@@ -247,8 +247,9 @@ to add `'image_edit'`. `inputs` for that source carries the seven keys in
 §3.3, not the chat composer's five — `inputs` is free-form JSONB and the
 `source` column says which shape to expect. `docs/llm-audit.md` documents both.
 
-A 502 writes one `exhausted` row with `attempts` / `last_failure` / the failure
-list, `composed_prompt = NULL` — the same as the standalone composer's 502.
+An exhausted chain writes one `exhausted` row with `attempts` / `last_failure` /
+the failure list, `composed_prompt = NULL` — the same as the standalone
+composer's own exhaustion path.
 
 `chat_images_events WHERE source = 'image_edit'` grouped by `status` and by day
 is the reading for this feature: how often edits are requested, how often the
@@ -322,9 +323,9 @@ tests):**
 
 - The full ladder: 403 foreign session, 404 unknown session, 404 unknown
   message, **409** on a text message, 422 blank instruction, 501 with no
-  composer task, 502 on chain exhaustion.
-- 502 writes exactly one `image_edit` / `exhausted` audit row and **no**
-  assistant row.
+  composer task, 5XX on chain exhaustion.
+- An exhausted chain writes exactly one `image_edit` / `exhausted` audit row
+  and **no** assistant row.
 - Success: response fields; a new assistant row exists with `content = ""`,
   `user_message_id` equal to the source's, `metadata.image.edit_of` equal to
   the source id, `image_ref = "previous"`, and a `compose_event_id` that

--- a/docs/superpowers/specs/2026-08-22-image-edit-endpoint-design.md
+++ b/docs/superpowers/specs/2026-08-22-image-edit-endpoint-design.md
@@ -82,7 +82,7 @@ third meaning on the request body would make the docs unreadable.
 | 404 | no such message in this session | `no such message` |
 | **409** | message exists but has no `metadata.image` | `not an image turn` |
 | 409 | the source image turn has no originating user message, or the session has no persona instance | (unreachable on every engine-written path; the edit has nothing to attach to) |
-| 422 | `instruction` blank, `aspect_ratio` off the allow-list | validation message |
+| 422 | `instruction` blank, `instruction` over `MAX_INSTRUCTION_CHARS` (4096 — parity with the standalone composer's `content` limit), or `aspect_ratio` off the allow-list | validation message |
 | 501 | no composer configured (§3.1) | `image prompt composer not configured` |
 | 429 | per-user in-flight cap reached (`CONCURRENT_STREAMS_PER_USER`, shared with chat/voice/compose) | `per-user in-flight cap reached` |
 | 5XX | composer chain exhausted | `image prompt composer failed` |
@@ -151,6 +151,15 @@ The compose block is the gate — an operator who enabled image turns gets edits
 with no further config, on the same models, with the engine prompt. The edit
 block exists so the prompt and the model can be tuned separately once there is
 a reading to tune against (the `image_edit` audit rows, §3.4).
+
+In fallback mode `resolve_image_edit_compose` resolves the chain by calling
+`resolve("chat_image_prompt_compose", None)` — the same call the chat path's
+own `resolve_image_prompt_compose` makes. On a round-robin or weighted
+`model`, that call advances the **same** cursor both call sites share (it
+lives on the one `ModelSpec` stored under `[tasks.chat_image_prompt_compose]`
+in `ModelConfig::tasks`). Correct given the two features deliberately share a
+chain, but worth stating: on a deployment with no edit block configured,
+edit traffic shifts which model the *next chat image compose* call lands on.
 
 Housekeeping that comes with a new task: `KNOWN_CHAT_TASKS` gains
 `chat_image_edit_compose`; the wire `task` on the composer call is
@@ -266,6 +275,17 @@ composer refuses or fails, and on which models.
   over cap). Not a new gate: it is the throttle every user-triggered LLM entry
   point already carries, and omitting it would have made this the only
   unbounded one. Every call is audited (§3.4).
+- **Idempotent chat replay picks up edit rows.** `upsert_user_message_in_tx`
+  (the dedup path behind `POST /comp/chat/{session_id}/message/stream` and the
+  async endpoint) selects a replayed turn's `assistant_chain` by
+  `WHERE user_message_id = $1 AND role = 'assistant'` — no `channel` filter,
+  no restriction to rows the streaming pipeline itself wrote. Because an edit
+  row's `user_message_id` is the source's, it lands in that `assistant_chain`
+  when its originating turn is replayed. Traced and harmless: `replay_stream`
+  skips the `Delta` frame on any row with empty `content` (every image-only
+  row, edits included) and never emits an `image_request` frame at all — it
+  already treats a chat-path image-only row this way, and an edit row is
+  wire-identical to one for this purpose.
 
 ## 4. Implementation shape
 
@@ -316,7 +336,12 @@ composer refuses or fails, and on which models.
   the built-in prompt.
 - `DEFAULT_EDIT_PROMPT` is non-empty and names both output fields (guards a
   broken-constant edit).
-- The shipped example config parses with the new task present.
+- The shipped example config still parses and boots with the new task's block
+  left commented out, exactly like the composer block above it — implemented
+  as `committed_example_config_leaves_the_image_edit_task_commented_out`,
+  which also asserts `validate_prompt_variants` accepts it. This guards
+  against a stray uncomment turning the example into a config that calls a
+  model nobody asked for, not against the block being absent altogether.
 
 **Server (`sqlx::test`, mocked OpenRouter, mirroring the recovery-endpoint
 tests):**

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -377,10 +377,43 @@ model_name_display_override = true
 # index or key falls back to the BUILT-IN prompt above, same as any other miss
 # — never an error.
 #
-# Variants are honored on THIS task only. An array/table `filter_prompt` on any
-# other task refuses to boot rather than sit there unreachable. A
-# [tasks.chat_image_prompt_compose.tiers.*] block refuses to boot in ANY shape:
-# the composer resolves with no tier, so the whole block is unreachable.
+# Variants are honored on this task and [tasks.chat_image_edit_compose] only.
+# An array/table `filter_prompt` on any other task refuses to boot rather than
+# sit there unreachable. A [tasks.chat_image_prompt_compose.tiers.*] block
+# refuses to boot in ANY shape: the composer resolves with no tier, so the
+# whole block is unreachable.
+#filter_prompt = """
+#…your override here…
+#"""
+
+# ── Image-EDIT composer (chat_image_edit_compose) ───────────────────────────
+# Powers POST /v2/comp/session/{session_id}/message/{message_id}/image/edit:
+# the consumer names an existing image turn and an instruction ("换套衣服"),
+# and the engine composes a NEW image prompt from that picture's subject and
+# force-emits an image turn for it. Same JSON contract as the composer above
+# ({"prompt": …, "caption": …}) and the same variant rules for filter_prompt.
+#
+# This block is OPTIONAL EVEN FOR THE ENDPOINT. With it absent the edit
+# endpoint runs on [tasks.chat_image_prompt_compose]'s chain and parameters,
+# using the engine's built-in EDIT prompt — so configuring image turns is
+# enough to get edits. The chat composer's own filter_prompt is never reused
+# here: it is written to compose from conversation context, not to revise a
+# picture. With BOTH blocks absent the endpoint answers 501.
+#
+# Configure this block to give edits their own model or their own prompt —
+# worth doing once engine.chat_images_events (source = 'image_edit') shows how
+# often edits are asked for and how often the composer refuses.
+#[tasks.chat_image_edit_compose]
+#model        = "x-ai/grok-4"
+#fallback     = ["google/gemini-3.1-flash-lite"]
+#retry_depth  = 1
+#temperature  = 0.7
+#max_tokens   = 700
+#reasoning    = { enabled = false }
+#
+# `filter_prompt` accepts the same three shapes as the composer above (plain /
+# array-by-index / table-by-key), selected per request via `prompt_variant` on
+# the edit body, with the same "a miss falls back to the built-in" rule.
 #filter_prompt = """
 #…your override here…
 #"""

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -341,7 +341,7 @@ model_name_display_override = true
 #max_tokens   = 700
 #reasoning    = { enabled = false }
 #
-# This is the ONLY task whose `filter_prompt` accepts VARIANTS. The consumer
+# This task's `filter_prompt` accepts VARIANTS. The consumer
 # picks one per chat turn via `image.prompt_variant` on the send-message body.
 # Three shapes:
 #


### PR DESCRIPTION
## What

`POST /v2/comp/session/{session_id}/message/{message_id}/image/edit` — the consumer names an image turn and an instruction (`换套衣服`), the engine composes a new image prompt from that picture's subject and force-emits an image turn for it. The engine composes; the consumer draws. This is what the removed engine draw endpoint (#203) was reaching for, in the delegate-only shape.

Spec: `docs/superpowers/specs/2026-08-22-image-edit-endpoint-design.md`

- **Config** — new optional `[tasks.chat_image_edit_compose]`. With it absent the endpoint runs on `[tasks.chat_image_prompt_compose]`'s chain using the engine's built-in edit prompt, so **configuring image turns is enough to get edits**; with both absent it answers 501. Its `filter_prompt` accepts the same three variant shapes as the chat composer — the second task ever to do so.
- **Composer** — `run_image_prompt_compose` is parameterized by rendered payload and wire task name rather than duplicated; the chat path's payload is byte-identical (`render_compose_payload` is a verbatim extraction).
- **Persistence** — one `chat_images_events` row (`source = 'image_edit'`, migration `0057`, seven-key `inputs`) plus one image-only assistant row: `content = ""`, `metadata.image` + `edit_of`, `image_ref = "previous"`, inheriting the **source's** `user_message_id`. It is an ordinary image turn, so history's `image: true` flag, the v1 recovery endpoint and the judge transcript all work on it unchanged, and an edit can itself be edited.
- **Nothing else runs** — no PDE, affinity, insight, memory, ghost streak or queue.
- Ladder: 403 / 404 / **409 not an image turn** / 422 / 501 / 429 / 5XX. `409`, not `404`: the message was found, its state forbids the action.

## Deviations from the spec, recorded

- **The composer call carries the per-user in-flight cap** (429), which §3.5 originally omitted. The sibling `POST /persona/{id}/image/compose` guards the identical workload, and without it this would be the engine's only unbounded LLM entry point. §3.5 was amended in this PR to match.
- **The edit-specific renderers live in `routes/image_edit.rs`**, not `pipeline/stream.rs` as §4 said — stream.rs is the largest file in the workspace and they have exactly one caller. §4 amended.
- A source image row with a NULL `user_message_id` answers 409 rather than widening `insert_assistant_batch` to `Option<Uuid>` across 31 call sites. No engine path writes such a row.
- In fallback mode the edit resolves through `chat_image_prompt_compose`'s round-robin cursor, so edit traffic shifts which model the next chat image compose lands on. Correct for a shared chain; now recorded in §3.1.

## Tests

16 in the new module: the full status ladder, success (row shape, `edit_of`, inherited `user_message_id`, `compose_event_id` → an `image_edit`/`ok` audit row), the **fallback config path**, discovery + byte-exact recovery through the v1 endpoint, edit-of-an-edit, the 429, and pure tests pinning the payload renderer and the seven-key `inputs` set. Plus store tests for the widened CHECK and llm tests for the resolver's three-way contract.

Gate: `cargo fmt --check` / `clippy -D warnings` / `cargo test --workspace` (1596) / OpenAPI drift — all green.

## Docs

`api-reference` + `llm-audit` + `model-config` (en/zh), `examples/model_config.toml`, `openapi.json` regenerated. The audit and config references had statements this branch falsified ("only `chat_image_prompt_compose` reads variants", the four-value `source` vocabulary); those are corrected here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
