### PR TITLE
docs: filter the cost query on the value's type, not the key's presence

### DIFF
--- a/docs/llm-audit.md
+++ b/docs/llm-audit.md
@@ -168,20 +168,32 @@ rows carried one:**
 
 ```sql
 SELECT task,
-       count(*)                                AS calls,
-       count(*) FILTER (WHERE usage ? 'cost')  AS priced,
-       sum((usage->>'cost')::numeric)          AS cost_of_priced
+       count(*)                                                       AS calls,
+       count(*) FILTER (WHERE jsonb_typeof(usage->'cost') = 'number') AS priced,
+       sum((usage->>'cost')::numeric)
+         FILTER (WHERE jsonb_typeof(usage->'cost') = 'number')        AS cost_of_priced
 FROM engine.llm_generations
 WHERE created_at >= now() - interval '7 days'
 GROUP BY task ORDER BY cost_of_priced DESC NULLS LAST;
 ```
 
+**Both halves filter on the value's type, not on the key's presence.**
+`usage ? 'cost'` is the obvious spelling and is wrong twice: a `"cost": null`
+counts as priced while adding nothing to the sum, and a non-numeric value —
+`"cost": "unknown"`, or an object — makes `::numeric` **raise** and abort the
+query instead of yielding `NULL`. `usage` is stored verbatim from the
+provider's response and the engine does not validate its shape, so the query
+has to. `jsonb_typeof(usage->'cost') = 'number'` is false for a JSON null, a
+non-number, a missing key, and a `NULL` `usage` alike.
+
 **`cost` is a provider-dependent key.** OpenRouter returns it inside `usage`;
 Venice direct does not emit it at all. A deployment that mixes the two — as
 the reference one does — gets `cost` on only part of its rows.
 
-`priced` is what makes the sum readable. A task served entirely by an
-unpriced provider sums to `NULL`, which is honest and obvious. The trap is a
+`priced` is what makes the sum readable: it counts the rows carrying a
+**numeric** cost, which is exactly the set the sum is taken over. A task
+served entirely by an unpriced provider sums to `NULL`, which is honest and
+obvious. The trap is a
 **mixed** task: one `[tasks.*]` whose primary is priced and whose fallback is
 not returns a plausible-looking total that silently covers a fraction of its
 calls. Read `priced / calls` before believing `cost_of_priced`.

--- a/docs/llm-audit.zh.md
+++ b/docs/llm-audit.zh.md
@@ -157,20 +157,29 @@ completed` tracing——落库是额外加的，不是取代那行日志。
 
 ```sql
 SELECT task,
-       count(*)                                AS calls,
-       count(*) FILTER (WHERE usage ? 'cost')  AS priced,
-       sum((usage->>'cost')::numeric)          AS cost_of_priced
+       count(*)                                                       AS calls,
+       count(*) FILTER (WHERE jsonb_typeof(usage->'cost') = 'number') AS priced,
+       sum((usage->>'cost')::numeric)
+         FILTER (WHERE jsonb_typeof(usage->'cost') = 'number')        AS cost_of_priced
 FROM engine.llm_generations
 WHERE created_at >= now() - interval '7 days'
 GROUP BY task ORDER BY cost_of_priced DESC NULLS LAST;
 ```
 
+**两处过滤判的都是值的类型，不是键在不在。** `usage ? 'cost'` 是最顺手的写法，
+但它错两次：`"cost": null` 会被算成 priced，却一分钱也不进那个 sum；而一个非数字
+的值——`"cost": "unknown"`，或者一个对象——会让 `::numeric` **直接抛错**，整条
+查询中断，而不是返回 `NULL`。`usage` 是供应商响应的原样落库，engine 不校验它的
+形状，所以只能由查询来判。`jsonb_typeof(usage->'cost') = 'number'` 对 JSON null、
+非数字、键不存在、`usage` 整个为 `NULL` 这四种情况一律为假。
+
 **`cost` 是取决于供应商的键，不是保证有的。** OpenRouter 会在 `usage` 里返回
 它，Venice 直连则完全不发这个键。同时用了两者的部署——参考部署就是——只有一部分
 行带 `cost`。
 
-`priced` 是让这个和能读的那一列。整条链路都跑在不带价的供应商上的 task，和是
-`NULL`，这很诚实、也一眼看得出。有坑的是**混合**的 task：一个 `[tasks.*]` 的主
+`priced` 是让这个和能读的那一列：它数的是带着**数值型** cost 的行，也正是那个
+sum 求和的范围。整条链路都跑在不带价的供应商上的 task，和是 `NULL`，这很诚实、
+也一眼看得出。有坑的是**混合**的 task：一个 `[tasks.*]` 的主
 模型带价、fallback 不带价，那么它会给出一个看着挺像样的总额，实际只覆盖了一部分
 调用。先看 `priced / calls`，再决定信不信 `cost_of_priced`。
 

--- a/docs/superpowers/specs/2026-08-24-llm-generations-audit-design.md
+++ b/docs/superpowers/specs/2026-08-24-llm-generations-audit-design.md
@@ -357,25 +357,39 @@ rows carried one** — the reason is below the query, and it is not a detail:
 
 ```sql
 SELECT task,
