### PR TITLE
docs: never sum llm_generations.cost without its coverage count

### DIFF
--- a/docs/llm-audit.md
+++ b/docs/llm-audit.md
@@ -158,20 +158,39 @@ call now writes here: `chat_companion`, `chat_voice`, `chat_product_qa`,
 
 ### Reading it
 
-`usage` is stored **unfiltered**, `cost` included.
-`OPENROUTER_USAGE_HIDDEN_KEYS` strips keys only on the way out to clients
-(see above); the database has always kept the whole object and continues to.
+`usage` is stored **unfiltered** — whatever the provider sent, `cost`
+included when the provider sent one. `OPENROUTER_USAGE_HIDDEN_KEYS` strips
+keys only on the way out to clients (see above); the database has always kept
+the whole object and continues to.
 
-Cost per task for a window:
+Cost per task for a window. **Never sum `cost` without also counting how many
+rows carried one:**
 
 ```sql
 SELECT task,
-       count(*)                       AS calls,
-       sum((usage->>'cost')::numeric) AS cost
+       count(*)                                AS calls,
+       count(*) FILTER (WHERE usage ? 'cost')  AS priced,
+       sum((usage->>'cost')::numeric)          AS cost_of_priced
 FROM engine.llm_generations
 WHERE created_at >= now() - interval '7 days'
-GROUP BY task ORDER BY cost DESC;
+GROUP BY task ORDER BY cost_of_priced DESC NULLS LAST;
 ```
+
+**`cost` is a provider-dependent key.** OpenRouter returns it inside `usage`;
+Venice direct does not emit it at all. A deployment that mixes the two — as
+the reference one does — gets `cost` on only part of its rows.
+
+`priced` is what makes the sum readable. A task served entirely by an
+unpriced provider sums to `NULL`, which is honest and obvious. The trap is a
+**mixed** task: one `[tasks.*]` whose primary is priced and whose fallback is
+not returns a plausible-looking total that silently covers a fraction of its
+calls. Read `priced / calls` before believing `cost_of_priced`.
+
+The engine does not derive the missing cost from tokens and a price table.
+That would make it a second authority on what a call cost, drifting against
+the provider's real pricing with nothing to signal the drift. For unpriced
+rows the provider's dashboard is the authority, and `generation_id` is the
+join key to it — which is what this table exists to give you.
 
 ### Failure semantics: fail-open
 

--- a/docs/llm-audit.zh.md
+++ b/docs/llm-audit.zh.md
@@ -148,20 +148,36 @@ completed` tracing——落库是额外加的，不是取代那行日志。
 
 ### 怎么读
 
-`usage` 落库是**未过滤**的，`cost` 也在里面。`OPENROUTER_USAGE_HIDDEN_KEYS`
-只在返回给 client 的那份上剔除 key（见上文）；数据库里的这份从来就是完整的，
-以后也一直是。
+`usage` 落库是**未过滤**的，供应商发了什么就存什么，`cost` 在的话也一并存下。
+`OPENROUTER_USAGE_HIDDEN_KEYS` 只在返回给 client 的那份上剔除 key（见上文）；
+数据库里的这份从来就是完整的，以后也一直是。
 
-按任务统计某个时间窗口的花费：
+按任务统计某个时间窗口的花费。**求 `cost` 的和时，必须同时数出有多少行真的
+带了这个键：**
 
 ```sql
 SELECT task,
-       count(*)                       AS calls,
-       sum((usage->>'cost')::numeric) AS cost
+       count(*)                                AS calls,
+       count(*) FILTER (WHERE usage ? 'cost')  AS priced,
+       sum((usage->>'cost')::numeric)          AS cost_of_priced
 FROM engine.llm_generations
 WHERE created_at >= now() - interval '7 days'
-GROUP BY task ORDER BY cost DESC;
+GROUP BY task ORDER BY cost_of_priced DESC NULLS LAST;
 ```
+
+**`cost` 是取决于供应商的键，不是保证有的。** OpenRouter 会在 `usage` 里返回
+它，Venice 直连则完全不发这个键。同时用了两者的部署——参考部署就是——只有一部分
+行带 `cost`。
+
+`priced` 是让这个和能读的那一列。整条链路都跑在不带价的供应商上的 task，和是
+`NULL`，这很诚实、也一眼看得出。有坑的是**混合**的 task：一个 `[tasks.*]` 的主
+模型带价、fallback 不带价，那么它会给出一个看着挺像样的总额，实际只覆盖了一部分
+调用。先看 `priced / calls`，再决定信不信 `cost_of_priced`。
+
+engine 不会拿 token 数乘一张价格表去折算缺失的成本。那等于让 engine 成为「这次
+调用花了多少钱」的第二个权威来源，而那张表会跟供应商的真实定价漂移，且漂了没有
+任何信号。不带价的那些行，权威在供应商自己的后台，`generation_id` 就是 join
+过去的那把键——这正是这张表存在的意义。
 
 ### 失败语义：fail-open
 

--- a/docs/superpowers/specs/2026-08-24-llm-generations-audit-design.md
+++ b/docs/superpowers/specs/2026-08-24-llm-generations-audit-design.md
@@ -352,20 +352,40 @@ forward only.
 
 ## 5. Reading it
 
-Cost per task for a window:
+Cost per task for a window. **Never sum `cost` without reporting how many
+rows carried one** — the reason is below the query, and it is not a detail:
 
 ```sql
 SELECT task,
        count(*)                                  AS calls,
