### PR TITLE
fix(pipeline): one audit-write timeout, 500ms

### DIFF
--- a/crates/eros-engine-server/src/pipeline/mod.rs
+++ b/crates/eros-engine-server/src/pipeline/mod.rs
@@ -21,14 +21,32 @@ use eros_engine_core::types::ConversationSignals;
 
 use crate::error::AppError;
 
-/// How long the audit write gets before it is abandoned. It covers the pool
-/// acquisition as well as the statement, and it is deliberately shorter than
-/// the pool's own 5s `acquire_timeout`: a turn waiting several seconds on an
-/// audit row is a worse outcome than a missing audit row, which is the same
-/// trade the fail-open contract already makes. Without it, `sqlx` has no
-/// client-side statement timeout, so an insert that HANGS — as opposed to one
-/// that is refused — stalls the turn indefinitely. This function runs 2-5
-/// times per chat turn, so that exposure is not hypothetical.
+/// How long **any** fail-open audit write gets before it is abandoned —
+/// `llm_generations` here, `chat_images_events` and `chat_vision_events` in
+/// `stream.rs`. One constant for all three because they are one operation: a
+/// single-row INSERT into the same Postgres, whose failure costs an audit row
+/// and never a turn. Two bounds for the same operation is two facts where
+/// there is one.
+///
+/// It covers the pool acquisition as well as the statement, and it is
+/// deliberately far below both the pool's 5s `acquire_timeout` and any
+/// LLM-sized budget (`FILTER_TIMEOUT` and its siblings). This is one local
+/// round trip, not a network call to a provider, so an LLM-sized bound would
+/// hide exactly the stall it exists to catch. With no bound at all, `sqlx` has
+/// no client-side statement timeout, so an insert that HANGS — as opposed to
+/// one that is refused — stalls the turn indefinitely.
+///
+/// **The number is chosen against the per-TURN cost, not the per-write one.**
+/// A chat turn makes up to four of these serially on its critical path
+/// (`chat_input_filter`, `pde_decision`, `chat_companion`,
+/// `chat_output_filter`), plus the image / vision events on the paths that
+/// have them — where what waits behind the write is the image marker, the
+/// endpoint's JSON body, the pre-stream 502, or the terminal SSE frame. A
+/// bound that reads as generous per write multiplies: at 2s the
+/// worst case was 8s of a turn spent waiting on audit rows, all of it outside
+/// the LLM timeout budget, and what the user sees is a reply that hangs. A
+/// single-row insert's p99 is milliseconds, so 500ms is still a hundredfold
+/// margin while capping the turn near 2s.
 ///
 /// What this does NOT do: dropping the future at the timeout does not
 /// guarantee Postgres receives a `CancelRequest`, so a genuinely stuck
@@ -38,7 +56,7 @@ use crate::error::AppError;
 /// recall is legitimately slower than an audit insert, so one bound cannot
 /// serve both. Bounding the caller is still strictly better than the
 /// alternative: without this, the turn stalls AND the connection is stuck.
-const AUDIT_WRITE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+const AUDIT_WRITE_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(500);
 
 /// One LLM generation, as the call site knows it. Five loose fields rather
 /// than a `&ChatResponse`: four streaming arms never own one, and two of them
