### PR TITLE
docs(spec): llm_generations — abandoned candidates, timeout budget, retention

### DIFF
--- a/docs/superpowers/specs/2026-08-24-llm-generations-audit-design.md
+++ b/docs/superpowers/specs/2026-08-24-llm-generations-audit-design.md
@@ -1,7 +1,11 @@
 # `engine.llm_generations` — one row per LLM generation — Design
 
 - **Date:** 2026-08-24
-- **Status:** Release A implemented; Release B not started
+- **Status:** Release A **released** as 1.6.1 and **not yet deployed** —
+  production runs 1.6.0. Release B not started. The two words are not
+  interchangeable here: §7.3's whole argument for validated foreign keys
+  rests on the code *serving traffic* already writing parent rows, which a
+  git tag does not establish. §7.0 is the check that does.
 - **Type:** New parent table + write-path change at every LLM call site;
   then foreign keys, a backfill, and column drops on eight live tables
 - **Owner:** enriquephl (sole dev)
@@ -55,6 +59,11 @@ Consequences, each deliberate:
 - **A generation may own several child rows.** One streamed reply can persist
   as multiple `chat_messages` rows via `continues_from_message_id`. The table
   is the parent of a one-to-many, and the write is idempotent (§4).
+- **A generation may own no child row at all.** Two sources: the five sweeper
+  tasks, which write nowhere else, and candidates the fallback chain answered
+  and then passed over (§4.5). Both were billed, which is the whole test. An
+  abandoned candidate is in fact the most valuable row in the table — it is
+  spend that appears in no other engine record.
 - **Filter calls are rows.** `chat_input_filter` and `chat_output_filter` cost
   money, so they get rows like anything else. `chat_messages.f_generation_id`
   is the one pointer that does **not** get a foreign key (§7) — a column
@@ -116,7 +125,11 @@ deployment-level work with no user behind them.
 this table is for. No bare `(created_at DESC)`: the composite serves the
 task-scoped form, and a global time scan over an audit table is not a hot path.
 
-## 4. Write path (Release A)
+## 4. Write path
+
+§4.1–§4.4 shipped in Release A. §4.5 is a gap Release A left; it is pure
+application code, touches no schema, and is therefore not bound by §8 — it
+rides in Release B's PR only because that is the next one open.
 
 ### 4.1 The helper already exists
 
@@ -242,6 +255,101 @@ the only place that holds `(task, session_id, response)` together exactly once.
 No trait, no middleware, no wrapper type: one function, twenty-three call
 sites, three lines each.
 
