### PR TITLE
feat(chat)!: reply_to_message_id quotes a line instead of rewinding history

### DIFF
--- a/crates/eros-engine-core/src/pde.rs
+++ b/crates/eros-engine-core/src/pde.rs
@@ -287,7 +287,7 @@ mod tests {
             memory_scope: Default::default(),
             affinity_scope: Default::default(),
             tips_amount_usd: None,
-            history_anchor: Default::default(),
+            quote: Default::default(),
         }
     }
 
@@ -301,7 +301,7 @@ mod tests {
             memory_scope: Default::default(),
             affinity_scope: Default::default(),
             tips_amount_usd: Some(amount),
-            history_anchor: Default::default(),
+            quote: Default::default(),
         }
     }
 

--- a/crates/eros-engine-core/src/types.rs
+++ b/crates/eros-engine-core/src/types.rs
@@ -70,28 +70,30 @@ pub enum Event {
         /// gets a tip fragment. `None` for normal messages.
         #[serde(default)]
         tips_amount_usd: Option<f64>,
-        /// Optional caller-supplied reply anchor (#reply_to). Defaults to
-        /// `Latest` (normal tail window) when absent.
+        /// The message this turn quotes, resolved from the caller's
+        /// `reply_to_message_id`. `None` on ordinary turns and when the id did
+        /// not resolve. Never affects which history rows are injected — a
+        /// quote points at one line, it does not rewind the conversation.
         #[serde(default)]
-        history_anchor: HistoryAnchor,
+        quote: Option<QuotedMessage>,
     },
     ProactiveTrigger,
     AppOpen,
 }
 
-/// Where the turn's main conversation history is anchored. `Latest` (default):
-/// the normal tail window. `At`: rewind to a quoted message — history up to and
-/// including `sent_at`, then the new message. `DropHistory`: the caller's
-/// `reply_to_message_id` was unresolvable, so inject no prior turns.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
-pub enum HistoryAnchor {
-    #[default]
-    Latest,
-    At {
-        message_id: Uuid,
-        sent_at: DateTime<Utc>,
-    },
-    DropHistory,
+/// A message the caller quoted via `reply_to_message_id`, resolved to its text.
+/// Rendered as the prompt's `[quote]` block so the model knows which line the
+/// user is pointing at — the history window is untouched either way.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QuotedMessage {
+    pub message_id: Uuid,
+    /// `chat_messages.role` of the quoted row — decides whether the prompt
+    /// attributes the line to the user or to the persona.
+    pub role: String,
+    pub content: String,
+    /// When the quoted line was sent. Renders as a relative age ("3 天前") so
+    /// the model can tell a callback to an old message from a same-breath one.
+    pub sent_at: DateTime<Utc>,
 }
 
 /// Which reference image an image turn should build on. `Face` = the static
@@ -350,26 +352,24 @@ mod tests {
     }
 
     #[test]
-    fn history_anchor_defaults_to_latest_and_event_omits_it() {
-        // Default is Latest.
-        assert_eq!(HistoryAnchor::default(), HistoryAnchor::Latest);
-
-        // An event JSON without `history_anchor` still parses, defaulting to Latest.
+    fn quote_defaults_to_none_and_event_omits_it() {
+        // An event JSON without `quote` still parses, defaulting to None.
         let raw = r#"{"UserMessage":{"content":"hi","message_id":"00000000-0000-0000-0000-000000000001"}}"#;
         let ev: Event = serde_json::from_str(raw).unwrap();
         match ev {
-            Event::UserMessage { history_anchor, .. } => {
-                assert_eq!(history_anchor, HistoryAnchor::Latest);
-            }
+            Event::UserMessage { quote, .. } => assert_eq!(quote, None),
             _ => panic!("expected UserMessage"),
         }
 
-        // At{...} round-trips through serde.
-        let at = HistoryAnchor::At {
+        // A resolved quote round-trips through serde — the queue path
+        // serializes the whole event.
+        let q = QuotedMessage {
             message_id: uuid::Uuid::nil(),
+            role: "assistant".into(),
+            content: "那我们礼拜六去看展".into(),
             sent_at: chrono::DateTime::<chrono::Utc>::from_timestamp(0, 0).unwrap(),
         };
-        let s = serde_json::to_string(&at).unwrap();
-        assert_eq!(serde_json::from_str::<HistoryAnchor>(&s).unwrap(), at);
+        let s = serde_json::to_string(&q).unwrap();
+        assert_eq!(serde_json::from_str::<QuotedMessage>(&s).unwrap(), q);
     }
 }

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -3176,7 +3176,7 @@
               "null"
             ],
             "format": "uuid",
-            "description": "Optional id of a `chat_messages` row in this session to anchor context on.\nWhen valid, history rewinds to (and includes) that message; when present\nbut unresolvable, history is dropped for this turn (recorded in metadata)."
+            "description": "Optional id of a `chat_messages` row in this session that this turn\nquotes. When it resolves, the quoted line is rendered into the prompt's\n`[quote]` block; when present but unresolvable the turn runs without one\n(recorded in metadata). History is never truncated either way."
           },
           "tier": {
             "type": [

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -1985,6 +1985,14 @@
             "format": "date-time",
             "description": "When this message reached the party it was addressed to — set by\n`POST /comp/chat/{session_id}/read` on an `assistant` row, and by the\nengine itself on a `user` row (the moment the turn handed the message to\nits first model; delivery, not that model's acknowledgement). Omitted\nwhile unread; permanently omitted on tips and voice `user` rows, which\nhave no reader. Absence means \"no receipt\", not \"not yet read\"."
           },
+          "reply_to_message_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "The message this `user` row quoted — the `reply_to_message_id` the\ncaller sent, already validated to belong to this session, so it always\nnames another row in the same history page or an older one. Omitted on\nordinary turns and on turns whose anchor failed to resolve (there is no\nbubble to point at). Lets a cold mount re-render the quote instead of\nlosing it on refresh."
+          },
           "role": {
             "type": "string",
             "description": "\"user\" | \"assistant\" | \"gift_user\" | \"system_error\""
@@ -2332,6 +2340,14 @@
             ],
             "format": "date-time",
             "description": "When this message reached the party it was addressed to. On an\n`assistant` row: when the client called `POST /comp/chat/{id}/read` —\nthe human read it. On a `user` row: when the engine handed the message\nto the first model of the turn (\"delivered to a model\", not that\nmodel's acknowledgement). **Omitted while unread**, so a client tests\nfor the key's presence; there is no `null` form. Omitted forever on\ntips and on voice `user` rows, which have no reader — treat absence as\n\"no receipt\", never as \"not yet read\"."
