### PR TITLE
feat: engine.llm_generations — one row per LLM generation (Release A)

### DIFF
--- a/crates/eros-engine-server/src/pipeline/dreaming.rs
+++ b/crates/eros-engine-server/src/pipeline/dreaming.rs
@@ -260,7 +260,17 @@ async fn classify_session(
         .await
         .map_err(|e| format!("memory_extraction LLM call failed: {e}"))?;
 
-    super::log_openrouter_usage(MEMORY_TASK, Some(session_id), &raw);
+    super::record_generation(
+        &state.pool,
+        super::GenerationRecord {
+            task: MEMORY_TASK,
+            session_id: Some(session_id),
+            generation_id: raw.generation_id.as_deref(),
+            model: raw.model.as_deref(),
+            usage: raw.usage.as_ref(),
+        },
+    )
+    .await;
 
     let candidates = parse_memory_candidates(&raw.reply);
 
@@ -680,6 +690,14 @@ mod tests {
         assert_eq!(written, 0, "empty memories → no rows");
         // mock.expect(1) is verified on MockServer drop: the request carried the
         // configured system prompt sentinel.
+
+        let model: Option<String> = sqlx::query_scalar(
+            "SELECT model FROM engine.llm_generations WHERE task = 'memory_extraction'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("the sweeper must record its generation");
+        assert!(model.is_some());
     }
 
     /// Spec 2026-08-09-voice-dreaming-ingestion §1: voice rows now reach the

--- a/crates/eros-engine-server/src/pipeline/mod.rs
+++ b/crates/eros-engine-server/src/pipeline/mod.rs
@@ -21,6 +21,16 @@ use eros_engine_core::types::ConversationSignals;
 
 use crate::error::AppError;
 
+/// How long the audit write gets before it is abandoned. It covers the pool
+/// acquisition as well as the statement, and it is deliberately shorter than
+/// the pool's own 5s `acquire_timeout`: a turn waiting several seconds on an
+/// audit row is a worse outcome than a missing audit row, which is the same
+/// trade the fail-open contract already makes. Without it, `sqlx` has no
+/// client-side statement timeout, so an insert that HANGS — as opposed to one
+/// that is refused — stalls the turn indefinitely. This function runs 2-5
+/// times per chat turn, so that exposure is not hypothetical.
+const AUDIT_WRITE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+
 /// One LLM generation, as the call site knows it. Five loose fields rather
 /// than a `&ChatResponse`: four streaming arms never own one, and two of them
 /// used to synthesise a fake with an empty `reply` purely to satisfy this
@@ -47,7 +57,7 @@ pub(super) struct GenerationRecord<'a> {
 ///
 /// Fail-open by design: an audit row is recoverable from the tracing line and
 /// from the provider's log, a user's reply is not. Nothing here can fail a
-/// turn.
+/// turn, and — see `AUDIT_WRITE_TIMEOUT` — nothing here can stall one either.
 ///
 /// Token / cost fields in the log line are best-effort parses off the opaque
 /// `usage` JSON — missing fields silently drop out. The row stores `usage`
@@ -84,23 +94,33 @@ pub(super) async fn record_generation(
 
     let generation_id = rec.generation_id?;
     let repo = eros_engine_store::generation::LlmGenerationRepo { pool };
-    match repo
-        .record(eros_engine_store::generation::LlmGenerationInsert {
-            generation_id,
-            session_id: rec.session_id,
-            task: rec.task,
-            model: rec.model,
-            usage: rec.usage,
-        })
-        .await
-    {
-        Ok(()) => Some(generation_id.to_string()),
-        Err(e) => {
+    let write = repo.record(eros_engine_store::generation::LlmGenerationInsert {
+        generation_id,
+        session_id: rec.session_id,
+        task: rec.task,
+        model: rec.model,
+        usage: rec.usage,
+    });
+    match tokio::time::timeout(AUDIT_WRITE_TIMEOUT, write).await {
+        Ok(Ok(())) => Some(generation_id.to_string()),
+        Ok(Err(e)) => {
             tracing::warn!(
                 task = rec.task,
                 generation_id = generation_id,
                 error = %e,
                 "llm_generations: audit write failed; child row will store NULL"
+            );
+            None
+        }
+        // Distinct message from the error arm: this one means the database (or
+        // the pool) is slow rather than refusing, which is an operational
+        // signal, not a schema one.
+        Err(_) => {
+            tracing::warn!(
+                task = rec.task,
+                generation_id = generation_id,
+                timeout_secs = AUDIT_WRITE_TIMEOUT.as_secs(),
+                "llm_generations: audit write timed out; child row will store NULL"
             );
             None
         }

--- a/crates/eros-engine-server/src/pipeline/mod.rs
+++ b/crates/eros-engine-server/src/pipeline/mod.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //! Pipeline module — shared helpers (`compute_signals_for_session`,
-//! `log_openrouter_usage`) plus the chat / post-process / dreaming
+//! `record_generation`) plus the chat / post-process / dreaming
 //! submodules. The streaming chat entry point is `stream::run_stream`.
 
 pub mod chat_queue;
@@ -21,18 +21,43 @@ use eros_engine_core::types::ConversationSignals;
 
 use crate::error::AppError;
 
-/// Emit one structured `openrouter: call completed` log line per call.
-/// Token / cost fields are best-effort parses off the opaque `usage`
-/// JSON — missing fields silently drop out of the line. Called from
-/// every codepath that owns the result of `OpenRouterClient::execute`
-/// (chat, dreaming, post_process), keeping `docs/llm-audit.md`'s
-/// "background paths emit usage only as tracing fields" claim honest.
-pub(super) fn log_openrouter_usage(
-    task: &str,
-    session_id: Option<Uuid>,
-    resp: &eros_engine_llm::openrouter::ChatResponse,
-) {
-    let usage_ref = resp.usage.as_ref();
+/// One LLM generation, as the call site knows it. Five loose fields rather
+/// than a `&ChatResponse`: four streaming arms never own one, and two of them
+/// used to synthesise a fake with an empty `reply` purely to satisfy this
+/// function's parameter.
+pub(super) struct GenerationRecord<'a> {
+    pub task: &'a str,
+    pub session_id: Option<Uuid>,
+    pub generation_id: Option<&'a str>,
+    pub model: Option<&'a str>,
+    pub usage: Option<&'a serde_json::Value>,
+}
+
+/// Record one billable generation to `engine.llm_generations` and emit the
+/// structured `openrouter: call completed` log line. Called from EVERY
+/// codepath that owns an LLM response — including the world, story and
+/// dreaming sweepers, for which this table is the only database record there
+/// is.
+///
+/// **The return value is the contract.** Callers must store what comes back in
+/// their own `generation_id` column, never `resp.generation_id`:
+///
+/// - `Some(id)` — the parent row is committed and may be referenced.
+/// - `None` — upstream gave no id, or the write failed. Store `NULL`.
+///
+/// Fail-open by design: an audit row is recoverable from the tracing line and
+/// from the provider's log, a user's reply is not. Nothing here can fail a
+/// turn.
+///
+/// Token / cost fields in the log line are best-effort parses off the opaque
+/// `usage` JSON — missing fields silently drop out. The row stores `usage`
+/// whole and unfiltered; `OPENROUTER_USAGE_HIDDEN_KEYS` applies only on the
+/// way out to clients.
+pub(super) async fn record_generation(
+    pool: &sqlx::PgPool,
+    rec: GenerationRecord<'_>,
+) -> Option<String> {
+    let usage_ref = rec.usage;
     let prompt_tokens = usage_ref
         .and_then(|u| u.get("prompt_tokens"))
         .and_then(|v| v.as_u64());
@@ -46,16 +71,40 @@ pub(super) fn log_openrouter_usage(
         .and_then(|u| u.get("cost"))
         .and_then(|v| v.as_f64());
     tracing::info!(
-        task = task,
-        session = ?session_id,
-        generation_id = ?resp.generation_id,
-        model = ?resp.model,
+        task = rec.task,
+        session = ?rec.session_id,
+        generation_id = ?rec.generation_id,
+        model = ?rec.model,
         prompt_tokens = ?prompt_tokens,
         completion_tokens = ?completion_tokens,
         total_tokens = ?total_tokens,
         cost = ?cost,
         "openrouter: call completed"
     );
+
+    let generation_id = rec.generation_id?;
+    let repo = eros_engine_store::generation::LlmGenerationRepo { pool };
+    match repo
+        .record(eros_engine_store::generation::LlmGenerationInsert {
+            generation_id,
+            session_id: rec.session_id,
+            task: rec.task,
+            model: rec.model,
+            usage: rec.usage,
+        })
+        .await
+    {
+        Ok(()) => Some(generation_id.to_string()),
+        Err(e) => {
+            tracing::warn!(
+                task = rec.task,
+                generation_id = generation_id,
+                error = %e,
+                "llm_generations: audit write failed; child row will store NULL"
+            );
+            None
+        }
+    }
 }
 
 /// Walk forward from the first `{` and return the substring up to its
@@ -393,5 +442,88 @@ mod tests {
     fn parse_llm_json_none_when_shape_mismatch() {
         // Valid JSON block, wrong shape: the fallback must also fail typed.
         assert!(super::parse_llm_json::<ParseProbe>(r#"prose {"other": 1} prose"#).is_none());
+    }
+}
+
+#[cfg(test)]
+mod generation_record_tests {
+    use super::*;
+    use sqlx::PgPool;
+    use uuid::Uuid;
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn records_the_row_and_returns_the_id(pool: PgPool) {
+        let usage = serde_json::json!({ "cost": 0.002 });
+        let out = record_generation(
+            &pool,
+            GenerationRecord {
+                task: "pde_decision",
+                session_id: None,
+                generation_id: Some("gen-1"),
+                model: Some("m"),
+                usage: Some(&usage),
+            },
+        )
+        .await;
+        assert_eq!(out.as_deref(), Some("gen-1"));
+
+        let task: String = sqlx::query_scalar(
+            "SELECT task FROM engine.llm_generations WHERE generation_id = 'gen-1'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(task, "pde_decision");
+    }
+
+    /// No id from upstream ⇒ no row, no query, and the caller stores NULL.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn returns_none_and_writes_nothing_when_upstream_gave_no_id(pool: PgPool) {
+        let out = record_generation(
+            &pool,
+            GenerationRecord {
+                task: "chat_vision",
+                session_id: None,
+                generation_id: None,
+                model: Some("m"),
+                usage: None,
+            },
+        )
+        .await;
+        assert!(out.is_none());
+
+        let rows: i64 = sqlx::query_scalar("SELECT count(*) FROM engine.llm_generations")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(rows, 0);
+    }
+
+    /// Fail-open: a parent write that cannot land degrades to `None` so the
+    /// child row stores NULL and the turn survives. Forced here by pointing at
+    /// a session id that does not exist, which the table's own FK rejects.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn degrades_to_none_when_the_write_fails(pool: PgPool) {
+        let out = record_generation(
+            &pool,
+            GenerationRecord {
+                task: "chat_companion",
+                session_id: Some(Uuid::new_v4()), // no such session
+                generation_id: Some("gen-doomed"),
+                model: None,
+                usage: None,
+            },
+        )
+        .await;
+        assert!(
+            out.is_none(),
+            "a failed parent write must degrade, not panic"
+        );
+
+        let rows: i64 = sqlx::query_scalar("SELECT count(*) FROM engine.llm_generations")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(rows, 0);
     }
 }

--- a/crates/eros-engine-server/src/pipeline/mod.rs
+++ b/crates/eros-engine-server/src/pipeline/mod.rs
@@ -29,6 +29,15 @@ use crate::error::AppError;
 /// client-side statement timeout, so an insert that HANGS — as opposed to one
 /// that is refused — stalls the turn indefinitely. This function runs 2-5
 /// times per chat turn, so that exposure is not hypothetical.
+///
+/// What this does NOT do: dropping the future at the timeout does not
+/// guarantee Postgres receives a `CancelRequest`, so a genuinely stuck
+/// statement can keep running server-side and its connection is churned rather
+/// than reused. That residual wants a server-side `statement_timeout`, which no
+/// query in this codebase sets and which is a pool-wide decision — a pgvector
+/// recall is legitimately slower than an audit insert, so one bound cannot
+/// serve both. Bounding the caller is still strictly better than the
+/// alternative: without this, the turn stalls AND the connection is stuck.
 const AUDIT_WRITE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
 
 /// One LLM generation, as the call site knows it. Five loose fields rather

--- a/crates/eros-engine-server/src/pipeline/post_process.rs
+++ b/crates/eros-engine-server/src/pipeline/post_process.rs
@@ -703,13 +703,16 @@ fn eval_skip_reason(
     }
 }
 
-/// Marker for a *successful* eval whose response still carried no OpenRouter
-/// `generation_id` — the join key to the OpenRouter log. The salvaged-garble
-/// fallback in `OpenRouterClient::execute` returns `Ok` with `generation_id:
-/// None` (and `usage: None`), so "the call returned `Ok`" does not by itself
-/// guarantee an audit trail. Without the id the row can't be tied to an
-/// OpenRouter record, so it still needs an explanation. `None` ⇒ a usable id is
-/// present.
+/// Marker for a *successful* eval whose `meta.generation_id` came back `None`
+/// — the join key to both the OpenRouter log and this call's
+/// `engine.llm_generations` row. Two distinct causes land here and this
+/// marker does not distinguish them: the salvaged-garble fallback in
+/// `OpenRouterClient::execute` can return `Ok` with `generation_id: None`
+/// (and `usage: None`) even though the call succeeded, and separately
+/// `record_generation` itself returns `None` when the provider DID give an
+/// id but the parent-table write failed (llm-generations-audit spec §6).
+/// Either way "the call returned `Ok`" does not by itself guarantee an audit
+/// trail. `None` ⇒ a usable id is present.
 fn meta_skip_reason(meta: &eros_engine_store::OpenRouterCallMeta) -> Option<&'static str> {
     meta.generation_id
         .is_none()
@@ -930,6 +933,9 @@ struct CallAudit {
     meta: eros_engine_store::OpenRouterCallMeta,
 }
 
+/// `generation_id` must be `record_generation`'s return value, never
+/// `resp.generation_id` — a caller passing the raw field would compile and
+/// silently reopen the unlaundered path this table exists to close.
 fn call_meta(
     resp: &eros_engine_llm::openrouter::ChatResponse,
     generation_id: Option<String>,

--- a/crates/eros-engine-server/src/pipeline/post_process.rs
+++ b/crates/eros-engine-server/src/pipeline/post_process.rs
@@ -824,9 +824,19 @@ async fn evaluate_affinity(
     let (raw, meta, recovered) =
         match tokio::time::timeout(AFFINITY_EVAL_TIMEOUT, state.openrouter.execute(req)).await {
             Ok(Ok(resp)) => {
-                super::log_openrouter_usage(AFFINITY_TASK, Some(session_id), &resp);
+                let generation_id = super::record_generation(
+                    &state.pool,
+                    super::GenerationRecord {
+                        task: AFFINITY_TASK,
+                        session_id: Some(session_id),
+                        generation_id: resp.generation_id.as_deref(),
+                        model: resp.model.as_deref(),
+                        usage: resp.usage.as_ref(),
+                    },
+                )
+                .await;
                 let meta = eros_engine_store::OpenRouterCallMeta {
-                    generation_id: resp.generation_id.clone(),
+                    generation_id,
                     model: resp.model.clone(),
                     usage: resp.usage.clone(),
                 };
@@ -901,7 +911,7 @@ async fn evaluate_affinity(
 const INSIGHT_TASK: &str = "insight_extraction";
 
 /// Stage 2 of the human chain. Split out from `INSIGHT_TASK` so the engine's
-/// own `log_openrouter_usage` line and `[[providers.*.body]]` rules can tell
+/// own `record_generation` call and `[[providers.*.body]]` rules can tell
 /// the two stages apart, and so `max_tokens` stops being one number covering
 /// two very different outputs. This does NOT help OpenRouter-side accounting:
 /// `task` is config routing only and is never serialized to the wire (see
@@ -922,9 +932,10 @@ struct CallAudit {
 
 fn call_meta(
     resp: &eros_engine_llm::openrouter::ChatResponse,
+    generation_id: Option<String>,
 ) -> eros_engine_store::OpenRouterCallMeta {
     eros_engine_store::OpenRouterCallMeta {
-        generation_id: resp.generation_id.clone(),
+        generation_id,
         model: resp.model.clone(),
         usage: resp.usage.clone(),
     }
@@ -948,6 +959,7 @@ async fn extract_insights(
     let (facts, facts_audit) = extract_facts(
         &state.openrouter,
         &state.model_config,
+        &state.pool,
         session_id,
         user_msg,
         assistant_msg,
@@ -982,6 +994,7 @@ async fn extract_insights(
     let (new_insights, struct_audit) = extract_structured_insights(
         &state.openrouter,
         &state.model_config,
+        &state.pool,
         session_id,
         &facts,
         existing.as_ref(),
@@ -1039,6 +1052,7 @@ async fn write_insight_event(
 async fn extract_facts(
     llm: &OpenRouterClient,
     model_config: &ModelConfig,
+    pool: &sqlx::PgPool,
     session_id: Uuid,
     user_msg: &str,
     assistant_msg: &str,
@@ -1078,8 +1092,21 @@ async fn extract_facts(
 
     let (raw, meta) = match llm.execute(req).await {
         Ok(resp) => {
-            super::log_openrouter_usage(INSIGHT_TASK, Some(session_id), &resp);
-            (resp.reply.trim().to_string(), call_meta(&resp))
+            let generation_id = super::record_generation(
+                pool,
+                super::GenerationRecord {
+                    task: INSIGHT_TASK,
+                    session_id: Some(session_id),
+                    generation_id: resp.generation_id.as_deref(),
+                    model: resp.model.as_deref(),
+                    usage: resp.usage.as_ref(),
+                },
+            )
+            .await;
+            (
+                resp.reply.trim().to_string(),
+                call_meta(&resp, generation_id),
+            )
         }
         Err(e) => {
             tracing::warn!("fact extraction LLM call failed: {e}");
@@ -1138,6 +1165,7 @@ fn extract_details_array(v: &serde_json::Value) -> Vec<serde_json::Value> {
 async fn extract_structured_insights(
     llm: &OpenRouterClient,
     model_config: &ModelConfig,
+    pool: &sqlx::PgPool,
     session_id: Uuid,
     facts: &[String],
     existing_insights: Option<&serde_json::Value>,
@@ -1169,8 +1197,18 @@ async fn extract_structured_insights(
 
     let (raw, meta) = match llm.execute(req).await {
         Ok(r) => {
-            super::log_openrouter_usage(INSIGHT_STRUCTURING_TASK, Some(session_id), &r);
-            (r.reply.trim().to_string(), call_meta(&r))
+            let generation_id = super::record_generation(
+                pool,
+                super::GenerationRecord {
+                    task: INSIGHT_STRUCTURING_TASK,
+                    session_id: Some(session_id),
+                    generation_id: r.generation_id.as_deref(),
+                    model: r.model.as_deref(),
+                    usage: r.usage.as_ref(),
+                },
+            )
+            .await;
+            (r.reply.trim().to_string(), call_meta(&r, generation_id))
         }
         Err(_) => return (empty(), None),
     };
@@ -1382,8 +1420,21 @@ async fn extract_character_facts(
 
     let (raw, meta) = match state.openrouter.execute(req).await {
         Ok(resp) => {
-            super::log_openrouter_usage(CHARACTER_EXTRACTION_TASK, Some(session_id), &resp);
-            (resp.reply.trim().to_string(), call_meta(&resp))
+            let generation_id = super::record_generation(
+                &state.pool,
+                super::GenerationRecord {
+                    task: CHARACTER_EXTRACTION_TASK,
+                    session_id: Some(session_id),
+                    generation_id: resp.generation_id.as_deref(),
+                    model: resp.model.as_deref(),
+                    usage: resp.usage.as_ref(),
+                },
+            )
+            .await;
+            (
+                resp.reply.trim().to_string(),
+                call_meta(&resp, generation_id),
+            )
         }
         Err(e) => {
             tracing::warn!("character fact extraction LLM call failed: {e}");
@@ -1462,8 +1513,18 @@ async fn structure_character_insights(
 
     let (raw, meta) = match state.openrouter.execute(req).await {
         Ok(r) => {
-            super::log_openrouter_usage(CHARACTER_STRUCTURING_TASK, Some(session_id), &r);
-            (r.reply.trim().to_string(), call_meta(&r))
+            let generation_id = super::record_generation(
+                &state.pool,
+                super::GenerationRecord {
+                    task: CHARACTER_STRUCTURING_TASK,
+                    session_id: Some(session_id),
+                    generation_id: r.generation_id.as_deref(),
+                    model: r.model.as_deref(),
+                    usage: r.usage.as_ref(),
+                },
+            )
+            .await;
+            (r.reply.trim().to_string(), call_meta(&r, generation_id))
         }
         Err(e) => {
             tracing::warn!("character structuring LLM call failed: {e}");
@@ -1680,8 +1741,21 @@ async fn extract_user_facts(
 
     let (raw, meta) = match state.openrouter.execute(req).await {
         Ok(resp) => {
-            super::log_openrouter_usage(USER_EXTRACTION_TASK, Some(session_id), &resp);
-            (resp.reply.trim().to_string(), call_meta(&resp))
+            let generation_id = super::record_generation(
+                &state.pool,
+                super::GenerationRecord {
+                    task: USER_EXTRACTION_TASK,
+                    session_id: Some(session_id),
+                    generation_id: resp.generation_id.as_deref(),
+                    model: resp.model.as_deref(),
+                    usage: resp.usage.as_ref(),
+                },
+            )
+            .await;
+            (
+                resp.reply.trim().to_string(),
+                call_meta(&resp, generation_id),
+            )
         }
         Err(e) => {
             tracing::warn!("user fact extraction LLM call failed: {e}");
@@ -1754,8 +1828,18 @@ async fn structure_user_insights(
 
     let (raw, meta) = match state.openrouter.execute(req).await {
         Ok(r) => {
-            super::log_openrouter_usage(USER_STRUCTURING_TASK, Some(session_id), &r);
-            (r.reply.trim().to_string(), call_meta(&r))
+            let generation_id = super::record_generation(
+                &state.pool,
+                super::GenerationRecord {
+                    task: USER_STRUCTURING_TASK,
+                    session_id: Some(session_id),
+                    generation_id: r.generation_id.as_deref(),
+                    model: r.model.as_deref(),
+                    usage: r.usage.as_ref(),
+                },
+            )
+            .await;
+            (r.reply.trim().to_string(), call_meta(&r, generation_id))
         }
         Err(e) => {
             tracing::warn!("user structuring LLM call failed: {e}");

--- a/crates/eros-engine-server/src/pipeline/story.rs
+++ b/crates/eros-engine-server/src/pipeline/story.rs
@@ -337,7 +337,17 @@ async fn direct_story(
         .execute(req)
         .await
         .map_err(|e| format!("world_stories_director LLM call failed: {e}"))?;
-    super::log_openrouter_usage(STORY_TASK, None, &raw);
+    super::record_generation(
+        &state.pool,
+        super::GenerationRecord {
+            task: STORY_TASK,
+            session_id: None,
+            generation_id: raw.generation_id.as_deref(),
+            model: raw.model.as_deref(),
+            usage: raw.usage.as_ref(),
+        },
+    )
+    .await;
 
     let output = parse_story_output(&raw.reply)
         .ok_or_else(|| "world_stories_director output did not parse".to_string())?;
@@ -643,6 +653,14 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(n, 0, "empty events ⇒ no memory rows");
+
+        let model: Option<String> = sqlx::query_scalar(
+            "SELECT model FROM engine.llm_generations WHERE task = 'world_stories_director'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("the sweeper must record its generation");
+        assert!(model.is_some());
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -691,6 +691,21 @@ fn drive_chat_burst(
                 let effective_ghost = is_ghost_fallback || regex_ghost;
 
                 let usage_full = last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok());
+                // Parent row FIRST, then every read below stores what came back.
+                // Rebinding here — the one point this attempt's stream has ended
+                // and nothing has read `last_gen_id` yet — is what keeps the
+                // persist and the Done frame consistent without touching either.
+                last_gen_id = super::record_generation(
+                    &state.pool,
+                    super::GenerationRecord {
+                        task: "chat_companion",
+                        session_id: Some(session_id),
+                        generation_id: last_gen_id.as_deref(),
+                        model: Some(model_id.as_str()),
+                        usage: usage_full.as_ref(),
+                    },
+                )
+                .await;
                 // One turn, one authoritative list: only the row that CONCLUDES
                 // the turn carries it. `!truncated` is exactly that row here —
                 // the served reply, the last-attempt empty ghost, or the
@@ -1053,6 +1068,24 @@ fn drive_chat_burst(
                 "chat stream attempt"
             );
 
+            // Hoisted above the three exit branches below: the parent row has
+            // to be written once, at the one point this attempt's stream has
+            // ended and nothing has read `last_gen_id` yet, so all four of the
+            // arm's reads (two persists, two Done frames) store what came back
+            // without a single edit of their own.
+            let usage_full = last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok());
+            last_gen_id = super::record_generation(
+                &state.pool,
+                super::GenerationRecord {
+                    task: "chat_companion",
+                    session_id: Some(session_id),
+                    generation_id: last_gen_id.as_deref(),
+                    model: Some(model_id.as_str()),
+                    usage: usage_full.as_ref(),
+                },
+            )
+            .await;
+
             if empty_completion {
                 if idx + 1 == chain.len() {
                     // Last attempt served a 200 OK with an empty body: ghost
@@ -1067,8 +1100,6 @@ fn drive_chat_burst(
                     let is_ghost = !plan_action.promises_image();
                     let msg_ulid = Ulid::new();
                     let msg_uuid: Uuid = msg_ulid.into();
-                    let usage_full =
-                        last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok());
                     // Filtered mode never persists a superseded attempt, so both
                     // of its persist sites ARE concluding rows — no `truncated`
                     // gate needed here, unlike live mode.
@@ -1280,7 +1311,7 @@ fn drive_chat_burst(
                     Some(f) => {
                     let hits = f.trigger.should_filter(&bare_model_id, &tag_refs, random_draw);
                     match hits {
-                        Some(h) => match run_output_filter(&state, f, &cleaned).await {
+                        Some(h) => match run_output_filter(&state, session_id, f, &cleaned).await {
                             Ok(out) => {
                                 let mut o = outcome.lock().unwrap();
                                 o.filtered = true;
@@ -1360,7 +1391,6 @@ fn drive_chat_burst(
                 };
             }
 
-            let usage_full = last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok());
             let (llm_attempts, gateway_errors) = split_failures(&chain_failures);
             let row = eros_engine_store::chat::AssistantInsert {
                 llm_attempts,
@@ -1794,6 +1824,7 @@ pub(crate) fn error_frame_fields_from_last(
 /// per-attempt audit log into `chat_messages.metadata`).
 async fn run_output_filter(
     state: &AppState,
+    session_id: Uuid,
     f: &eros_engine_llm::model_config::ResolvedOutputFilter,
     original: &str,
 ) -> Result<RunFilterOutcome, FilterFailOpen> {
@@ -1852,7 +1883,17 @@ async fn run_output_filter(
                 continue;
             }
         };
-        super::log_openrouter_usage("chat_output_filter", None, &resp);
+        let generation_id = super::record_generation(
+            &state.pool,
+            super::GenerationRecord {
+                task: "chat_output_filter",
+                session_id: Some(session_id),
+                generation_id: resp.generation_id.as_deref(),
+                model: resp.model.as_deref(),
+                usage: resp.usage.as_ref(),
+            },
+        )
+        .await;
         let text = resp.reply.trim().to_string();
         // Empty reply check before the validity gate: "model returned literally
         // nothing" is distinguished from "model returned a short non-empty
@@ -1886,7 +1927,7 @@ async fn run_output_filter(
             retries_filter: idx as u32,
             filter_model,
             f_client_msg_id,
-            f_generation_id: resp.generation_id,
+            f_generation_id: generation_id,
             attempts,
             failures,
         });
@@ -2115,6 +2156,8 @@ struct LastParseAttempt {
 /// the rest of the chain before the caller falls back to the rule engine.
 async fn run_pde_decision(
     client: &eros_engine_llm::openrouter::OpenRouterClient,
+    pool: &sqlx::PgPool,
+    session_id: Uuid,
     p: &eros_engine_llm::model_config::ResolvedPde,
     ctx: &str,
 ) -> PdeDecisionRun {
@@ -2172,7 +2215,17 @@ async fn run_pde_decision(
                 continue;
             }
         };
-        super::log_openrouter_usage("pde_decision", None, &resp);
+        let generation_id = super::record_generation(
+            pool,
+            super::GenerationRecord {
+                task: "pde_decision",
+                session_id: Some(session_id),
+                generation_id: resp.generation_id.as_deref(),
+                model: resp.model.as_deref(),
+                usage: resp.usage.as_ref(),
+            },
+        )
+        .await;
         let text = resp.reply.trim().to_string();
         if text.is_empty() {
             tracing::warn!(model = %model_id, "pde: empty reply; next");
@@ -2187,7 +2240,7 @@ async fn run_pde_decision(
                     raw: None,
                     model: resp.model.or_else(|| Some(model_id.clone())),
                     usage: resp.usage,
-                    generation_id: resp.generation_id,
+                    generation_id,
                     failures,
                 };
             }
@@ -2198,7 +2251,7 @@ async fn run_pde_decision(
                     raw: text,
                     model: resp.model.or_else(|| Some(model_id.clone())),
                     usage: resp.usage,
-                    generation_id: resp.generation_id,
+                    generation_id,
                 });
                 continue;
             }
@@ -2601,6 +2654,7 @@ struct VisionRun {
 /// content-level failures also advance the chain.
 async fn run_vision(
     state: &AppState,
+    session_id: Uuid,
     v: &eros_engine_llm::model_config::ResolvedVision,
     image_url: &str,
     caption: &str,
@@ -2663,16 +2717,26 @@ async fn run_vision(
                 continue;
             }
         };
-        super::log_openrouter_usage("chat_vision", None, &resp);
+        let generation_id = super::record_generation(
+            &state.pool,
+            super::GenerationRecord {
+                task: "chat_vision",
+                session_id: Some(session_id),
+                generation_id: resp.generation_id.as_deref(),
+                model: resp.model.as_deref(),
+                usage: resp.usage.as_ref(),
+            },
+        )
+        .await;
         let text = resp.reply.trim().to_string();
         if text.is_empty() {
             tracing::warn!(model = %model_id, "chat_vision: empty reply; next");
             last_failure = Some("empty");
             // Content-level failure: the provider answered and was billed
-            // above by `log_openrouter_usage`, even though the reply was
+            // above by `record_generation`, even though the reply was
             // blank. Record who answered in case the whole chain exhausts.
             last_model = Some(resp.model.clone().unwrap_or_else(|| model_id.clone()));
-            last_generation_id = resp.generation_id.clone();
+            last_generation_id = generation_id.clone();
             last_usage = resp.usage.clone();
             continue;
         }
@@ -2682,7 +2746,7 @@ async fn run_vision(
                 tracing::warn!(model = %model_id, "chat_vision: unparseable describe JSON; next");
                 last_failure = Some("unparseable");
                 last_model = Some(resp.model.clone().unwrap_or_else(|| model_id.clone()));
-                last_generation_id = resp.generation_id.clone();
+                last_generation_id = generation_id.clone();
                 last_usage = resp.usage.clone();
                 continue;
             }
@@ -2691,7 +2755,7 @@ async fn run_vision(
             tracing::warn!(model = %model_id, invalidity = %reason, "chat_vision: invalid describe; next");
             last_failure = Some(reason);
             last_model = Some(resp.model.clone().unwrap_or_else(|| model_id.clone()));
-            last_generation_id = resp.generation_id.clone();
+            last_generation_id = generation_id.clone();
             last_usage = resp.usage.clone();
             continue;
         }
@@ -2700,7 +2764,7 @@ async fn run_vision(
             outcome: Some(VisionOutcome {
                 vision: serde_json::to_value(&vision).unwrap_or(serde_json::Value::Null),
                 vision_model,
-                v_generation_id: resp.generation_id,
+                v_generation_id: generation_id,
                 usage: resp.usage,
             }),
             attempts,
@@ -2893,6 +2957,7 @@ async fn build_input_filter_transcript(
 /// it carries whatever was accumulated before that point and nothing more.
 async fn run_input_filter(
     state: &AppState,
+    session_id: Uuid,
     f: &eros_engine_llm::model_config::ResolvedInputFilter,
     recent_transcript: &str,
     raw_input: &str,
@@ -2949,7 +3014,17 @@ async fn run_input_filter(
                 continue;
             }
         };
-        super::log_openrouter_usage("chat_input_filter", None, &resp);
+        let generation_id = super::record_generation(
+            &state.pool,
+            super::GenerationRecord {
+                task: "chat_input_filter",
+                session_id: Some(session_id),
+                generation_id: resp.generation_id.as_deref(),
+                model: resp.model.as_deref(),
+                usage: resp.usage.as_ref(),
+            },
+        )
+        .await;
         let text = resp.reply.trim().to_string();
         if text.is_empty() {
             tracing::warn!(model = %model_id, "input-filter: empty reply; next");
@@ -2986,7 +3061,7 @@ async fn run_input_filter(
                 rewritten_text: content,
                 filter_model,
                 reason: verdict.reason.filter(|r| !r.trim().is_empty()),
-                f_generation_id: resp.generation_id,
+                f_generation_id: generation_id,
             }),
             failures,
         );
@@ -3118,7 +3193,7 @@ pub(crate) struct ComposeRun {
     pub(crate) last_failure: Option<&'static str>,
     /// The most recent post-response identifiers, captured on a CONTENT-level
     /// failure (`empty` / `empty_prompt`) — the provider answered and
-    /// `log_openrouter_usage` already logged the call, but the reply itself
+    /// `record_generation` already logged the call, but the reply itself
     /// was unusable. `None` when every attempt failed at the transport level
     /// (`model_error` / `timeout`), where no response — and nothing to
     /// attribute usage to — ever came back. `outcome: Some(_)` never needs
@@ -3172,8 +3247,11 @@ pub(crate) fn render_compose_payload(
 /// Shared with `routes/persona.rs`: the standalone compose endpoint's
 /// non-stream mode maps an `outcome: None` here to a 502 instead of the chat
 /// path's fail-open (spec 2026-08-03 §3.6 — no portrait fallback there).
+/// `session_id` is `Some` from the chat path; the standalone endpoint has no
+/// session to attribute the generation to, so it passes `None`.
 pub(crate) async fn run_image_prompt_compose(
     state: &AppState,
+    session_id: Option<Uuid>,
     c: &eros_engine_llm::model_config::ResolvedImagePromptCompose,
     user_payload: &str,
     task: &'static str,
@@ -3236,16 +3314,26 @@ pub(crate) async fn run_image_prompt_compose(
                 continue;
             }
         };
-        super::log_openrouter_usage(task, None, &resp);
+        let generation_id = super::record_generation(
+            &state.pool,
+            super::GenerationRecord {
+                task,
+                session_id,
+                generation_id: resp.generation_id.as_deref(),
+                model: resp.model.as_deref(),
+                usage: resp.usage.as_ref(),
+            },
+        )
+        .await;
         let text = resp.reply.trim().to_string();
         if text.is_empty() {
             tracing::warn!(model = %model_id, "image-compose: empty reply; next");
             last_failure = Some("empty");
             // Content-level failure: the provider answered (and was billed
-            // above by `log_openrouter_usage`) even though the reply was
+            // above by `record_generation`) even though the reply was
             // blank. Record who answered in case the whole chain exhausts.
             last_model = Some(resp.model.clone().unwrap_or_else(|| model_id.clone()));
-            last_generation_id = resp.generation_id.clone();
+            last_generation_id = generation_id.clone();
             last_usage = resp.usage.clone();
             continue;
         }
@@ -3254,7 +3342,7 @@ pub(crate) async fn run_image_prompt_compose(
             tracing::warn!(model = %model_id, "image-compose: empty prompt after parse; next");
             last_failure = Some("empty_prompt");
             last_model = Some(resp.model.clone().unwrap_or_else(|| model_id.clone()));
-            last_generation_id = resp.generation_id.clone();
+            last_generation_id = generation_id.clone();
             last_usage = resp.usage.clone();
             continue;
         }
@@ -3263,7 +3351,7 @@ pub(crate) async fn run_image_prompt_compose(
                 prompt,
                 caption,
                 model: resp.model.unwrap_or_else(|| model_id.clone()),
-                generation_id: resp.generation_id,
+                generation_id,
                 usage: resp.usage,
                 variant: c.variant_key.clone(),
             }),
@@ -3433,6 +3521,7 @@ async fn build_delegated_image_prompt(
         Some(c) => {
             run_image_prompt_compose(
                 state,
+                Some(session_id),
                 &c,
                 &render_compose_payload(
                     persona,
@@ -4039,7 +4128,14 @@ pub fn run_stream(
                             }
                         });
                     }
-                    let run = run_pde_decision(&state.openrouter, p, &ctx).await;
+                    let run = run_pde_decision(
+                        &state.openrouter,
+                        &state.pool,
+                        user_msg.session_id,
+                        p,
+                        &ctx,
+                    )
+                    .await;
                     let plan = match (&run.status, &run.verdict) {
                         (PdeStatus::Ok, Some(v)) => {
                             let action = guard_action(
@@ -4462,6 +4558,21 @@ pub fn run_stream(
                 }
 
                 let usage_full = last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok());
+                // Parent row BEFORE the persist below: the child stores what
+                // comes back, so it can never point at a row that does not
+                // exist yet. The chain-exhausted branch above already cleared
+                // the trio, so a canned fallback phrase records nothing.
+                last_gen_id = super::record_generation(
+                    &state.pool,
+                    super::GenerationRecord {
+                        task: PRODUCT_QA_TASK,
+                        session_id: Some(user_msg.session_id),
+                        generation_id: last_gen_id.as_deref(),
+                        model: served_model.as_deref(),
+                        usage: usage_full.as_ref(),
+                    },
+                )
+                .await;
                 // This executor persists exactly ONE row per turn — it has no
                 // superseded-bubble concept — so this row is always the
                 // concluding row and always owns the whole list.
@@ -4483,18 +4594,6 @@ pub fn run_stream(
                 {
                     tracing::warn!("stream: product_qa persist failed: {e}");
                 }
-                super::log_openrouter_usage(
-                    PRODUCT_QA_TASK,
-                    Some(user_msg.session_id),
-                    &eros_engine_llm::openrouter::ChatResponse {
-                        reply: String::new(), // usage log only — never echo content
-                        generation_id: last_gen_id.clone(),
-                        model: served_model.clone(),
-                        usage: usage_full.clone(),
-                        finish_reason: None,
-                        failures: Vec::new(),
-                    },
-                );
 
                 let mut usage_wire = usage_full;
                 filter_usage_keys(&mut usage_wire, &state.config.openrouter_usage_hidden_keys);
@@ -4714,7 +4813,14 @@ pub fn run_stream(
                     if let Some(image_url) = user_msg.image_url.as_deref() {
                         let (run, status) = match state.model_config.resolve_vision() {
                             Some(v) => {
-                                let run = run_vision(&state, &v, image_url, &user_msg.content).await;
+                                let run = run_vision(
+                                    &state,
+                                    user_msg.session_id,
+                                    &v,
+                                    image_url,
+                                    &user_msg.content,
+                                )
+                                .await;
                                 let status = if run.outcome.is_some() { "ok" } else { "exhausted" };
                                 (run, status)
                             }
@@ -4851,8 +4957,14 @@ pub fn run_stream(
                             .await
                             .transcript
                         };
-                        let (rewrite, in_failures) =
-                            run_input_filter(&state, &f, &transcript, &user_msg.content).await;
+                        let (rewrite, in_failures) = run_input_filter(
+                            &state,
+                            user_msg.session_id,
+                            &f,
+                            &transcript,
+                            &user_msg.content,
+                        )
+                        .await;
                         // Best-effort audit write, written whether or not a
                         // rewrite was produced — this is the gap
                         // `set_user_input_rewrite` (fires only on success)
@@ -12596,6 +12708,137 @@ data: [DONE]\n\n";
         );
     }
 
+    /// The chat reply's generation lands in the parent table with the session
+    /// it belongs to, and `chat_messages.generation_id` points at that same
+    /// row. The `session_id` half is the point: it is what lets a chat turn's
+    /// provider spend be attributed to its conversation from Postgres alone.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn chat_companion_generation_is_recorded_and_linked(pool: PgPool) {
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+        use futures_util::StreamExt;
+        use wiremock::matchers::{body_string_contains, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+
+        // Judge ("pde/judge"): a plain `reply_text` verdict so the turn takes
+        // the normal live-mode chat path.
+        let verdict = serde_json::json!({ "action": "reply_text" }).to_string();
+        let judge_body = serde_json::json!({
+            "id": "gen-judge-1", "model": "pde/judge",
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            "choices": [{"message": {"content": verdict}}],
+        });
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("pde/judge"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(judge_body))
+            .mount(&mock)
+            .await;
+
+        // Chat ("deepseek/x"): the terminal SSE chunk carries the generation id
+        // and a usage block — without an `id` there is nothing to record and the
+        // assertions below could only ever fail.
+        let chat_body = "data: {\"choices\":[{\"delta\":{\"content\":\"REPLY\"}}],\"usage\":{\"prompt_tokens\":7,\"completion_tokens\":3,\"total_tokens\":10},\"id\":\"gen-chat-1\",\"model\":\"deepseek/x\"}\n\ndata: [DONE]\n\n";
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("deepseek/x"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(chat_body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+
+        let user_id = Uuid::new_v4();
+        let (_g, instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = std::sync::Arc::new(
+            eros_engine_llm::model_config::ModelConfig::from_toml_str(
+                "[tasks.chat_companion]\nmodel=\"deepseek/x\"\n\
+                 [tasks.pde_decision]\nmodel=\"pde/judge\"\nfilter_prompt=\"Decide the action.\"\n",
+            )
+            .unwrap(),
+        );
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "k".into(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+
+        let chat_repo = ChatRepo { pool: &pool };
+        let umid = match chat_repo
+            .upsert_user_message_idempotent(
+                session_id,
+                "在吗",
+                "01JGENLINK00000000000000AA",
+                "user",
+                None,
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
+
+        let frames: Vec<ProtocolFrame> = run_stream(
+            std::sync::Arc::new(state),
+            PersistedUserMessage {
+                user_message_id: umid,
+                session_id,
+                user_id,
+                instance_id,
+                content: "在吗".into(),
+                prompt_traits: vec![],
+                audit: None,
+                tier: None,
+                memory_scope: Default::default(),
+                affinity_scope: Default::default(),
+                tips_amount_usd: None,
+                image_url: None,
+                image: None,
+                quote: Default::default(),
+            },
+            None,
+        )
+        .collect()
+        .await;
+
+        let deltas: String = frames
+            .iter()
+            .filter_map(|f| match f {
+                ProtocolFrame::Delta { content, .. } => Some(content.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            deltas.contains("REPLY"),
+            "the turn must have served the mocked reply; got {frames:?}",
+        );
+
+        let (task, sid): (String, Option<Uuid>) = sqlx::query_as(
+            "SELECT task, session_id FROM engine.llm_generations \
+             WHERE generation_id = 'gen-chat-1'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("the chat reply must record its generation");
+        assert_eq!(task, "chat_companion");
+        assert_eq!(sid, Some(session_id), "the chat turn's session, not NULL");
+
+        let stored: Option<String> = sqlx::query_scalar(
+            "SELECT generation_id FROM engine.chat_messages \
+             WHERE session_id = $1 AND role = 'assistant'",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(stored.as_deref(), Some("gen-chat-1"));
+    }
+
     /// A judge call that failed is audited twice over: `status` becomes the
     /// pointer value (`error` / `timeout` are retired), the provider's own
     /// status lands in `llm_attempts`, and — because the judge is one of spec
@@ -15630,8 +15873,8 @@ data: [DONE]\n\n";
         }
     }
 
-    #[tokio::test]
-    async fn pde_parse_error_walks_to_next_model() {
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn pde_parse_error_walks_to_next_model(pool: PgPool) {
         use wiremock::matchers::{body_string_contains, path as wm_path};
         use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -15659,14 +15902,14 @@ data: [DONE]\n\n";
             format!("{}/api/v1/chat/completions", mock.uri()),
         );
         let p = test_resolved_pde(vec!["model-a".into(), "model-b".into()]);
-        let run = run_pde_decision(&client, &p, "ctx").await;
+        let run = run_pde_decision(&client, &pool, Uuid::new_v4(), &p, "ctx").await;
         assert_eq!(run.status, PdeStatus::Ok);
         assert_eq!(run.verdict.unwrap().action, PdeAction::ReplyText);
         assert_eq!(run.model.as_deref(), Some("model-b"));
     }
 
-    #[tokio::test]
-    async fn pde_request_puts_configured_sampling_on_the_wire() {
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn pde_request_puts_configured_sampling_on_the_wire(pool: PgPool) {
         // Issue #246 end-to-end lock. ChatRequest derives Default and every
         // call-site literal ends in `..Default::default()`, so a site that
         // forgets `sampling` still COMPILES and silently sends nothing — the
@@ -15694,7 +15937,7 @@ data: [DONE]\n\n";
             presence_penalty: Some(0.15),
             repetition_penalty: Some(1.25),
         };
-        let run = run_pde_decision(&client, &p, "ctx").await;
+        let run = run_pde_decision(&client, &pool, Uuid::new_v4(), &p, "ctx").await;
         assert_eq!(run.status, PdeStatus::Ok);
 
         let sent: serde_json::Value = mock
@@ -15711,8 +15954,8 @@ data: [DONE]\n\n";
         assert_eq!(sent["repetition_penalty"], 1.25);
     }
 
-    #[tokio::test]
-    async fn pde_unset_sampling_stays_off_the_wire() {
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn pde_unset_sampling_stays_off_the_wire(pool: PgPool) {
         // The other half of the contract: an untuned task must produce a
         // byte-identical body to before #246 — no key, not a default value.
         use wiremock::matchers::path as wm_path;
@@ -15733,7 +15976,9 @@ data: [DONE]\n\n";
         );
         let p = test_resolved_pde(vec!["model-a".into()]);
         assert_eq!(
-            run_pde_decision(&client, &p, "ctx").await.status,
+            run_pde_decision(&client, &pool, Uuid::new_v4(), &p, "ctx")
+                .await
+                .status,
             PdeStatus::Ok
         );
 
@@ -15758,8 +16003,8 @@ data: [DONE]\n\n";
         }
     }
 
-    #[tokio::test]
-    async fn pde_whole_chain_parse_error_preserves_last_raw() {
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn pde_whole_chain_parse_error_preserves_last_raw(pool: PgPool) {
         use wiremock::matchers::path as wm_path;
         use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -15776,7 +16021,7 @@ data: [DONE]\n\n";
             format!("{}/api/v1/chat/completions", mock.uri()),
         );
         let p = test_resolved_pde(vec!["model-a".into(), "model-b".into()]);
-        let run = run_pde_decision(&client, &p, "ctx").await;
+        let run = run_pde_decision(&client, &pool, Uuid::new_v4(), &p, "ctx").await;
         assert_eq!(run.status, PdeStatus::ParseError);
         assert_eq!(run.raw.as_deref(), Some("nope"));
         assert!(run.verdict.is_none());

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -698,7 +698,7 @@ fn drive_chat_burst(
                 last_gen_id = super::record_generation(
                     &state.pool,
                     super::GenerationRecord {
-                        task: "chat_companion",
+                        task: task_name,
                         session_id: Some(session_id),
                         generation_id: last_gen_id.as_deref(),
                         model: Some(model_id.as_str()),
@@ -1077,7 +1077,7 @@ fn drive_chat_burst(
             last_gen_id = super::record_generation(
                 &state.pool,
                 super::GenerationRecord {
-                    task: "chat_companion",
+                    task: task_name,
                     session_id: Some(session_id),
                     generation_id: last_gen_id.as_deref(),
                     model: Some(model_id.as_str()),
@@ -13184,6 +13184,139 @@ data: [DONE]\n\n";
             decision_row.expect("companion_decision_events row must land within timeout");
         assert_eq!(proposed.as_deref(), Some("product_qa"));
         assert_eq!(acted.as_deref(), Some("product_qa"));
+    }
+
+    /// The product_qa reply's generation lands in the parent table under the
+    /// turn's session, and `chat_messages.generation_id` points at the same
+    /// row. product_qa rebinds `last_gen_id` after its candidate loop, like
+    /// voice and unlike the two main chat arms (the bespoke-arm pattern spec
+    /// §4.3 calls out), so this checks the rebind actually wires up both
+    /// halves of the link — same guarantee as the chat-companion arm's
+    /// `chat_companion_generation_is_recorded_and_linked`.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn chat_product_qa_generation_is_recorded_and_linked(pool: PgPool) {
+        use eros_engine_store::chat::{ChatRepo, UpsertUserOutcome};
+        use futures_util::StreamExt;
+        use wiremock::matchers::{body_string_contains, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+
+        // Judge ("pde/judge"): a `product_qa` verdict, empty inner_state.
+        let verdict = serde_json::json!({ "action": "product_qa", "inner_state": "" }).to_string();
+        let judge_body = serde_json::json!({
+            "id": "gj", "model": "pde/judge",
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            "choices": [{"message": {"content": verdict}}],
+        });
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("pde/judge"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(judge_body))
+            .mount(&mock)
+            .await;
+
+        // Product-QA executor ("qa/exec"): the terminal SSE chunk carries the
+        // generation id — without one, record_generation short-circuits on
+        // `generation_id: None` and there is nothing to assert.
+        let qa_body = "data: {\"choices\":[{\"delta\":{\"content\":\"这是产品说明\"}}],\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":5,\"total_tokens\":8},\"id\":\"gen-qa-1\",\"model\":\"qa/exec\"}\n\ndata: [DONE]\n\n";
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("qa/exec"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(qa_body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+
+        let user_id = Uuid::new_v4();
+        let (_g, instance_id, session_id) = seed_persona_and_session(&pool, user_id).await;
+
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = std::sync::Arc::new(
+            eros_engine_llm::model_config::ModelConfig::from_toml_str(
+                "[tasks.chat_companion]\nmodel=\"deepseek/x\"\n\
+                 [tasks.pde_decision]\nmodel=\"pde/judge\"\nfilter_prompt=\"Decide the action and inner_state.\"\n\
+                 [tasks.chat_product_qa]\nmodel=\"qa/exec\"\nfilter_prompt=\"Answer using the product docs below.\"\n",
+            )
+            .unwrap(),
+        );
+        state.openrouter = std::sync::Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "k".into(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+
+        let chat_repo = ChatRepo { pool: &pool };
+        let user_message_id = match chat_repo
+            .upsert_user_message_idempotent(
+                session_id,
+                "这个产品支持退货吗",
+                "01JPDEQALINK000000000000A",
+                "user",
+                None,
+            )
+            .await
+            .unwrap()
+        {
+            UpsertUserOutcome::Inserted { message_id } => message_id,
+            _ => unreachable!(),
+        };
+
+        let frames: Vec<ProtocolFrame> = run_stream(
+            std::sync::Arc::new(state),
+            PersistedUserMessage {
+                user_message_id,
+                session_id,
+                user_id,
+                instance_id,
+                content: "这个产品支持退货吗".into(),
+                prompt_traits: vec![],
+                audit: None,
+                tier: None,
+                memory_scope: Default::default(),
+                affinity_scope: Default::default(),
+                tips_amount_usd: None,
+                image_url: None,
+                image: None,
+                quote: Default::default(),
+            },
+            None,
+        )
+        .collect()
+        .await;
+
+        assert!(
+            !frames
+                .iter()
+                .any(|f| matches!(f, ProtocolFrame::Error { .. })),
+            "unexpected error frame: {frames:?}"
+        );
+
+        let (task, sid): (String, Option<Uuid>) = sqlx::query_as(
+            "SELECT task, session_id FROM engine.llm_generations \
+             WHERE generation_id = 'gen-qa-1'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("the product_qa reply must record its generation");
+        assert_eq!(task, "chat_product_qa");
+        assert_eq!(
+            sid,
+            Some(session_id),
+            "the product_qa turn's session, not NULL"
+        );
+
+        let stored: Option<String> = sqlx::query_scalar(
+            "SELECT generation_id FROM engine.chat_messages \
+             WHERE user_message_id = $1 AND role = 'assistant'",
+        )
+        .bind(user_message_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(stored.as_deref(), Some("gen-qa-1"));
     }
 
     /// Spec §6 failure path: "executor exhausted → fallback text emitted AND

--- a/crates/eros-engine-server/src/pipeline/voice.rs
+++ b/crates/eros-engine-server/src/pipeline/voice.rs
@@ -854,6 +854,20 @@ pub fn run_voice_turn(
         // gets the FULL unfiltered usage; the wire `Done` frame below gets a
         // separate, hidden-keys-filtered copy (mirrors the text/replay paths).
         let usage_full = last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok());
+        // Parent row BEFORE the persist below: the chain has ended and nothing
+        // has read `last_gen_id` yet, so the assistant row and the Done frame
+        // both store what came back rather than an id with no parent.
+        last_gen_id = crate::pipeline::record_generation(
+            &state.pool,
+            crate::pipeline::GenerationRecord {
+                task: "chat_voice",
+                session_id: Some(turn.session_id),
+                generation_id: last_gen_id.as_deref(),
+                model: served_model.as_deref(),
+                usage: usage_full.as_ref(),
+            },
+        )
+        .await;
         // Symmetric with the chat stream's assistant row: the resolved 6-bool
         // scope, not a back-projected label (spec 2026-08-14; the legacy
         // `relationship_scope` key shipped for one release in v1.2.0).

--- a/crates/eros-engine-server/src/pipeline/voice.rs
+++ b/crates/eros-engine-server/src/pipeline/voice.rs
@@ -1652,6 +1652,125 @@ data: [DONE]\n\n";
         );
     }
 
+    /// The voice reply's generation lands in the parent table under the
+    /// turn's own session, and `chat_messages.generation_id` points at that
+    /// same row. Voice rebinds `last_gen_id` after the candidate loop rather
+    /// than inside it (the bespoke-arm pattern spec §4.3 calls out), so this
+    /// checks the rebind actually wires up both halves of the link.
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn chat_voice_generation_is_recorded_and_linked(pool: sqlx::PgPool) {
+        use eros_engine_llm::model_config::ModelConfig;
+        use futures_util::StreamExt;
+        use wiremock::matchers::path as wm_path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        // The terminal chunk must carry an `id` — without one, record_generation
+        // short-circuits on `generation_id: None` and there is nothing to assert.
+        let body = "data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":2,\"total_tokens\":3},\"id\":\"gen-voice-1\",\"model\":\"primary\"}\n\ndata: [DONE]\n\n";
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw(body, "text/event-stream"),
+            )
+            .mount(&mock)
+            .await;
+
+        // Seed persona + instance + session.
+        let user_id = Uuid::new_v4();
+        let genome_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_genomes (name, system_prompt, art_metadata) \
+             VALUES ('V', 'You are V.', '{}'::jsonb) RETURNING id",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let instance_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.persona_instances (genome_id, owner_uid) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(genome_id).bind(user_id).fetch_one(&pool).await.unwrap();
+        let session_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_sessions (user_id, instance_id) VALUES ($1, $2) RETURNING id",
+        )
+        .bind(user_id)
+        .bind(instance_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        // Persist the user turn as the route would.
+        let repo = ChatRepo { pool: &pool };
+        let umid = match repo
+            .insert_voice_user_message(session_id, "hello", "01J9000000000000000000VOIC2", None)
+            .await
+            .unwrap()
+        {
+            eros_engine_store::chat::VoiceUserInsert::Inserted(id) => id,
+            other => panic!("expected Inserted, got {other:?}"),
+        };
+
+        // State with a chat_voice task + mock OpenRouter.
+        let mut state = crate::routes::companion::test_state(pool.clone());
+        state.model_config = Arc::new(
+            ModelConfig::from_toml_str(
+                "[tasks.chat_voice]\nmodel = \"primary\"\nmax_tokens = 100\nrecall = false\n",
+            )
+            .unwrap(),
+        );
+        state.openrouter = Arc::new(
+            eros_engine_llm::openrouter::OpenRouterClient::with_base_url(
+                "test-key".into(),
+                format!("{}/api/v1/chat/completions", mock.uri()),
+            ),
+        );
+
+        let resolved = state.model_config.resolve_voice().unwrap();
+        let frames: Vec<ProtocolFrame> = run_voice_turn(
+            Arc::new(state),
+            VoiceTurn {
+                session_id,
+                instance_id,
+                user_id,
+                user_message_id: umid,
+                content: "hello".into(),
+                affinity_scope: AffinityScope::full(),
+                memory_scope: MemoryScope::default(),
+                session_metadata: serde_json::json!({}),
+            },
+            resolved,
+        )
+        .collect()
+        .await;
+
+        assert!(
+            !frames
+                .iter()
+                .any(|f| matches!(f, ProtocolFrame::Error { .. })),
+            "unexpected error frame: {frames:?}"
+        );
+
+        let (task, sid): (String, Option<Uuid>) = sqlx::query_as(
+            "SELECT task, session_id FROM engine.llm_generations \
+             WHERE generation_id = 'gen-voice-1'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("the voice reply must record its generation");
+        assert_eq!(task, "chat_voice");
+        assert_eq!(sid, Some(session_id), "the voice turn's session, not NULL");
+
+        let stored: Option<String> = sqlx::query_scalar(
+            "SELECT generation_id FROM engine.chat_messages \
+             WHERE session_id = $1 AND role = 'assistant'",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(stored.as_deref(), Some("gen-voice-1"));
+    }
+
     /// Task 0 (affinity dead-row fix): `companion_affinity` is session-keyed
     /// and populated only by the text pipeline, so a voice-channel session's
     /// own `session_id` never has a row. The turn here runs on a voice

--- a/crates/eros-engine-server/src/pipeline/world.rs
+++ b/crates/eros-engine-server/src/pipeline/world.rs
@@ -316,7 +316,17 @@ async fn direct_world(
         .execute(req)
         .await
         .map_err(|e| format!("world_director LLM call failed: {e}"))?;
-    super::log_openrouter_usage(WORLD_TASK, None, &raw);
+    super::record_generation(
+        &state.pool,
+        super::GenerationRecord {
+            task: WORLD_TASK,
+            session_id: None,
+            generation_id: raw.generation_id.as_deref(),
+            model: raw.model.as_deref(),
+            usage: raw.usage.as_ref(),
+        },
+    )
+    .await;
 
     let output = parse_director_output(&raw.reply)
         .ok_or_else(|| "world_director output did not parse".to_string())?;
@@ -926,6 +936,14 @@ mod tests {
         assert_eq!(digests[instance_id.to_string()], "W 在筹备开店");
         assert_eq!(version, 2);
         assert!(claimed.is_none());
+
+        let model: Option<String> = sqlx::query_scalar(
+            "SELECT model FROM engine.llm_generations WHERE task = 'world_director'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("the sweeper must record its generation");
+        assert!(model.is_some());
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/crates/eros-engine-server/src/pipeline/world_town.rs
+++ b/crates/eros-engine-server/src/pipeline/world_town.rs
@@ -218,7 +218,17 @@ async fn run_comment_round(
         .execute(req)
         .await
         .map_err(|e| format!("world_comment LLM call failed: {e}"))?;
-    super::log_openrouter_usage("world_comment", None, &raw);
+    super::record_generation(
+        &state.pool,
+        super::GenerationRecord {
+            task: "world_comment",
+            session_id: None,
+            generation_id: raw.generation_id.as_deref(),
+            model: raw.model.as_deref(),
+            usage: raw.usage.as_ref(),
+        },
+    )
+    .await;
 
     let output = parse_comment_output(&raw.reply)
         .ok_or_else(|| "world_comment output did not parse".to_string())?;
@@ -330,7 +340,17 @@ async fn run_reply(
         .execute(req)
         .await
         .map_err(|e| format!("world_reply LLM call failed: {e}"))?;
-    super::log_openrouter_usage("world_reply", None, &raw);
+    super::record_generation(
+        &state.pool,
+        super::GenerationRecord {
+            task: "world_reply",
+            session_id: None,
+            generation_id: raw.generation_id.as_deref(),
+            model: raw.model.as_deref(),
+            usage: raw.usage.as_ref(),
+        },
+    )
+    .await;
 
     let content = raw.reply.trim();
     if content.is_empty() {
@@ -641,6 +661,14 @@ mod tests {
         run_comment_round(&state, &resolved, owner)
             .await
             .expect("noop ok");
+
+        let model: Option<String> = sqlx::query_scalar(
+            "SELECT model FROM engine.llm_generations WHERE task = 'world_comment'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("the sweeper must record its generation");
+        assert!(model.is_some());
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
@@ -736,6 +764,14 @@ mod tests {
             last_reply_at, None,
             "cap skip should not burn cooldown on fresh post"
         );
+
+        let model: Option<String> = sqlx::query_scalar(
+            "SELECT model FROM engine.llm_generations WHERE task = 'world_reply'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("the sweeper must record its generation");
+        assert!(model.is_some());
     }
 
     #[test]

--- a/crates/eros-engine-server/src/routes/image_edit.rs
+++ b/crates/eros-engine-server/src/routes/image_edit.rs
@@ -378,6 +378,7 @@ async fn edit_image(
         .expect("has_task checked above");
     let run = run_image_prompt_compose(
         &state,
+        Some(session_id),
         &resolved,
         &render_edit_payload(
             &persona,

--- a/crates/eros-engine-server/src/routes/persona.rs
+++ b/crates/eros-engine-server/src/routes/persona.rs
@@ -331,6 +331,7 @@ pub async fn compose_image(
     // the whole chain ⇒ 502 — no portrait fallback on this endpoint (§3.6).
     let run = run_image_prompt_compose(
         &state,
+        None,
         &resolved,
         &render_compose_payload(
             &persona,
@@ -715,6 +716,24 @@ async fn compose_stream(
         // the provider even though it never opened — see the per-arm decisions
         // above.
         let (exhausted_attempts, exhausted_gateways) = split_failures(&chain_failures);
+        // A candidate that streamed metadata and then ended with no content did
+        // get a response from the provider even though it never opened — that
+        // response was billed, so it gets an audit row. No session: standalone
+        // compose endpoint, same rationale as the streamed-through-open site.
+        let usage_json = last_usage
+            .as_ref()
+            .and_then(|u| serde_json::to_value(u).ok());
+        let last_generation_id = crate::pipeline::record_generation(
+            &state.pool,
+            crate::pipeline::GenerationRecord {
+                task: "chat_image_prompt_compose",
+                session_id: None,
+                generation_id: last_generation_id.as_deref(),
+                model: last_model.as_deref(),
+                usage: usage_json.as_ref(),
+            },
+        )
+        .await;
         record_compose_event(
             &state.pool,
             ImageComposeEventInsert {
@@ -809,22 +828,23 @@ async fn compose_stream(
                 }
             }
         }
-        // Usage is logged on EVERY terminal path, failures included: a stream
-        // that died mid-flight may still have been billed, and reconciling
-        // that is this endpoint's job. Same synthesis as the chat path's
-        // streaming arms.
-        crate::pipeline::log_openrouter_usage(
-            "chat_image_prompt_compose",
-            None,
-            &eros_engine_llm::openrouter::ChatResponse {
-                reply: String::new(), // usage log only — never echo content
-                generation_id: generation_id.clone(),
-                model: served_model.clone(),
-                usage: usage.as_ref().and_then(|u| serde_json::to_value(u).ok()),
-                finish_reason: None,
-                failures: Vec::new(),
+        // Usage is recorded on EVERY terminal path, failures included: a stream that
+        // died mid-flight may still have been billed, and reconciling that is this
+        // endpoint's job.
+        let usage_json = usage.as_ref().and_then(|u| serde_json::to_value(u).ok());
+        // No session: this is the standalone compose endpoint, which has no
+        // conversation to attach a session id to.
+        let generation_id = crate::pipeline::record_generation(
+            &state.pool,
+            crate::pipeline::GenerationRecord {
+                task: "chat_image_prompt_compose",
+                session_id: None,
+                generation_id: generation_id.as_deref(),
+                model: served_model.as_deref(),
+                usage: usage_json.as_ref(),
             },
-        );
+        )
+        .await;
         let (subject, caption) = parse_compose_reply(acc.trim());
         // Whatever this request's chain lost: the candidates that failed before
         // one opened, plus this one's own death if it died. Whichever arm below

--- a/crates/eros-engine-store/migrations/0059_llm_generations.sql
+++ b/crates/eros-engine-store/migrations/0059_llm_generations.sql
@@ -1,0 +1,68 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- engine.llm_generations — one row per billable LLM generation, from every
+-- call site in the engine. The parent this schema never had: nine
+-- generation_id columns across eight tables, and five tasks (world_director,
+-- world_stories_director, world_comment, world_reply, memory_extraction) that
+-- record nothing at all, so "what did this deployment spend, and on what"
+-- could only be answered from the provider's dashboard.
+--
+-- Keyed on the provider's own opaque handle, stored verbatim: it IS the join
+-- key to the provider's log, so a surrogate id would add a column and remove
+-- nothing.
+--
+-- session_id is nullable because several tasks legitimately have none (the
+-- standalone compose endpoint, the world/story sweepers, world_comment and
+-- world_reply), and nullable ⇒ ON DELETE SET NULL: the cost record must
+-- outlive the conversation it came from.
+--
+-- task is NOT NULL — a row that cannot say which task it belongs to answers
+-- none of the questions this table exists for — but carries NO CHECK. The
+-- vocabulary is [tasks.*] config, which a deployer may extend; a CHECK would
+-- turn adding a config section into an insert failure on a live turn.
+--
+-- model and usage stay nullable: upstream occasionally omits them, and the row
+-- is still a true record of a billable call.
+--
+-- No user_id. engine.* takes no new columns pointing at an external identity
+-- system; session_id → chat_sessions.user_id answers attribution for the rows
+-- that have a session, and the rest are deployment-level work with no user.
+--
+-- Foreign keys FROM the nine child columns are deliberately NOT here. They
+-- cannot ship in the same release as the write path that populates this table:
+-- fly.toml runs `migrate` before traffic swaps, so the machines still serving
+-- would be writing child rows without parents. See the spec, §8.
+--
+-- Spec: docs/superpowers/specs/2026-08-24-llm-generations-audit-design.md
+
+CREATE TABLE engine.llm_generations (
+    generation_id TEXT PRIMARY KEY,
+    session_id    UUID REFERENCES engine.chat_sessions(id) ON DELETE SET NULL,
+    task          TEXT NOT NULL,
+    model         TEXT,
+    usage         JSONB,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Without this, every chat_sessions delete seq-scans this table for the
+-- ON DELETE SET NULL above.
+CREATE INDEX idx_llm_generations_session
+    ON engine.llm_generations (session_id);
+-- "spend per task over a window" — the query this table exists for.
+CREATE INDEX idx_llm_generations_task_created
+    ON engine.llm_generations (task, created_at DESC);
+
+-- Supabase lockdown, mirroring 0045. REVOKEs are guarded by pg_roles existence
+-- so non-Supabase Postgres (incl. the sqlx test DB) skips them silently. RLS is
+-- enabled unconditionally; with no policy, only owner/service_role can touch it.
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
+        REVOKE ALL ON engine.llm_generations FROM anon;
+    END IF;
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+        REVOKE ALL ON engine.llm_generations FROM authenticated;
+    END IF;
+END
+$$;
+
+ALTER TABLE engine.llm_generations ENABLE ROW LEVEL SECURITY;

--- a/crates/eros-engine-store/src/generation.rs
+++ b/crates/eros-engine-store/src/generation.rs
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! Writer for `engine.llm_generations` — one row per billable LLM generation.
+
+use sqlx::PgPool;
+use uuid::Uuid;
+
+/// One `engine.llm_generations` row. `generation_id` is the provider's opaque
+/// handle and is not optional — a call that produced no id produced no row.
+/// `session_id` is `None` for the tasks that have no conversation behind them
+/// (world/story sweepers, the standalone compose endpoint).
+pub struct LlmGenerationInsert<'a> {
+    pub generation_id: &'a str,
+    pub session_id: Option<Uuid>,
+    pub task: &'a str,
+    pub model: Option<&'a str>,
+    pub usage: Option<&'a serde_json::Value>,
+}
+
+pub struct LlmGenerationRepo<'a> {
+    pub pool: &'a PgPool,
+}
+
+impl LlmGenerationRepo<'_> {
+    /// Record one generation. Idempotent by primary key: a streamed reply that
+    /// persists as several `chat_messages` rows calls this once per row, and
+    /// the first write wins. `created_at` is the column default rather than a
+    /// parameter — it is the moment the engine recorded the generation, and
+    /// taking it from callers would invite each one to pass a different clock.
+    pub async fn record(&self, g: LlmGenerationInsert<'_>) -> Result<(), sqlx::Error> {
+        sqlx::query(
+            "INSERT INTO engine.llm_generations \
+               (generation_id, session_id, task, model, usage) \
+             VALUES ($1,$2,$3,$4,$5) \
+             ON CONFLICT (generation_id) DO NOTHING",
+        )
+        .bind(g.generation_id)
+        .bind(g.session_id)
+        .bind(g.task)
+        .bind(g.model)
+        .bind(g.usage)
+        .execute(self.pool)
+        .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testutil::seed_chat_session;
+    use sqlx::PgPool;
+    use uuid::Uuid;
+
+    fn usage() -> serde_json::Value {
+        serde_json::json!({ "prompt_tokens": 11, "completion_tokens": 7, "cost": 0.0004 })
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn record_round_trips_every_column(pool: PgPool) {
+        let session = seed_chat_session(&pool, Uuid::new_v4()).await;
+        let repo = LlmGenerationRepo { pool: &pool };
+        let u = usage();
+        repo.record(LlmGenerationInsert {
+            generation_id: "gen-abc",
+            session_id: Some(session),
+            task: "chat_companion",
+            model: Some("vendor/model"),
+            usage: Some(&u),
+        })
+        .await
+        .expect("insert");
+
+        let (sid, task, model, stored): (
+            Option<Uuid>,
+            String,
+            Option<String>,
+            Option<serde_json::Value>,
+        ) = sqlx::query_as(
+            "SELECT session_id, task, model, usage FROM engine.llm_generations \
+                 WHERE generation_id = $1",
+        )
+        .bind("gen-abc")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(sid, Some(session));
+        assert_eq!(task, "chat_companion");
+        assert_eq!(model.as_deref(), Some("vendor/model"));
+        assert_eq!(stored.unwrap()["cost"], 0.0004);
+    }
+
+    /// One streamed reply can persist as several `chat_messages` rows
+    /// (`continues_from_message_id`), so the child writer calls this once per
+    /// row for a single generation. The second call must be a no-op, not an
+    /// error and not an overwrite.
+    #[sqlx::test(migrations = "./migrations")]
+    async fn record_is_idempotent_and_first_write_wins(pool: PgPool) {
+        let repo = LlmGenerationRepo { pool: &pool };
+        repo.record(LlmGenerationInsert {
+            generation_id: "gen-dup",
+            session_id: None,
+            task: "chat_companion",
+            model: Some("first"),
+            usage: None,
+        })
+        .await
+        .expect("first insert");
+        repo.record(LlmGenerationInsert {
+            generation_id: "gen-dup",
+            session_id: None,
+            task: "chat_companion",
+            model: Some("second"),
+            usage: None,
+        })
+        .await
+        .expect("second insert must not error");
+
+        let rows: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM engine.llm_generations WHERE generation_id = $1",
+        )
+        .bind("gen-dup")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(rows, 1);
+        let model: Option<String> =
+            sqlx::query_scalar("SELECT model FROM engine.llm_generations WHERE generation_id = $1")
+                .bind("gen-dup")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(model.as_deref(), Some("first"), "first write wins");
+    }
+
+    /// The world/story sweepers and the standalone compose endpoint have no
+    /// session at all.
+    #[sqlx::test(migrations = "./migrations")]
+    async fn record_accepts_a_null_session(pool: PgPool) {
+        let repo = LlmGenerationRepo { pool: &pool };
+        repo.record(LlmGenerationInsert {
+            generation_id: "gen-sessionless",
+            session_id: None,
+            task: "world_director",
+            model: None,
+            usage: None,
+        })
+        .await
+        .expect("insert");
+
+        let sid: Option<Uuid> = sqlx::query_scalar(
+            "SELECT session_id FROM engine.llm_generations WHERE generation_id = $1",
+        )
+        .bind("gen-sessionless")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert!(sid.is_none());
+    }
+
+    /// The cost record must outlive the conversation: deleting the session
+    /// blanks the pointer instead of taking the row with it.
+    #[sqlx::test(migrations = "./migrations")]
+    async fn deleting_the_session_blanks_the_pointer_and_keeps_the_row(pool: PgPool) {
+        let session = seed_chat_session(&pool, Uuid::new_v4()).await;
+        let repo = LlmGenerationRepo { pool: &pool };
+        repo.record(LlmGenerationInsert {
+            generation_id: "gen-outlives",
+            session_id: Some(session),
+            task: "affinity_evaluation",
+            model: None,
+            usage: None,
+        })
+        .await
+        .expect("insert");
+
+        sqlx::query("DELETE FROM engine.chat_sessions WHERE id = $1")
+            .bind(session)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let sid: Option<Option<Uuid>> = sqlx::query_scalar(
+            "SELECT session_id FROM engine.llm_generations WHERE generation_id = $1",
+        )
+        .bind("gen-outlives")
+        .fetch_optional(&pool)
+        .await
+        .unwrap();
+        assert_eq!(sid, Some(None), "row survives, pointer blanked");
+    }
+
+    /// `task` carries no CHECK on purpose: a deployer adding a `[tasks.*]`
+    /// section must never turn a live turn into an insert failure.
+    #[sqlx::test(migrations = "./migrations")]
+    async fn record_accepts_a_task_name_the_engine_does_not_ship(pool: PgPool) {
+        let repo = LlmGenerationRepo { pool: &pool };
+        repo.record(LlmGenerationInsert {
+            generation_id: "gen-unknown-task",
+            session_id: None,
+            task: "some_deployer_task",
+            model: None,
+            usage: None,
+        })
+        .await
+        .expect("an unrecognised task name must insert");
+    }
+}

--- a/crates/eros-engine-store/src/lib.rs
+++ b/crates/eros-engine-store/src/lib.rs
@@ -7,6 +7,7 @@ pub mod chat;
 pub mod chat_queue;
 pub mod decision;
 pub mod error_handling;
+pub mod generation;
 pub mod human_insight;
 pub mod image_events;
 pub mod insight;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -110,8 +110,8 @@ eros-engine-server :8080
     │              │
     │              ▼
     ├─► routes::persona (/persona/{instance_id}/image/compose)
-    │       └─► image-prompt composer LLM — audited to chat_images_events,
-    │           nothing else persisted (no chat state, no affinity, no memory)
+    │       └─► image-prompt composer LLM — audited to chat_images_events
+    │           and llm_generations; no chat state, no affinity, no memory
     │
     └────────────► Postgres (`engine` schema)
                        chat_sessions / chat_messages
@@ -121,6 +121,7 @@ eros-engine-server :8080
                        human_insights
                        companion_decision_events
                        chat_images_events / chat_vision_events
+                       llm_generations (every LLM call, audit)
 ```
 
 The post-process spawn returns `()` and is fire-and-forget by design — the user-facing response doesn't block on the affinity / memory / insight writes. If any of them fail, the chat reply still lands; failures are logged but not surfaced.

--- a/docs/architecture.zh.md
+++ b/docs/architecture.zh.md
@@ -106,8 +106,8 @@ eros-engine-server :8080
     │              │
     │              ▼
     ├─► routes::persona（/persona/{instance_id}/image/compose）
-    │       └─► 出图 prompt 合成器 LLM——落一行到 chat_images_events，
-    │           其余不落任何表（无聊天状态、无好感度、无记忆）
+    │       └─► 出图 prompt 合成器 LLM——落一行到 chat_images_events 和
+    │           llm_generations；无聊天状态、无好感度、无记忆
     │
     └────────────► Postgres（`engine` schema）
                        chat_sessions / chat_messages
@@ -117,6 +117,7 @@ eros-engine-server :8080
                        human_insights
                        companion_decision_events
                        chat_images_events / chat_vision_events
+                       llm_generations（每次 LLM 调用，审计）
 ```
 
 post-process spawn 返回 `()` 是 fire-and-forget 設計——用戶面前的響應不會被 affinity / memory / insight 寫入阻塞。它們任何一個失敗，對話回覆還是會落地；失敗會記日誌但不會冒給用戶。

--- a/docs/llm-audit.md
+++ b/docs/llm-audit.md
@@ -90,8 +90,12 @@ Behaviour:
 - Unset or empty → today's pass-through behaviour.
 
 Background paths (`pipeline::dreaming`, `pipeline::post_process`,
-`pipeline::world`, `pipeline::story`) emit usage only as `tracing::info!`
-fields:
+`pipeline::world`, `pipeline::story`) never surface these three fields on a
+client frame — there is no client connected to them. What they do produce,
+via `pipeline::record_generation`, is the same `tracing::info!` line every
+other call site emits, plus — since migration `0059` — one row in
+`engine.llm_generations`; see [LLM generations
+ledger](#llm-generations-ledger) below.
 
 ```
 openrouter: call completed session=… generation_id=… model=…
@@ -101,28 +105,110 @@ prompt_tokens=… completion_tokens=… total_tokens=… cost=…
 - `world_director` — World Memories director sweeper (background). One call
   per enrolled owner per `interval_hours`. `user` =
   `11111111-1111-1111-1111-111111111112` (world subsystem sentinel, distinct
-  from dreaming's `11111111-1111-1111-1111-111111111111`). Usage/cost emitted
-  as tracing fields via `log_openrouter_usage("world_director", None, …)`;
-  nothing on any client frame.
+  from dreaming's `11111111-1111-1111-1111-111111111111`). Recorded as
+  `task = "world_director"`; nothing on any client frame.
 - `world_comment` — World Town hourly comment round (background). One
   batched call per owner with new feed activity. `user` =
   `11111111-1111-1111-1111-111111111112` (shared world-subsystem sentinel).
-  Usage/cost emitted as tracing fields via
-  `log_openrouter_usage("world_comment", None, …)`; nothing on any client
-  frame.
+  Recorded as `task = "world_comment"`; nothing on any client frame.
 - `world_reply` — World Town reply responder (background). One call per
   debounced user comment, capped per owner per UTC day. Same sentinel user;
-  usage/cost emitted as tracing fields via
-  `log_openrouter_usage("world_reply", None, …)`; nothing on any client
-  frame.
+  recorded as `task = "world_reply"`; nothing on any client frame.
 - `world_stories_director` — World Stories director (background), module
   `pipeline::story`. Runs as the second phase of the same sweeper tick as
   `world_director`; one call per claimed persona instance per its own
   `interval_hours`. `user` = `11111111-1111-1111-1111-111111111113` (story
-  subsystem sentinel, continuing the dreaming/world sequence). Usage/cost
-  emitted as tracing fields via
-  `log_openrouter_usage("world_stories_director", None, …)`; nothing on any
-  client frame.
+  subsystem sentinel, continuing the dreaming/world sequence). Recorded as
+  `task = "world_stories_director"`; nothing on any client frame.
+
+## LLM generations ledger
+
+Migration `0059` adds `engine.llm_generations`, one row per **billable LLM
+generation** — a provider response that carried a `generation_id`, which is
+the unit the provider bills and the unit its own log exposes:
+
+```sql
+CREATE TABLE engine.llm_generations (
+    generation_id TEXT PRIMARY KEY,
+    session_id    UUID REFERENCES engine.chat_sessions(id) ON DELETE SET NULL,
+    task          TEXT NOT NULL,
+    model         TEXT,
+    usage         JSONB,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+`pipeline::record_generation` writes this row from every LLM call site in the
+engine, replacing the old `log_openrouter_usage`. It still emits the
+identical `openrouter: call completed` tracing line shown above — the row is
+in addition to that line, not instead of it.
+
+**Full task vocabulary.** Every `[tasks.*]` key that makes a chat-completion
+call now writes here: `chat_companion`, `chat_voice`, `chat_product_qa`,
+`chat_input_filter`, `chat_output_filter`, `chat_vision`,
+`chat_image_prompt_compose`, `chat_image_edit_compose`, `pde_decision`,
+`affinity_evaluation`, `insight_extraction`, `insight_structuring`,
+`character_insight_extraction`, `character_insight_structuring`,
+`user_insight_extraction`, `user_insight_structuring`, `memory_extraction`,
+`world_director`, `world_stories_director`, `world_comment`, `world_reply`.
+
+**Five of those previously wrote nothing to the database at all** —
+`world_director`, `world_stories_director`, `world_comment`, `world_reply`,
+`memory_extraction`. `engine.llm_generations` is now their only record.
+
+### Reading it
+
+`usage` is stored **unfiltered**, `cost` included.
+`OPENROUTER_USAGE_HIDDEN_KEYS` strips keys only on the way out to clients
+(see above); the database has always kept the whole object and continues to.
+
+Cost per task for a window:
+
+```sql
+SELECT task,
+       count(*)                       AS calls,
+       sum((usage->>'cost')::numeric) AS cost
+FROM engine.llm_generations
+WHERE created_at >= now() - interval '7 days'
+GROUP BY task ORDER BY cost DESC;
+```
+
+### Failure semantics: fail-open
+
+A parent write that fails to land — most likely a `session_id` that no
+longer resolves — logs a `warn!` and returns `None` rather than failing the
+turn. The caller stores that `None` as `NULL` in its own child
+`generation_id` column, and the reply is served exactly as it would have
+been. **For that one call, the tracing line above and the provider's own log
+are the only remaining record** — the audit row is simply gone.
+
+### No foreign keys yet
+
+**The child tables' `generation_id` columns — `chat_messages`,
+`companion_affinity_events`, `companion_insights_events`,
+`companion_decision_events`, `chat_images_events`, `chat_vision_events`,
+`character_insights_events`, `user_insights_events` — do not reference this
+table.** They can't yet: `fly.toml` runs the migration before traffic moves
+to the new machines, so a foreign key shipped in the same release as this
+write path would reject inserts from the previous build still serving live
+traffic. A later release adds the foreign keys together with a backfill of
+the pre-existing rows. Until then the two sides line up in practice, not by
+constraint — do not read this document as saying the link is enforced today.
+
+### Two known limits
+
+**A chain that walks several fallback models can write several rows for one
+turn.** Every candidate response that carried a `generation_id` gets its own
+row, whether or not its content is the one ultimately served — each was
+separately billed, so each is the intended unit.
+
+**The voice and product-QA arms record only the served attempt.** Both reset
+their working `generation_id` at the start of every candidate and call
+`record_generation` once, after the candidate loop ends, with whatever the
+served attempt left behind. A candidate that streamed a response — and was
+billed for it — before the chain moved on to another model leaves no row.
+The main chat arms record inside the per-candidate loop itself and do not
+have this gap.
 
 ## App-attribution headers
 
@@ -192,7 +278,11 @@ as shown above.
   (not the retired JSONB blob), and any off-schema key the LLM emits still
   lands in the event payload but nowhere else — a future events↔store
   reconciliation has to compare on payload keys ∩ `human_insights` column
-  set, not full equality.
+  set, not full equality. Since migration `0059`, every one of the calls
+  above — plus `chat_voice`, `chat_product_qa`, `chat_input_filter`,
+  `chat_output_filter`, and the five background sweepers that wrote none of
+  the above — also lands one row in `engine.llm_generations`; see [LLM
+  generations ledger](#llm-generations-ledger) above.
 - **Hash.** The engine does not transform `user` — callers are
   responsible for sending a hash.
 - **Sanitise.** `metadata` keys and values are size / shape-checked,
@@ -560,14 +650,16 @@ describe ran and failed on every chain model" (`exhausted`).
 
 ## Observability
 
-On every successful OpenRouter call *other than* the primary chat reply
-(`chat_companion`) and the voice turn (`chat_voice`), the engine logs an
-`info`-level event carrying `generation_id`, `model`, and best-effort parsed
-token/cost fields from `usage`. Those two highest-volume tasks never call
-that logging helper — their own per-attempt log is a `stream_metrics` event
-(`model` / `attempt` / `ttft_ms` / `total_ms` / `outcome`) with no
-`generation_id` or cost breakdown. The `audit` object itself is not logged —
-it is forwarded upstream and never echoed into engine logs.
+`record_generation` — called from every LLM call site in the engine — logs
+an `info`-level `openrouter: call completed` event carrying `generation_id`,
+`model`, and best-effort parsed token/cost fields from `usage`, and persists
+the same facts as a row (see [LLM generations
+ledger](#llm-generations-ledger) above). `chat_companion` and `chat_voice`,
+the two highest-volume tasks, additionally log a `stream_metrics` event per
+attempt (`model` / `attempt` / `ttft_ms` / `total_ms` / `outcome`) that the
+other tasks don't emit — that log is about per-attempt stream timing, not
+generation identity, and predates this table. The `audit` object itself is
+not logged — it is forwarded upstream and never echoed into engine logs.
 
 ## Why not persist?
 

--- a/docs/llm-audit.md
+++ b/docs/llm-audit.md
@@ -184,6 +184,13 @@ failing the turn; the caller stores that `None` as `NULL` in its own child
 `generation_id` column, and the reply is served exactly as it would have
 been.
 
+**The client sees the same degradation.** Every streaming arm's wire `done`
+frame sources its `generation_id` from what `record_generation` returned, not
+from the provider response directly — so a degraded parent write blanks that
+field on the frame the client receives for that turn too, not only the row
+in the database. The frame then matches the DB (both `NULL`), which is the
+point, but it means an internal audit-write failure is visible on the wire.
+
 **What survives a degraded write depends on the task.** The five background
 sweepers (`world_director`, `world_stories_director`, `world_comment`,
 `world_reply`, `memory_extraction`) write no child row of their own — for
@@ -209,6 +216,14 @@ traffic. A later release adds the foreign keys together with a backfill of
 the pre-existing rows. Until then the two sides line up in practice, not by
 constraint — do not read this document as saying the link is enforced today.
 
+**`chat_messages.f_generation_id` is the exception: it never gets one, in
+that later release or any other.** It is a ninth `generation_id`-bearing
+column — the filter generation, distinct from `chat_messages.generation_id`
+above — written by a separate `mark_filtered` `UPDATE` path that would need
+its own degrade branch, and production carries exactly one non-null value in
+it. This is a permanent decision (design spec §7.2), not a later-release
+item like the eight columns above.
+
 ### Two known limits
 
 **A chain that walks several fallback models can write several rows for one
@@ -216,8 +231,9 @@ turn.** Every candidate response that carried a `generation_id` gets its own
 row, whether or not its content is the one ultimately served — each was
 separately billed, so each is the intended unit.
 
-**The voice and product-QA arms record only the served attempt.** Both reset
-their working `generation_id` at the start of every candidate and call
+**The voice arm, the product-QA arm, and the standalone compose endpoint's
+streaming mode record only the served attempt.** All three reset their
+working `generation_id` at the start of every candidate and call
 `record_generation` once, after the candidate loop ends, with whatever the
 served attempt left behind. A candidate that streamed a response — and was
 billed for it — before the chain moved on to another model leaves no row.

--- a/docs/llm-audit.md
+++ b/docs/llm-audit.md
@@ -175,12 +175,26 @@ GROUP BY task ORDER BY cost DESC;
 
 ### Failure semantics: fail-open
 
-A parent write that fails to land — most likely a `session_id` that no
-longer resolves — logs a `warn!` and returns `None` rather than failing the
-turn. The caller stores that `None` as `NULL` in its own child
+The only structural cause the schema itself can produce for a parent write
+failing is `session_id` failing its foreign key: `task`, `model`, and
+`usage` carry no constraint that can fail, and a `generation_id` collision is
+absorbed by `ON CONFLICT DO NOTHING`. Anything else is a transient database
+error. Either way, the helper logs a `warn!` and returns `None` rather than
+failing the turn; the caller stores that `None` as `NULL` in its own child
 `generation_id` column, and the reply is served exactly as it would have
-been. **For that one call, the tracing line above and the provider's own log
-are the only remaining record** — the audit row is simply gone.
+been.
+
+**What survives a degraded write depends on the task.** The five background
+sweepers (`world_director`, `world_stories_director`, `world_comment`,
+`world_reply`, `memory_extraction`) write no child row of their own — for
+them a degraded write loses the record entirely, and the tracing line above
+plus the provider's own log are what's left. Every other task's child row
+sets its own `model` and `usage` straight from the provider response,
+independent of what `record_generation` returns (e.g. `stream.rs`'s
+`AssistantInsert.model` / `.usage`) — those survive a degraded write today.
+Only the join key, `generation_id`, is lost. **After a later release drops
+the now-redundant `model` / `usage` columns from those child tables**, that
+loss becomes total for them too — see the design spec, §6.
 
 ### No foreign keys yet
 
@@ -654,12 +668,12 @@ describe ran and failed on every chain model" (`exhausted`).
 an `info`-level `openrouter: call completed` event carrying `generation_id`,
 `model`, and best-effort parsed token/cost fields from `usage`, and persists
 the same facts as a row (see [LLM generations
-ledger](#llm-generations-ledger) above). `chat_companion` and `chat_voice`,
-the two highest-volume tasks, additionally log a `stream_metrics` event per
-attempt (`model` / `attempt` / `ttft_ms` / `total_ms` / `outcome`) that the
-other tasks don't emit — that log is about per-attempt stream timing, not
-generation identity, and predates this table. The `audit` object itself is
-not logged — it is forwarded upstream and never echoed into engine logs.
+ledger](#llm-generations-ledger) above). `chat_companion` additionally logs a
+`stream_metrics` event per attempt (`model` / `attempt` / `ttft_ms` /
+`total_ms` / `outcome`) that no other task — including `chat_voice` — emits;
+that log is about per-attempt stream timing, not generation identity, and
+predates this table. The `audit` object itself is not logged — it is
+forwarded upstream and never echoed into engine logs.
 
 ## Why not persist?
 

--- a/docs/llm-audit.zh.md
+++ b/docs/llm-audit.zh.md
@@ -84,7 +84,11 @@ OPENROUTER_USAGE_HIDDEN_KEYS=cost,cost_details
 - 未设或空 → 维持现状（完整透传）。
 
 后台路径（`pipeline::dreaming`、`pipeline::post_process`、
-`pipeline::world`、`pipeline::story`）的 usage 只通过 `tracing::info!` 字段输出：
+`pipeline::world`、`pipeline::story`）从不把这三个字段返回给 client——它们本来
+就没有 client 连着。它们真正产出的是：`pipeline::record_generation` 打的、
+与其它所有调用点相同的那行 `tracing::info!`，外加——自 migration `0059`
+起——`engine.llm_generations` 里的一行记录；见下面的
+[LLM 生成记录表](#llm-生成记录表)。
 
 ```
 openrouter: call completed session=… generation_id=… model=…
@@ -94,23 +98,101 @@ prompt_tokens=… completion_tokens=… total_tokens=… cost=…
 - `world_director` —— World Memories 导演清扫（后台）。每个已加入的 owner 每
   `interval_hours` 调一次。`user` = `11111111-1111-1111-1111-111111111112`
   （world 子系统哨兵，与 dreaming 的 `11111111-1111-1111-1111-111111111111`
-  不同）。Usage/cost 通过 tracing 字段输出，走
-  `log_openrouter_usage("world_director", None, …)`；不出现在任何 client 帧上。
+  不同）。落库时 `task = "world_director"`；不出现在任何 client 帧上。
 - `world_comment` —— World Town 每小时评论轮（后台）。每个有新动态的 owner
   批量调一次。`user` = `11111111-1111-1111-1111-111111111112`（world 子系统
-  共享哨兵）。Usage/cost 通过 tracing 字段输出，走
-  `log_openrouter_usage("world_comment", None, …)`；不出现在任何 client 帧上。
+  共享哨兵）。落库时 `task = "world_comment"`；不出现在任何 client 帧上。
 - `world_reply` —— World Town 回复响应器（后台）。每条经防抖的用户留言调一
-  次，按 owner 每 UTC 自然日封顶。同一个哨兵 user；usage/cost 通过 tracing
-  字段输出，走 `log_openrouter_usage("world_reply", None, …)`；不出现在任何
-  client 帧上。
+  次，按 owner 每 UTC 自然日封顶。同一个哨兵 user；落库时
+  `task = "world_reply"`；不出现在任何 client 帧上。
 - `world_stories_director` —— World Stories 导演（后台），模块
   `pipeline::story`。作为 `world_director` 同一个 sweeper tick 的第二阶段
   运行；每个被认领的 persona instance 按自己的 `interval_hours` 调一次。
   `user` = `11111111-1111-1111-1111-111111111113`（story 子系统哨兵，延续
-  dreaming/world 的序列）。Usage/cost 通过 tracing 字段输出，走
-  `log_openrouter_usage("world_stories_director", None, …)`；不出现在任何
-  client 帧上。
+  dreaming/world 的序列）。落库时 `task = "world_stories_director"`；不出现在
+  任何 client 帧上。
+
+## LLM 生成记录表
+
+Migration `0059` 新增 `engine.llm_generations`：每一次**可计费的 LLM
+生成**一行——「可计费」指 provider 返回了 `generation_id` 的那次响应，这正是
+provider 计费的单位，也是它自己日志暴露的单位：
+
+```sql
+CREATE TABLE engine.llm_generations (
+    generation_id TEXT PRIMARY KEY,
+    session_id    UUID REFERENCES engine.chat_sessions(id) ON DELETE SET NULL,
+    task          TEXT NOT NULL,
+    model         TEXT,
+    usage         JSONB,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+`pipeline::record_generation` 在引擎里的每一个 LLM 调用点写这一行，取代了旧的
+`log_openrouter_usage`。它仍然打出上面那行完全相同的 `openrouter: call
+completed` tracing——落库是额外加的，不是取代那行日志。
+
+**完整的任务词表。** 每一个会发起 chat-completion 调用的 `[tasks.*]` key
+现在都会写这张表：`chat_companion`、`chat_voice`、`chat_product_qa`、
+`chat_input_filter`、`chat_output_filter`、`chat_vision`、
+`chat_image_prompt_compose`、`chat_image_edit_compose`、`pde_decision`、
+`affinity_evaluation`、`insight_extraction`、`insight_structuring`、
+`character_insight_extraction`、`character_insight_structuring`、
+`user_insight_extraction`、`user_insight_structuring`、`memory_extraction`、
+`world_director`、`world_stories_director`、`world_comment`、`world_reply`。
+
+**其中五个此前在数据库里完全没有留下任何痕迹**——`world_director`、
+`world_stories_director`、`world_comment`、`world_reply`、
+`memory_extraction`。`engine.llm_generations` 现在是它们唯一的记录。
+
+### 怎么读
+
+`usage` 落库是**未过滤**的，`cost` 也在里面。`OPENROUTER_USAGE_HIDDEN_KEYS`
+只在返回给 client 的那份上剔除 key（见上文）；数据库里的这份从来就是完整的，
+以后也一直是。
+
+按任务统计某个时间窗口的花费：
+
+```sql
+SELECT task,
+       count(*)                       AS calls,
+       sum((usage->>'cost')::numeric) AS cost
+FROM engine.llm_generations
+WHERE created_at >= now() - interval '7 days'
+GROUP BY task ORDER BY cost DESC;
+```
+
+### 失败语义：fail-open
+
+父行写入失败时——最常见的原因是 `session_id` 已经解析不出来了——helper 打一条
+`warn!`，返回 `None`，而不是让这一轮失败。调用方把这个 `None` 存进自己那个子表
+的 `generation_id` 列，值为 `NULL`，回复照常送达，跟审计写入成功时一模一样。
+**对那一次调用而言，上面那行 tracing 和 provider 自己的日志，就是仅剩的
+记录**——审计行就这么没了。
+
+### 还没有外键
+
+**子表的 `generation_id` 列——`chat_messages`、`companion_affinity_events`、
+`companion_insights_events`、`companion_decision_events`、
+`chat_images_events`、`chat_vision_events`、`character_insights_events`、
+`user_insights_events`——目前都不引用这张表。** 现在还不能加：`fly.toml` 在
+流量切到新机器之前就跑 `migrate`，如果外键跟这条写入路径同一个 release 上线，
+仍在服务真实流量的旧机器写子行时就会撞上约束。之后的 release 会连同一次历史
+数据回填一起把外键补上。在那之前，两边在实践中对得上，但没有约束保证——不要
+从这份文档读出「这个关联今天已经强制生效」的结论。
+
+### 两个已知的局限
+
+**一条走了好几个 fallback 模型的链路，一轮可能写出好几行。** 每一个拿到过
+`generation_id` 的候选响应都单独落一行，不管它的内容最终有没有被采用——
+每一个都单独计过费，所以每一个都是这张表要记的单位。
+
+**语音和 product-QA 这两条链只记被采用的那次尝试。** 两者都在每个候选开始时
+把手上的 `generation_id` 清空，等候选循环结束后才调用一次
+`record_generation`，用的是被采用的那次尝试留下的值。一个已经流式返回、
+已经计费的候选，如果链路随后换到了下一个模型，就不会留下任何一行。主聊天链路
+是在逐候选循环内部记录的，没有这个缺口。
 
 ## App-attribution headers
 
@@ -172,7 +254,11 @@ material 会直接拒绝加载，而不是像以前那样在构造时 warn-and-d
   `existing_insights` 上下文现在是从 `human_insights` 反向投影出来的（不再是
   已废弃的 JSONB blob），LLM 吐出的任何 schema 之外的 key 仍然会进事件
   payload，但不会落在其它任何地方——以后做 events↔store 对账时，要按
-  payload key 与 `human_insights` 列集合的交集比较，不能直接判等。
+  payload key 与 `human_insights` 列集合的交集比较，不能直接判等。自
+  migration `0059` 起，上面这些调用——加上 `chat_voice`、`chat_product_qa`、
+  `chat_input_filter`、`chat_output_filter`，以及此前一行都不写的那五个
+  后台 sweeper——现在也都会在 `engine.llm_generations` 里各落一行；见上面的
+  [LLM 生成记录表](#llm-生成记录表)。
 - **不 hash。**引擎不会变换 `user` —— caller 负责送 hash。
 - **不消毒。**`metadata` 的 key / value 只检查 size / shape，不查内容。
 - **不解读。**引擎不会按 audit 字段分组、聚合、报警。Caller 自己接。
@@ -491,13 +577,14 @@ CHECK 里——事后收窄 CHECK 要过一次 migration，而这个仓库的一
 
 ## 可观测性
 
-除了主聊天回复（`chat_companion`）和语音回合（`chat_voice`）之外，每次
-成功的 OpenRouter 调用，引擎都会打一条 info 级别日志，带
-`generation_id` / `model` 以及 best-effort 解析出来的 token / cost。这
-两个调用量最大的任务不走这条日志——它们各自的 per-attempt 日志是一条
-`stream_metrics` 事件（`model` / `attempt` / `ttft_ms` / `total_ms` /
-`outcome`），没有 `generation_id` 也没有 cost 明细。`audit` 对象本身
-不写入日志——它只转发给上游，从不回写进引擎日志。
+`record_generation`——引擎里每一个 LLM 调用点都会走它——会打一条 info 级别的
+`openrouter: call completed` 日志，带 `generation_id` / `model` 以及
+best-effort 解析出来的 token / cost，并把同样的事实落成一行（见上面的
+[LLM 生成记录表](#llm-生成记录表)）。`chat_companion` 和 `chat_voice`
+这两个调用量最大的任务，额外还有一条 per-attempt 的 `stream_metrics` 事件
+（`model` / `attempt` / `ttft_ms` / `total_ms` / `outcome`），是其它任务没有
+的——那条日志说的是单次尝试的流式耗时，不是生成身份，比这张表出现得更早。
+`audit` 对象本身不写入日志——它只转发给上游，从不回写进引擎日志。
 
 ## 为什么不持久化？
 

--- a/docs/llm-audit.zh.md
+++ b/docs/llm-audit.zh.md
@@ -172,6 +172,12 @@ GROUP BY task ORDER BY cost DESC;
 失败；调用方把这个 `None` 存进自己那个子表的 `generation_id` 列，值为
 `NULL`，回复照常送达，跟审计写入成功时一模一样。
 
+**客户端看到的是同一种降级。** 每条流式链路 wire 上的 `done` 帧，
+`generation_id` 都是从 `record_generation` 的返回值取的，不是直接取自
+provider 响应——所以一次降级的父行写入，连同这一轮客户端收到的那个字段一起
+被清空，不只是数据库里的那一行。这样帧和数据库对得上（都是 `NULL`），这正是
+目的所在，但代价是：一次内部审计写入失败，客户端在 wire 上是看得见的。
+
 **写入降级之后，剩下什么取决于任务。** 五个后台 sweeper（`world_director`、
 `world_stories_director`、`world_comment`、`world_reply`、
 `memory_extraction`）没有自己的子表行——对它们而言，一次降级写入就是彻底丢掉
@@ -193,17 +199,24 @@ GROUP BY task ORDER BY cost DESC;
 数据回填一起把外键补上。在那之前，两边在实践中对得上，但没有约束保证——不要
 从这份文档读出「这个关联今天已经强制生效」的结论。
 
+**`chat_messages.f_generation_id` 是例外：不管是那个后续 release 还是以后
+任何一次，它都不会加外键。** 这是第九个带 `generation_id` 的列——过滤生成
+id，跟上面的 `chat_messages.generation_id` 是两回事——由另一条 `mark_filtered`
+`UPDATE` 路径写入，加约束就得给这条路径单独配一条降级分支，而生产环境里这一列
+非空值只有一个。这是一个永久性决定（设计 spec §7.2），不是像上面八列那样等
+下一个 release 补上的待办。
+
 ### 两个已知的局限
 
 **一条走了好几个 fallback 模型的链路，一轮可能写出好几行。** 每一个拿到过
 `generation_id` 的候选响应都单独落一行，不管它的内容最终有没有被采用——
 每一个都单独计过费，所以每一个都是这张表要记的单位。
 
-**语音和 product-QA 这两条链只记被采用的那次尝试。** 两者都在每个候选开始时
-把手上的 `generation_id` 清空，等候选循环结束后才调用一次
-`record_generation`，用的是被采用的那次尝试留下的值。一个已经流式返回、
-已经计费的候选，如果链路随后换到了下一个模型，就不会留下任何一行。主聊天链路
-是在逐候选循环内部记录的，没有这个缺口。
+**语音链、product-QA 链，以及独立 compose 端点的流式模式，都只记被采用的那次
+尝试。** 三者都在每个候选开始时把手上的 `generation_id` 清空，等候选循环
+结束后才调用一次 `record_generation`，用的是被采用的那次尝试留下的值。一个
+已经流式返回、已经计费的候选，如果链路随后换到了下一个模型，就不会留下任何
+一行。主聊天链路是在逐候选循环内部记录的，没有这个缺口。
 
 ## App-attribution headers
 

--- a/docs/llm-audit.zh.md
+++ b/docs/llm-audit.zh.md
@@ -165,11 +165,22 @@ GROUP BY task ORDER BY cost DESC;
 
 ### 失败语义：fail-open
 
-父行写入失败时——最常见的原因是 `session_id` 已经解析不出来了——helper 打一条
-`warn!`，返回 `None`，而不是让这一轮失败。调用方把这个 `None` 存进自己那个子表
-的 `generation_id` 列，值为 `NULL`，回复照常送达，跟审计写入成功时一模一样。
-**对那一次调用而言，上面那行 tracing 和 provider 自己的日志，就是仅剩的
-记录**——审计行就这么没了。
+父行写入失败时，schema 本身能造成的结构性原因只有一个：`session_id` 没能通过
+外键校验——`task`、`model`、`usage` 都没有能失败的约束，`generation_id`
+撞车则由 `ON CONFLICT DO NOTHING` 吸收掉了。除此之外的失败都是数据库层面的
+瞬时错误。不管是哪种，helper 都打一条 `warn!`，返回 `None`，而不是让这一轮
+失败；调用方把这个 `None` 存进自己那个子表的 `generation_id` 列，值为
+`NULL`，回复照常送达，跟审计写入成功时一模一样。
+
+**写入降级之后，剩下什么取决于任务。** 五个后台 sweeper（`world_director`、
+`world_stories_director`、`world_comment`、`world_reply`、
+`memory_extraction`）没有自己的子表行——对它们而言，一次降级写入就是彻底丢掉
+这条记录，剩下的只有上面那行 tracing 和 provider 自己的日志。其余任务的子表
+行，`model` 和 `usage` 是直接从 provider 响应里取的，跟 `record_generation`
+返回什么无关（比如 `stream.rs` 的 `AssistantInsert.model` / `.usage`）——
+它们在一次降级写入之后照样保得住。丢掉的只是 join key `generation_id`。
+**等以后某个 release 把这些子表上已经冗余的 `model` / `usage` 列也删掉之后**，
+对它们而言才会变成彻底丢失——见设计 spec §6。
 
 ### 还没有外键
 
@@ -580,11 +591,11 @@ CHECK 里——事后收窄 CHECK 要过一次 migration，而这个仓库的一
 `record_generation`——引擎里每一个 LLM 调用点都会走它——会打一条 info 级别的
 `openrouter: call completed` 日志，带 `generation_id` / `model` 以及
 best-effort 解析出来的 token / cost，并把同样的事实落成一行（见上面的
-[LLM 生成记录表](#llm-生成记录表)）。`chat_companion` 和 `chat_voice`
-这两个调用量最大的任务，额外还有一条 per-attempt 的 `stream_metrics` 事件
-（`model` / `attempt` / `ttft_ms` / `total_ms` / `outcome`），是其它任务没有
-的——那条日志说的是单次尝试的流式耗时，不是生成身份，比这张表出现得更早。
-`audit` 对象本身不写入日志——它只转发给上游，从不回写进引擎日志。
+[LLM 生成记录表](#llm-生成记录表)）。`chat_companion` 额外还有一条
+per-attempt 的 `stream_metrics` 事件（`model` / `attempt` / `ttft_ms` /
+`total_ms` / `outcome`），是其它任务——包括 `chat_voice`——都没有的：那条
+日志说的是单次尝试的流式耗时，不是生成身份，比这张表出现得更早。`audit`
+对象本身不写入日志——它只转发给上游，从不回写进引擎日志。
 
 ## 为什么不持久化？
 

--- a/docs/superpowers/specs/2026-08-24-llm-generations-audit-design.md
+++ b/docs/superpowers/specs/2026-08-24-llm-generations-audit-design.md
@@ -121,24 +121,37 @@ task-scoped form, and a global time scan over an audit table is not a hot path.
 ### 4.1 The helper already exists
 
 `pipeline::log_openrouter_usage(task, session_id, &resp)` is already called
-from **19 of the 22** LLM call sites, and it already carries exactly the five
-facts this table stores. Streaming arms that never own a whole `ChatResponse`
-already synthesise one for it (`stream.rs` product-QA arm, `persona.rs`
-compose arm). The change is to make that function persist as well as trace:
+from **19 of the 23** LLM call sites, and it already carries exactly the five
+facts this table stores. The change is to make that function persist as well as
+trace:
 
 ```rust
 // crates/eros-engine-server/src/pipeline/mod.rs
-pub(super) async fn record_generation<'a>(
+pub(super) struct GenerationRecord<'a> {
+    pub task: &'a str,
+    pub session_id: Option<Uuid>,
+    pub generation_id: Option<&'a str>,
+    pub model: Option<&'a str>,
+    pub usage: Option<&'a serde_json::Value>,
+}
+
+pub(super) async fn record_generation(
     pool: &PgPool,
-    task: &str,
-    session_id: Option<Uuid>,
-    resp: &'a ChatResponse,
-) -> Option<&'a str>
+    rec: GenerationRecord<'_>,
+) -> Option<String>
 ```
 
 Renamed, because it now records a fact to two sinks rather than emitting a log
 line. The existing `tracing::info!` stays inside it verbatim — the structured
 log line is what operators grep today and nothing about it changes.
+
+**Five loose fields, not `&ChatResponse`.** Four streaming arms never own a
+`ChatResponse` — they hold `last_gen_id` / `model_id` / `usage_full` as
+separate locals — and two of them (`stream.rs` product-QA, `persona.rs`
+compose) today synthesise a fake `ChatResponse` with an empty `reply` purely to
+satisfy the logger's parameter. Taking the fields directly deletes those
+synthetic values instead of adding two more. A named-field struct rather than
+five positional `Option`s, matching `DecisionEventInsert` and its siblings.
 
 Backed by `LlmGenerationRepo::record` in a new
 `crates/eros-engine-store/src/generation.rs`, issuing:
@@ -163,13 +176,27 @@ Call sites stop reading `resp.generation_id` and use what `record_generation`
 returns:
 
 ```rust
-let gen = record_generation(&pool, TASK, Some(session_id), &resp).await;
-// ... write the child row with `gen`, not `resp.generation_id`
+let gen = record_generation(&state.pool, GenerationRecord {
+    task: TASK,
+    session_id: Some(session_id),
+    generation_id: resp.generation_id.as_deref(),
+    model: resp.model.as_deref(),
+    usage: resp.usage.as_ref(),
+}).await;
+// ... write the child row with `gen.as_deref()`, not `resp.generation_id`
 ```
 
 `Some(id)` — the parent row is committed, the child may reference it.
 `None` — either upstream gave no id, or the parent write failed (§6). Either
 way the child must store `NULL`.
+
+In the four streaming arms the returned value is **rebound onto `last_gen_id`**
+at the point the stream loop ends, so every persist site downstream in that arm
+picks up the degraded value with no further edit:
+
+```rust
+last_gen_id = record_generation(&state.pool, GenerationRecord { .. }).await;
+```
 
 This is what makes the foreign keys in Release B safe by construction: there is
 no path that yields a `generation_id` to a child writer without the parent row
@@ -177,14 +204,16 @@ already existing.
 
 ### 4.3 Call sites
 
-Nineteen sites need only the new parameter and `.await`. Three need a call
-that does not exist yet, and five need a real `session_id`:
+Nineteen sites need only the new parameter and `.await`. Four need a call that
+does not exist yet, one needs its existing call moved, and five need a real
+`session_id`:
 
 | task | site | change |
 |---|---|---|
-| `chat_companion` | `stream.rs` main reply arm | **new call** — synthesise a `ChatResponse` from `last_gen_id` / `served_model` / `usage_full`, as the product-QA arm already does |
-| `chat_voice` | `voice.rs` stream arm | **new call**, same synthesis |
-| `chat_image_edit_compose` | `image_edit.rs` | **new call** |
+| `chat_companion` | `stream.rs` live arm + filtered arm | **new call** — rebind `last_gen_id` where the stream loop ends, covering all of that arm's persist sites at once |
+| `chat_voice` | `voice.rs` stream arm | **new call**, same rebind |
+| `chat_image_edit_compose` | `image_edit.rs`, both terminal paths | **new call** — the exhausted path was billed too |
+| `chat_product_qa` | `stream.rs` product-QA arm | existing call **moves earlier**: today it runs after the persist, which would leave the child pointing at an uncommitted parent |
 | `chat_output_filter`, `chat_input_filter`, `pde_decision`, `chat_vision`, `chat_image_prompt_compose` (chat path) | `stream.rs` | pass the **real `session_id`** instead of today's `None` |
 
 That last row is a fix, not a rename. Those sites pass `None` because a log
@@ -210,8 +239,8 @@ them, `llm_generations` becomes their only record in the database.
 paths that would each have to write the parent separately. The call site is
 the only place that holds `(task, session_id, response)` together exactly once.
 
-No trait, no middleware, no wrapper type: one function, twenty-two call sites,
-three lines each.
+No trait, no middleware, no wrapper type: one function, twenty-three call
+sites, three lines each.
 
 ## 5. Reading it
 

--- a/docs/superpowers/specs/2026-08-24-llm-generations-audit-design.md
+++ b/docs/superpowers/specs/2026-08-24-llm-generations-audit-design.md
@@ -1,0 +1,388 @@
+# `engine.llm_generations` — one row per LLM generation — Design
+
+- **Date:** 2026-08-24
+- **Status:** Approved, not yet implemented
+- **Type:** New parent table + write-path change at every LLM call site;
+  then foreign keys, a backfill, and column drops on eight live tables
+- **Owner:** enriquephl (sole dev)
+- **Target:** `eros-engine` 1.7.x, **two PRs and two separate releases**
+  (§8 is a hard constraint, not a preference)
+- **Depends on:** migrations through `0058`. Production is on `0054`, so
+  `0055`–`0058` ship alongside Release A.
+
+## 1. Problem
+
+Every LLM call the engine makes gets billed, and the only handle on that bill
+is the provider's `generation_id`. Today that handle is scattered across nine
+columns on eight tables, each shaped by whatever the feature that wrote it
+happened to need:
+
+| column | table |
+|---|---|
+| `generation_id` | `chat_messages` |
+| `f_generation_id` | `chat_messages` |
+| `generation_id` | `companion_affinity_events` |
+| `generation_id` | `companion_insights_events` |
+| `generation_id` | `companion_decision_events` |
+| `generation_id` | `chat_images_events` |
+| `generation_id` | `chat_vision_events` |
+| `generation_id` | `character_insights_events` |
+| `generation_id` | `user_insights_events` |
+
+Five call sites write no `generation_id` at all — `world_director`,
+`world_stories_director`, `world_comment`, `world_reply`, `memory_extraction`.
+Their spend leaves no trace in the database whatsoever.
+
+So there is no answer to "what did this deployment spend, and on what" that
+does not begin with exporting the provider's dashboard. There is no table to
+`GROUP BY task`, no table to join a cost onto a session, and no way to notice
+that a task is being called more often than it should.
+
+**One table, one row per generation, every call site writing to it.**
+
+## 2. What counts as a generation
+
+A generation is **one billable provider response that carried a
+`generation_id`**. That is the unit the provider bills and the unit its log
+exposes, so it is the unit this table keys on.
+
+Consequences, each deliberate:
+
+- **Failed attempts are not rows.** A hop that timed out, was refused, or died
+  in transport has no `generation_id` (`OpenRouterClient::execute` returns
+  `generation_id: None` on those paths). `llm_attempts` / `gateway_errors`
+  (migration 0050) already hold that story and keep it.
+- **A generation may own several child rows.** One streamed reply can persist
+  as multiple `chat_messages` rows via `continues_from_message_id`. The table
+  is the parent of a one-to-many, and the write is idempotent (§4).
+- **Filter calls are rows.** `chat_input_filter` and `chat_output_filter` cost
+  money, so they get rows like anything else. `chat_messages.f_generation_id`
+  is the one pointer that does **not** get a foreign key (§7) — a column
+  constraint is a separate question from whether the row exists.
+- **Voyage embeddings are not rows.** Different provider, no OpenRouter
+  `generation_id`, different billing line.
+- **Image generation is not a row.** Since v0.7.1 the engine emits
+  `image_request` and the downstream draws. What `chat_images_events` records
+  is the *composer* call — a text completion — and that is a row.
+
+## 3. Schema — migration `0059_llm_generations.sql` (Release A)
+
+```sql
+CREATE TABLE engine.llm_generations (
+    generation_id TEXT PRIMARY KEY,
+    session_id    UUID REFERENCES engine.chat_sessions(id) ON DELETE SET NULL,
+    task          TEXT NOT NULL,
+    model         TEXT,
+    usage         JSONB,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_llm_generations_session
+    ON engine.llm_generations (session_id);
+CREATE INDEX idx_llm_generations_task_created
+    ON engine.llm_generations (task, created_at DESC);
+```
+
+Plus the Supabase lockdown block (`REVOKE` guarded by `pg_roles` existence,
+then `ENABLE ROW LEVEL SECURITY`), copied from `0045`.
+
+**`generation_id TEXT PRIMARY KEY`.** The provider's own opaque handle, stored
+verbatim. It is the join key to the provider's log, so a surrogate id would add
+a column and remove nothing.
+
+**`session_id` nullable ⇒ `ON DELETE SET NULL`.** Several tasks legitimately
+have no session: the standalone compose endpoint, the world and story sweepers,
+`world_comment` / `world_reply`. And an audit row must outlive what it points
+at — the cost is still reconcilable after the conversation is deleted.
+
+**`task NOT NULL`, no `CHECK`.** A row that cannot say which task it belongs to
+answers none of the questions this table exists for. But the vocabulary is
+`[tasks.*]` config, which a deployer may extend: a `CHECK` would turn adding a
+config section into a runtime insert failure — a live turn dying because the
+audit table did not recognise a legal task name.
+
+**`model` and `usage` nullable.** Upstream occasionally omits them. The row is
+still a true record of a billable call, which is the test for `NOT NULL` — not
+"does the writer usually have it".
+
+**No `user_id`.** `engine.*` does not take new columns pointing at an external
+identity system. `session_id → chat_sessions.user_id` answers the attribution
+question for rows that have a session, and rows that do not have one are
+deployment-level work with no user behind them.
+
+**Two indexes.** `(session_id)` because without it every
+`chat_sessions` delete seq-scans this table for the `ON DELETE SET NULL`.
+`(task, created_at DESC)` because "spend per task over a window" is the query
+this table is for. No bare `(created_at DESC)`: the composite serves the
+task-scoped form, and a global time scan over an audit table is not a hot path.
+
+## 4. Write path (Release A)
+
+### 4.1 The helper already exists
+
+`pipeline::log_openrouter_usage(task, session_id, &resp)` is already called
+from **19 of the 22** LLM call sites, and it already carries exactly the five
+facts this table stores. Streaming arms that never own a whole `ChatResponse`
+already synthesise one for it (`stream.rs` product-QA arm, `persona.rs`
+compose arm). The change is to make that function persist as well as trace:
+
+```rust
+// crates/eros-engine-server/src/pipeline/mod.rs
+pub(super) async fn record_generation<'a>(
+    pool: &PgPool,
+    task: &str,
+    session_id: Option<Uuid>,
+    resp: &'a ChatResponse,
+) -> Option<&'a str>
+```
+
+Renamed, because it now records a fact to two sinks rather than emitting a log
+line. The existing `tracing::info!` stays inside it verbatim — the structured
+log line is what operators grep today and nothing about it changes.
+
+Backed by `LlmGenerationRepo::record` in a new
+`crates/eros-engine-store/src/generation.rs`, issuing:
+
+```sql
+INSERT INTO engine.llm_generations
+    (generation_id, session_id, task, model, usage)
+VALUES ($1, $2, $3, $4, $5)
+ON CONFLICT (generation_id) DO NOTHING
+```
+
+`ON CONFLICT DO NOTHING` is required, not defensive: a continued reply calls
+the child write once per `chat_messages` row for a single generation.
+
+`created_at` is the row default rather than a parameter. It is the moment the
+engine recorded the generation, within milliseconds of the response; taking it
+from the caller would invite each call site to pass a subtly different clock.
+
+### 4.2 The return value is the contract
+
+Call sites stop reading `resp.generation_id` and use what `record_generation`
+returns:
+
+```rust
+let gen = record_generation(&pool, TASK, Some(session_id), &resp).await;
+// ... write the child row with `gen`, not `resp.generation_id`
+```
+
+`Some(id)` — the parent row is committed, the child may reference it.
+`None` — either upstream gave no id, or the parent write failed (§6). Either
+way the child must store `NULL`.
+
+This is what makes the foreign keys in Release B safe by construction: there is
+no path that yields a `generation_id` to a child writer without the parent row
+already existing.
+
+### 4.3 Call sites
+
+Nineteen sites need only the new parameter and `.await`. Three need a call
+that does not exist yet, and five need a real `session_id`:
+
+| task | site | change |
+|---|---|---|
+| `chat_companion` | `stream.rs` main reply arm | **new call** — synthesise a `ChatResponse` from `last_gen_id` / `served_model` / `usage_full`, as the product-QA arm already does |
+| `chat_voice` | `voice.rs` stream arm | **new call**, same synthesis |
+| `chat_image_edit_compose` | `image_edit.rs` | **new call** |
+| `chat_output_filter`, `chat_input_filter`, `pde_decision`, `chat_vision`, `chat_image_prompt_compose` (chat path) | `stream.rs` | pass the **real `session_id`** instead of today's `None` |
+
+That last row is a fix, not a rename. Those sites pass `None` because a log
+line did not need the session; a table that cannot attribute a chat-turn cost
+to its conversation is worth much less.
+
+Full task vocabulary after this PR: `chat_companion`, `chat_voice`,
+`chat_product_qa`, `chat_input_filter`, `chat_output_filter`, `chat_vision`,
+`chat_image_prompt_compose`, `chat_image_edit_compose`, `pde_decision`,
+`affinity_evaluation`, `insight_extraction`, `insight_structuring`,
+`character_insight_extraction`, `character_insight_structuring`,
+`user_insight_extraction`, `user_insight_structuring`, `memory_extraction`,
+`world_director`, `world_stories_director`, `world_comment`, `world_reply`.
+
+**Coverage is complete in Release A**, including the five tasks that write no
+child row today. Because the helper is shared, they cost nothing extra — for
+them, `llm_generations` becomes their only record in the database.
+
+### 4.4 Why not push the write into the store repos
+
+`AffinityEventRepo::record` and its siblings do not know the task name, and
+`chat_messages` reaches the database through several insert / upsert / update
+paths that would each have to write the parent separately. The call site is
+the only place that holds `(task, session_id, response)` together exactly once.
+
+No trait, no middleware, no wrapper type: one function, twenty-two call sites,
+three lines each.
+
+## 5. Reading it
+
+Cost per task for a window:
+
+```sql
+SELECT task,
+       count(*)                                  AS calls,
+       sum((usage->>'cost')::numeric)            AS cost
+FROM engine.llm_generations
+WHERE created_at >= now() - interval '7 days'
+GROUP BY task ORDER BY cost DESC;
+```
+
+`usage` is stored **unfiltered**, including `cost`. `OPENROUTER_USAGE_HIDDEN_KEYS`
+strips keys on the way out to clients only; the database has always kept the
+whole object and continues to.
+
+## 6. Failure semantics — fail-open, and what it costs
+
+If the parent insert fails, the helper logs at `warn!` and returns `None`. The
+child row is written with `generation_id = NULL` and the turn proceeds. A chat
+reply is never lost to an audit write.
+
+**The cost of that choice, stated plainly.** After Release B drops the
+redundant `model` / `usage` columns (§7), a degraded write means that call's
+model, token counts, and cost are gone from the database entirely. The tracing
+line still names them, and the provider's log still holds them, but nothing in
+Postgres does. This is the accepted trade: a dropped audit row is recoverable
+from two other places, a dropped user reply is not.
+
+## 7. Release B — migration `0060_llm_generation_fks.sql`
+
+One file, one transaction, in this order.
+
+### 7.1 Backfill
+
+Roughly 55,000 historical rows across the eight tables (production, measured).
+Each source contributes `DISTINCT ON (generation_id)` with a literal `task`:
+
+| source | `task` |
+|---|---|
+| `chat_messages` `channel IS NULL` | `chat_companion` |
+| `chat_messages` `channel = 'voice'` | `chat_voice` |
+| `chat_messages` `channel = 'product_qa'` | `chat_product_qa` |
+| `chat_messages.f_generation_id` | `chat_output_filter` |
+| `companion_affinity_events` | `affinity_evaluation` |
+| `companion_insights_events` `stage = 'facts'` / `'structured'` | `insight_extraction` / `insight_structuring` |
+| `companion_decision_events` | `pde_decision` |
+| `chat_images_events` `source = 'image_edit'` | `chat_image_edit_compose` |
+| `chat_images_events` other sources | `chat_image_prompt_compose` |
+| `chat_vision_events` | `chat_vision` |
+| `character_insights_events` `stage` | `character_insight_extraction` / `_structuring` |
+| `user_insights_events` `stage` | `user_insight_extraction` / `_structuring` |
+
+Timestamps come from `sent_at` (`chat_messages`) or `created_at` (all others),
+so backfilled rows keep their real position in time.
+
+**Every `session_id` goes through `LEFT JOIN engine.chat_sessions` and lands as
+`NULL` when it does not resolve.** Migration 0058 recorded that
+`chat_images_events`, `companion_insights_events` and `companion_decision_events`
+carry dangling session ids and deliberately left them dangling. Copying one into
+`llm_generations.session_id` would violate this table's own — validated —
+foreign key and abort the migration, taking the engine's boot with it.
+
+Every insert carries `ON CONFLICT (generation_id) DO NOTHING`. Where the same
+id appears in two source tables the first writer wins; the ordering above is
+the tiebreak and no such collision is expected.
+
+### 7.2 Indexes, then constraints
+
+An index on each of the eight `generation_id` columns — none has one today, and
+an unindexed child column makes the parent's `ON DELETE` seq-scan it.
+
+Then eight foreign keys to `engine.llm_generations(generation_id)`, each
+`ON DELETE SET NULL` (nullable reference column, audit trail outlives its
+parent).
+
+`chat_messages.f_generation_id` gets **no** foreign key. The filter generation
+is in the parent table like any other, but the column stays unconstrained: it
+is written by a separate `UPDATE` path (`mark_filtered`) that would need its own
+degrade branch, and production has exactly **one** non-null value in it. The
+constraint would buy nothing and add a second failure mode to the filter path.
+
+### 7.3 Validated, not `NOT VALID`
+
+These constraints are added **validated**, reversing migration 0058's blanket
+rule. The difference is where the orphans could come from:
+
+- 0058 constrained columns whose parents (`chat_sessions`, `chat_messages`,
+  `persona_instances`) are deleted by forces outside the migration — a user
+  deleted between the orphan check and the deploy is enough to fail the scan,
+  and a failed release command means the engine does not boot with no rollback
+  path.
+- Here the parent rows are produced by the same transaction, from the very
+  child tables being constrained. `ADD FOREIGN KEY` takes `SHARE ROW EXCLUSIVE`
+  on both sides, so nothing writes a new child row between the backfill and the
+  scan. And the deploy order (§8) guarantees the code running during the
+  migration is Release A, which already writes parents. There is no source of
+  an orphan.
+
+55,000 rows scan in milliseconds. Taking the retrospective guarantee here is
+free; skipping it would leave a permanent "someday" on the table.
+
+### 7.4 Drop the redundant columns
+
+`model` and `usage` come off all eight child tables. The same generation's
+model and usage now live in exactly one place, reached by a join on
+`generation_id`.
+
+`chat_messages.filter_model` goes too: it is the model of the
+`f_generation_id` generation, which is in the parent table.
+
+Verified before writing this spec: `eros-engine-web` reads none of these
+columns (`SELECT` on `engine.chat_messages` was revoked from `service_role` in
+its migration `018`, and no web RPC references `model` or `usage` on any
+`engine.*` table), and no engine read path outside test assertions selects
+them. The work is deleting `.bind()` calls and rewriting the tests that assert
+on them.
+
+### 7.5 Documentation
+
+`docs/llm-audit.md` and `docs/llm-audit.zh.md` describe the current split
+("background paths emit usage only as tracing fields") and must be rewritten
+around the new table. `docs/architecture.md` gains the table. Scan
+`docs/api-reference.md` for any response field sourced from a dropped column.
+
+## 8. Deploy order is a hard constraint
+
+**Release A must be fully rolled out before Release B's migration runs.**
+
+`infra/engine/fly.toml` sets `release_command = "migrate"`, which Fly runs
+**before** traffic moves to the new machines. The moment Release B's foreign
+keys exist, the machines still serving traffic are running Release A — or, if
+the two were merged into one release, the *previous* build, which writes
+`generation_id` into child rows without ever writing a parent. Every such
+insert would violate the constraint, and for `chat_messages` that is a user's
+reply failing to persist.
+
+Merging the two PRs into one release breaks production. They are separate
+releases with a completed rollout in between, and PR 2 does not open until
+Release A is live.
+
+## 9. Testing
+
+**Store (`generation.rs`)**
+- Insert, then insert the same `generation_id` again — one row, first write wins.
+- `session_id = NULL` accepted.
+- Deleting the session sets `session_id` to `NULL` and keeps the row.
+
+**Helper**
+- Returns the id on success; returns `None` and leaves the child column `NULL`
+  when the insert fails.
+- Returns `None` when `resp.generation_id` is `None`, without touching the DB.
+- The `tracing` line is unchanged (existing log assertions keep passing).
+
+**Call sites** — one test per task asserting a `llm_generations` row with the
+right `task` and a `session_id` where the site has one. The five previously
+unaudited tasks get their first database-level assertion here.
+
+**Migration 0060** — a sqlx test that migrates to `0059`, inserts child rows
+including one with a dangling `session_id`, runs `0060`, and asserts: parent
+rows exist with the right `task`, the dangling one landed as `NULL`, the
+constraints are `convalidated`, and the dropped columns are gone.
+
+## 10. Out of scope
+
+- Failed attempts without a `generation_id` — `llm_attempts` / `gateway_errors`
+  already own that.
+- Voyage embedding calls.
+- Image-provider generations (the engine emits `image_request`; the downstream
+  draws and bills).
+- Any endpoint exposing this table. It is an operator table read through
+  `supabase db query`; an API for it is a separate proposal.

--- a/docs/superpowers/specs/2026-08-24-llm-generations-audit-design.md
+++ b/docs/superpowers/specs/2026-08-24-llm-generations-audit-design.md
@@ -1,12 +1,12 @@
 # `engine.llm_generations` — one row per LLM generation — Design
 
 - **Date:** 2026-08-24
-- **Status:** Approved, not yet implemented
+- **Status:** Release A implemented; Release B not started
 - **Type:** New parent table + write-path change at every LLM call site;
   then foreign keys, a backfill, and column drops on eight live tables
 - **Owner:** enriquephl (sole dev)
-- **Target:** `eros-engine` 1.7.x, **two PRs and two separate releases**
-  (§8 is a hard constraint, not a preference)
+- **Target:** Release A ships in `eros-engine` 1.6.1. **Two PRs and two
+  separate releases** (§8 is a hard constraint, not a preference)
 - **Depends on:** migrations through `0058`. Production is on `0054`, so
   `0055`–`0058` ship alongside Release A.
 

--- a/docs/superpowers/specs/2026-08-24-llm-generations-audit-design.md
+++ b/docs/superpowers/specs/2026-08-24-llm-generations-audit-design.md
@@ -361,6 +361,16 @@ its migration `018`, and no web RPC references `model` or `usage` on any
 them. The work is deleting `.bind()` calls and rewriting the tests that assert
 on them.
 
+**Known property, not a Release-B surprise: `llm_generations.model` is
+heterogeneous across tasks.** The two `chat_companion` streaming arms
+(`stream.rs`'s live and filtered arms) record `model: Some(model_id.as_str())`
+— the *requested* config slug, which may carry an `@provider` suffix — while
+every non-streaming call site records `resp.model`, the model the provider
+actually served. This already matches what `AssistantInsert.model` stores
+today, so nothing regresses, but once the child `model` columns are dropped,
+`llm_generations.model` is the only copy left and a reader joining across
+tasks needs to know the two are not the same kind of value.
+
 ### 7.5 Documentation
 
 `docs/llm-audit.md` and `docs/llm-audit.zh.md` describe the current split

--- a/docs/world-system.md
+++ b/docs/world-system.md
@@ -352,12 +352,16 @@ re-enrolling resumes the same world/life.
 
 ## Audit & cost
 
-The three World Memories / Town tasks log token usage as tracing fields via
-the shared world sentinel user `11111111-1111-1111-1111-111111111112`;
-`world_stories_director` logs under its own sentinel
-`11111111-1111-1111-1111-111111111113` (dreaming = `…111`, world = `…112`,
-stories = `…113` — per-subsystem spend attribution; see
-[LLM / OpenRouter audit](llm-audit.md)). Steady-state cost per enrolled owner
+The three World Memories / Town tasks tag every call with the shared world
+sentinel user `11111111-1111-1111-1111-111111111112`; `world_stories_director`
+tags its own calls with sentinel `11111111-1111-1111-1111-111111111113`
+(dreaming = `…111`, world = `…112`, stories = `…113` — per-subsystem spend
+attribution). Since migration `0059`, all four also write one row per call to
+`engine.llm_generations` (`task = world_director` / `world_stories_director` /
+`world_comment` / `world_reply`), in addition to the `openrouter: call
+completed` tracing line — previously they left no database trace at all. See
+[LLM / OpenRouter audit → LLM generations
+ledger](llm-audit.md#llm-generations-ledger). Steady-state cost per enrolled owner
 **with a worldview** per day is bounded by: 1 director call + at most
 `24h/round_secs` comment rounds (only those with activity) + at most
 `daily_cap` replies + up to `24h/interval_hours` story calls per

--- a/docs/world-system.zh.md
+++ b/docs/world-system.zh.md
@@ -309,11 +309,16 @@ context_days = 7            # 每轮喂给导演的聊天/亲密度证据窗口
 
 ## 审计与成本
 
-World Memories / Town 三个任务都以共享的世界哨兵用户
-`11111111-1111-1111-1111-111111111112` 把 token 用量记为 tracing 字段；
-`world_stories_director` 用自己的哨兵 `11111111-1111-1111-1111-111111111113`
-（dreaming = `…111`、world = `…112`、stories = `…113`——按子系统分摊花费；见
-[LLM / OpenRouter 审计](llm-audit.zh.md)）。稳态下每个**已配置世界观**的
+World Memories / Town 三个任务都用共享的世界哨兵用户
+`11111111-1111-1111-1111-111111111112` 标记每次调用；`world_stories_director`
+用自己的哨兵 `11111111-1111-1111-1111-111111111113`（dreaming = `…111`、
+world = `…112`、stories = `…113`——按子系统分摊花费）。自 migration `0059`
+起，这四个任务的每次调用也都会在 `engine.llm_generations` 里各落一行
+（`task = world_director` / `world_stories_director` / `world_comment` /
+`world_reply`），在 `openrouter: call completed` 这行 tracing 之外——此前它们
+在数据库里完全没有留下任何痕迹。见
+[LLM / OpenRouter 审计 → LLM 生成记录表](llm-audit.zh.md#llm-生成记录表)。
+稳态下每个**已配置世界观**的
 注册 owner 每天的成本上界是：1 次导演调用 + 至多 `24h/round_secs` 次评论轮
 （且只有有活动的那些）+ 至多 `daily_cap` 条回复 + 每个**近期有聊天的**
 instance 至多 `24h/interval_hours` 次故事回合——没人碰的世界依然恰好只花


### PR DESCRIPTION
Adds `engine.llm_generations`: one row per billable LLM generation, keyed on the provider's own `generation_id`, carrying `session_id` / `task` / `model` / `usage` / `created_at`. Spend can now be grouped by task and joined to a session from Postgres, instead of only from the provider's dashboard.

`pipeline::log_openrouter_usage` becomes `record_generation`: it writes the row and returns the id the caller stores in its own column. No child write reads `resp.generation_id` any more, so a failed audit write degrades that column to `NULL` instead of failing the turn. The `openrouter: call completed` tracing line is carried over verbatim.

Coverage is complete — including the five tasks that left no database trace at all: `world_director`, `world_stories_director`, `world_comment`, `world_reply`, `memory_extraction`. Five `stream.rs` sites that passed `session_id: None` now pass the real session.

## Release A of two. Do not merge Release B into the same release.

The foreign keys from the nine child columns, the backfill of ~55k historical rows, and the drop of the redundant `model` / `usage` columns are all Release B.

`infra/engine/fly.toml` sets `release_command = "migrate"`, which runs **before** traffic swaps. Foreign keys shipped alongside this write path would be enforced against machines still running the previous build — which write child rows without parents. For `chat_messages` that is a user's reply failing to persist.

Spec: `docs/superpowers/specs/2026-08-24-llm-generations-audit-design.md` §8.

## Known limits, recorded rather than hidden

- A chain that walks several models writes several rows for one turn — one per candidate response that carried a `generation_id`. That is the intended unit: each was separately billed.
- The voice, product-QA and standalone-compose arms record only the served attempt. They reset their id per candidate and record after the loop, so a candidate billed and then abandoned mid-chain leaves no row. The two main chat arms do not have this gap.
- `chat_messages.f_generation_id` is a ninth `generation_id`-bearing column that will **never** get a foreign key — see spec §7.2.

## Operational notes for deploy

- This release command also applies `0055`–`0058` (production is on `0054`). `0058` is the heavy one, not `0059`.
- A serialized insert now sits in the chat turn's critical path, outside the LLM timeout budget at every site. Pool is `max_connections(20)` / `acquire_timeout(5s)`. Worth watching `acquire_timeout` errors and p99 turn latency for the first hours.
- The table has no retention policy. Roughly one row per LLM call; it will outgrow `chat_messages` in row count eventually.
- Rollback is clean: the table is purely additive, and reverting the app leaves an orphan table nothing writes to.

## Verification

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` (1615 passed / 0 failed, output pristine), and the openapi snapshot — all green.