### PR TITLE
chore(release): v1.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,7 +531,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "eros-engine-core"
-version = "1.6.2"
+version = "1.7.0"
 dependencies = [
  "chrono",
  "serde",
@@ -541,7 +541,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-llm"
-version = "1.6.2"
+version = "1.7.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-server"
-version = "1.6.2"
+version = "1.7.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "eros-engine-store"
-version = "1.6.2"
+version = "1.7.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "1.6.2"
+version = "1.7.0"
 edition = "2021"
 license = "AGPL-3.0-only"
 repository = "https://github.com/etherfunlab/eros-engine"

--- a/README.ja.md
+++ b/README.ja.md
@@ -69,14 +69,14 @@ eros-engine-llm   = "1.0"   # optional: model and embedding clients
 各 `v*` タグについて、複数アーキテクチャ対応のイメージを GitHub Container Registry へ公開しています。
 
 ```bash
-docker pull ghcr.io/etherfunlab/eros-engine:1.6.2
+docker pull ghcr.io/etherfunlab/eros-engine:1.7.0
 # Or follow the latest tagged release
 docker pull ghcr.io/etherfunlab/eros-engine:latest
 ```
 
 ```bash
 docker run --rm -p 8080:8080 --env-file .env \
-  ghcr.io/etherfunlab/eros-engine:1.6.2 serve
+  ghcr.io/etherfunlab/eros-engine:1.7.0 serve
 ```
 
 Postgres と `.env` は利用者側で用意してください。同じ `docker/Dockerfile` を任意のコンテナ環境へ配備できます。詳細は [Deploying](docs/deploying.md) を参照してください。

--- a/README.md
+++ b/README.md
@@ -69,14 +69,14 @@ eros-engine-llm   = "1.0"   # optional: model and embedding clients
 Multi-architecture images are published to GitHub Container Registry for every `v*` tag:
 
 ```bash
-docker pull ghcr.io/etherfunlab/eros-engine:1.6.2
+docker pull ghcr.io/etherfunlab/eros-engine:1.7.0
 # Or follow the latest tagged release
 docker pull ghcr.io/etherfunlab/eros-engine:latest
 ```
 
 ```bash
 docker run --rm -p 8080:8080 --env-file .env \
-  ghcr.io/etherfunlab/eros-engine:1.6.2 serve
+  ghcr.io/etherfunlab/eros-engine:1.7.0 serve
 ```
 
 Bring your own Postgres and `.env`; the same `docker/Dockerfile` can be deployed to any container host. See [Deploying](docs/deploying.md).

--- a/README.zh.md
+++ b/README.zh.md
@@ -69,14 +69,14 @@ eros-engine-llm   = "1.0"   # optional: model and embedding clients
 每个 `v*` tag 都会向 GitHub Container Registry 发布多架构镜像：
 
 ```bash
-docker pull ghcr.io/etherfunlab/eros-engine:1.6.2
+docker pull ghcr.io/etherfunlab/eros-engine:1.7.0
 # Or follow the latest tagged release
 docker pull ghcr.io/etherfunlab/eros-engine:latest
 ```
 
 ```bash
 docker run --rm -p 8080:8080 --env-file .env \
-  ghcr.io/etherfunlab/eros-engine:1.6.2 serve
+  ghcr.io/etherfunlab/eros-engine:1.7.0 serve
 ```
 
 你需要自行提供 Postgres 和 `.env`；同一个 `docker/Dockerfile` 可部署到任意容器托管平台。详见[部署](docs/deploying.zh.md)。

--- a/crates/eros-engine-llm/Cargo.toml
+++ b/crates/eros-engine-llm/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "openrouter", "voyage", "embeddings", "llm"]
 categories = ["api-bindings"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "1.6.2" }
+eros-engine-core = { path = "../eros-engine-core", version = "1.7.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/eros-engine-server/Cargo.toml
+++ b/crates/eros-engine-server/Cargo.toml
@@ -13,9 +13,9 @@ name = "eros-engine"
 path = "src/main.rs"
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "1.6.2" }
-eros-engine-llm  = { path = "../eros-engine-llm", version = "1.6.2" }
-eros-engine-store = { path = "../eros-engine-store", version = "1.6.2" }
+eros-engine-core = { path = "../eros-engine-core", version = "1.7.0" }
+eros-engine-llm  = { path = "../eros-engine-llm", version = "1.7.0" }
+eros-engine-store = { path = "../eros-engine-store", version = "1.7.0" }
 axum = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0-only",
       "identifier": "AGPL-3.0-only"
     },
-    "version": "1.6.2"
+    "version": "1.7.0"
   },
   "servers": [
     {

--- a/crates/eros-engine-store/Cargo.toml
+++ b/crates/eros-engine-store/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["companion", "memory", "pgvector", "postgres", "sqlx"]
 categories = ["database"]
 
 [dependencies]
-eros-engine-core = { path = "../eros-engine-core", version = "1.6.2" }
+eros-engine-core = { path = "../eros-engine-core", version = "1.7.0" }
 sqlx = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
Version bump only — nine files: workspace version, the five path-dep pins, `Cargo.lock`, the regenerated openapi snapshot, and the docker-pull tag in all three READMEs.

## Delta since v1.6.2

**Features**
- #315 — `feat(db)`: Release B1 — backfill `engine.llm_generations`, constrain the eight child columns, stop writing `model`/`usage`

**Fixes**
- #316 — `fix(pipeline)`: `AUDIT_WRITE_TIMEOUT` back to 2s

**Docs**
- #314 — `docs(spec)`: `filter_model` is a discriminator, not a redundant copy
- #313 — `docs(spec)`: Release B is two releases — the DROP cannot ship with the code

## Why minor, not patch

B1 stops writing `model` and `usage` to the eight child tables. `0061` does not drop the columns until B2, but from this release they are no longer populated, so what a downstream reader can rely on has changed.

## Deploy note

`0060` runs as `release_command` with `SET LOCAL lock_timeout = '3s'`. A failed release command aborts before traffic moves and leaves the previous build serving, so a timeout there is a re-run, not an incident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMVHMm5mWjcv8VzWidHXBz