+### 4.5 Abandoned candidates leave no row (Release B)
+
+Three arms walk a fallback chain **while streaming**, and all three record
+once, after the chain loop ends, with whatever the served attempt left
+behind. Each keeps a working trio (`last_gen_id` / `last_usage` /
+`served_model`) that only ever holds one candidate's metadata, because an
+abandoned attempt must not leak its model or usage onto a later fallback's
+reply. That is correct for the reply and is exactly what erases the abandoned
+attempt's audit row: a candidate that streamed a response, was billed for it,
+and was then passed over leaves no trace in `llm_generations`.
+
+The two main chat arms do not have this gap: they call `record_generation`
+inside the per-candidate loop, at the point that attempt's stream ends.
+
+The evidence is lost two different ways, and each needs its own fix.
+
+**Loss 1 — a superseded candidate is overwritten.** Line numbers are as of
+`b8e03af`; verify before editing.
+
+| file | where the previous candidate's evidence dies |
+|---|---|
+| `pipeline/voice.rs:714` | loop-top reset of the trio |
+| `pipeline/stream.rs:4380` | loop-top reset of the trio |
+| `routes/persona.rs:554` | next iteration overwrites `last_generation_id` |
+
+`persona.rs` looks like four reset points (576, 595, 645, 681) but is not:
+its per-candidate evidence lives in a `let` inside the loop, and the
+chain-level `last_generation_id` those branches assign is simply overwritten
+by the following iteration. One drain at the top of `for model_id in chain`
+dominates all four.
+
+**Fix — drain at the top of the loop.** Record whatever the previous
+candidate left, then let the existing reset run. The return value is
+discarded: no child row will ever point at an abandoned generation, and
+`llm_generations` already holds rows with no children (the five sweeper
+tasks). The first iteration finds `None` and does nothing.
+
+```rust
+// first statement of the candidate loop, before the existing resets
+if let Some(id) = last_gen_id.take() {
+    let usage_full = last_usage.as_ref().and_then(|u| serde_json::to_value(u).ok());
+    let _ = record_generation(&state.pool, GenerationRecord {
+        task: TASK,
+        session_id: Some(session_id),   // `None` in persona.rs — standalone endpoint
+        generation_id: Some(&id),
+        model: served_model.as_deref(),
+        usage: usage_full.as_ref(),
+    })
+    .await;
+}
+```
+
+**Loss 2 — the *last* candidate's evidence dies on an early return.** Two
+arms give up after the loop without reaching their `record_generation`, and
+both are reachable holding a real `generation_id`:
+
+| file | branch |
+|---|---|
+| `pipeline/voice.rs:839-850` | `if acc.is_empty()` — "a stream that sent only metadata (id/model) and then errored or ended without content" — emits an Error frame and returns |
+| `pipeline/stream.rs:4536-4555` | chain exhausted **and** no canned phrase configured — emits an Error frame and returns |
+
+A third site looks like the same bug and is not: `stream.rs:4528` clears the
+trio on purpose so a canned fallback phrase is not attributed to a real
+generation. That clearing must survive the fix.
+
+**Fix — move the existing call above the exhausted block, do not add one.**
+In both arms, hoist `usage_full` and the post-loop `record_generation` to
+just above the `acc.is_empty()` / chain-exhausted handling. One move covers
+the early return *and* the normal path, and it makes `4528` correct for free:
+the generation is recorded because it was billed, and the subsequent clear
+still keeps it off the canned-phrase row.
+
+`persona.rs` needs no move — its exhausted arm already records at 726.
+
+**The hoist is the part that gets missed.** `usage_full` is computed from
+`last_usage` immediately before the record; moving one without the other
+compiles and silently writes `usage: None`. This exact mistake was caught in
+Release A's filtered arm and would not have been caught by the compiler.
+
+Three drains and two moves, not one edit repeated at every reset. The two
+fixes cannot double-record — the drain fires for the *previous* candidate, the
+move for the last one — and `ON CONFLICT (generation_id) DO NOTHING` (§4.1)
+makes it harmless if a future edit makes them overlap.
+
+**Cost.** One extra write per abandoned candidate, on the fallback path
+only. A turn whose first candidate answers pays nothing.
+
+**Not "accumulate into a `Vec`, flush after the loop."** Both arms in Loss 2
+`return` out of the chain, and a pending vector goes out of scope with the
+stack — the vector reintroduces exactly the bug being fixed.
+
+**Not backfillable.** Abandoned candidates from before this change left no
+`generation_id` in any table, so §7.1 cannot recover them. The gap closes
+forward only.
+
 ## 5. Reading it
 
 Cost per task for a window:
@@ -272,13 +380,80 @@ line still names them, and the provider's log still holds them, but nothing in
 Postgres does. This is the accepted trade: a dropped audit row is recoverable
 from two other places, a dropped user reply is not.
 
+### 6.1 The exposure is the timeout budget, not the write count (Release B)
+
+Release A put serial database writes on the chat turn's critical path, which
+reads like a latency risk. The arithmetic says it is not:
+
+- At most **four** audit writes are on the critical path — `chat_input_filter`,
+  `pde_decision`, `chat_companion`, `chat_output_filter`. The post-process
+  batch (`affinity_evaluation`, the insight stages, `memory_extraction`) runs
+  in a task spawned after the reply has streamed, off the path entirely.
+- A single-row `INSERT` against same-region Supabase costs 1–3 ms. Four of
+  them is ~12 ms against a turn measured in seconds.
+- The pool is 20 connections with a 5 s `acquire_timeout`
+  (`eros-engine-store/src/pool.rs`). Production writes ~3,000 generations a
+  day — 0.035/s. Saturating that pool takes four orders of magnitude of
+  growth, not one.
+
+What is actually mis-sized is `AUDIT_WRITE_TIMEOUT`, today 2 s
+(`pipeline/mod.rs:41`). It bounds one write; it does not bound a turn. With
+the database degraded rather than down, a turn can block **4 × 2 s = 8 s**
+serially, all of it outside the LLM timeout budget, and what the user sees is
+a reply that hangs.
+
+**Set it to 500 ms.** A single-row insert's p99 is milliseconds, so 500 ms is
+already a hundredfold margin, and the worst case falls to 2 s per turn. One
+constant — no per-turn budget object, no shared deadline threaded through the
+call sites.
+
+**Land it before Release A reaches production, if the ordering allows.** The
+8 s exposure was introduced by 1.6.1, which is tagged but not deployed, so it
+has never run against real traffic. Shipping the constant in whatever build
+deploys next means it never does. This is a preference about sequencing, not
+a constraint like §8 — the change is one line and correct in either order.
+
+Two numbers to watch once Release A is deployed, both already emitted:
+
+- the count of `llm_generations: audit write timed out` warnings — non-zero
+  means the pool or the database is degrading, and it is the earliest signal
+  either produces;
+- pool `acquire_timeout` errors.
+
 ## 7. Release B — migration `0060_llm_generation_fks.sql`
 
 One file, one transaction, in this order.
 