-       sum((usage->>'cost')::numeric)            AS cost
+       count(*) FILTER (WHERE usage ? 'cost')    AS priced,
+       sum((usage->>'cost')::numeric)            AS cost_of_priced
 FROM engine.llm_generations
 WHERE created_at >= now() - interval '7 days'
-GROUP BY task ORDER BY cost DESC;
+GROUP BY task ORDER BY cost_of_priced DESC NULLS LAST;
 ```
 
 `usage` is stored **unfiltered**, including `cost`. `OPENROUTER_USAGE_HIDDEN_KEYS`
 strips keys on the way out to clients only; the database has always kept the
 whole object and continues to.
+
+**`cost` is a provider-dependent key, not a guaranteed one.** OpenRouter
+returns it; Venice direct does not put it in `usage` at all. Measured on
+production 22 minutes after 1.6.1 went live: 44 of 204 rows carried a `cost`
+(21.6%), with 160 rows served by Venice direct.
+
+`priced` is what makes the number readable. A task served entirely by Venice
+sums to `NULL`, which is honest. **The dangerous case is a mixed task**: at
+that measurement `chat_companion` ran on both `deepseek/deepseek-v4-flash-0731`
+(OpenRouter, priced) and `gemma-4-uncensored@venice` (unpriced), so a bare
+`sum(cost)` returned a plausible figure covering 18 of its 27 calls. A number
+that looks like a total and is two thirds of one is worse than a `NULL`.
+
+Deriving the missing cost from tokens and a price table is deliberately **not**
+done: it would make the engine a second authority on what a call cost, and
+that table drifts against the provider's real pricing with no signal. The
+provider's own dashboard remains the authority for unpriced rows; this table's
+job is to tell you which rows those are.
 
 ## 6. Failure semantics — fail-open, and what it costs
 


### PR DESCRIPTION
Docs-only. Comes out of reading the table on production, 22 minutes after
1.6.1 went live.

## What the data said

```
total=204   with_cost=44 (21.6%)   venice_direct=160
```

`cost` is a **provider-dependent** key. OpenRouter returns it inside `usage`;
Venice direct does not emit it at all. The reference deployment mixes both, so
most rows have no `cost`.

A task served entirely by an unpriced provider sums to `NULL` — honest, and
obvious to whoever reads it. The trap is a **mixed** task:

| task | calls | priced | cost_of_priced |
|---|---|---|---|
| `chat_companion` | 36 | 21 | 0.05483235 |
| `character_insight_structuring` | 25 | 25 | 0.00275260 |
| `affinity_evaluation` | 34 | 0 | NULL |
| `pde_decision` | 36 | 0 | NULL |

`chat_companion` runs on `deepseek/deepseek-v4-flash-0731` (priced) and
`gemma-4-uncensored@venice` (unpriced), so the old bare `sum(cost)` returned a
plausible figure covering 21 of 36 calls. A number that looks like a total and
is well under one is worse than a `NULL`.

## The change

The documented query — spec §5, `docs/llm-audit.md`, `docs/llm-audit.zh.md` —
now carries the coverage count beside the sum and sorts `NULLS LAST` so
unpriced tasks stop floating to the top:

```sql
SELECT task,
       count(*)                                AS calls,
       count(*) FILTER (WHERE usage ? 'cost')  AS priced,
       sum((usage->>'cost')::numeric)          AS cost_of_priced
FROM engine.llm_generations
WHERE created_at >= now() - interval '7 days'
GROUP BY task ORDER BY cost_of_priced DESC NULLS LAST;
```

Verified against production — the table above is its actual output.

## Not doing

Deriving the missing cost from tokens and a price table. That makes the engine
a second authority on what a call cost, drifting against the provider's real
pricing with nothing to signal the drift. For unpriced rows the provider's
dashboard stays the authority and `generation_id` is the join key to it —
which is the job this table was built for.

## Also verified on production while reading this

Not part of the diff, recorded because it is the first live look at the table:

- Zero orphans across all eight child `generation_id` columns since cutover —
  the laundering invariant holds in production, and spec §7.0's precondition
  for Release B now passes.
- Zero degraded audit writes: 0 of 29 assistant rows carry a NULL
  `generation_id`.
- 100% session attribution on every task, so spec §4.3's `None` → real
  `session_id` fix is doing its job.
- Row rate is consistent with the 14-day baseline in spec §7.6 (~5.8
  generations per chat turn against a measured 5.7); the retention estimate
  does not move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
