### PR TITLE
fix(chat): system_error notices name the turn that failed

### DIFF
--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -2008,6 +2008,14 @@
             ],
             "format": "double",
             "description": "Structured tip amount for `role='gift_user'` rows. Omitted from\nresponse when None (`skip_serializing_if`). Lets clients render tips\nat the right point in the timeline without parsing the `(打赏 $X)`\ncontent marker. Spec:\ndocs/superpowers/specs/2026-05-26-tip-role-and-filter-audit-design.md §3.4."
+          },
+          "user_message_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "The `role='user'` row whose turn produced this row — set on assistant\nrows and on `system_error` notices. Lets a client attach a reply, or a\nfailure notice, to the message that caused it instead of assuming the\nnewest user row is the one. Omitted on user rows themselves."
           }
         }
       },
@@ -2355,6 +2363,14 @@
           "sent_at": {
             "type": "string",
             "format": "date-time"
+          },
+          "user_message_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "The `role='user'` row whose turn produced this row — set on assistant\nrows and on `system_error` notices. Same key-presence contract; the BFF\nhistory entry carries the same field."
           }
         }
       },

--- a/crates/eros-engine-server/src/pipeline/chat_queue.rs
+++ b/crates/eros-engine-server/src/pipeline/chat_queue.rs
@@ -178,6 +178,7 @@ pub(crate) async fn settle_turn(
                     repo.mark_failed_with_notice(
                         turn.queue_id,
                         turn.session_id,
+                        turn.user_message_id,
                         &msg,
                         FAILURE_NOTICE,
                     )

--- a/crates/eros-engine-server/src/pipeline/chat_queue.rs
+++ b/crates/eros-engine-server/src/pipeline/chat_queue.rs
@@ -175,14 +175,8 @@ pub(crate) async fn settle_turn(
                 ) {
                     repo.mark_done(turn.queue_id).await
                 } else {
-                    repo.mark_failed_with_notice(
-                        turn.queue_id,
-                        turn.session_id,
-                        turn.user_message_id,
-                        &msg,
-                        FAILURE_NOTICE,
-                    )
-                    .await
+                    repo.mark_failed_with_notice(turn.queue_id, &msg, FAILURE_NOTICE)
+                        .await
                 }
             } else {
                 repo.release(turn.queue_id, &msg).await

--- a/crates/eros-engine-server/src/pipeline/voice.rs
+++ b/crates/eros-engine-server/src/pipeline/voice.rs
@@ -976,6 +976,7 @@ mod tests {
             read_at: None,
             image: false,
             reply_to_message_id: None,
+            user_message_id: None,
         }
     }
 

--- a/crates/eros-engine-server/src/routes/bff/companion.rs
+++ b/crates/eros-engine-server/src/routes/bff/companion.rs
@@ -74,6 +74,12 @@ pub struct BffHistoryEntry {
     /// losing it on refresh.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_to_message_id: Option<Uuid>,
+    /// The `role='user'` row whose turn produced this row — set on assistant
+    /// rows and on `system_error` notices. Lets a client attach a reply, or a
+    /// failure notice, to the message that caused it instead of assuming the
+    /// newest user row is the one. Omitted on user rows themselves.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_message_id: Option<Uuid>,
 }
 
 /// Parse the raw `metadata->>'reply_to_message_id'` text the slim projection
@@ -186,6 +192,7 @@ async fn bff_get_history(
             read_at: r.read_at,
             image: r.image,
             reply_to_message_id: parse_anchor(r.reply_to_message_id),
+            user_message_id: r.user_message_id,
         })
         .collect();
     let total = messages.len();
@@ -246,6 +253,7 @@ async fn bff_start_chat(
                 read_at: r.read_at,
                 image: r.image,
                 reply_to_message_id: parse_anchor(r.reply_to_message_id),
+                user_message_id: r.user_message_id,
             })
             .collect()
     };