+### 7.0 Precondition — Release A must be *deployed*, and this is how you check
+
+Do not run `0060` until this returns true:
+
+```sql
+SELECT count(*) > 0
+FROM engine.llm_generations
+WHERE created_at > now() - interval '1 hour';
+```
+
+A recent row is the only evidence that the build **currently serving traffic**
+writes parent rows. Checking the tag proves nothing — 1.6.1 was tagged and
+published while production still ran 1.6.0. Checking `fly image show` is
+closer but still not enough: the image can be correct on machines that have
+not taken traffic yet, and `release_command = "migrate"` runs before traffic
+moves (§8).
+
+If the query returns false, every foreign key in this migration is a live
+failure mode: the running code writes `generation_id` into child rows with no
+parent, and for `chat_messages` that is a user's reply failing to persist.
+
 ### 7.1 Backfill
 
-Roughly 55,000 historical rows across the eight tables (production, measured).
+Roughly 55,000 historical rows across the eight tables (production, measured
+2026-08-24) — **a moving figure, not a fixed one.** The same measurement put
+the eight tables at ~2,700 new generations a day, so the backfill grows by
+that much for every day Release B waits. Re-measure before writing the
+migration; nothing in the design depends on the number, but the runtime
+estimate in §7.3 does.
+
 Each source contributes `DISTINCT ON (generation_id)` with a literal `task`:
 
 | source | `task` |
@@ -378,6 +553,63 @@ tasks needs to know the two are not the same kind of value.
 around the new table. `docs/architecture.md` gains the table. Scan
 `docs/api-reference.md` for any response field sourced from a dropped column.
 
+`docs/llm-audit.md` and `.zh.md` carry a **"Two known limits"** section whose
+second limit is exactly the §4.5 gap. That limit is deleted by this PR, not
+edited — the remaining one (a fallback chain writing several rows for one
+turn) stays and stops being a pair.
+
+### 7.6 Retention — none, and the numbers that would change that
+
+**No retention policy.** The table grows without bound and that is the
+decision, not an omission.
+
+Baseline, measured in production on 2026-08-24 over the trailing 14 days:
+
+| source | generations / day |
+|---|---|
+| `companion_insights_events` | 818 |
+| `character_insights_events` | 498 |
+| `chat_messages` | 478 |
+| `companion_decision_events` | 461 |
+| `companion_affinity_events` | 365 |
+| `chat_images_events` | 89 |
+| `chat_vision_events` | 1 |
+| **eight child tables** | **~2,710** |
+
+Release A also records the two filter tasks and the five sweepers, which
+write no child row — call it **3,500–4,000 rows/day**. At ~500 bytes a row
+including all three indexes, that is **~0.7 GB/year**. For comparison,
+`chat_messages` is 22,179 rows in 29 MB. This table passes `chat_messages`
+in **row count** within two months and will never come close to it in bytes
+per row: it stores a 45-byte id and a ~110-byte usage object, not a
+conversation.
+
+0.7 GB/year is not a cost line on Supabase, and pruning now would throw away
+the only reconciliation history the engine has ever had — the reading this
+table was built to produce does not exist yet.
+
+**Trigger — revisit when either holds:**
+
+- the table exceeds **10 GB**, or
+- the `GROUP BY task` window query in §5 exceeds **2 s**.
+
+**If it fires, in this order:** roll up into a daily summary
+(`day, task, calls, cost, prompt_tokens, completion_tokens`) *first*, then
+delete detail rows behind the rollup. The rollup is what makes the deletion
+acceptable, because deletion is not free:
+
+> Every foreign key in §7.2 is `ON DELETE SET NULL`. Deleting a parent row
+> **nulls `generation_id` on its child rows** — a `chat_messages` row that
+> has carried its provider handle since it was written silently loses it.
+> That is the real price of retention here, and it is why the rollup comes
+> first: the cost curve survives, the per-generation handle does not.
+
+The `ON DELETE` clause stays `SET NULL` regardless. `NO ACTION` would protect
+the child handles, but it would also mean a retention job can only delete
+parents that happen to have no children, and it contradicts the repo's own
+rule that a nullable reference column takes `SET NULL`. A future retention
+decision can `ALTER` the constraint; nothing here forecloses it.
+
 ## 8. Deploy order is a hard constraint
 
 **Release A must be fully rolled out before Release B's migration runs.**