+          },
+          "reply_to_message_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "The message this `user` row quoted — the `reply_to_message_id` it was\nsent with, validated at send time to belong to this session. Omitted on\nordinary turns and on turns whose anchor failed to resolve (those record\n`metadata.reply_to_error`, which stays audit-only). Same key-presence\ncontract as `read_at`; the BFF history entry carries the same field."
           },
           "role": {
             "type": "string"

--- a/crates/eros-engine-server/src/pipeline/chat_queue.rs
+++ b/crates/eros-engine-server/src/pipeline/chat_queue.rs
@@ -309,20 +309,21 @@ async fn drive_turn(
         crate::routes::companion::validate_llm_audit(params.audit.clone()).unwrap_or_default();
 
     // Spec §9: an older-than-latest driving message must see everything that
-    // landed after it — HistoryAnchor::Latest is exactly "the most recent
-    // window as of now". reply_to quotes still anchor explicitly.
-    let history_anchor = match params.reply_to_message_id {
-        None => eros_engine_core::types::HistoryAnchor::Latest,
+    // landed after it, so history is always the most recent window. A quote
+    // only adds the [quote] block on top of it.
+    let quote = match params.reply_to_message_id {
+        None => None,
         Some(id) => match chat_repo
-            .message_sent_at_in_session(turn.session_id, id)
+            .message_by_id_in_session(turn.session_id, id)
             .await
         {
-            Ok(Some(sent_at)) => eros_engine_core::types::HistoryAnchor::At {
-                message_id: id,
-                sent_at,
-            },
-            Ok(None) => eros_engine_core::types::HistoryAnchor::DropHistory,
-            Err(e) => return TurnOutcome::Failure(format!("anchor resolve failed: {e}")),
+            Ok(row) => row.map(|m| eros_engine_core::types::QuotedMessage {
+                message_id: m.id,
+                role: m.role,
+                content: m.content,
+                sent_at: m.sent_at,
+            }),
+            Err(e) => return TurnOutcome::Failure(format!("quote resolve failed: {e}")),
         },
     };
 
@@ -344,7 +345,7 @@ async fn drive_turn(
         tips_amount_usd: params.tips_amount_usd,
         image_url: params.image_url.clone(),
         image: params.image.clone(),
-        history_anchor,
+        quote,
     };
 
     drive_to_exhaustion(Arc::new(state.clone()), user_msg, None, tap).await

--- a/crates/eros-engine-server/src/pipeline/handlers.rs
+++ b/crates/eros-engine-server/src/pipeline/handlers.rs
@@ -61,23 +61,6 @@ const CHAT_TASK: &str = "chat_companion";
 /// Maximum number of recent messages pulled into the prompt.
 const HISTORY_WINDOW: i64 = 20;
 
-/// Resolved fetch strategy for the main history of a turn. Pure mapping of the
-/// event's `HistoryAnchor`, factored out so it can be unit-tested.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum HistoryFetch {
-    Latest,
-    Anchored(Option<chrono::DateTime<chrono::Utc>>),
-}
-
-fn history_fetch_for(anchor: eros_engine_core::types::HistoryAnchor) -> HistoryFetch {
-    use eros_engine_core::types::HistoryAnchor;
-    match anchor {
-        HistoryAnchor::Latest => HistoryFetch::Latest,
-        HistoryAnchor::At { sent_at, .. } => HistoryFetch::Anchored(Some(sent_at)),
-        HistoryAnchor::DropHistory => HistoryFetch::Anchored(None),
-    }
-}
-
 /// Partition caller traits by a tier's resolved allow-list.
 /// - `allow == None` → no gating: all kept, none dropped.
 /// - `allow == Some(set)` → keep only traits whose `tag` ∈ `set`; the rest
@@ -716,35 +699,31 @@ pub(super) async fn build_reply_request(
     user_message_id: Uuid,
 ) -> Result<(ChatRequest, Vec<String>), AppError> {
     let chat_repo = ChatRepo { pool: &state.pool };
-    let history_anchor = match &input.event {
-        eros_engine_core::types::Event::UserMessage { history_anchor, .. } => *history_anchor,
-        _ => eros_engine_core::types::HistoryAnchor::Latest,
+    // A quote points at one line; it never narrows the window. Every turn gets
+    // the same newest-N history, so quoting something from last week does not
+    // cost the model everything said since.
+    let quote = match &input.event {
+        eros_engine_core::types::Event::UserMessage { quote, .. } => quote.as_ref(),
+        _ => None,
     };
-    let history = match history_fetch_for(history_anchor) {
-        HistoryFetch::Latest => {
-            let mut rows = chat_repo.history(session_id, HISTORY_WINDOW, 0).await?;
-            // The prompt's model-facing messages come ONLY from this vector, so
-            // a driving row missing from it means the model answers a message
-            // it never sees. On the stream path the driving row is always the
-            // newest row and this is a no-op; on the async worker path a LIFO
-            // burst (or anything that landed while the turn waited) can bury it
-            // past HISTORY_WINDOW. Pin it back at its chronological position —
-            // older than everything in the window, so it goes first.
-            if !rows.iter().any(|m| m.id == user_message_id) {
-                if let Some(driving) = chat_repo
-                    .message_by_id_in_session(session_id, user_message_id)
-                    .await?
-                {
-                    rows.insert(0, driving);
-                }
-            }
-            rows
-        }
-        HistoryFetch::Anchored(anchor) => {
-            chat_repo
-                .history_anchored(session_id, user_message_id, anchor, HISTORY_WINDOW)
+    let history = {
+        let mut rows = chat_repo.history(session_id, HISTORY_WINDOW, 0).await?;
+        // The prompt's model-facing messages come ONLY from this vector, so
+        // a driving row missing from it means the model answers a message
+        // it never sees. On the stream path the driving row is always the
+        // newest row and this is a no-op; on the async worker path a LIFO
+        // burst (or anything that landed while the turn waited) can bury it
+        // past HISTORY_WINDOW. Pin it back at its chronological position —
+        // older than everything in the window, so it goes first.
+        if !rows.iter().any(|m| m.id == user_message_id) {
+            if let Some(driving) = chat_repo
+                .message_by_id_in_session(session_id, user_message_id)
                 .await?
+            {
+                rows.insert(0, driving);
+            }
         }
+        rows
     };
 
     // Recall query for the current user turn: the effective caption, or — for an
@@ -881,6 +860,7 @@ pub(super) async fn build_reply_request(
         &emotional_context,
         world.as_ref(),
         stories.as_ref(),
+        quote,
     );
 
     if let Event::UserMessage {
@@ -1664,7 +1644,7 @@ mod tests {
             memory_scope: Default::default(),
             affinity_scope: Default::default(),
             tips_amount_usd: None,
-            history_anchor: Default::default(),
+            quote: Default::default(),
         };
         let extracted = audit_from_event(&ev);
         assert_eq!(extracted, Some(&audit));
@@ -2273,27 +2253,6 @@ mod tests {
         );
         assert_eq!(pairs_after[0], ("u0".to_string(), "a0".to_string()));
         assert_eq!(pairs_after[1], ("u1".to_string(), "a1".to_string()));
-    }
-
-    #[test]
-    fn history_fetch_for_maps_each_anchor() {
-        use eros_engine_core::types::HistoryAnchor;
-        let ts = chrono::DateTime::<chrono::Utc>::from_timestamp(123, 0).unwrap();
-        assert_eq!(
-            history_fetch_for(HistoryAnchor::Latest),
-            HistoryFetch::Latest
-        );
-        assert_eq!(
-            history_fetch_for(HistoryAnchor::At {
-                message_id: uuid::Uuid::nil(),
-                sent_at: ts
-            }),
-            HistoryFetch::Anchored(Some(ts)),
-        );
-        assert_eq!(
-            history_fetch_for(HistoryAnchor::DropHistory),
-            HistoryFetch::Anchored(None),
-        );
     }
 
     // ─── fetch_world_context ────────────────────────────────────────────

--- a/crates/eros-engine-server/src/pipeline/post_process.rs
+++ b/crates/eros-engine-server/src/pipeline/post_process.rs
@@ -1976,7 +1976,7 @@ mod tests {
             memory_scope: Default::default(),
             affinity_scope: Default::default(),
             tips_amount_usd: None,
-            history_anchor: Default::default(),
+            quote: Default::default(),
         };
         // Only `user` is taken; session_id/metadata are ignored by design.
         assert_eq!(client_id_from_event(&event).as_deref(), Some("u_abc"));
@@ -1993,7 +1993,7 @@ mod tests {
             memory_scope: Default::default(),
             affinity_scope: Default::default(),
             tips_amount_usd: None,
-            history_anchor: Default::default(),
+            quote: Default::default(),
         };
         assert_eq!(client_id_from_event(&event), None);
     }
@@ -3147,7 +3147,7 @@ mod tests {
             memory_scope: Default::default(),
             affinity_scope: Default::default(),
             tips_amount_usd: None,
-            history_anchor: Default::default(),
+            quote: Default::default(),
         };
 
         // Mirrors what `pde::decide` would compute for a short user message
@@ -3308,7 +3308,7 @@ mod tests {
             memory_scope: Default::default(),
             affinity_scope: Default::default(),
             tips_amount_usd: None,
-            history_anchor: Default::default(),
+            quote: Default::default(),
         };
         let plan = ActionPlan {
             action_type: ActionType::ReplyImage,
@@ -3438,7 +3438,7 @@ mod tests {
             memory_scope: Default::default(),
             affinity_scope: Default::default(),
             tips_amount_usd: None,
-            history_anchor: Default::default(),
+            quote: Default::default(),
         };
         let plan = ActionPlan {
             action_type: ActionType::ReplyImage,
@@ -3968,7 +3968,7 @@ mod tests {
             memory_scope: Default::default(),
             affinity_scope: Default::default(),
             tips_amount_usd: None,
-            history_anchor: Default::default(),
+            quote: Default::default(),
         };
         let plan = ActionPlan {
             action_type: ActionType::ReplyText,

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -3856,9 +3856,10 @@ pub struct PersistedUserMessage {
     pub image_url: Option<String>,
     /// Image reply parameters supplied by the client, forwarded from the request.
     pub image: Option<crate::routes::companion_stream::ImageReplyParams>,
-    /// Where this turn's main history is anchored (resolved from the request's
-    /// `reply_to_message_id`). `Latest` for ordinary turns.
-    pub history_anchor: eros_engine_core::types::HistoryAnchor,
+    /// The message this turn quotes, resolved from the request's
+    /// `reply_to_message_id`. `None` for ordinary turns and for an id that did
+    /// not resolve; history is the normal window either way.
+    pub quote: Option<eros_engine_core::types::QuotedMessage>,
 }
 
 /// Produce a stream of `ProtocolFrame` events for a single burst. The
@@ -3946,7 +3947,7 @@ pub fn run_stream(
                 memory_scope: user_msg.memory_scope,
                 affinity_scope: user_msg.affinity_scope,
                 tips_amount_usd: user_msg.tips_amount_usd,
-                history_anchor: user_msg.history_anchor,
+                quote: user_msg.quote.clone(),
             },
             affinity: affinity.clone(),
             persona,
@@ -4666,7 +4667,7 @@ pub fn run_stream(
                         memory_scope: user_msg.memory_scope,
                         affinity_scope: user_msg.affinity_scope,
                         tips_amount_usd: user_msg.tips_amount_usd,
-                        history_anchor: user_msg.history_anchor,
+                        quote: user_msg.quote.clone(),
                     };
                     let user_id_bg = user_msg.user_id;
                     let instance_id_bg = user_msg.instance_id;
@@ -5181,7 +5182,7 @@ pub fn run_stream(
                     memory_scope: user_msg.memory_scope,
                     affinity_scope: user_msg.affinity_scope,
                     tips_amount_usd: user_msg.tips_amount_usd,
-                    history_anchor: user_msg.history_anchor,
+                    quote: user_msg.quote.clone(),
                 };
                 let user_id_bg = user_msg.user_id;
                 let instance_id_bg = user_msg.instance_id;
@@ -6414,7 +6415,7 @@ mod tests {
                 memory_scope: Default::default(),
                 affinity_scope: Default::default(),
                 tips_amount_usd: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             affinity: pde_test_affinity(),
             persona: pde_test_persona(),
@@ -6659,7 +6660,7 @@ mod tests {
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -7021,7 +7022,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -7119,7 +7120,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -7256,7 +7257,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -7401,7 +7402,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -7512,7 +7513,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -7614,7 +7615,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -7726,7 +7727,7 @@ data: [DONE]\n\n";
                     force: true,
                     ..Default::default()
                 }),
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -7909,7 +7910,7 @@ data: [DONE]\n\n";
                     prompt_variant: prompt_variant.map(str::to_string),
                     ..Default::default()
                 }),
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -8012,7 +8013,7 @@ data: [DONE]\n\n";
                     force: true,
                     ..Default::default()
                 }),
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -8507,7 +8508,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: Some("https://example.invalid/u.jpg".into()),
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -8631,7 +8632,7 @@ data: [DONE]\n\n";
                     force: true,
                     ..Default::default()
                 }),
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -8756,7 +8757,7 @@ data: [DONE]\n\n";
                 // keeps the judge's reply_text_image. NOT forced — force now
                 // means reply_image (spec 2026-08-03 §1).
                 image: Some(crate::routes::companion_stream::ImageReplyParams::default()),
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -8938,7 +8939,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: Some(crate::routes::companion_stream::ImageReplyParams::default()),
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -9072,7 +9073,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: Some(crate::routes::companion_stream::ImageReplyParams::default()),
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -9241,7 +9242,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: Some(crate::routes::companion_stream::ImageReplyParams::default()),
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -9424,7 +9425,7 @@ data: [DONE]\n\n";
                 // keeps the judge's reply_text_image. NOT forced — force now
                 // means reply_image (spec 2026-08-03 §1).
                 image: Some(crate::routes::companion_stream::ImageReplyParams::default()),
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -9597,7 +9598,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -9916,7 +9917,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -10041,7 +10042,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -10179,7 +10180,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -10341,7 +10342,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -10456,7 +10457,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -10571,7 +10572,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -10667,7 +10668,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: Some(20.0),
                 image_url: None,
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -10775,7 +10776,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -10885,7 +10886,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -11014,7 +11015,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -11216,7 +11217,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -11342,7 +11343,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -11465,7 +11466,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -11576,7 +11577,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: Some(0.5),
                 image_url: None,
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -11752,7 +11753,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: Some("https://x/y.png".into()),
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -11951,7 +11952,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: Some("https://x/bad.png".into()),
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -12099,7 +12100,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: Some("https://x/522.png".into()),
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -12236,7 +12237,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: Some("https://x/523.png".into()),
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -12395,7 +12396,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -12553,7 +12554,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -12685,7 +12686,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -12841,7 +12842,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -13088,7 +13089,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -13292,7 +13293,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -13440,7 +13441,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -13571,7 +13572,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -13608,6 +13609,141 @@ data: [DONE]\n\n";
         assert!(
             chat_sent.contains("[inner_state]") && chat_sent.contains("有点开心"),
             "inner_state still injected alongside tone; got {chat_sent}",
+        );
+    }
+
+    /// Quoting an old line adds the `[quote]` block and changes nothing else.
+    /// The rewind this endpoint used to do (history truncated at the anchor)
+    /// is gone: replying to something from last week must not cost the model
+    /// everything said since. Both halves are asserted here.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn run_stream_quote_injects_the_block_without_truncating_history(pool: PgPool) {
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+        use futures_util::StreamExt;
+        use wiremock::matchers::{body_string_contains, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        let judge_body = serde_json::json!({
+            "id": "gj", "model": "pde/judge",
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            "choices": [{"message": {"content": r#"{"action":"reply_text"}"#}}],
+        });
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("pde/judge"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(judge_body))
+            .mount(&mock)
+            .await;
+        let chat_body = "data: {\"choices\":[{\"delta\":{\"content\":\"REPLY\"}}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1,\"total_tokens\":2},\"id\":\"g\",\"model\":\"deepseek/x\"}\n\ndata: [DONE]\n\n";
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("deepseek/x"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(chat_body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+
+        let user_id = Uuid::new_v4();
+        let (_g, instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = std::sync::Arc::new(
+            eros_engine_llm::model_config::ModelConfig::from_toml_str(
+                "[tasks.chat_companion]\nmodel=\"deepseek/x\"\n\
+                 [tasks.pde_decision]\nmodel=\"pde/judge\"\nfilter_prompt=\"Decide.\"\n",
+            )
+            .unwrap(),
+        );
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "k".into(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+
+        // The quoted line, then two turns that landed after it. Under the old
+        // rewind semantics those two would be excluded from the prompt.
+        let chat_repo = ChatRepo { pool: &pool };
+        let anchor = chat_repo
+            .append_message(session_id, "assistant", "那我们礼拜六去看展")
+            .await
+            .unwrap();
+        chat_repo
+            .append_message(session_id, "user", "AFTERWARDS-ONE")
+            .await
+            .unwrap();
+        chat_repo
+            .append_message(session_id, "assistant", "AFTERWARDS-TWO")
+            .await
+            .unwrap();
+
+        let umid = match chat_repo
+            .upsert_user_message_idempotent(
+                session_id,
+                "等等，那个展",
+                "01JQUOTE00000000000000000A",
+                "user",
+                None,
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
+
+        let frames: Vec<ProtocolFrame> = run_stream(
+            std::sync::Arc::new(state),
+            PersistedUserMessage {
+                user_message_id: umid,
+                session_id,
+                user_id,
+                instance_id,
+                content: "等等，那个展".into(),
+                prompt_traits: vec![],
+                audit: None,
+                tier: None,
+                memory_scope: Default::default(),
+                affinity_scope: Default::default(),
+                tips_amount_usd: None,
+                image_url: None,
+                image: None,
+                quote: Some(eros_engine_core::types::QuotedMessage {
+                    message_id: anchor,
+                    role: "assistant".into(),
+                    content: "那我们礼拜六去看展".into(),
+                    sent_at: chrono::Utc::now(),
+                }),
+            },
+            None,
+        )
+        .collect()
+        .await;
+
+        let deltas: String = frames
+            .iter()
+            .filter_map(|f| match f {
+                ProtocolFrame::Delta { content, .. } => Some(content.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(deltas.contains("REPLY"), "quoted turn still replies");
+
+        let reqs = mock.received_requests().await.unwrap();
+        let chat_req = reqs
+            .iter()
+            .find(|r| String::from_utf8_lossy(&r.body).contains("deepseek/x"))
+            .expect("the chat call must have fired");
+        let chat_sent = String::from_utf8_lossy(&chat_req.body);
+        assert!(
+            chat_sent.contains("[quote]") && chat_sent.contains("那我们礼拜六去看展"),
+            "the quoted line must reach the chat prompt as a [quote] block; got {chat_sent}",
+        );
+        assert!(
+            chat_sent.contains("AFTERWARDS-ONE") && chat_sent.contains("AFTERWARDS-TWO"),
+            "a quote must NOT rewind history — turns after the anchor stay in the \
+             window; got {chat_sent}",
         );
     }
 
@@ -13696,7 +13832,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -13833,7 +13969,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: Some(1.0),
                 image_url: None,
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -13984,7 +14120,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: Some(1.0),
                 image_url: None,
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -14220,7 +14356,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -14336,7 +14472,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -14476,7 +14612,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -14571,7 +14707,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -15170,7 +15306,7 @@ data: [DONE]\n\n";
                 memory_scope: Default::default(),
                 affinity_scope: Default::default(),
                 tips_amount_usd: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             affinity: test_affinity(),
             persona: test_persona(),
@@ -15226,7 +15362,7 @@ data: [DONE]\n\n";
                 memory_scope: Default::default(),
                 affinity_scope: Default::default(),
                 tips_amount_usd: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             affinity: test_affinity(),
             persona: p,
@@ -15370,7 +15506,7 @@ data: [DONE]\n\n";
                 memory_scope: Default::default(),
                 affinity_scope: Default::default(),
                 tips_amount_usd: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             affinity: test_affinity(),
             persona: p,
@@ -15763,7 +15899,7 @@ data: [DONE]\n\n";
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )
@@ -17268,7 +17404,7 @@ data: [DONE]\n\n"
                 tips_amount_usd: None,
                 image_url: None,
                 image: None,
-                history_anchor: Default::default(),
+                quote: Default::default(),
             },
             None,
         )

--- a/crates/eros-engine-server/src/pipeline/voice.rs
+++ b/crates/eros-engine-server/src/pipeline/voice.rs
@@ -975,6 +975,7 @@ mod tests {
             channel: None,
             read_at: None,
             image: false,
+            reply_to_message_id: None,
         }
     }
 

--- a/crates/eros-engine-server/src/prompt.rs
+++ b/crates/eros-engine-server/src/prompt.rs
@@ -29,6 +29,7 @@ use eros_engine_core::affinity::Affinity;
 use eros_engine_core::persona::CompanionPersona;
 use eros_engine_core::scope::AffinityScope;
 use eros_engine_core::types::PromptTrait;
+use eros_engine_core::types::QuotedMessage;
 use eros_engine_core::types::ReplyStyle;
 
 /// World-memories injection payload: the persona's resident digest plus
@@ -115,6 +116,37 @@ fn period_cn(hour: u32) -> &'static str {
 /// UTC+8 — an unset persona then shares their wall clock rather than guessing.
 fn now_context(timezone: Option<&str>) -> String {
     now_context_at(Utc::now(), timezone)
+}
+
+/// How long ago a quoted line was said, in coarse buckets. The point of a
+/// quote is usually that the line is *not* recent, and "3 天前" is the whole
+/// difference between a callback and a same-breath correction. Deliberately
+/// coarse: the model reads ordinals, not clocks.
+fn relative_age(sent_at: chrono::DateTime<Utc>) -> String {
+    relative_age_from(Utc::now(), sent_at)
+}
+
+fn relative_age_from(now: chrono::DateTime<Utc>, sent_at: chrono::DateTime<Utc>) -> String {
+    let mins = (now - sent_at).num_minutes();
+    match mins {
+        // Negative = clock skew between the row and this host; treat as now.
+        i64::MIN..=0 => "刚刚说".into(),
+        1..=59 => format!("{mins} 分钟前说"),
+        _ => {
+            let hours = mins / 60;
+            match hours {
+                1..=23 => format!("{hours} 小时前说"),
+                _ => {
+                    let days = hours / 24;
+                    if days <= 30 {
+                        format!("{days} 天前说")
+                    } else {
+                        "很久以前说".into()
+                    }
+                }
+            }
+        }
+    }
 }
 
 fn now_context_at(now: chrono::DateTime<Utc>, timezone: Option<&str>) -> String {
@@ -503,6 +535,9 @@ pub fn build_prompt(
     // World-stories injection (stories spec §5.4). `None` or empty ⇒ the
     // [world_stories] block is omitted, prompt byte-identical.
     stories: Option<&StoriesContext>,
+    // The line this turn quotes (caller's `reply_to_message_id`, resolved).
+    // `None` ⇒ the `[quote]` block is omitted. History is unaffected either way.
+    quote: Option<&QuotedMessage>,
 ) -> String {
     let name = persona.genome.name.as_str();
     let age = meta_i32(persona, "age")
@@ -688,6 +723,27 @@ pub fn build_prompt(
         _ => String::new(),
     };
 
+    // Volatile (per-turn) quote block: the user tapped a specific line and is
+    // replying to THAT, which the tail window alone cannot express — the quoted
+    // line may be days back, or buried under unrelated turns. Renders the line
+    // with its speaker and relative age; history is untouched. `None` ⇒ omitted.
+    let quote_section = match quote {
+        Some(q) => {
+            let speaker = if q.role == "assistant" {
+                name
+            } else {
+                "用户"
+            };
+            format!(
+                "\n[quote]（用户这一轮回复的是下面这句话，{age}的，不是最后一条消息；\
+                 先接住它，再往下说）\n{speaker}：{}",
+                q.content.trim(),
+                age = relative_age(q.sent_at),
+            )
+        }
+        None => String::new(),
+    };
+
     // 铁律 ⑦: gender-consistency reinforcement (redundancy = weighting). Only for
     // binary genders, with a role-play exception. Skipped for non-binary/absent.
     // Rendered LAST so the numbering stays contiguous whether or not it fires —
@@ -732,7 +788,7 @@ pub fn build_prompt(
          [user_profile]\n{profile_str}\n\
          \n\
          [shared_memories]\n{rel_str}{world_section}{stories_section}\
-         {attitude}{state}{hints_section}{tone_section}{avoid_section}{emotional_section}\n\
+         {attitude}{state}{hints_section}{tone_section}{avoid_section}{emotional_section}{quote_section}\n\
          \n\
          [now]\n{tc}\n\
          {recent_section}\
@@ -1075,6 +1131,7 @@ mod tests {
             &[],
             None,
             None,
+            None,
         );
         assert!(
             !p.contains("[additional_guidance]"),
@@ -1114,6 +1171,7 @@ mod tests {
             &[],
             None,
             None,
+            None,
         );
         assert!(
             p.contains("[additional_guidance]"),
@@ -1148,6 +1206,7 @@ mod tests {
             &[],
             None,
             None,
+            None,
         );
         let topics = p.find("[topics]").expect("topics");
         let traits_i = p.find("[additional_guidance]").expect("traits");
@@ -1173,6 +1232,7 @@ mod tests {
             &[],
             &[],
             &[],
+            None,
             None,
             None,
         );
@@ -1208,9 +1268,120 @@ mod tests {
                 &[],
                 None,
                 None,
+                None,
             );
             assert!(!p.contains("[reply_tone]"), "no section for {tone:?}: {p}");
         }
+    }
+
+    fn quoted(role: &str, content: &str, minutes_ago: i64) -> QuotedMessage {
+        QuotedMessage {
+            message_id: uuid::Uuid::nil(),
+            role: role.into(),
+            content: content.into(),
+            sent_at: Utc::now() - chrono::Duration::minutes(minutes_ago),
+        }
+    }
+
+    #[test]
+    fn build_prompt_renders_quote_with_speaker_and_age() {
+        // The persona's own line is attributed to the persona; anything else
+        // reads as the user's. Age is what separates a callback from a
+        // same-breath correction, so it renders alongside.
+        let mine = quoted("assistant", "那我们礼拜六去看展", 60 * 24 * 3);
+        let p = build_prompt(
+            &fixture_persona(),
+            &[],
+            &[],
+            None,
+            ReplyStyle::Neutral,
+            &[],
+            None,
+            &[],
+            AffinityScope::default(),
+            &[],
+            &[],
+            &[],
+            None,
+            None,
+            Some(&mine),
+        );
+        assert!(p.contains("[quote]"), "section present: {p}");
+        assert!(
+            p.contains("Aria：那我们礼拜六去看展"),
+            "an assistant row is attributed to the persona: {p}"
+        );
+        assert!(p.contains("3 天前说"), "relative age renders: {p}");
+        assert!(
+            p.find("[quote]").unwrap() < p.find("[now]").unwrap(),
+            "[quote] renders in the volatile block before [now]"
+        );
+
+        let theirs = quoted("user", "我上次说的那个地方", 0);
+        let p = build_prompt(
+            &fixture_persona(),
+            &[],
+            &[],
+            None,
+            ReplyStyle::Neutral,
+            &[],
+            None,
+            &[],
+            AffinityScope::default(),
+            &[],
+            &[],
+            &[],
+            None,
+            None,
+            Some(&theirs),
+        );
+        assert!(
+            p.contains("用户：我上次说的那个地方"),
+            "a user row is attributed to the user: {p}"
+        );
+    }
+
+    #[test]
+    fn build_prompt_omits_quote_when_none() {
+        let p = build_prompt(
+            &fixture_persona(),
+            &[],
+            &[],
+            None,
+            ReplyStyle::Neutral,
+            &[],
+            None,
+            &[],
+            AffinityScope::default(),
+            &[],
+            &[],
+            &[],
+            None,
+            None,
+            None,
+        );
+        assert!(!p.contains("[quote]"), "no quote ⇒ no section: {p}");
+    }
+
+    #[test]
+    fn relative_age_buckets_are_coarse_and_never_negative() {
+        let now = chrono::DateTime::<Utc>::from_timestamp(1_800_000_000, 0).unwrap();
+        let ago = |secs: i64| relative_age_from(now, now - chrono::Duration::seconds(secs));
+        assert_eq!(ago(0), "刚刚说");
+        assert_eq!(ago(59), "刚刚说");
+        assert_eq!(ago(60), "1 分钟前说");
+        assert_eq!(ago(59 * 60), "59 分钟前说");
+        assert_eq!(ago(60 * 60), "1 小时前说");
+        assert_eq!(ago(23 * 3600), "23 小时前说");
+        assert_eq!(ago(24 * 3600), "1 天前说");
+        assert_eq!(ago(30 * 24 * 3600), "30 天前说");
+        assert_eq!(ago(31 * 24 * 3600), "很久以前说");
+        // Clock skew between the row's host and this one must not render a
+        // negative age — it reads as a future message to the model.
+        assert_eq!(
+            relative_age_from(now, now + chrono::Duration::hours(2)),
+            "刚刚说"
+        );
     }
 
     #[test]
@@ -1228,6 +1399,7 @@ mod tests {
             &[],
             &[],
             &[],
+            None,
             None,
             None,
         );
@@ -1279,6 +1451,7 @@ mod tests {
             &[],
             None,
             None,
+            None,
         );
         // head, then the constant guard, then identity.
         assert!(s.starts_with("AUTHORED HEAD\n\n"), "{s}");
@@ -1312,6 +1485,7 @@ mod tests {
             &[],
             None,
             None,
+            None,
         );
         // No head → starts with the guard, which still precedes identity.
         assert!(
@@ -1340,6 +1514,7 @@ mod tests {
             &[],
             &[],
             &[],
+            None,
             None,
             None,
         );
@@ -1376,6 +1551,7 @@ mod tests {
             &[],
             &[],
             &[],
+            None,
             None,
             None,
         );
@@ -1421,6 +1597,7 @@ mod tests {
             &[],
             None,
             None,
+            None,
         );
         assert!(s.contains("你是 Aria，男性，24 岁，INFP 性格。"), "{s}");
         assert!(s.contains("⑦ 你是男性，严格遵守自己的性别"), "{s}");
@@ -1443,6 +1620,7 @@ mod tests {
             &[],
             &[],
             &[],
+            None,
             None,
             None,
         );
@@ -1474,6 +1652,7 @@ mod tests {
             &[],
             None,
             None,
+            None,
         );
         assert!(s.contains("你是 Aria，24 岁，INFP 性格。"), "{s}");
         assert!(!s.contains("⑧"), "no gender → no ⑧: {s}");
@@ -1496,6 +1675,7 @@ mod tests {
             &[],
             &[],
             &[],
+            None,
             None,
             None,
         );
@@ -1527,6 +1707,7 @@ mod tests {
             &[],
             None,
             None,
+            None,
         );
         assert!(s.contains("你所在时区：Asia/Tokyo。"), "{s}");
     }
@@ -1551,6 +1732,7 @@ mod tests {
             &pairs,
             &[],
             &[],
+            None,
             None,
             None,
         );
@@ -1608,6 +1790,7 @@ mod tests {
             &[],
             None,
             None,
+            None,
         );
         assert!(
             !s.contains("[recent_conversation]"),
@@ -1630,6 +1813,7 @@ mod tests {
             &[],
             &[],
             &[],
+            None,
             None,
             None,
         );
@@ -1663,6 +1847,7 @@ mod tests {
             &[],
             None,
             None,
+            None,
         );
         let groups = vec![("基础画像".to_string(), vec!["住在上海".to_string()])];
         let b = build_prompt(
@@ -1678,6 +1863,7 @@ mod tests {
             &[],
             &["我看着你".to_string()],
             &["最近聊得不错".to_string()],
+            None,
             None,
             None,
         );
@@ -1717,6 +1903,7 @@ mod tests {
             &[],
             None,
             None,
+            None,
         );
         let b = build_prompt(
             &p,
@@ -1731,6 +1918,7 @@ mod tests {
             &[],
             &[],
             &[],
+            None,
             None,
             None,
         );
@@ -1760,6 +1948,7 @@ mod tests {
             &[],
             &["我看着你".to_string(), "我盯着你".to_string()],
             &[],
+            None,
             None,
             None,
         );
@@ -1795,6 +1984,7 @@ mod tests {
             &[],
             None,
             None,
+            None,
         );
         assert!(!s.contains("[avoid_repetition]"), "{s}");
     }
@@ -1819,6 +2009,7 @@ mod tests {
             &[],
             &[],
             &reasons,
+            None,
             None,
             None,
         );
@@ -1858,6 +2049,7 @@ mod tests {
             &[],
             None,
             None,
+            None,
         );
         assert!(!s.contains("[emotional_context]"), "{s}");
     }
@@ -1882,6 +2074,7 @@ mod tests {
             &[],
             &[],
             Some(&world),
+            None,
             None,
         );
         let block_at = p.find("[world_memories]").expect("block present");
@@ -1910,6 +2103,7 @@ mod tests {
             &[],
             None,
             None,
+            None,
         );
         assert!(!without.contains("[world_memories]"));
         // Empty context must also omit the block AND be byte-identical.
@@ -1928,6 +2122,7 @@ mod tests {
             &[],
             &[],
             Some(&empty),
+            None,
             None,
         );
         assert_eq!(without, with_empty, "empty world ⇒ byte-identical prompt");
@@ -1954,6 +2149,7 @@ mod tests {
             &[],
             None,
             Some(&stories),
+            None,
         );
         let at = p.find("[world_stories]").expect("block present");
         assert!(p[at..].contains("开店倒计时一周"));
@@ -1980,6 +2176,7 @@ mod tests {
             &[],
             None,
             None,
+            None,
         );
         assert!(!without.contains("[world_stories]"));
         let with_empty = build_prompt(
@@ -1997,6 +2194,7 @@ mod tests {
             &[],
             None,
             Some(&StoriesContext::default()),
+            None,
         );
         assert_eq!(without, with_empty, "empty stories ⇒ byte-identical prompt");
     }
@@ -2298,6 +2496,7 @@ mod tests {
             &[],
             None,
             None,
+            None,
         );
         assert!(p.contains("warmth=") && p.contains("intimacy=") && p.contains("tension="));
         assert!(!p.contains("trust=") && !p.contains("intrigue=") && !p.contains("patience="));
@@ -2323,6 +2522,7 @@ mod tests {
             &[],
             &[],
             &[],
+            None,
             None,
             None,
         );
@@ -2394,6 +2594,7 @@ mod tests {
             &[],
             None,
             None,
+            None,
         );
         // What survives of the old ⑨: the half that governs what the reply
         // engages with. Its other half ("别开口就自述动作或凝视") was an opener
@@ -2458,6 +2659,7 @@ mod tests {
             &[],
             &[],
             &[],
+            None,
             None,
             None,
         );

--- a/crates/eros-engine-server/src/routes/bff/companion.rs
+++ b/crates/eros-engine-server/src/routes/bff/companion.rs
@@ -76,6 +76,13 @@ pub struct BffHistoryEntry {
     pub reply_to_message_id: Option<Uuid>,
 }
 
+/// Parse the raw `metadata->>'reply_to_message_id'` text the slim projection
+/// carries. Anything that is not a UUID is dropped rather than surfaced — the
+/// column is unconstrained JSONB, and one bad row must not fail the page.
+fn parse_anchor(raw: Option<String>) -> Option<Uuid> {
+    raw.and_then(|s| Uuid::parse_str(&s).ok())
+}
+
 #[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct BffHistoryResponse {
     pub session_id: Uuid,
@@ -178,7 +185,7 @@ async fn bff_get_history(
             channel: r.channel,
             read_at: r.read_at,
             image: r.image,
-            reply_to_message_id: r.reply_to_message_id,
+            reply_to_message_id: parse_anchor(r.reply_to_message_id),
         })
         .collect();
     let total = messages.len();
@@ -238,7 +245,7 @@ async fn bff_start_chat(
                 channel: r.channel,
                 read_at: r.read_at,
                 image: r.image,
-                reply_to_message_id: r.reply_to_message_id,
+                reply_to_message_id: parse_anchor(r.reply_to_message_id),
             })
             .collect()
     };
@@ -877,6 +884,53 @@ mod tests {
             failed.get("reply_to_error").is_none(),
             "reply_to_error stays audit-only; got {failed}"
         );
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn bff_history_survives_a_malformed_reply_anchor(pool: PgPool) {
+        // `metadata` is unconstrained JSONB. A `::uuid` cast in the projection
+        // would fail the WHOLE page on one bad value; the anchor is carried as
+        // text and parsed per row instead, so a junk value costs its own key
+        // and nothing else.
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+
+        sqlx::query(
+            "INSERT INTO engine.chat_messages \
+                 (session_id, role, content, metadata, sent_at) \
+             VALUES ($1, 'user', 'junk string', \
+                     '{\"reply_to_message_id\": \"not-a-uuid\"}'::jsonb, \
+                     now() - interval '3 seconds'),
+                    ($1, 'user', 'junk number', \
+                     '{\"reply_to_message_id\": 42}'::jsonb, \
+                     now() - interval '2 seconds'),
+                    ($1, 'user', 'json null', \
+                     '{\"reply_to_message_id\": null}'::jsonb, \
+                     now() - interval '1 second')",
+        )
+        .bind(session_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let state = test_state(pool);
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        let (status, body) =
+            send_request(&mut app, bff_history_request(&token, session_id, "")).await;
+        assert_eq!(status, StatusCode::OK, "the page still renders: {body}");
+
+        let messages = body["messages"].as_array().expect("messages array");
+        assert_eq!(messages.len(), 3, "every row survives: {body}");
+        for m in messages {
+            assert!(
+                m.get("reply_to_message_id").is_none(),
+                "an unparseable anchor is dropped, not surfaced; got {m}"
+            );
+        }
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/crates/eros-engine-server/src/routes/bff/companion.rs
+++ b/crates/eros-engine-server/src/routes/bff/companion.rs
@@ -66,6 +66,14 @@ pub struct BffHistoryEntry {
     /// docs/superpowers/specs/2026-08-21-image-turn-discovery-design.md.
     #[serde(skip_serializing_if = "is_false")]
     pub image: bool,
+    /// The message this `user` row quoted — the `reply_to_message_id` the
+    /// caller sent, already validated to belong to this session, so it always
+    /// names another row in the same history page or an older one. Omitted on
+    /// ordinary turns and on turns whose anchor failed to resolve (there is no
+    /// bubble to point at). Lets a cold mount re-render the quote instead of
+    /// losing it on refresh.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reply_to_message_id: Option<Uuid>,
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
@@ -170,6 +178,7 @@ async fn bff_get_history(
             channel: r.channel,
             read_at: r.read_at,
             image: r.image,
+            reply_to_message_id: r.reply_to_message_id,
         })
         .collect();
     let total = messages.len();
@@ -229,6 +238,7 @@ async fn bff_start_chat(
                 channel: r.channel,
                 read_at: r.read_at,
                 image: r.image,
+                reply_to_message_id: r.reply_to_message_id,
             })
             .collect()
     };
@@ -786,6 +796,87 @@ mod tests {
                 "BFF must not surface prompt_traits from metadata; got {m}"
             );
         }
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn bff_history_exposes_reply_to_message_id_on_quoted_rows(pool: PgPool) {
+        // The anchor is written by the send path onto the user row's
+        // `metadata.reply_to_message_id`; history must hand it back so a cold
+        // mount can re-render the quote. A turn whose anchor failed to resolve
+        // carries `reply_to_error` instead — audit-only, never surfaced.
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+
+        let anchor: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_messages (session_id, role, content, sent_at) \
+             VALUES ($1, 'user', 'the earlier plan', now() - interval '3 seconds') \
+             RETURNING id",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "INSERT INTO engine.chat_messages \
+                 (session_id, role, content, metadata, sent_at) \
+             VALUES ($1, 'user', 'wait, about that', \
+                     jsonb_build_object('reply_to_message_id', $2::text), \
+                     now() - interval '2 seconds'),
+                    ($1, 'user', 'stale quote', \
+                     '{\"reply_to_error\": \"not_found\"}'::jsonb, \
+                     now() - interval '1 second')",
+        )
+        .bind(session_id)
+        .bind(anchor)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let state = test_state(pool);
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        let (status, body) =
+            send_request(&mut app, bff_history_request(&token, session_id, "")).await;
+        assert_eq!(status, StatusCode::OK, "got body: {body}");
+
+        let messages = body["messages"].as_array().expect("messages array");
+        assert_eq!(messages.len(), 3);
+
+        let quoting = messages
+            .iter()
+            .find(|m| m["content"] == "wait, about that")
+            .expect("quoting row");
+        assert_eq!(
+            quoting["reply_to_message_id"],
+            json!(anchor.to_string()),
+            "the quoting row must carry its anchor; got {quoting}"
+        );
+
+        let anchored = messages
+            .iter()
+            .find(|m| m["content"] == "the earlier plan")
+            .expect("anchor row");
+        assert!(
+            anchored.get("reply_to_message_id").is_none(),
+            "an ordinary row must omit reply_to_message_id; got {anchored}"
+        );
+
+        let failed = messages
+            .iter()
+            .find(|m| m["content"] == "stale quote")
+            .expect("failed-anchor row");
+        assert!(
+            failed.get("reply_to_message_id").is_none(),
+            "an unresolved anchor has no bubble to point at; got {failed}"
+        );
+        assert!(
+            failed.get("reply_to_error").is_none(),
+            "reply_to_error stays audit-only; got {failed}"
+        );
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -142,6 +142,13 @@ pub struct ChatHistoryEntry {
     /// never recorded (fail-open audit) — genuinely unrecoverable.
     #[serde(skip_serializing_if = "is_false")]
     pub image: bool,
+    /// The message this `user` row quoted — the `reply_to_message_id` it was
+    /// sent with, validated at send time to belong to this session. Omitted on
+    /// ordinary turns and on turns whose anchor failed to resolve (those record
+    /// `metadata.reply_to_error`, which stays audit-only). Same key-presence
+    /// contract as `read_at`; the BFF history entry carries the same field.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reply_to_message_id: Option<Uuid>,
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
@@ -758,6 +765,12 @@ async fn get_history(
         .map(|m| ChatHistoryEntry {
             id: m.id,
             image: m.metadata.as_ref().and_then(|md| md.get("image")).is_some(),
+            reply_to_message_id: m
+                .metadata
+                .as_ref()
+                .and_then(|md| md.get("reply_to_message_id"))
+                .and_then(|v| v.as_str())
+                .and_then(|s| Uuid::parse_str(s).ok()),
             role: m.role,
             content: m.content,
             sent_at: m.sent_at,
@@ -2491,6 +2504,76 @@ mod tests {
             messages[1]
         );
         assert_eq!(messages[2]["image"], true, "image turn is flagged");
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn history_carries_the_reply_anchor_of_quoted_turns(pool: PgPool) {
+        // The send path records the resolved anchor on the user row's
+        // `metadata.reply_to_message_id`; history hands it back so a client can
+        // re-render the quote. An anchor that failed to resolve leaves only
+        // `reply_to_error`, which is audit-only and never surfaced.
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Nova").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+        let anchor: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_messages (session_id, role, content, sent_at) \
+             VALUES ($1, 'user', 'the earlier plan', now() - interval '3 seconds') RETURNING id",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO engine.chat_messages (session_id, role, content, metadata, sent_at) \
+             VALUES ($1, 'user', 'wait, about that', \
+                     jsonb_build_object('reply_to_message_id', $2::text), \
+                     now() - interval '2 seconds'),
+                    ($1, 'user', 'stale quote', \
+                     '{\"reply_to_error\": \"not_found\"}'::jsonb, \
+                     now() - interval '1 second')",
+        )
+        .bind(session_id)
+        .bind(anchor)
+        .execute(&pool)
+        .await
+        .unwrap();
+        let jwt = mint_test_jwt(user_id);
+        let mut router = build_router(test_state(pool.clone()));
+
+        let (status, body) = send_request(
+            &mut router,
+            Request::builder()
+                .uri(format!("/comp/chat/{session_id}/history"))
+                .header(header::AUTHORIZATION, format!("Bearer {jwt}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let messages = body["messages"].as_array().unwrap();
+        assert_eq!(messages.len(), 3);
+        assert!(
+            messages[0].get("reply_to_message_id").is_none(),
+            "an ordinary row omits the key: {}",
+            messages[0]
+        );
+        assert_eq!(
+            messages[1]["reply_to_message_id"],
+            anchor.to_string(),
+            "the quoting row echoes its anchor: {}",
+            messages[1]
+        );
+        assert!(
+            messages[2].get("reply_to_message_id").is_none(),
+            "an unresolved anchor has no bubble to point at: {}",
+            messages[2]
+        );
+        assert!(
+            messages[2].get("reply_to_error").is_none(),
+            "reply_to_error stays audit-only: {}",
+            messages[2]
+        );
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/crates/eros-engine-server/src/routes/companion_async.rs
+++ b/crates/eros-engine-server/src/routes/companion_async.rs
@@ -25,7 +25,7 @@ use crate::routes::companion::{
     validate_llm_audit, validate_prompt_traits, LlmAuditDto, PromptTraitDto,
 };
 use crate::routes::companion_stream::{
-    build_user_row_metadata, persisted_content_role, resolve_history_anchor, resolve_text_turn,
+    build_user_row_metadata, persisted_content_role, resolve_quote, resolve_text_turn,
     validate_image_capability, validate_payload, AffinityScopeDto, ImageReplyParams,
     StreamPreErrorBody, StreamSendRequest,
 };
@@ -130,9 +130,8 @@ pub async fn send_message_async(
     let (_session, _persona, _instance_id) = resolve_text_turn(&state, session_id, user_id).await?;
 
     let chat_repo = ChatRepo { pool: &state.pool };
-    let history_anchor =
-        resolve_history_anchor(&chat_repo, session_id, req.reply_to_message_id).await?;
-    let persisted_metadata = build_user_row_metadata(&req, &history_anchor);
+    let quote = resolve_quote(&chat_repo, session_id, req.reply_to_message_id).await?;
+    let persisted_metadata = build_user_row_metadata(&req, quote.as_ref());
     let (persisted_content, persisted_role) = persisted_content_role(&req);
 
     let params = serde_json::to_value(QueuedTurnParams {

--- a/crates/eros-engine-server/src/routes/companion_stream.rs
+++ b/crates/eros-engine-server/src/routes/companion_stream.rs
@@ -17,7 +17,7 @@ use uuid::Uuid;
 
 use eros_engine_core::persona::CompanionPersona;
 use eros_engine_core::scope::{AffinityAxis, AffinityScope, MemoryScope};
-use eros_engine_core::types::HistoryAnchor;
+use eros_engine_core::types::QuotedMessage;
 use eros_engine_llm::model_config::StyleKey;
 use eros_engine_store::chat::{ChatRepo, ChatSession};
 use eros_engine_store::chat_queue::{ChatQueueRepo, ClaimedEnqueueOutcome, ClaimedTurn};
@@ -132,9 +132,10 @@ pub struct StreamSendRequest {
     pub image_url: Option<String>,
     #[serde(default)]
     pub image: Option<ImageReplyParams>,
-    /// Optional id of a `chat_messages` row in this session to anchor context on.
-    /// When valid, history rewinds to (and includes) that message; when present
-    /// but unresolvable, history is dropped for this turn (recorded in metadata).
+    /// Optional id of a `chat_messages` row in this session that this turn
+    /// quotes. When it resolves, the quoted line is rendered into the prompt's
+    /// `[quote]` block; when present but unresolvable the turn runs without one
+    /// (recorded in metadata). History is never truncated either way.
     #[serde(default)]
     pub reply_to_message_id: Option<Uuid>,
 }
@@ -387,31 +388,34 @@ pub(crate) async fn resolve_text_turn(
     Ok((session, persona, instance_id))
 }
 
-/// Resolve the optional reply anchor. A present-but-unresolvable id does not
-/// fail the request — we drop history for this turn and flag it (DropHistory).
-pub(crate) async fn resolve_history_anchor(
+/// Resolve the caller's `reply_to_message_id` into the message it quotes. A
+/// present-but-unresolvable id does not fail the request and does not touch
+/// history — the turn simply runs without a `[quote]` block, and
+/// `build_user_row_metadata` records `reply_to_error` on the persisted row.
+pub(crate) async fn resolve_quote(
     chat_repo: &ChatRepo<'_>,
     session_id: Uuid,
     reply_to: Option<Uuid>,
-) -> Result<HistoryAnchor, AppError> {
-    let history_anchor = match reply_to {
-        None => HistoryAnchor::Latest,
-        Some(id) => match chat_repo.message_sent_at_in_session(session_id, id).await? {
-            Some(sent_at) => HistoryAnchor::At {
-                message_id: id,
-                sent_at,
-            },
-            None => HistoryAnchor::DropHistory,
-        },
+) -> Result<Option<QuotedMessage>, AppError> {
+    let Some(id) = reply_to else {
+        return Ok(None);
     };
-    Ok(history_anchor)
+    Ok(chat_repo
+        .message_by_id_in_session(session_id, id)
+        .await?
+        .map(|m| QuotedMessage {
+            message_id: m.id,
+            role: m.role,
+            content: m.content,
+            sent_at: m.sent_at,
+        }))
 }
 
 // Build metadata: conditionally include tips_amount_usd, tier, and image_url.
 // tier is omitted entirely (not written as null) when absent — keeps JSONB shape sparse.
 pub(crate) fn build_user_row_metadata(
     req: &StreamSendRequest,
-    history_anchor: &HistoryAnchor,
+    quote: Option<&QuotedMessage>,
 ) -> Option<serde_json::Value> {
     let mut meta_map = serde_json::Map::new();
     if let Some(amount) = req.tips_amount_usd {
@@ -450,14 +454,19 @@ pub(crate) fn build_user_row_metadata(
             .collect();
         meta_map.insert("prompt_traits_raw".into(), serde_json::Value::Array(arr));
     }
-    match history_anchor {
-        HistoryAnchor::At { message_id, .. } => {
-            meta_map.insert("reply_to_message_id".into(), serde_json::json!(message_id));
+    // A quote that resolved is the anchor the history routes hand back; one the
+    // caller asked for but we could not find leaves an audit-only error marker.
+    match (quote, req.reply_to_message_id) {
+        (Some(q), _) => {
+            meta_map.insert(
+                "reply_to_message_id".into(),
+                serde_json::json!(q.message_id),
+            );
         }
-        HistoryAnchor::DropHistory => {
+        (None, Some(_)) => {
             meta_map.insert("reply_to_error".into(), serde_json::json!("not_found"));
         }
-        HistoryAnchor::Latest => {}
+        (None, None) => {}
     }
     if meta_map.is_empty() {
         None
@@ -553,13 +562,12 @@ pub async fn send_message_stream(
     // and `Some` only on Replay, where the body is still the sole owner.
     let mut guard = Some(guard);
 
-    // Resolve the optional reply anchor BEFORE the upsert so the outcome can be
+    // Resolve the quoted message BEFORE the upsert so the outcome can be
     // recorded in the new row's metadata. A present-but-unresolvable id does not
-    // fail the request — we drop history for this turn and flag it (DropHistory).
-    let history_anchor =
-        resolve_history_anchor(&chat_repo, session_id, req.reply_to_message_id).await?;
+    // fail the request — the turn just runs without a [quote] block.
+    let quote = resolve_quote(&chat_repo, session_id, req.reply_to_message_id).await?;
 
-    let persisted_metadata = build_user_row_metadata(&req, &history_anchor);
+    let persisted_metadata = build_user_row_metadata(&req, quote.as_ref());
     let (persisted_content, persisted_role) = persisted_content_role(&req);
     let params_value = serde_json::to_value(crate::routes::companion_async::QueuedTurnParams {
         tier: req.tier.clone(),
@@ -615,7 +623,7 @@ pub async fn send_message_stream(
                     tips_amount_usd: req.tips_amount_usd,
                     image_url: req.image_url.clone(),
                     image: req.image.clone(),
-                    history_anchor,
+                    quote: quote.clone(),
                 };
                 let turn = ClaimedTurn {
                     queue_id,
@@ -1681,6 +1689,69 @@ data: [DONE]\n\n";
         assert_eq!(stored["affinity_scope_raw"], serde_json::json!("chemistry"));
         assert_eq!(stored["prompt_traits_raw"][0]["tag"], "nsfw_boost");
         assert_eq!(stored["prompt_traits_raw"][0]["text"], "be daring");
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn resolve_quote_carries_content_and_scopes_by_session(pool: PgPool) {
+        use eros_engine_store::chat::ChatRepo;
+        let user_id = Uuid::new_v4();
+        let genome_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata) \
+             VALUES ('S', 'p', '{}'::jsonb) RETURNING id",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let instance_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_instances (genome_id, owner_uid) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(genome_id).bind(user_id).fetch_one(&pool).await.unwrap();
+        let mut sessions = Vec::new();
+        for _ in 0..2 {
+            sessions.push(
+                sqlx::query_scalar::<_, Uuid>(
+                    "INSERT INTO engine.chat_sessions (user_id, instance_id) \
+                     VALUES ($1, $2) RETURNING id",
+                )
+                .bind(user_id)
+                .bind(instance_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap(),
+            );
+        }
+        let chat_repo = ChatRepo { pool: &pool };
+        let msg = chat_repo
+            .append_message(sessions[0], "assistant", "那我们礼拜六去看展")
+            .await
+            .unwrap();
+
+        // No id at all → no quote, and no DB round-trip to make one.
+        assert!(resolve_quote(&chat_repo, sessions[0], None)
+            .await
+            .unwrap()
+            .is_none());
+
+        // Resolvable → the whole line, not just its id: the prompt renders the
+        // text, so resolution has to fetch it here.
+        let q = resolve_quote(&chat_repo, sessions[0], Some(msg))
+            .await
+            .unwrap()
+            .expect("in-session id resolves");
+        assert_eq!(q.message_id, msg);
+        assert_eq!(q.role, "assistant");
+        assert_eq!(q.content, "那我们礼拜六去看展");
+
+        // Real id, wrong session → None (never leaks another session's text).
+        assert!(resolve_quote(&chat_repo, sessions[1], Some(msg))
+            .await
+            .unwrap()
+            .is_none());
+        // Unknown id → None, not an error.
+        assert!(resolve_quote(&chat_repo, sessions[0], Some(Uuid::new_v4()))
+            .await
+            .unwrap()
+            .is_none());
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -120,8 +120,13 @@ pub struct ChatMessageSlim {
     /// resolve (those carry `metadata.reply_to_error` instead, which stays an
     /// audit-only key). Lets a history viewer re-render the quoted bubble after
     /// a cold mount.
+    ///
+    /// Carried as raw text, not `::uuid`: `metadata` is unconstrained JSONB, and
+    /// a cast that meets one malformed value fails the whole page rather than
+    /// the one row. The caller parses and drops what does not parse — the same
+    /// thing the canonical history route does with its own extract.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reply_to_message_id: Option<Uuid>,
+    pub reply_to_message_id: Option<String>,
 }
 
 pub struct ChatRepo<'a> {
@@ -318,7 +323,7 @@ impl<'a> ChatRepo<'a> {
                     (metadata->>'tips_amount_usd')::float8 AS tips_amount_usd, \
                     channel, read_at, \
                     (metadata->'image' IS NOT NULL) AS image, \
-                    (metadata->>'reply_to_message_id')::uuid AS reply_to_message_id \
+                    metadata->>'reply_to_message_id' AS reply_to_message_id \
              FROM engine.chat_messages \
              WHERE session_id = $1 \
              ORDER BY sent_at DESC \

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -284,27 +284,11 @@ impl<'a> ChatRepo<'a> {
         Ok(rows)
     }
 
-    /// `sent_at` of message `id` within `session_id`; `None` if the id is not in
-    /// this session (or does not exist). Resolves a caller-supplied
-    /// `reply_to_message_id` into a history anchor.
-    pub async fn message_sent_at_in_session(
-        &self,
-        session_id: Uuid,
-        id: Uuid,
-    ) -> Result<Option<DateTime<Utc>>, sqlx::Error> {
-        sqlx::query_scalar(
-            "SELECT sent_at FROM engine.chat_messages WHERE id = $1 AND session_id = $2",
-        )
-        .bind(id)
-        .bind(session_id)
-        .fetch_optional(self.pool)
-        .await
-    }
-
     /// Full row for message `id` within `session_id`; `None` if the id is not
     /// in this session (or does not exist). Used to pin a driving message back
     /// into the prompt when a burst of newer traffic pushed it out of the
-    /// newest-N `history()` window.
+    /// newest-N `history()` window, and to resolve a caller's
+    /// `reply_to_message_id` into the quote the prompt renders.
     pub async fn message_by_id_in_session(
         &self,
         session_id: Uuid,
@@ -317,57 +301,6 @@ impl<'a> ChatRepo<'a> {
         .bind(session_id)
         .fetch_optional(self.pool)
         .await
-    }
-
-    /// History for a quote-anchored turn, chronological.
-    ///
-    /// `anchor = Some(ts)` (rewind): returns **at most `limit` rows total**,
-    /// chronological. The current message (`current_msg_id`, whose
-    /// `sent_at > ts`) is always included and **counts toward `limit`**; it
-    /// sorts first under `DESC` so `LIMIT` only trims the oldest
-    /// below-anchor rows. Messages with `sent_at` strictly between `ts` and
-    /// the current message's `sent_at` are excluded. This matches the
-    /// `history()` window contract — both use `limit` rows total including
-    /// the newest (current) message.
-    ///
-    /// `anchor = None` (drop history): only the `current_msg_id` row.
-    ///
-    /// Uses the existing `(session_id, sent_at DESC)` index — no migration.
-    pub async fn history_anchored(
-        &self,
-        session_id: Uuid,
-        current_msg_id: Uuid,
-        anchor: Option<DateTime<Utc>>,
-        limit: i64,
-    ) -> Result<Vec<ChatMessage>, sqlx::Error> {
-        let mut rows = match anchor {
-            Some(ts) => {
-                sqlx::query_as::<_, ChatMessage>(
-                    "SELECT * FROM engine.chat_messages \
-                     WHERE session_id = $1 AND (sent_at <= $2 OR id = $3) \
-                     ORDER BY sent_at DESC \
-                     LIMIT $4",
-                )
-                .bind(session_id)
-                .bind(ts)
-                .bind(current_msg_id)
-                .bind(limit)
-                .fetch_all(self.pool)
-                .await?
-            }
-            None => {
-                sqlx::query_as::<_, ChatMessage>(
-                    "SELECT * FROM engine.chat_messages \
-                     WHERE session_id = $1 AND id = $2",
-                )
-                .bind(session_id)
-                .bind(current_msg_id)
-                .fetch_all(self.pool)
-                .await?
-            }
-        };
-        rows.reverse();
-        Ok(rows)
     }
 
     /// Projection-narrowed read used by BFF endpoints (and any caller that
@@ -3234,168 +3167,6 @@ mod tests {
             .unwrap();
         // Only the non-truncated assistant row, newest-first.
         assert_eq!(got, vec!["assistant-0".to_string()]);
-    }
-
-    async fn insert_at(
-        pool: &PgPool,
-        session_id: Uuid,
-        role: &str,
-        content: &str,
-        sent_at: DateTime<Utc>,
-    ) -> Uuid {
-        sqlx::query_scalar(
-            "INSERT INTO engine.chat_messages (session_id, role, content, sent_at) \
-             VALUES ($1, $2, $3, $4) RETURNING id",
-        )
-        .bind(session_id)
-        .bind(role)
-        .bind(content)
-        .bind(sent_at)
-        .fetch_one(pool)
-        .await
-        .unwrap()
-    }
-
-    #[sqlx::test(migrations = "./migrations")]
-    async fn message_sent_at_in_session_scopes_by_session(pool: PgPool) {
-        let repo = ChatRepo { pool: &pool };
-        let s = throwaway_session(&pool).await;
-        let other = throwaway_session(&pool).await;
-        let base = chrono::Utc::now();
-        let m = insert_at(&pool, s.id, "user", "hi", base).await;
-        let n = insert_at(&pool, other.id, "user", "yo", base).await;
-
-        assert!(repo
-            .message_sent_at_in_session(s.id, m)
-            .await
-            .unwrap()
-            .is_some());
-        // id exists but in a different session → None.
-        assert!(repo
-            .message_sent_at_in_session(s.id, n)
-            .await
-            .unwrap()
-            .is_none());
-        // nonexistent id → None.
-        assert!(repo
-            .message_sent_at_in_session(s.id, Uuid::new_v4())
-            .await
-            .unwrap()
-            .is_none());
-    }
-
-    #[sqlx::test(migrations = "./migrations")]
-    async fn history_anchored_rewind_drops_between_and_keeps_m_and_u(pool: PgPool) {
-        let repo = ChatRepo { pool: &pool };
-        let s = throwaway_session(&pool).await;
-        let base = chrono::Utc::now();
-        // A B M C D E U with strictly increasing sent_at.
-        let labels = ["A", "B", "M", "C", "D", "E", "U"];
-        let mut ids = Vec::new();
-        for (i, label) in labels.iter().enumerate() {
-            let role = if i % 2 == 0 { "user" } else { "assistant" };
-            ids.push(
-                insert_at(
-                    &pool,
-                    s.id,
-                    role,
-                    label,
-                    base + chrono::Duration::seconds(i as i64),
-                )
-                .await,
-            );
-        }
-        let m = ids[2];
-        let u = ids[6];
-        let m_ts = repo
-            .message_sent_at_in_session(s.id, m)
-            .await
-            .unwrap()
-            .unwrap();
-
-        let rows = repo
-            .history_anchored(s.id, u, Some(m_ts), 20)
-            .await
-            .unwrap();
-        let got: Vec<&str> = rows.iter().map(|r| r.content.as_str()).collect();
-        assert_eq!(
-            got,
-            vec!["A", "B", "M", "U"],
-            "C/D/E dropped; M and U kept, chronological"
-        );
-    }
-
-    #[sqlx::test(migrations = "./migrations")]
-    async fn history_anchored_drop_history_returns_only_current(pool: PgPool) {
-        let repo = ChatRepo { pool: &pool };
-        let s = throwaway_session(&pool).await;
-        let base = chrono::Utc::now();
-        insert_at(&pool, s.id, "user", "old1", base).await;
-        insert_at(
-            &pool,
-            s.id,
-            "assistant",
-            "old2",
-            base + chrono::Duration::seconds(1),
-        )
-        .await;
-        let u = insert_at(
-            &pool,
-            s.id,
-            "user",
-            "current",
-            base + chrono::Duration::seconds(2),
-        )
-        .await;
-
-        let rows = repo.history_anchored(s.id, u, None, 20).await.unwrap();
-        let got: Vec<&str> = rows.iter().map(|r| r.content.as_str()).collect();
-        assert_eq!(
-            got,
-            vec!["current"],
-            "DropHistory → only the current message"
-        );
-    }
-
-    #[sqlx::test(migrations = "./migrations")]
-    async fn history_anchored_rewind_counts_current_toward_limit(pool: PgPool) {
-        let repo = ChatRepo { pool: &pool };
-        let s = throwaway_session(&pool).await;
-        let base = chrono::Utc::now();
-        // A B M C D E U with strictly increasing sent_at.
-        let labels = ["A", "B", "M", "C", "D", "E", "U"];
-        let mut ids = Vec::new();
-        for (i, label) in labels.iter().enumerate() {
-            let role = if i % 2 == 0 { "user" } else { "assistant" };
-            ids.push(
-                insert_at(
-                    &pool,
-                    s.id,
-                    role,
-                    label,
-                    base + chrono::Duration::seconds(i as i64),
-                )
-                .await,
-            );
-        }
-        let m = ids[2];
-        let u = ids[6];
-        let m_ts = repo
-            .message_sent_at_in_session(s.id, m)
-            .await
-            .unwrap()
-            .unwrap();
-
-        // limit=3: qualifying rows are {A,B,M (sent_at<=ts)} + {U}; DESC = U,M,B,A; LIMIT 3 = U,M,B;
-        // reversed = [B, M, U]. The current message U always survives (highest sent_at sorts first
-        // under DESC); the oldest below-anchor row (A) is trimmed. U counts toward the limit.
-        let rows = repo.history_anchored(s.id, u, Some(m_ts), 3).await.unwrap();
-        let got: Vec<&str> = rows.iter().map(|r| r.content.as_str()).collect();
-        assert_eq!(
-            got,
-            vec!["B", "M", "U"],
-            "limit caps total incl. U; oldest (A) trimmed; U survives"
-        );
     }
 
     #[sqlx::test(migrations = "./migrations")]

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -113,6 +113,15 @@ pub struct ChatMessageSlim {
     /// `(metadata->'image' IS NOT NULL)` so the slim query stays slim.
     /// Spec: docs/superpowers/specs/2026-08-21-image-turn-discovery-design.md.
     pub image: bool,
+    /// Reply anchor this `user` row quoted, from
+    /// `metadata->>'reply_to_message_id'` — the `chat_messages` id the caller
+    /// passed as `reply_to_message_id` on send, already validated to live in
+    /// this session. NULL on ordinary turns and on turns whose anchor failed to
+    /// resolve (those carry `metadata.reply_to_error` instead, which stays an
+    /// audit-only key). Lets a history viewer re-render the quoted bubble after
+    /// a cold mount.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reply_to_message_id: Option<Uuid>,
 }
 
 pub struct ChatRepo<'a> {
@@ -375,7 +384,8 @@ impl<'a> ChatRepo<'a> {
             "SELECT id, role, content, sent_at, client_msg_id, \
                     (metadata->>'tips_amount_usd')::float8 AS tips_amount_usd, \
                     channel, read_at, \
-                    (metadata->'image' IS NOT NULL) AS image \
+                    (metadata->'image' IS NOT NULL) AS image, \
+                    (metadata->>'reply_to_message_id')::uuid AS reply_to_message_id \
              FROM engine.chat_messages \
              WHERE session_id = $1 \
              ORDER BY sent_at DESC \

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -293,16 +293,20 @@ curl -N -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/js
   http://localhost:8080/comp/chat/<session_id>/message/stream
 ```
 
-**Optional: reply anchor (rewind).** The body may include
-`reply_to_message_id` — the UUID of a `chat_messages` row in this session to
-anchor this turn's context on. When it resolves, history rewinds to (and
-includes) that message: rows sent after it are excluded from the prompt, and
-the anchor is recorded on the persisted user row's
-`metadata.reply_to_message_id`. A present-but-unresolvable id (unknown, or
-belonging to another session) does not fail the request — history is dropped
-for this turn (only the current message is in context) and the row's
-`metadata.reply_to_error` is set to `"not_found"`. Omit the field for the
-normal latest-history behavior.
+**Optional: quote.** The body may include `reply_to_message_id` — the UUID of a
+`chat_messages` row in this session that this turn replies to. When it
+resolves, the quoted line is rendered into the reply prompt as a `[quote]`
+block (its text, whether the persona or the user said it, and how long ago),
+and the anchor is recorded on the persisted user row's
+`metadata.reply_to_message_id`, from which both history routes echo it back.
+
+**A quote points at one line; it does not rewind the conversation.** The
+history window is the same newest-N with or without it, so quoting something
+from last week costs the model nothing that was said since. A
+present-but-unresolvable id (unknown, or belonging to another session) does not
+fail the request and does not change the context either: the turn simply runs
+without a `[quote]` block, and the row's `metadata.reply_to_error` is set to
+`"not_found"`.
 
 ```bash
 curl -N -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json" \
@@ -624,9 +628,9 @@ the image. The flag also tells a rehydrating client that a turn promised an
 image (the `image_request` SSE frame is the turn's last frame and wire-only —
 a disconnect before it fires would otherwise be undetectable from history).
 
-`reply_to_message_id` echoes the reply anchor a `user` row was sent with (see
-**Optional: reply anchor (rewind)** above): the id of the row it quoted, always
-in this same session. Same key-presence contract — omitted on ordinary turns,
+`reply_to_message_id` echoes the quote a `user` row was sent with (see
+**Optional: quote** above): the id of the row it quoted, always in this same
+session. Same key-presence contract — omitted on ordinary turns,
 and omitted when the anchor failed to resolve, since there is no bubble to
 point at. That failure is recorded as `metadata.reply_to_error` on the row and
 stays audit-only; a client that needs to know its quote was dropped should read
@@ -1276,8 +1280,8 @@ contract and `image-request` discovery semantics as the canonical history
 route above, including the "404 on a flagged row = unrecoverable" reading.
 The `POST /bff/v1/comp/chat/start` bundle serializes history through this
 same entry shape and therefore carries the flag too. `reply_to_message_id`
-echoes the reply anchor a `user` row was sent with (see the stream route's
-**reply anchor** section) — the id of the row it quoted, always in this same
+echoes the quote a `user` row was sent with (see the stream route's
+**Optional: quote** section) — the id of the row it quoted, always in this same
 session; omitted on ordinary turns and on turns whose anchor failed to resolve,
 so a cold mount can re-render the quote without keeping local state. Same auth, ownership check, and
 `limit ∈ [1, 50]` clamp as the canonical history route. **Intentional

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -624,6 +624,14 @@ the image. The flag also tells a rehydrating client that a turn promised an
 image (the `image_request` SSE frame is the turn's last frame and wire-only —
 a disconnect before it fires would otherwise be undetectable from history).
 
+`reply_to_message_id` echoes the reply anchor a `user` row was sent with (see
+**Optional: reply anchor (rewind)** above): the id of the row it quoted, always
+in this same session. Same key-presence contract — omitted on ordinary turns,
+and omitted when the anchor failed to resolve, since there is no bubble to
+point at. That failure is recorded as `metadata.reply_to_error` on the row and
+stays audit-only; a client that needs to know its quote was dropped should read
+the SSE turn it sent, not history.
+
 ### `GET /comp/chat/{session_id}/messages/{message_id}/image-request`
 
 The delegated `image_request` payload for one persisted image turn — the
@@ -1267,7 +1275,11 @@ an image (omitted on every other row, never `false`) — the same key-presence
 contract and `image-request` discovery semantics as the canonical history
 route above, including the "404 on a flagged row = unrecoverable" reading.
 The `POST /bff/v1/comp/chat/start` bundle serializes history through this
-same entry shape and therefore carries the flag too. Same auth, ownership check, and
+same entry shape and therefore carries the flag too. `reply_to_message_id`
+echoes the reply anchor a `user` row was sent with (see the stream route's
+**reply anchor** section) — the id of the row it quoted, always in this same
+session; omitted on ordinary turns and on turns whose anchor failed to resolve,
+so a cold mount can re-render the quote without keeping local state. Same auth, ownership check, and
 `limit ∈ [1, 50]` clamp as the canonical history route. **Intentional
 divergence:** the default `limit` is 50 (the canonical route defaults to 20),
 because the BFF exists for a cold mount that wants a full backscroll in one
@@ -1280,9 +1292,10 @@ round-trip.
     { "id": "3cc06c53-…", "client_msg_id": "c_abc", "role": "user",      "content": "alpha", "sent_at": "…", "read_at": "…" },
     { "id": "9f2e7a10-…", "client_msg_id": null,    "role": "assistant", "content": "beta",  "sent_at": "…", "read_at": "…" },
     { "id": "a1b2c3d4-…", "client_msg_id": null,    "role": "assistant", "content": "gamma", "sent_at": "…", "channel": "product_qa" },
-    { "id": "b5c6d7e8-…", "client_msg_id": null,    "role": "assistant", "content": "",      "sent_at": "…", "image": true }
+    { "id": "b5c6d7e8-…", "client_msg_id": null,    "role": "assistant", "content": "",      "sent_at": "…", "image": true },
+    { "id": "c9d0e1f2-…", "client_msg_id": "c_def", "role": "user",      "content": "wait, about that", "sent_at": "…", "reply_to_message_id": "3cc06c53-…" }
   ],
-  "total": 4
+  "total": 5
 }
 ```
 

--- a/docs/api-reference.zh.md
+++ b/docs/api-reference.zh.md
@@ -538,6 +538,12 @@ composed prompt 当时就没记下来——真的取不回来了，应当如实�
 静默丢掉。这个标记同时让重连的客户端知道某一轮承诺过一张图（`image_request`
 SSE 帧是整轮最后一帧且只走线上——在它发出前断线，光看 history 本来无从察觉）。
 
+`reply_to_message_id` 回显 `user` 行发送时带的回复锚点（见上面**可选：回复锚点
+（回卷）**）：它引用的那条消息的 id，一定在同一个 session 里。键出现即为真的
+约定同上——普通轮次省略；锚点没解析成功的轮次也省略，因为没有可指的气泡。
+那次失败以 `metadata.reply_to_error` 记在行上，只供审计；客户端要知道自己的
+引用被丢掉了，应当看它发出那一轮的 SSE，而不是翻 history。
+
 ### `GET /comp/chat/{session_id}/messages/{message_id}/image-request`
 
 取回一条已落库图片轮的 `image_request` 载荷——给没收到 SSE 帧的消费方
@@ -1115,6 +1121,10 @@ canonical `/comp/*` 路由永遠不會為了遷就前端而被改形狀——而
 连同「带标记的行 404 = 真的取不回来」的读法，都与上面 canonical history
 一节相同。`POST /bff/v1/comp/chat/start` 打包的历史走的是同一个条目形状，
 所以同样带这个标记。
+`reply_to_message_id` 回显 `user` 行发送时带的回复锚点（见 stream 路由的
+**回复锚点**一节）——它引用的那条消息的 id，一定在同一个 session 里；
+普通轮次、以及锚点没解析成功的轮次都省略该字段，这样冷启动不必自己存状态
+就能把引用重新渲染出来。
 鑒權、ownership 檢查、`limit ∈ [1, 50]` 夾取
 都與 canonical history 路由相同。**刻意差異：** 默認 `limit` 是 50
 （canonical 默認 20），因為 BFF 是為「冷啟動一次拉一整屏 backscroll」設計的。
@@ -1126,9 +1136,10 @@ canonical `/comp/*` 路由永遠不會為了遷就前端而被改形狀——而
     { "id": "3cc06c53-…", "client_msg_id": "c_abc", "role": "user",      "content": "alpha", "sent_at": "…" },
     { "id": "9f2e7a10-…", "client_msg_id": null,    "role": "assistant", "content": "beta",  "sent_at": "…" },
     { "id": "a1b2c3d4-…", "client_msg_id": null,    "role": "assistant", "content": "gamma", "sent_at": "…", "channel": "product_qa" },
-    { "id": "b5c6d7e8-…", "client_msg_id": null,    "role": "assistant", "content": "",      "sent_at": "…", "image": true }
+    { "id": "b5c6d7e8-…", "client_msg_id": null,    "role": "assistant", "content": "",      "sent_at": "…", "image": true },
+    { "id": "c9d0e1f2-…", "client_msg_id": "c_def", "role": "user",      "content": "wait, about that", "sent_at": "…", "reply_to_message_id": "3cc06c53-…" }
   ],
-  "total": 4
+  "total": 5
 }
 ```
 

--- a/docs/api-reference.zh.md
+++ b/docs/api-reference.zh.md
@@ -265,13 +265,17 @@ curl -N -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/js
   http://localhost:8080/comp/chat/<session_id>/message/stream
 ```
 
-**可选：回复锚点（回卷）。** 请求体可附加 `reply_to_message_id` ——
-本 session 内某条 `chat_messages` 行的 UUID，把本轮上下文锚定到那条消息。
-解析成功时，历史回卷到（且包含）那条消息：晚于它发送的行不进入 prompt，
-锚点记录在落库的用户行的 `metadata.reply_to_message_id` 上。传了但解析
-不到（id 不存在，或属于别的 session）不会让请求失败——本轮丢弃历史
-（上下文里只剩当前这条消息），并在该行的 `metadata.reply_to_error` 写入
-`"not_found"`。省略该字段即为正常的最新历史行为。
+**可选：引用。** 请求体可附加 `reply_to_message_id` —— 本 session 内某条
+`chat_messages` 行的 UUID，表示这一轮是在回复那条消息。解析成功时，被引用
+那句会以 `[quote]` 块进入回复 prompt（原文、是角色还是用户说的、以及多久
+之前说的），锚点记录在落库的用户行的 `metadata.reply_to_message_id` 上，
+两条 history 路由都从那里回显。
+
+**引用只是指向一句话，不回卷对话。** 带不带引用，历史窗口都是同样的最新
+N 条，所以引用上周的某句话不会让模型丢掉这期间说过的任何内容。传了但解析
+不到（id 不存在，或属于别的 session）同样不会让请求失败、也不改变上下文：
+这一轮只是没有 `[quote]` 块，并在该行的 `metadata.reply_to_error` 写入
+`"not_found"`。
 
 ```bash
 curl -N -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json" \
@@ -538,8 +542,8 @@ composed prompt 当时就没记下来——真的取不回来了，应当如实�
 静默丢掉。这个标记同时让重连的客户端知道某一轮承诺过一张图（`image_request`
 SSE 帧是整轮最后一帧且只走线上——在它发出前断线，光看 history 本来无从察觉）。
 
-`reply_to_message_id` 回显 `user` 行发送时带的回复锚点（见上面**可选：回复锚点
-（回卷）**）：它引用的那条消息的 id，一定在同一个 session 里。键出现即为真的
+`reply_to_message_id` 回显 `user` 行发送时带的引用（见上面**可选：引用**）：
+它引用的那条消息的 id，一定在同一个 session 里。键出现即为真的
 约定同上——普通轮次省略；锚点没解析成功的轮次也省略，因为没有可指的气泡。
 那次失败以 `metadata.reply_to_error` 记在行上，只供审计；客户端要知道自己的
 引用被丢掉了，应当看它发出那一轮的 SSE，而不是翻 history。
@@ -1121,8 +1125,8 @@ canonical `/comp/*` 路由永遠不會為了遷就前端而被改形狀——而
 连同「带标记的行 404 = 真的取不回来」的读法，都与上面 canonical history
 一节相同。`POST /bff/v1/comp/chat/start` 打包的历史走的是同一个条目形状，
 所以同样带这个标记。
-`reply_to_message_id` 回显 `user` 行发送时带的回复锚点（见 stream 路由的
-**回复锚点**一节）——它引用的那条消息的 id，一定在同一个 session 里；
+`reply_to_message_id` 回显 `user` 行发送时带的引用（见 stream 路由的**可选：引用**
+一节）——它引用的那条消息的 id，一定在同一个 session 里；
 普通轮次、以及锚点没解析成功的轮次都省略该字段，这样冷启动不必自己存状态
 就能把引用重新渲染出来。
 鑒權、ownership 檢查、`limit ∈ [1, 50]` 夾取


### PR DESCRIPTION
`reply_to_message_id` was half a feature: the send path validated the anchor and
recorded it, but it truncated the prompt's history at that message and no read
path ever handed the anchor back. Two commits: make the read path complete, then
fix what the write path does.

## 1. Both history routes echo the anchor (`14f5ea4`)

`ChatHistoryEntry` and `BffHistoryEntry` gain an optional `reply_to_message_id`,
projected from `metadata->>'reply_to_message_id'` with the same key-presence
contract as `read_at` / `image`. Without it a cold mount lost every quote on
refresh — the relationship existed only in the sender's local state.

`reply_to_error` stays audit-only: an anchor that failed to resolve has no
bubble to point at.

## 2. A quote points at one line; it does not rewind (`540f57b`)

Old behavior: history truncated at the anchor, and dropped **entirely** when the
id did not resolve. Neither is what a reply means in a chat client — quoting
something from last week should not cost the model everything said since, and a
cosmetic UI affordance should not be able to blank the conversation on a stale
id.

The resolved row now rides the turn as `QuotedMessage` and renders into the
reply prompt as a `[quote]` block:

```
[quote]（用户这一轮回复的是下面这句话，3 天前说的，不是最后一条消息；先接住它，再往下说）
Aria：那我们礼拜六去看展
```

The line, who said it, and a coarse relative age — enough for the model to tell
a callback from a same-breath correction. The history window is the same
newest-N with or without a quote; an unresolvable id just omits the block.

Ages are deliberately coarse (`刚刚` / `N 分钟前` / `N 小时前` / `N 天前` /
`很久以前`, capped at 30 days). Clock skew that puts a row in the future
collapses to `刚刚` rather than rendering a negative age.

Removed with the rewind path — no other callers: `HistoryAnchor`,
`ChatRepo::history_anchored`, `ChatRepo::message_sent_at_in_session`.

Persisted metadata is unchanged, so commit 1's field keeps working across the
change.

## Breaking

A turn sent with `reply_to_message_id` now sees the full recent history rather
than history truncated at that message. No known consumer sends the field today,
so this is a semantics correction rather than a migration.

## Tests

- `run_stream_quote_injects_the_block_without_truncating_history` — the
  regression lock: turns that landed after the anchor must stay in the prompt
- `build_prompt_renders_quote_with_speaker_and_age` / `..._omits_quote_when_none`
- `relative_age_buckets_are_coarse_and_never_negative`
- `resolve_quote_carries_content_and_scopes_by_session` — a real id from another
  session resolves to `None`, never leaking that session's text
- one field test per history route

fmt / clippy / 1597 tests / openapi snapshot all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)