@@ -883,6 +891,67 @@ mod tests {
         assert!(
             failed.get("reply_to_error").is_none(),
             "reply_to_error stays audit-only; got {failed}"
+        );
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn bff_history_carries_user_message_id_on_replies_and_error_notices(pool: PgPool) {
+        // #295: a `system_error` notice is written after the client has already
+        // disconnected, so history is the only place it can be read — and it is
+        // useless without the turn it belongs to. Assistant rows carry the same
+        // field; user rows omit it.
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+
+        let driving: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_messages (session_id, role, content, sent_at) \
+             VALUES ($1, 'user', 'hi', now() - interval '3 seconds') RETURNING id",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO engine.chat_messages \
+                 (session_id, role, content, user_message_id, sent_at) \
+             VALUES ($1, 'assistant', 'hey', $2, now() - interval '2 seconds'),
+                    ($1, 'system_error', '出错了', $2, now() - interval '1 second')",
+        )
+        .bind(session_id)
+        .bind(driving)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let state = test_state(pool);
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+        let (status, body) =
+            send_request(&mut app, bff_history_request(&token, session_id, "")).await;
+        assert_eq!(status, StatusCode::OK, "got body: {body}");
+
+        let messages = body["messages"].as_array().expect("messages array");
+        assert_eq!(messages.len(), 3);
+        for role in ["assistant", "system_error"] {
+            let m = messages
+                .iter()
+                .find(|m| m["role"] == role)
+                .unwrap_or_else(|| panic!("{role} row"));
+            assert_eq!(
+                m["user_message_id"],
+                json!(driving.to_string()),
+                "a {role} row names the turn it belongs to; got {m}"
+            );
+        }
+        let u = messages
+            .iter()
+            .find(|m| m["role"] == "user")
+            .expect("user row");
+        assert!(
+            u.get("user_message_id").is_none(),
+            "the driving row itself omits the key; got {u}"
         );
     }
 