-       count(*)                                  AS calls,
-       count(*) FILTER (WHERE usage ? 'cost')    AS priced,
-       sum((usage->>'cost')::numeric)            AS cost_of_priced
+       count(*)                                                       AS calls,
+       count(*) FILTER (WHERE jsonb_typeof(usage->'cost') = 'number') AS priced,
+       sum((usage->>'cost')::numeric)
+         FILTER (WHERE jsonb_typeof(usage->'cost') = 'number')        AS cost_of_priced
 FROM engine.llm_generations
 WHERE created_at >= now() - interval '7 days'
 GROUP BY task ORDER BY cost_of_priced DESC NULLS LAST;
 ```
 
-`usage` is stored **unfiltered**, including `cost`. `OPENROUTER_USAGE_HIDDEN_KEYS`
-strips keys on the way out to clients only; the database has always kept the
-whole object and continues to.
+**The filter tests the value's type, not the key's presence, and both halves
+need it.** `usage ? 'cost'` is the obvious spelling and is wrong twice over:
+a `"cost": null` counts as priced while contributing nothing to the sum, so
+`priced` overstates coverage; and a non-numeric value — `"cost": "unknown"`,
+or an object — makes `::numeric` **raise** and abort the whole query rather
+than yielding `NULL`. `jsonb_typeof(usage->'cost') = 'number'` is false for
+both, and for a missing key and a `NULL` `usage`, so no unparseable value ever
+reaches the cast. `usage` is written verbatim from a provider's response; the
+engine does not validate its shape and should not have to.
+
+`usage` is stored **unfiltered** — whatever the provider sent, `cost` included
+when the provider sent one. `OPENROUTER_USAGE_HIDDEN_KEYS` strips keys on the
+way out to clients only; the database has always kept the whole object and
+continues to.
 
 **`cost` is a provider-dependent key, not a guaranteed one.** OpenRouter
 returns it; Venice direct does not put it in `usage` at all. Measured on
 production 22 minutes after 1.6.1 went live: 44 of 204 rows carried a `cost`
 (21.6%), with 160 rows served by Venice direct.
 
-`priced` is what makes the number readable. A task served entirely by Venice
-sums to `NULL`, which is honest. **The dangerous case is a mixed task**: at
+`priced` is what makes the number readable: it is the count of rows carrying a
+**numeric** cost, which is exactly the set the sum is over. A task served
+entirely by Venice sums to `NULL`, which is honest. **The dangerous case is a
+mixed task**: at
 that measurement `chat_companion` ran on both `deepseek/deepseek-v4-flash-0731`
 (OpenRouter, priced) and `gemma-4-uncensored@venice` (unpriced), so a bare
 `sum(cost)` returned a plausible figure covering 18 of its 27 calls. A number


### PR DESCRIPTION
Follow-up to #309, from a codex review I ran **after** merging it — I skipped
that PR's review gate without flagging it. Two findings, both real.

## High — `usage ? 'cost'` is wrong twice

| `usage` | `usage ? 'cost'` | `jsonb_typeof(usage->'cost') = 'number'` |
|---|---|---|
| `{"cost": 0.01}` | true | true |
| `{"cost": null}` | **true** | false |
| `{"cost": "x"}` | **true** | false |
| `{}` | false | false |
| `NULL` | NULL | NULL |

1. A `"cost": null` satisfies key-presence and counts as `priced`, while
   contributing nothing to the sum — so `priced` overstates coverage, which is
   the exact failure the column was added to prevent.
2. A non-numeric value makes `(usage->>'cost')::numeric` **raise** and abort
   the query instead of yielding NULL. This is an operator query run by hand
   against production; an abort is the worst of the three outcomes.

`usage` is stored verbatim from a provider response and the engine does not
validate its shape, so the query has to. The type filter is applied to **both**
halves — the count and the sum — so `priced` means exactly "the rows the sum is
taken over".

## Medium — spec §5 contradicted itself

The unchanged sentence "`usage` is stored **unfiltered**, including `cost`"
implies universal presence and sat directly above the new paragraph saying
`cost` is provider-dependent. It now matches the wording `docs/llm-audit.md`
and `.zh.md` already carried.

## Verified

The corrected query, against production:

| task | calls | priced | cost_of_priced |
|---|---|---|---|
| `chat_companion` | 55 | 30 | 0.09078486 |
| `character_insight_structuring` | 42 | 42 | 0.00491386 |
| `affinity_evaluation` | 53 | 0 | NULL |
| `pde_decision` | 55 | 0 | NULL |

The two spellings were also verified to differ on the exact shapes above.

## Clean in that review

EN/ZH equivalence, and no leakage of downstream product names, URLs or private
infrastructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