@@ -128,7 +146,7 @@ pub(super) async fn record_generation(
             tracing::warn!(
                 task = rec.task,
                 generation_id = generation_id,
-                timeout_secs = AUDIT_WRITE_TIMEOUT.as_secs(),
+                timeout_ms = AUDIT_WRITE_TIMEOUT.as_millis(),
                 "llm_generations: audit write timed out; child row will store NULL"
             );
             None

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -1625,17 +1625,6 @@ fn filter_output_invalidity(text: &str, finish_reason: Option<&str>) -> Option<&
 /// Per-model timeout for a single filter LLM call.
 pub(crate) const FILTER_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
 
-/// Cap on a single audit-table INSERT (`chat_images_events` /
-/// `chat_vision_events`). Fail-open already covers a write that errors —
-/// this bounds one that stalls instead: a saturated pool or a wedged
-/// connection must not delay the turn's own response (the image marker, the
-/// endpoint's JSON body, the pre-stream 502, the terminal SSE frame) behind
-/// an await that never returns. Deliberately much shorter than
-/// `FILTER_TIMEOUT`: this is one local Postgres round trip, not a
-/// network LLM call, so a generous LLM-sized budget would hide exactly the
-/// stall this timeout exists to bound.
-pub(crate) const AUDIT_WRITE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
-
 /// `[tasks.*]` key the out-of-character product-answer executor serves. Stamped
 /// on every failure that executor records, so one `chat_messages` row says which
 /// chain broke without the reader inferring it from `channel`.
@@ -3117,7 +3106,7 @@ pub(crate) async fn record_compose_event(
     ev: eros_engine_store::image_events::ImageComposeEventInsert<'_>,
 ) -> Option<uuid::Uuid> {
     let repo = eros_engine_store::image_events::ImageComposeEventRepo { pool };
-    match tokio::time::timeout(AUDIT_WRITE_TIMEOUT, repo.record(ev)).await {
+    match tokio::time::timeout(super::AUDIT_WRITE_TIMEOUT, repo.record(ev)).await {
         Ok(Ok(id)) => Some(id),
         Ok(Err(e)) => {
             tracing::warn!(error = %e, "chat_images_events: audit write failed");
@@ -4863,7 +4852,7 @@ pub fn run_stream(
                         // not detached, so write ordering holds — only
                         // bounded.
                         match tokio::time::timeout(
-                            AUDIT_WRITE_TIMEOUT,
+                            super::AUDIT_WRITE_TIMEOUT,
                             repo.record(eros_engine_store::image_events::ChatVisionEventInsert {
                                 llm_attempts: vision_attempts,
                                 gateway_errors: vision_gateways,

--- a/docs/superpowers/specs/2026-08-24-llm-generations-audit-design.md
+++ b/docs/superpowers/specs/2026-08-24-llm-generations-audit-design.md
@@ -407,6 +407,19 @@ already a hundredfold margin, and the worst case falls to 2 s per turn. One
 constant — no per-turn budget object, no shared deadline threaded through the
 call sites.
 
+**"One constant" is literal.** The repo carried two, same name, sibling
+modules: `pipeline/mod.rs` at 2 s for `llm_generations`, and
+`pipeline/stream.rs` at 3 s for `chat_images_events` / `chat_vision_events`,
+the latter predating this work. Changing only one would have widened the
+split to 0.5 s against 3 s. All three are the same operation — a single-row
+fail-open INSERT into the same database — so `stream.rs`'s copy is deleted
+and its two call sites read `super::AUDIT_WRITE_TIMEOUT`. The image and
+vision writes come down from 3 s with the same argument, and the same
+consequence when they trip: one telemetry row lost, never a turn.
+
+The timed-out `warn!` also switches from `timeout_secs` to `timeout_ms` —
+`Duration::as_secs()` on 500 ms logs `0`.
+
 **Land it before Release A reaches production, if the ordering allows.** The
 8 s exposure was introduced by 1.6.1, which is tagged but not deployed, so it
 has never run against real traffic. Shipping the constant in whatever build


### PR DESCRIPTION
Implements spec §6.1. The engine is still on 1.6.0, so landing this before
v1.6.1 deploys means the exposure below never runs against real traffic.

## The two constants

The repo carried **two** constants named `AUDIT_WRITE_TIMEOUT`, in sibling
modules, with different values:

| where | value | guards | since |
|---|---|---|---|
| `pipeline/mod.rs` | 2s | `llm_generations` | #304 |
| `pipeline/stream.rs` | 3s | `chat_images_events`, `chat_vision_events` | #260 |

All three are the same operation — a single-row fail-open `INSERT` into the
same Postgres, whose failure costs an audit row and never a turn. Changing
only `mod.rs` would have widened the split to 0.5s against 3s, so
`stream.rs`'s copy is deleted and its two call sites read
`super::AUDIT_WRITE_TIMEOUT`.

## Why 500ms

The number is chosen against the per-**turn** cost, not the per-write one. A
chat turn makes up to four of these serially on its critical path
(`chat_input_filter`, `pde_decision`, `chat_companion`,
`chat_output_filter`), plus the image / vision events on the paths that have
them. A bound that reads as generous per write multiplies: at 2s the worst
case was **8s** of a turn spent waiting on audit rows, all of it outside the
LLM timeout budget, and what the user sees is a reply that hangs.

A single-row insert's p99 is milliseconds, so 500ms is still a hundredfold
margin while capping the turn near 2s. The image and vision writes come down
from 3s with the same argument and the same consequence when they trip: one
telemetry row lost, never a turn.

Not changed: the residual noted in the doc comment — dropping the future does
not guarantee Postgres receives a `CancelRequest`. That wants a server-side
`statement_timeout`, which is a pool-wide decision no query in this codebase
makes.

## Also

- The timed-out `warn!` switches from `timeout_secs` to `timeout_ms` —
  `Duration::as_secs()` on 500ms logs `0`.
- Spec §6.1 records the unification.

## Verified locally

`fmt` · `clippy --workspace --all-targets -D warnings` · `test --workspace`
(1615 passed, 0 failed) · `print-openapi` diff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