--- a/crates/eros-engine-server/src/routes/companion.rs
+++ b/crates/eros-engine-server/src/routes/companion.rs
@@ -149,6 +149,11 @@ pub struct ChatHistoryEntry {
     /// contract as `read_at`; the BFF history entry carries the same field.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_to_message_id: Option<Uuid>,
+    /// The `role='user'` row whose turn produced this row — set on assistant
+    /// rows and on `system_error` notices. Same key-presence contract; the BFF
+    /// history entry carries the same field.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_message_id: Option<Uuid>,
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
@@ -764,6 +769,7 @@ async fn get_history(
         .into_iter()
         .map(|m| ChatHistoryEntry {
             id: m.id,
+            user_message_id: m.user_message_id,
             image: m.metadata.as_ref().and_then(|md| md.get("image")).is_some(),
             reply_to_message_id: m
                 .metadata

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -127,6 +127,12 @@ pub struct ChatMessageSlim {
     /// thing the canonical history route does with its own extract.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_to_message_id: Option<String>,
+    /// The `role='user'` row that drove the turn this row belongs to. Set on
+    /// assistant rows, and on the `system_error` notices the queue worker and
+    /// the stale-claim reaper write (#295) — those are written after the client
+    /// has disconnected, so history is the only place it can read them.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_message_id: Option<Uuid>,
 }
 
 pub struct ChatRepo<'a> {
@@ -323,7 +329,8 @@ impl<'a> ChatRepo<'a> {
                     (metadata->>'tips_amount_usd')::float8 AS tips_amount_usd, \
                     channel, read_at, \
                     (metadata->'image' IS NOT NULL) AS image, \
-                    metadata->>'reply_to_message_id' AS reply_to_message_id \
+                    metadata->>'reply_to_message_id' AS reply_to_message_id, \
+                    user_message_id \
              FROM engine.chat_messages \
              WHERE session_id = $1 \
              ORDER BY sent_at DESC \

--- a/crates/eros-engine-store/src/chat_queue.rs
+++ b/crates/eros-engine-store/src/chat_queue.rs
@@ -282,6 +282,7 @@ impl<'a> ChatQueueRepo<'a> {
         &self,
         queue_id: Uuid,
         session_id: Uuid,
+        user_message_id: Uuid,
         error: &str,
         notice_content: &str,
     ) -> Result<(), sqlx::Error> {
@@ -294,12 +295,17 @@ impl<'a> ChatQueueRepo<'a> {
         .bind(error)
         .execute(&mut *tx)
         .await?;
+        // Bound to the turn that failed, like every assistant row. Without it a
+        // client routing replies per driving message has to guess "latest user
+        // row in the session", which is wrong the moment another turn arrives
+        // in between.
         sqlx::query(
-            "INSERT INTO engine.chat_messages (session_id, role, content) \
-             VALUES ($1, 'system_error', $2)",
+            "INSERT INTO engine.chat_messages (session_id, role, content, user_message_id) \
+             VALUES ($1, 'system_error', $2, $3)",
         )
         .bind(session_id)
         .bind(notice_content)
+        .bind(user_message_id)
         .execute(&mut *tx)
         .await?;
         sqlx::query("UPDATE engine.chat_sessions SET last_active_at = now() WHERE id = $1")
@@ -337,11 +343,18 @@ impl<'a> ChatQueueRepo<'a> {
         .await?;
         if !failed.is_empty() {
             let sessions: Vec<Uuid> = failed.iter().map(|(_, s, _)| *s).collect();
+            // Each notice carries the driving message of the turn it belongs to
+            // — the RETURNING above already knows it per row. Unnest both arrays
+            // in step so the pairing survives the batch.
+            let driving: Vec<Uuid> = failed.iter().map(|(_, _, m)| *m).collect();
             sqlx::query(
-                "INSERT INTO engine.chat_messages (session_id, role, content) \
-                 SELECT unnest($1::uuid[]), 'system_error', $2",
+                "INSERT INTO engine.chat_messages \
+                   (session_id, role, content, user_message_id) \
+                 SELECT s, 'system_error', $3, m \
+                 FROM unnest($1::uuid[], $2::uuid[]) AS t(s, m)",
             )
             .bind(&sessions)
+            .bind(&driving)
             .bind(notice_content)
             .execute(&mut *tx)
             .await?;
@@ -739,6 +752,52 @@ mod tests {
         assert!(repo.claim_next().await.unwrap().is_some());
     }
 
+    /// #295: each reaped turn's notice names the message that drove it. The
+    /// reaper fails a whole batch in one INSERT, so the risk is not "no id" but
+    /// a CROSS-PAIRED one — session A's notice carrying session B's driving
+    /// message. Two turns, reaped together, each checked against its own.
+    #[sqlx::test(migrations = "./migrations")]
+    async fn reap_stale_binds_each_notice_to_its_own_driving_message(pool: PgPool) {
+        let (user_a, session_a) = seed_session(&pool).await;
+        let (user_b, session_b) = seed_session(&pool).await;
+        let repo = ChatQueueRepo { pool: &pool };
+        let (msg_a, q_a) = seed_queued(&pool, session_a, user_a, "a", 100).await;
+        let (msg_b, q_b) = seed_queued(&pool, session_b, user_b, "b", 100).await;
+        for q in [q_a, q_b] {
+            sqlx::query(
+                "UPDATE engine.chat_turn_queue SET status='claimed', attempts=3, \
+                 claimed_at = now() - interval '1 hour' WHERE id = $1",
+            )
+            .bind(q)
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        let failed = repo
+            .reap_stale(std::time::Duration::from_secs(300), 3, "出错了")
+            .await
+            .unwrap();
+        assert_eq!(failed.len(), 2, "both exhausted claims go terminal");
+
+        for (session, driving) in [(session_a, msg_a), (session_b, msg_b)] {
+            let got: Option<Uuid> = sqlx::query_scalar(
+                "SELECT user_message_id FROM engine.chat_messages \
+                 WHERE session_id = $1 AND role = 'system_error'",
+            )
+            .bind(session)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+            assert_eq!(
+                got,
+                Some(driving),
+                "the notice in session {session} must name that session's own \
+                 driving message, not the other turn's"
+            );
+        }
+    }
+
     #[sqlx::test(migrations = "./migrations")]
     async fn reap_stale_releases_young_attempts_and_fails_exhausted_ones(pool: PgPool) {
         let (user_id, session_id) = seed_session(&pool).await;
@@ -827,9 +886,15 @@ mod tests {
         let repo = ChatQueueRepo { pool: &pool };
         seed_queued(&pool, session_id, user_id, "x", 10).await;
         let t = repo.claim_next().await.unwrap().unwrap();
-        repo.mark_failed_with_notice(t.queue_id, session_id, "upstream 500", "出错了")
-            .await
-            .unwrap();
+        repo.mark_failed_with_notice(
+            t.queue_id,
+            session_id,
+            t.user_message_id,
+            "upstream 500",
+            "出错了",
+        )
+        .await
+        .unwrap();
         let (status, last_error): (String, Option<String>) =
             sqlx::query_as("SELECT status, last_error FROM engine.chat_turn_queue WHERE id = $1")
                 .bind(t.queue_id)
@@ -838,8 +903,10 @@ mod tests {
                 .unwrap();
         assert_eq!(status, "failed");
         assert_eq!(last_error.as_deref(), Some("upstream 500"));
-        let notice: String = sqlx::query_scalar(
-            "SELECT content FROM engine.chat_messages \
+        // The notice is bound to the turn that failed (#295): a client routing
+        // replies per driving message must not have to guess "latest user row".
+        let (notice, driving): (String, Option<Uuid>) = sqlx::query_as(
+            "SELECT content, user_message_id FROM engine.chat_messages \
              WHERE session_id = $1 AND role = 'system_error'",
         )
         .bind(session_id)
@@ -847,6 +914,7 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(notice, "出错了");
+        assert_eq!(driving, Some(t.user_message_id));
     }
 
     #[sqlx::test(migrations = "./migrations")]

--- a/crates/eros-engine-store/src/chat_queue.rs
+++ b/crates/eros-engine-store/src/chat_queue.rs
@@ -278,23 +278,33 @@ impl<'a> ChatQueueRepo<'a> {
     /// all. Split writes leave orphan states — a `failed` turn with no
     /// visible signal, or a stranded claim that gets a second signal from the
     /// reaper.
+    /// Takes neither the session nor the driving message: both come back from
+    /// the flip's own `RETURNING`, so the notice cannot be filed against a
+    /// session the message does not belong to. The foreign key only checks that
+    /// the message exists, not whose it is — reading the pair off one row makes
+    /// the mismatch unrepresentable instead of merely unlikely. It also makes
+    /// the two writes agree on a queue id that matches nothing: previously that
+    /// flipped no row and still wrote a notice.
     pub async fn mark_failed_with_notice(
         &self,
         queue_id: Uuid,
-        session_id: Uuid,
-        user_message_id: Uuid,
         error: &str,
         notice_content: &str,
     ) -> Result<(), sqlx::Error> {
         let mut tx = self.pool.begin().await?;
-        sqlx::query(
+        let flipped: Option<(Uuid, Uuid)> = sqlx::query_as(
             "UPDATE engine.chat_turn_queue \
-             SET status = 'failed', last_error = $2 WHERE id = $1",
+             SET status = 'failed', last_error = $2 WHERE id = $1 \
+             RETURNING session_id, user_message_id",
         )
         .bind(queue_id)
         .bind(error)
-        .execute(&mut *tx)
+        .fetch_optional(&mut *tx)
         .await?;
+        let Some((session_id, user_message_id)) = flipped else {
+            tx.commit().await?;
+            return Ok(());
+        };
         // Bound to the turn that failed, like every assistant row. Without it a
         // client routing replies per driving message has to guess "latest user
         // row in the session", which is wrong the moment another turn arrives
@@ -886,15 +896,9 @@ mod tests {
         let repo = ChatQueueRepo { pool: &pool };
         seed_queued(&pool, session_id, user_id, "x", 10).await;
         let t = repo.claim_next().await.unwrap().unwrap();
-        repo.mark_failed_with_notice(
-            t.queue_id,
-            session_id,
-            t.user_message_id,
-            "upstream 500",
-            "出错了",
-        )
-        .await
-        .unwrap();
+        repo.mark_failed_with_notice(t.queue_id, "upstream 500", "出错了")
+            .await
+            .unwrap();
         let (status, last_error): (String, Option<String>) =
             sqlx::query_as("SELECT status, last_error FROM engine.chat_turn_queue WHERE id = $1")
                 .bind(t.queue_id)
@@ -915,6 +919,38 @@ mod tests {
         .unwrap();
         assert_eq!(notice, "出错了");
         assert_eq!(driving, Some(t.user_message_id));
+        // The notice's session and driving message come off the same queue row,
+        // so a notice can never be filed against a session its message does not
+        // belong to.
+        let notice_session: Uuid = sqlx::query_scalar(
+            "SELECT m.session_id FROM engine.chat_messages m \
+             WHERE m.id = (SELECT id FROM engine.chat_messages \
+                           WHERE session_id = $1 AND role = 'system_error')",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(notice_session, session_id);
+    }
+
+    /// A queue id that matches nothing must write nothing. Before the flip
+    /// started reading its own `RETURNING`, this updated no row and still filed
+    /// a `system_error` notice.
+    #[sqlx::test(migrations = "./migrations")]
+    async fn mark_failed_with_notice_is_a_noop_on_an_unknown_queue_id(pool: PgPool) {
+        seed_session(&pool).await;
+        ChatQueueRepo { pool: &pool }
+            .mark_failed_with_notice(Uuid::new_v4(), "upstream 500", "出错了")
+            .await
+            .unwrap();
+        let notices: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM engine.chat_messages WHERE role = 'system_error'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(notices, 0, "no queue row flipped ⇒ no notice");
     }
 
     #[sqlx::test(migrations = "./migrations")]

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -630,7 +630,14 @@ a disconnect before it fires would otherwise be undetectable from history).
 
 `reply_to_message_id` echoes the quote a `user` row was sent with (see
 **Optional: quote** above): the id of the row it quoted, always in this same
-session. Same key-presence contract — omitted on ordinary turns,
+session.
+
+`user_message_id` names the `role='user'` row whose turn produced this row. It
+is present on assistant rows and on `system_error` notices, and omitted on the
+user rows themselves. The notices matter most: the queue worker and the
+stale-claim reaper write them after the client has already disconnected, so
+history is the only place a client can find them — and a notice is useless
+without knowing which turn failed. Do not assume the newest user row is the one. Same key-presence contract — omitted on ordinary turns,
 and omitted when the anchor failed to resolve, since there is no bubble to
 point at. That failure is recorded as `metadata.reply_to_error` on the row and
 stays audit-only; a client that needs to know its quote was dropped should read
@@ -1279,7 +1286,9 @@ an image (omitted on every other row, never `false`) — the same key-presence
 contract and `image-request` discovery semantics as the canonical history
 route above, including the "404 on a flagged row = unrecoverable" reading.
 The `POST /bff/v1/comp/chat/start` bundle serializes history through this
-same entry shape and therefore carries the flag too. `reply_to_message_id`
+same entry shape and therefore carries the flag too. `user_message_id` names the
+`role='user'` row whose turn produced this row — present on assistant rows and
+on `system_error` notices, omitted on user rows. `reply_to_message_id`
 echoes the quote a `user` row was sent with (see the stream route's
 **Optional: quote** section) — the id of the row it quoted, always in this same
 session; omitted on ordinary turns and on turns whose anchor failed to resolve,

--- a/docs/api-reference.zh.md
+++ b/docs/api-reference.zh.md
@@ -543,7 +543,12 @@ composed prompt 当时就没记下来——真的取不回来了，应当如实�
 SSE 帧是整轮最后一帧且只走线上——在它发出前断线，光看 history 本来无从察觉）。
 
 `reply_to_message_id` 回显 `user` 行发送时带的引用（见上面**可选：引用**）：
-它引用的那条消息的 id，一定在同一个 session 里。键出现即为真的
+它引用的那条消息的 id，一定在同一个 session 里。
+
+`user_message_id` 指向产生这一行的那一轮的 `role='user'` 行。assistant 行和
+`system_error` 通知行上都有，user 行本身省略。通知行最要紧：队列 worker 和
+陈旧认领回收器是在客户端早已断线之后才写它们的，history 是客户端唯一能读到的
+地方 —— 而一条不知道对应哪一轮的通知没有用。不要假设最新那条 user 行就是它。键出现即为真的
 约定同上——普通轮次省略；锚点没解析成功的轮次也省略，因为没有可指的气泡。
 那次失败以 `metadata.reply_to_error` 记在行上，只供审计；客户端要知道自己的
 引用被丢掉了，应当看它发出那一轮的 SSE，而不是翻 history。
@@ -1125,6 +1130,8 @@ canonical `/comp/*` 路由永遠不會為了遷就前端而被改形狀——而
 连同「带标记的行 404 = 真的取不回来」的读法，都与上面 canonical history
 一节相同。`POST /bff/v1/comp/chat/start` 打包的历史走的是同一个条目形状，
 所以同样带这个标记。
+`user_message_id` 指向产生这一行的那一轮的 `role='user'` 行 —— assistant 行和
+`system_error` 通知行上都有，user 行省略。
 `reply_to_message_id` 回显 `user` 行发送时带的引用（见 stream 路由的**可选：引用**
 一节）——它引用的那条消息的 id，一定在同一个 session 里；
 普通轮次、以及锚点没解析成功的轮次都省略该字段，这样冷启动不必自己存状态


### PR DESCRIPTION
Closes #295.

## The bug

`ChatQueueRepo::mark_failed_with_notice` and `::reap_stale` both insert a
`system_error` row into `engine.chat_messages` without `user_message_id`, even
though the queue row that produced the notice knows exactly which user message
failed. A consumer that routes replies per driving message is left guessing
"latest user row in the session" — wrong the moment another turn arrives in
between, which is precisely when a turn is failing.

## The fix

Both inserts bind it.

`reap_stale` fails a whole batch in one INSERT, so the risk there is not a
missing id but a **cross-paired** one — session A's notice carrying session B's
driving message. The two arrays are now unnested in step:

```sql
SELECT s, 'system_error', $3, m FROM unnest($1::uuid[], $2::uuid[]) AS t(s, m)
```

`reap_stale_binds_each_notice_to_its_own_driving_message` reaps two turns in two
sessions together and checks each notice against its own.

## Scope note: the read path had to come with it

Binding the id alone does not reach anyone. These notices are written by the
queue worker and the stale-claim reaper **after the client has disconnected** —
that is why they are a database row rather than an SSE frame — so history is the
only place a consumer can read them. Neither history route exposed
`user_message_id`, so a notice would still have arrived with no way to tell which
turn it belonged to, which is the problem this issue is about.

So `ChatHistoryEntry` and `BffHistoryEntry` gain an optional `user_message_id`,
same key-presence contract as `read_at` / `image` / `reply_to_message_id`.
Assistant rows carry it too — the same "which turn is this" question, and it was
already in the column.

No migration: `chat_messages.user_message_id` has existed since `0019`, and
`0058` gave it a foreign key last week.

## Tests

- `reap_stale_binds_each_notice_to_its_own_driving_message` — the cross-pairing
  lock described above
- `mark_failed_with_notice_writes_both_or_neither` extended to assert the bound id
- `bff_history_carries_user_message_id_on_replies_and_error_notices` — assistant
  and `system_error` rows both name the turn; the driving user row itself omits
  the key

fmt / clippy / 1603 tests / openapi snapshot green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)