### PR TITLE
fix(store): carry tips_amount_usd as text in history_slim, parse per row

### DIFF
--- a/crates/eros-engine-server/src/routes/bff/companion.rs
+++ b/crates/eros-engine-server/src/routes/bff/companion.rs
@@ -89,6 +89,14 @@ fn parse_anchor(raw: Option<String>) -> Option<Uuid> {
     raw.and_then(|s| Uuid::parse_str(&s).ok())
 }
 
+/// Parse the raw `metadata->>'tips_amount_usd'` text the slim projection
+/// carries. Same contract as `parse_anchor`: the column is unconstrained
+/// JSONB, and one bad row must not fail the page — what does not parse is
+/// dropped rather than surfaced (#302).
+fn parse_tip(raw: Option<String>) -> Option<f64> {
+    raw.and_then(|s| s.parse().ok())
+}
+
 #[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct BffHistoryResponse {
     pub session_id: Uuid,
@@ -187,7 +195,7 @@ async fn bff_get_history(
             role: r.role,
             content: r.content,
             sent_at: r.sent_at,
-            tips_amount_usd: r.tips_amount_usd,
+            tips_amount_usd: parse_tip(r.tips_amount_usd),
             channel: r.channel,
             read_at: r.read_at,
             image: r.image,
@@ -248,7 +256,7 @@ async fn bff_start_chat(
                 role: r.role,
                 content: r.content,
                 sent_at: r.sent_at,
-                tips_amount_usd: r.tips_amount_usd,
+                tips_amount_usd: parse_tip(r.tips_amount_usd),
                 channel: r.channel,
                 read_at: r.read_at,
                 image: r.image,
@@ -1000,6 +1008,61 @@ mod tests {
                 "an unparseable anchor is dropped, not surfaced; got {m}"
             );
         }
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn bff_history_survives_a_malformed_tip(pool: PgPool) {
+        // Same failure mode as the reply anchor above, last cast standing
+        // (#302): a `::float8` in the projection would fail the WHOLE page on
+        // one bad `tips_amount_usd`. The tip is carried as text and parsed per
+        // row, so a junk value costs its own key and nothing else.
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+
+        sqlx::query(
+            "INSERT INTO engine.chat_messages \
+                 (session_id, role, content, metadata, sent_at) \
+             VALUES ($1, 'gift_user', 'junk string', \
+                     '{\"tips_amount_usd\": \"twenty\"}'::jsonb, \
+                     now() - interval '4 seconds'),
+                    ($1, 'gift_user', 'json object', \
+                     '{\"tips_amount_usd\": {\"usd\": 20}}'::jsonb, \
+                     now() - interval '3 seconds'),
+                    ($1, 'gift_user', 'json null', \
+                     '{\"tips_amount_usd\": null}'::jsonb, \
+                     now() - interval '2 seconds'),
+                    ($1, 'gift_user', '(打赏 $20)', \
+                     '{\"tips_amount_usd\": 20.0}'::jsonb, \
+                     now() - interval '1 second')",
+        )
+        .bind(session_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let state = test_state(pool);
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        let (status, body) =
+            send_request(&mut app, bff_history_request(&token, session_id, "")).await;
+        assert_eq!(status, StatusCode::OK, "the page still renders: {body}");
+
+        let messages = body["messages"].as_array().expect("messages array");
+        assert_eq!(messages.len(), 4, "every row survives: {body}");
+        for m in &messages[..3] {
+            assert!(
+                m.get("tips_amount_usd").is_none(),
+                "an unparseable tip is dropped, not surfaced; got {m}"
+            );
+        }
+        assert_eq!(
+            messages[3]["tips_amount_usd"],
+            json!(20.0),
+            "the well-formed tip still parses: {body}"
+        );
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/crates/eros-engine-server/src/routes/bff/companion.rs
+++ b/crates/eros-engine-server/src/routes/bff/companion.rs
@@ -92,9 +92,13 @@ fn parse_anchor(raw: Option<String>) -> Option<Uuid> {
 /// Parse the raw `metadata->>'tips_amount_usd'` text the slim projection
 /// carries. Same contract as `parse_anchor`: the column is unconstrained
 /// JSONB, and one bad row must not fail the page — what does not parse is
-/// dropped rather than surfaced (#302).
+/// dropped rather than surfaced (#302). Non-finite values ("NaN", "inf",
+/// overflow) are dropped too: `f64::parse` accepts them but serde_json
+/// serializes them as `null`, which would put the key on the wire instead
+/// of omitting it.
 fn parse_tip(raw: Option<String>) -> Option<f64> {
-    raw.and_then(|s| s.parse().ok())
+    raw.and_then(|s| s.parse::<f64>().ok())
+        .filter(|v| v.is_finite())
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
@@ -1026,12 +1030,15 @@ mod tests {
                  (session_id, role, content, metadata, sent_at) \
              VALUES ($1, 'gift_user', 'junk string', \
                      '{\"tips_amount_usd\": \"twenty\"}'::jsonb, \
-                     now() - interval '4 seconds'),
+                     now() - interval '5 seconds'),
                     ($1, 'gift_user', 'json object', \
                      '{\"tips_amount_usd\": {\"usd\": 20}}'::jsonb, \
-                     now() - interval '3 seconds'),
+                     now() - interval '4 seconds'),
                     ($1, 'gift_user', 'json null', \
                      '{\"tips_amount_usd\": null}'::jsonb, \
+                     now() - interval '3 seconds'),
+                    ($1, 'gift_user', 'non-finite', \
+                     '{\"tips_amount_usd\": \"NaN\"}'::jsonb, \
                      now() - interval '2 seconds'),
                     ($1, 'gift_user', '(打赏 $20)', \
                      '{\"tips_amount_usd\": 20.0}'::jsonb, \
@@ -1051,15 +1058,16 @@ mod tests {
         assert_eq!(status, StatusCode::OK, "the page still renders: {body}");
 
         let messages = body["messages"].as_array().expect("messages array");
-        assert_eq!(messages.len(), 4, "every row survives: {body}");
-        for m in &messages[..3] {
+        assert_eq!(messages.len(), 5, "every row survives: {body}");
+        for m in &messages[..4] {
             assert!(
                 m.get("tips_amount_usd").is_none(),
-                "an unparseable tip is dropped, not surfaced; got {m}"
+                "an unparseable or non-finite tip is dropped, not surfaced \
+                 (serde_json would render NaN as null); got {m}"
             );
         }
         assert_eq!(
-            messages[3]["tips_amount_usd"],
+            messages[4]["tips_amount_usd"],
             json!(20.0),
             "the well-formed tip still parses: {body}"
         );

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -122,12 +122,17 @@ pub struct ChatMessageSlim {
     /// Client-supplied message id forwarded during streaming (idempotency
     /// key). NULL for rows that never carried one (e.g. assistant turns).
     pub client_msg_id: Option<String>,
-    /// Structured tip amount extracted from `metadata->>'tips_amount_usd'`.
-    /// Present on `role='gift_user'` rows that carry tip metadata; NULL on
-    /// all other rows. Lets BFF / FE render tips as a structured field
-    /// instead of parsing the `(打赏 $X)` content marker.
+    /// Tip amount extracted from `metadata->>'tips_amount_usd'`. Present on
+    /// `role='gift_user'` rows that carry tip metadata; NULL on all other
+    /// rows. Lets BFF / FE render tips as a structured field instead of
+    /// parsing the `(打赏 $X)` content marker.
+    ///
+    /// Carried as raw text, not `::float8`, for the same reason as
+    /// `reply_to_message_id` below: `metadata` is unconstrained JSONB, and a
+    /// cast that meets one malformed value fails the whole page rather than
+    /// the one row. The caller parses and drops what does not parse.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tips_amount_usd: Option<f64>,
+    pub tips_amount_usd: Option<String>,
     /// Conversation-flavor marker: `"product_qa"` = out-of-character product
     /// answer (excluded from companion context). NULL for normal turns.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -353,7 +358,7 @@ impl<'a> ChatRepo<'a> {
     ) -> Result<Vec<ChatMessageSlim>, sqlx::Error> {
         let mut rows = sqlx::query_as::<_, ChatMessageSlim>(
             "SELECT id, role, content, sent_at, client_msg_id, \
-                    (metadata->>'tips_amount_usd')::float8 AS tips_amount_usd, \
+                    metadata->>'tips_amount_usd' AS tips_amount_usd, \
                     channel, read_at, \
                     (metadata->'image' IS NOT NULL) AS image, \
                     metadata->>'reply_to_message_id' AS reply_to_message_id, \


### PR DESCRIPTION
Fixes the failure mode in #302: `history_slim`'s `(metadata->>'tips_amount_usd')::float8` was the last SQL cast in the slim projection over unconstrained JSONB — one non-numeric value under that key fails the **whole** history page, i.e. the chat screen failing to load.

Mirrors #300's reply-anchor fix: the slim projection carries the raw text, `ChatMessageSlim.tips_amount_usd` becomes `Option<String>`, and the BFF parses per row via `parse_tip` next to `parse_anchor` — a malformed value costs its own key and nothing else. Wire contract unchanged: `tips_amount_usd` stays a JSON number on `BffHistoryEntry`; no OpenAPI drift. Additive, no migration.

Regression test mirrors `bff_history_survives_a_malformed_reply_anchor`: junk string / JSON object / JSON null / well-formed tip in one page — page renders, three drop the key, the real tip still parses to `20.0`.

Gates: fmt / clippy / test (1,621 pass) / openapi — clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GEdpTPjzZFuLauVrAiozjv