@@ -410,6 +642,28 @@ Release A is live.
 **Call sites** — one test per task asserting a `llm_generations` row with the
 right `task` and a `session_id` where the site has one. The five previously
 unaudited tasks get their first database-level assertion here.
+
+**Abandoned candidates (§4.5)** — the two losses fail independently, so each
+needs its own test. Assertions count rows in `llm_generations`; a test that
+only checks the served path passes today and would keep passing with the fix
+reverted.
+
+*Loss 1, one test per arm* (voice, product-QA, compose): candidate 1 streams
+a response carrying a `generation_id` and then fails; candidate 2 succeeds.
+Assert **two** rows, and that the persisted child row points at candidate 2.
+
+*Loss 2, one test per arm* (voice, product-QA): a single candidate streams
+metadata — `generation_id`, `model`, `usage` — and then ends with no content,
+so the arm takes its early-return branch. Assert **one** row carrying that id
+**with a non-null `usage`**. The usage assertion is what catches a move that
+left `usage_full` behind.
+
+*The canned-phrase branch* (`stream.rs:4528`) gets its own test: chain
+exhausted after a candidate streamed metadata, with a phrase configured.
+Assert the abandoned generation has a row while the persisted message's
+`generation_id` is `NULL`. The branch clears the trio precisely so the canned
+phrase is not attributed to a real generation, and the move must not undo
+that.
 
 **Migration 0060** — a sqlx test that migrates to `0059`, inserts child rows
 including one with a dangling `session_id`, runs `0060`, and asserts: parent


### PR DESCRIPTION
Docs-only. Re-evaluates the three gaps Release A (#304, v1.6.1) left behind,
before Release B's implementation plan is written. No code, no migration.

## What changed in the spec

**§4.5 — abandoned candidates.** The voice, product-QA and compose arms lose
a billed candidate's generation **two** distinct ways:

1. *A superseded candidate is overwritten* at the loop top — `voice.rs:714`,
   `stream.rs:4380`, `persona.rs:554`. `persona.rs`'s four apparent reset
   points collapse to one: its per-candidate evidence is a `let` inside the
   loop, and the chain-level carry is simply overwritten by the next
   iteration.
2. *The last candidate dies on an early return* — `voice.rs:839-850` and
   `stream.rs:4536-4555` both emit an Error frame and return when the stream
   carried only metadata, never reaching the post-loop record.

Fix is three drains plus **two moves of the existing call**, not five new
calls. Moving it above the exhausted block also makes `stream.rs:4528`'s
deliberate trio-clear correct for free. The `usage_full` hoist is called out
explicitly — moving one without the other compiles and silently writes
`usage: None`, which is the mistake caught in Release A's filtered arm.

**§6.1 — write amplification is not the exposure; the timeout is.** At most
four audit writes sit on the critical path (~12 ms) against a pool doing
0.035 writes/s. What is mis-sized is `AUDIT_WRITE_TIMEOUT`: 2 s bounds a
write, not a turn, so a degraded database can add 8 s outside the LLM
budget. 500 ms. Preferably landed before v1.6.1 deploys, since the exposure
has never run against real traffic.

**§7.0 — deploy precondition.** §7.3's validated-FK argument rests on the
code *serving traffic* writing parent rows. A git tag does not establish
that, and neither does `fly image show` — `release_command = "migrate"` runs
before traffic moves. A query for a recent `llm_generations` row does. The
status line now separates "released" from "deployed"; v1.6.1 is the former
only.

**§7.6 — retention: none, with triggers.** Measured baseline of ~2,710
generations/day across the eight child tables, ~0.7 GB/year. Records what
any future deletion costs: `ON DELETE SET NULL` means deleting a parent
silently strips the provider handle a `chat_messages` row has carried since
it was written — which is why a rollup has to come before any delete.

## Also

- §2 gains the "a generation may own no child row" case.
- §7.1's 55k backfill figure is marked as a moving target, with its growth rate.
- §7.5 notes `docs/llm-audit.md`'s "Two known limits" loses its second limit.
- §9 gains tests that fail independently for each of the two losses.

## Not in this PR

Implementation. It waits on production data — the engine still runs 1.6.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)