### PR TITLE
feat(image-edit): persist_instruction lands the instruction as a user row

### DIFF
--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -1396,7 +1396,7 @@
           "companion"
         ],
         "summary": "Revise an existing image turn.",
-        "description": "The instruction is an input to a picture, not something the user said to\nthe character: it is recorded on the audit row, never as a chat message.\nThe new assistant row inherits the source's `user_message_id`, so the edit\nbelongs to the turn the original picture answered.",
+        "description": "By default the instruction is an input to a picture: it is recorded on the\naudit row, never as a chat message, and the new assistant row inherits the\nsource's `user_message_id` — the edit belongs to the turn the original\npicture answered. With `persist_instruction` the instruction is persisted\nas a `role='user'` message quoting the source turn, and the new row hangs\noff it — the user asked the character for a revision, and history replays\nthe exchange.",
         "operationId": "edit_image",
         "parameters": [
           {
@@ -2629,6 +2629,10 @@
             "type": "string",
             "description": "What to change, in the user's words (\"换套衣服\"). Required, non-blank."
           },
+          "persist_instruction": {
+            "type": "boolean",
+            "description": "Persist the instruction as a `role='user'` chat message quoting the\nsource image turn (`metadata.reply_to_message_id`), and hang the new\nimage row off it. The persisted row is an ordinary user message —\nvisible to companion context, memory extraction and later affinity\nevaluation like anything else the user said. Default false: the\naudit-only contract, byte-for-byte."
+          },
           "prompt_variant": {
             "type": [
               "string",
@@ -2678,6 +2682,13 @@
           "image_ref": {
             "type": "string",
             "description": "Always `\"previous\"`: on an edit turn that means the `edit_of` picture."
+          },
+          "instruction_message_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The persisted instruction message, when `persist_instruction` was set."
           },
           "message_id": {
             "type": "string",

--- a/crates/eros-engine-server/src/routes/image_edit.rs
+++ b/crates/eros-engine-server/src/routes/image_edit.rs
@@ -8,8 +8,15 @@
 //! v0.7.1 is unchanged, and the persisted row is an ordinary image turn, so
 //! history discovery and the v1 recovery endpoint work on it unmodified.
 //!
+//! With `persist_instruction` the instruction additionally lands as an
+//! ordinary `role='user'` row quoting the source turn, and the new image row
+//! hangs off it — after which the whole turn is shape-identical to a chat-path
+//! image turn.
+//!
 //! Nothing else about a turn runs here: no PDE verdict, no affinity, no
-//! insight or memory extraction, no queue.
+//! insight or memory extraction, no queue. A persisted instruction row is
+//! visible to later turns' pipelines like any user message; this call
+//! triggers none of them.
 
 use axum::extract::{Extension, Path, State};
 use axum::Json;
@@ -59,6 +66,14 @@ pub struct ImageEditRequest {
     /// selection rules as the chat path's `image.prompt_variant`.
     #[serde(default)]
     pub prompt_variant: Option<String>,
+    /// Persist the instruction as a `role='user'` chat message quoting the
+    /// source image turn (`metadata.reply_to_message_id`), and hang the new
+    /// image row off it. The persisted row is an ordinary user message —
+    /// visible to companion context, memory extraction and later affinity
+    /// evaluation like anything else the user said. Default false: the
+    /// audit-only contract, byte-for-byte.
+    #[serde(default)]
+    pub persist_instruction: bool,
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
@@ -80,6 +95,10 @@ pub struct ImageEditResponse {
     /// The composer's caption for the new picture.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
+    /// The persisted instruction message, when `persist_instruction` was set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<String>)]
+    pub instruction_message_id: Option<Uuid>,
 }
 
 /// The edit composer's payload. Mirrors `compose_user_payload`'s five slots,
@@ -276,10 +295,13 @@ mod payload_tests {
 
 /// Revise an existing image turn.
 ///
-/// The instruction is an input to a picture, not something the user said to
-/// the character: it is recorded on the audit row, never as a chat message.
-/// The new assistant row inherits the source's `user_message_id`, so the edit
-/// belongs to the turn the original picture answered.
+/// By default the instruction is an input to a picture: it is recorded on the
+/// audit row, never as a chat message, and the new assistant row inherits the
+/// source's `user_message_id` — the edit belongs to the turn the original
+/// picture answered. With `persist_instruction` the instruction is persisted
+/// as a `role='user'` message quoting the source turn, and the new row hangs
+/// off it — the user asked the character for a revision, and history replays
+/// the exchange.
 #[utoipa::path(
     post,
     path = "/v2/comp/session/{session_id}/message/{message_id}/image/edit",
@@ -323,11 +345,17 @@ async fn edit_image(
         .and_then(|m| m.get("image"))
         .cloned()
         .ok_or_else(|| AppError::Conflict("not an image turn".into()))?;
-    // The edit belongs to the turn the source answered; a source with no turn
-    // has nothing to attach to. No engine path produces one.
-    let source_user_message_id = source.user_message_id.ok_or_else(|| {
-        AppError::Conflict("source image turn has no originating user message".into())
-    })?;
+    // Without `persist_instruction` the edit belongs to the turn the source
+    // answered, and a source with no turn has nothing to attach to (no engine
+    // path produces one). With it, the new user row is the anchor and the
+    // source's is never read — `None` here means exactly that branch.
+    let source_user_message_id = if req.persist_instruction {
+        None
+    } else {
+        Some(source.user_message_id.ok_or_else(|| {
+            AppError::Conflict("source image turn has no originating user message".into())
+        })?)
+    };
     let instance_id = session
         .instance_id
         .ok_or_else(|| AppError::Conflict("session has no persona instance".into()))?;
@@ -470,24 +498,31 @@ async fn edit_image(
         eros_engine_core::types::ImageRef::Previous,
         Some(message_id),
     );
-    chat_repo
-        .insert_assistant_batch(
-            session_id,
-            source_user_message_id,
-            &[AssistantInsert {
-                id: new_id,
-                content: String::new(),
-                assistant_action_type: "reply".into(),
-                continues_from_message_id: None,
-                truncated: false,
-                generation_id: None,
-                filter_audit: None,
-                metadata: Some(serde_json::json!({ "image": image_marker })),
-                llm_attempts: None,
-                gateway_errors: None,
-            }],
-        )
-        .await?;
+    let insert = AssistantInsert {
+        id: new_id,
+        content: String::new(),
+        assistant_action_type: "reply".into(),
+        continues_from_message_id: None,
+        truncated: false,
+        generation_id: None,
+        filter_audit: None,
+        metadata: Some(serde_json::json!({ "image": image_marker })),
+        llm_attempts: None,
+        gateway_errors: None,
+    };
+    let instruction_message_id = match source_user_message_id {
+        Some(umid) => {
+            chat_repo
+                .insert_assistant_batch(session_id, umid, &[insert])
+                .await?;
+            None
+        }
+        None => Some(
+            chat_repo
+                .insert_instruction_turn(session_id, &instruction, message_id, &insert)
+                .await?,
+        ),
+    };
 
     Ok(Json(ImageEditResponse {
         message_id: new_id,
@@ -497,6 +532,7 @@ async fn edit_image(
         image_ref: "previous".into(),
         aspect_ratio,
         caption: outcome.caption,
+        instruction_message_id,
     }))
 }
 
@@ -786,9 +822,16 @@ mod tests {
         let state = with_composer(test_state(pool.clone()), &mock.uri(), EDIT_TASK_TOML);
         let mut app = build_router(state);
         let token = mint_test_jwt(user_id);
+        // `persist_instruction` on the failing call: an exhausted composer
+        // must persist neither the instruction row nor a message.
         let (status, _) = send_request(
             &mut app,
-            edit_req(session_id, mid, &token, json!({"instruction": "换套衣服"})),
+            edit_req(
+                session_id,
+                mid,
+                &token,
+                json!({"instruction": "换套衣服", "persist_instruction": true}),
+            ),
         )
         .await;
         assert!(status.is_server_error(), "got {status}");
@@ -829,7 +872,12 @@ mod tests {
 
         let (status, body) = send_request(
             &mut app,
-            edit_req(session_id, mid, &token, json!({"instruction": "换套衣服"})),
+            edit_req(
+                session_id,
+                mid,
+                &token,
+                json!({"instruction": "换套衣服", "persist_instruction": false}),
+            ),
         )
         .await;
         assert_eq!(status, StatusCode::OK, "body={body}");
@@ -838,6 +886,8 @@ mod tests {
         assert_eq!(body["caption"], json!("换了条裙子"));
         // Inherited from the source marker when the request omits it.
         assert_eq!(body["aspect_ratio"], json!("3:4"));
+        // An explicit false is the v1 contract: no instruction row, no key.
+        assert!(body.get("instruction_message_id").is_none(), "got {body}");
 
         use base64::Engine as _;
         let decoded = String::from_utf8(
@@ -1009,6 +1059,100 @@ mod tests {
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn persist_instruction_lands_a_user_row_and_anchors_the_image_to_it(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+        let (_, mid) = seed_image_turn(&pool, session_id).await;
+
+        let mock = MockServer::start().await;
+        mount_editor(&mock).await;
+        let state = with_composer(test_state(pool.clone()), &mock.uri(), EDIT_TASK_TOML);
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        let (status, body) = send_request(
+            &mut app,
+            edit_req(
+                session_id,
+                mid,
+                &token,
+                json!({"instruction": "  换套衣服  ", "persist_instruction": true}),
+            ),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "body={body}");
+
+        let instruction_id =
+            Uuid::parse_str(body["instruction_message_id"].as_str().unwrap()).unwrap();
+        let new_id = Uuid::parse_str(body["message_id"].as_str().unwrap()).unwrap();
+
+        // The instruction row is an ordinary user message quoting the source
+        // turn — the same metadata key the chat stream path writes.
+        let (role, content, quote): (String, String, Option<String>) = sqlx::query_as(
+            "SELECT role, content, metadata->>'reply_to_message_id' \
+             FROM engine.chat_messages WHERE id = $1",
+        )
+        .bind(instruction_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(role, "user");
+        assert_eq!(content, "换套衣服", "stored trimmed");
+        assert_eq!(quote, Some(mid.to_string()));
+
+        // The image row hangs off the instruction, not the source's turn.
+        let row_umid: Option<Uuid> =
+            sqlx::query_scalar("SELECT user_message_id FROM engine.chat_messages WHERE id = $1")
+                .bind(new_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(row_umid, Some(instruction_id));
+
+        // History replays the whole exchange: instruction (quote handed back)
+        // directly followed by the new picture.
+        let (status, hist) = send_request(
+            &mut app,
+            Request::builder()
+                .method("GET")
+                .uri(format!("/comp/chat/{session_id}/history"))
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let entries = hist
+            .as_array()
+            .or_else(|| hist["messages"].as_array())
+            .expect("history array");
+        let i_user = entries
+            .iter()
+            .position(|e| e["id"] == json!(instruction_id.to_string()))
+            .expect("instruction row in history");
+        let i_image = entries
+            .iter()
+            .position(|e| e["id"] == json!(new_id.to_string()))
+            .expect("image row in history");
+        assert_eq!(
+            i_image,
+            i_user + 1,
+            "instruction directly precedes the picture"
+        );
+        assert_eq!(
+            entries[i_user]["reply_to_message_id"],
+            json!(mid.to_string())
+        );
+        assert_eq!(entries[i_image]["image"], json!(true));
+        assert_eq!(
+            entries[i_image]["user_message_id"],
+            json!(instruction_id.to_string())
+        );
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
     async fn an_edit_can_itself_be_edited(pool: PgPool) {
         let user_id = Uuid::new_v4();
         let genome_id = seed_genome(&pool, "Aria").await;
@@ -1041,6 +1185,30 @@ mod tests {
         .await;
         assert_eq!(status, StatusCode::OK, "body={second}");
         assert_eq!(second["edit_of"], json!(first_id.to_string()));
+
+        // With the switch on, an edit of an edit anchors to its own new
+        // instruction row — not to the chain it descends from.
+        let (status, third) = send_request(
+            &mut app,
+            edit_req(
+                session_id,
+                first_id,
+                &token,
+                json!({"instruction": "背景换成海边", "persist_instruction": true}),
+            ),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "body={third}");
+        let instruction_id =
+            Uuid::parse_str(third["instruction_message_id"].as_str().unwrap()).unwrap();
+        let third_id = Uuid::parse_str(third["message_id"].as_str().unwrap()).unwrap();
+        let row_umid: Option<Uuid> =
+            sqlx::query_scalar("SELECT user_message_id FROM engine.chat_messages WHERE id = $1")
+                .bind(third_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(row_umid, Some(instruction_id));
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -666,6 +666,61 @@ pub enum VoiceUserInsert {
 /// Core of `upsert_user_message_idempotent`, callable inside a caller-owned
 /// transaction so the async enqueue path can add a queue row atomically.
 /// Does NOT begin or commit — the caller owns the transaction boundary.
+/// One assistant row, inside the caller's transaction. The single INSERT both
+/// `insert_assistant_batch` and `insert_instruction_turn` go through.
+async fn insert_assistant_row_in_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    session_id: Uuid,
+    user_message_id: Uuid,
+    row: &AssistantInsert,
+) -> Result<(), sqlx::Error> {
+    let (pre_filter, filter_model, filter_triggers, f_client_msg_id, f_generation_id) =
+        match &row.filter_audit {
+            Some(a) => (
+                Some(a.pre_filter_content.as_str()),
+                Some(a.filter_model.as_str()),
+                // JSON null and SQL NULL are equivalent "no predicate data"
+                // for this audit column; normalize JSON null to SQL NULL so
+                // `filter_triggers IS NULL` is a clean "no predicates fired"
+                // probe. (Binding Value::Null would otherwise write JSONB 'null'.)
+                (!a.filter_triggers.is_null()).then_some(&a.filter_triggers),
+                Some(a.f_client_msg_id.as_str()),
+                a.f_generation_id.as_deref(),
+            ),
+            None => (None, None, None, None, None),
+        };
+    sqlx::query(
+        "INSERT INTO engine.chat_messages \
+           (id, session_id, role, content, user_message_id, \
+            continues_from_message_id, truncated, generation_id, \
+            assistant_action_type, \
+            pre_filter_content, filter_model, filter_triggers, \
+            f_client_msg_id, f_generation_id, metadata, \
+            llm_attempts, gateway_errors) \
+         VALUES ($1, $2, 'assistant', $3, $4, $5, $6, $7, $8, \
+                 $9, $10, $11, $12, $13, $14, $15, $16)",
+    )
+    .bind(row.id)
+    .bind(session_id)
+    .bind(&row.content)
+    .bind(user_message_id)
+    .bind(row.continues_from_message_id)
+    .bind(row.truncated)
+    .bind(&row.generation_id)
+    .bind(&row.assistant_action_type)
+    .bind(pre_filter)
+    .bind(filter_model)
+    .bind(filter_triggers)
+    .bind(f_client_msg_id)
+    .bind(f_generation_id)
+    .bind(&row.metadata)
+    .bind(&row.llm_attempts)
+    .bind(&row.gateway_errors)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
 pub(crate) async fn upsert_user_message_in_tx(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     session_id: Uuid,
@@ -1000,50 +1055,7 @@ impl<'a> ChatRepo<'a> {
         }
         let mut tx = self.pool.begin().await?;
         for row in rows {
-            let (pre_filter, filter_model, filter_triggers, f_client_msg_id, f_generation_id) =
-                match &row.filter_audit {
-                    Some(a) => (
-                        Some(a.pre_filter_content.as_str()),
-                        Some(a.filter_model.as_str()),
-                        // JSON null and SQL NULL are equivalent "no predicate data"
-                        // for this audit column; normalize JSON null to SQL NULL so
-                        // `filter_triggers IS NULL` is a clean "no predicates fired"
-                        // probe. (Binding Value::Null would otherwise write JSONB 'null'.)
-                        (!a.filter_triggers.is_null()).then_some(&a.filter_triggers),
-                        Some(a.f_client_msg_id.as_str()),
-                        a.f_generation_id.as_deref(),
-                    ),
-                    None => (None, None, None, None, None),
-                };
-            sqlx::query(
-                "INSERT INTO engine.chat_messages \
-                   (id, session_id, role, content, user_message_id, \
-                    continues_from_message_id, truncated, generation_id, \
-                    assistant_action_type, \
-                    pre_filter_content, filter_model, filter_triggers, \
-                    f_client_msg_id, f_generation_id, metadata, \
-                    llm_attempts, gateway_errors) \
-                 VALUES ($1, $2, 'assistant', $3, $4, $5, $6, $7, $8, \
-                         $9, $10, $11, $12, $13, $14, $15, $16)",
-            )
-            .bind(row.id)
-            .bind(session_id)
-            .bind(&row.content)
-            .bind(user_message_id)
-            .bind(row.continues_from_message_id)
-            .bind(row.truncated)
-            .bind(&row.generation_id)
-            .bind(&row.assistant_action_type)
-            .bind(pre_filter)
-            .bind(filter_model)
-            .bind(filter_triggers)
-            .bind(f_client_msg_id)
-            .bind(f_generation_id)
-            .bind(&row.metadata)
-            .bind(&row.llm_attempts)
-            .bind(&row.gateway_errors)
-            .execute(&mut *tx)
-            .await?;
+            insert_assistant_row_in_tx(&mut tx, session_id, user_message_id, row).await?;
         }
         sqlx::query("UPDATE engine.chat_sessions SET last_active_at = now() WHERE id = $1")
             .bind(session_id)
@@ -1051,6 +1063,45 @@ impl<'a> ChatRepo<'a> {
             .await?;
         tx.commit().await?;
         Ok(())
+    }
+
+    /// Persist an image-edit instruction as a `role='user'` row quoting the
+    /// source image turn, plus the assistant image row hanging off it — one
+    /// transaction, so an instruction with no picture never exists. The quote
+    /// key is the same `metadata.reply_to_message_id` the chat stream path
+    /// writes, so history hands it back unchanged. Returns the user row's id.
+    /// Bumps `last_active_at` once.
+    pub async fn insert_instruction_turn(
+        &self,
+        session_id: Uuid,
+        instruction: &str,
+        source_message_id: Uuid,
+        row: &AssistantInsert,
+    ) -> Result<Uuid, sqlx::Error> {
+        let mut tx = self.pool.begin().await?;
+        let user_message_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_messages (session_id, role, content, metadata) \
+             VALUES ($1, 'user', $2, $3) RETURNING id",
+        )
+        .bind(session_id)
+        .bind(instruction)
+        .bind(serde_json::json!({ "reply_to_message_id": source_message_id }))
+        .fetch_one(&mut *tx)
+        .await?;
+        insert_assistant_row_in_tx(&mut tx, session_id, user_message_id, row).await?;
+        // One transaction has one `now()`, so both rows' `sent_at` would tie —
+        // and history orders by `sent_at` alone. Stamp the picture with real
+        // statement time so it always replays after its instruction.
+        sqlx::query("UPDATE engine.chat_messages SET sent_at = clock_timestamp() WHERE id = $1")
+            .bind(row.id)
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("UPDATE engine.chat_sessions SET last_active_at = now() WHERE id = $1")
+            .bind(session_id)
+            .execute(&mut *tx)
+            .await?;
+        tx.commit().await?;
+        Ok(user_message_id)
     }
 
     /// Idempotently persist a user turn on the voice channel. Mirrors the

--- a/crates/eros-engine-store/src/chat.rs
+++ b/crates/eros-engine-store/src/chat.rs
@@ -1091,11 +1091,17 @@ impl<'a> ChatRepo<'a> {
         insert_assistant_row_in_tx(&mut tx, session_id, user_message_id, row).await?;
         // One transaction has one `now()`, so both rows' `sent_at` would tie —
         // and history orders by `sent_at` alone. Stamp the picture with real
-        // statement time so it always replays after its instruction.
-        sqlx::query("UPDATE engine.chat_messages SET sent_at = clock_timestamp() WHERE id = $1")
-            .bind(row.id)
-            .execute(&mut *tx)
-            .await?;
+        // statement time, floored one microsecond (the column's precision)
+        // above the instruction row's `now()`: `clock_timestamp()` alone could
+        // land on the same microsecond or, on a clock step, before it.
+        sqlx::query(
+            "UPDATE engine.chat_messages \
+             SET sent_at = GREATEST(clock_timestamp(), now() + interval '1 microsecond') \
+             WHERE id = $1",
+        )
+        .bind(row.id)
+        .execute(&mut *tx)
+        .await?;
         sqlx::query("UPDATE engine.chat_sessions SET last_active_at = now() WHERE id = $1")
             .bind(session_id)
             .execute(&mut *tx)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -529,19 +529,28 @@ consumer draws it, exactly as for a chat image turn.
   "instruction": "换套衣服",
   "style": "realistic",
   "aspect_ratio": "3:4",
-  "prompt_variant": "a"
+  "prompt_variant": "a",
+  "persist_instruction": true
 }
 ```
 
 - `instruction` — required, non-blank, ≤4096 chars. What to change, in the
-  user's words. It is an input to a picture, not a chat message: it is recorded
-  on the audit row and never persisted as conversation.
+  user's words. Without `persist_instruction` it is an input to a picture, not
+  a chat message: recorded on the audit row and never persisted as
+  conversation.
 - `style` — `realistic` (default) | `semi_realistic` | `anime`. Pass the style
   the source was drawn with; the engine does not record it on the message.
 - `aspect_ratio` — `1:1` | `3:4` | `4:3` | `9:16` | `16:9`. Defaults to the
   source turn's.
 - `prompt_variant` — selects a `[tasks.chat_image_edit_compose].filter_prompt`
   variant, with the same rules as the chat path's `image.prompt_variant`.
+- `persist_instruction` — default `false`. When set, the instruction is
+  persisted as an ordinary `role='user'` message quoting the source turn
+  (`metadata.reply_to_message_id`, the same key the chat path writes), and the
+  new image row hangs off it instead of inheriting the source's turn. History
+  then replays the exchange: user instruction → assistant picture. The row is
+  a real user message — visible to companion context, memory extraction and
+  later affinity evaluation like anything else the user said.
 
 ```json
 {
@@ -550,9 +559,14 @@ consumer draws it, exactly as for a chat image turn.
   "composed_prompt": "<base64>",
   "image_ref": "previous",
   "aspect_ratio": "3:4",
-  "caption": "换了条裙子"
+  "caption": "换了条裙子",
+  "instruction_message_id": "…"
 }
 ```
+
+`instruction_message_id` is present only when `persist_instruction` was set:
+the persisted instruction message, so a client can render the user bubble
+without refetching history.
 
 `composed_prompt` is base64(STANDARD) of the UTF-8 wire prompt — the same
 encoding as the SSE `image_request` frame and the recovery endpoint, so an
@@ -565,9 +579,11 @@ The new message is an ordinary image turn: it appears in history with
 `GET /comp/chat/{session_id}/messages/{message_id}/image-request`. Its
 `metadata.image` additionally carries `edit_of`. An edit can itself be edited.
 
-Nothing else about a turn runs: no PDE decision, no affinity movement, no
-insight or memory extraction. The new row inherits the source's
-`user_message_id` — the edit belongs to the turn the original picture answered.
+Nothing else about a turn runs on this call: no PDE decision, no affinity
+movement, no insight or memory extraction. Without `persist_instruction` the
+new row inherits the source's `user_message_id` — the edit belongs to the turn
+the original picture answered; with it, the new row's `user_message_id` is the
+persisted instruction message.
 
 | Status | Meaning |
 |---|---|

--- a/docs/api-reference.zh.md
+++ b/docs/api-reference.zh.md
@@ -457,17 +457,24 @@ curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json"
   "instruction": "换套衣服",
   "style": "realistic",
   "aspect_ratio": "3:4",
-  "prompt_variant": "a"
+  "prompt_variant": "a",
+  "persist_instruction": true
 }
 ```
 
 - `instruction` —— 必填，非空白，≤4096 字。要改什么，用用户自己的话写。
-  它是画图的输入，不是一条聊天消息：只记在审计行上，不落成对话。
+  不带 `persist_instruction` 时它是画图的输入，不是一条聊天消息：
+  只记在审计行上，不落成对话。
 - `style` —— `realistic`（缺省）| `semi_realistic` | `anime`。传原图用的风格；
   引擎不会把风格记在消息上。
 - `aspect_ratio` —— `1:1` | `3:4` | `4:3` | `9:16` | `16:9`。缺省沿用原图回合的。
 - `prompt_variant` —— 选 `[tasks.chat_image_edit_compose].filter_prompt` 的变体，
   规则与聊天路径的 `image.prompt_variant` 相同。
+- `persist_instruction` —— 缺省 `false`。设上时，指令落成一条普通的
+  `role='user'` 消息，引用原图回合（`metadata.reply_to_message_id`，
+  与聊天路径写的是同一个键），新图片行挂在它上面，不再沿用原图的回合。
+  历史自然回放整轮：用户指令 → 角色新图。这条 user row 是真实的用户消息 ——
+  和用户说的其他话一样，进 companion context、记忆抽取和之后的好感度评估。
 
 ```json
 {
@@ -476,9 +483,13 @@ curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json"
   "composed_prompt": "<base64>",
   "image_ref": "previous",
   "aspect_ratio": "3:4",
-  "caption": "换了条裙子"
+  "caption": "换了条裙子",
+  "instruction_message_id": "…"
 }
 ```
+
+`instruction_message_id` 只在设了 `persist_instruction` 时出现：
+落库的那条指令消息，客户端不用重拉历史就能渲染用户气泡。
 
 `composed_prompt` 是 UTF-8 提示词的 base64（STANDARD）—— 与 SSE `image_request`
 帧、恢复端点的编码一致，现成的画图链路可直接消费。`image_ref` 恒为 `previous`，
@@ -488,8 +499,10 @@ curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json"
 `GET /comp/chat/{session_id}/messages/{message_id}/image-request` 恢复。它的
 `metadata.image` 另外带一个 `edit_of`。编辑出来的图还可以再编辑。
 
-回合的其余部分一概不跑：不做 PDE 判定、不动好感度、不抽 insight 与记忆。
-新行沿用原图行的 `user_message_id` —— 这次编辑属于原图所回应的那个回合。
+这次调用里回合的其余部分一概不跑：不做 PDE 判定、不动好感度、不抽 insight
+与记忆。不带 `persist_instruction` 时新行沿用原图行的 `user_message_id` ——
+这次编辑属于原图所回应的那个回合；带上时，新行的 `user_message_id`
+就是落库的那条指令消息。
 
 | 状态码 | 含义 |
 |---|---|

--- a/docs/superpowers/specs/2026-09-02-image-edit-persist-instruction-design.md
+++ b/docs/superpowers/specs/2026-09-02-image-edit-persist-instruction-design.md
@@ -1,0 +1,145 @@
+# Image edit `persist_instruction` — Design
+
+**Date:** 2026-09-02
+**Status:** approved
+**Extends:** `2026-08-22-image-edit-endpoint-design.md` (v1)
+
+## 1. What this is
+
+v1 of the image-edit endpoint treats the instruction as an input to a picture:
+it is recorded on the audit row only, and the new image-only assistant row
+inherits the source turn's `user_message_id`. The consequence is that the
+user's own words leave no trace in the conversation — after a refresh the
+thread shows a new picture with no message that asked for it.
+
+v2 adds an opt-in switch, `persist_instruction`. When set, the instruction is
+persisted as an ordinary `role='user'` chat message quoting the source image
+turn, and the new image row hangs off that message. History then replays the
+whole exchange naturally: user instruction → assistant picture.
+
+The design intent behind the switch: although the endpoint is named "edit",
+the interaction is the user *asking* the character for a revision. The
+persisted row is a real user message — it is not filtered from companion
+context, memory extraction, or later affinity evaluation. No new metadata
+keys are invented; the row uses the existing quote mechanism.
+
+## 2. Contract
+
+### 2.1 Request
+
+`ImageEditRequest` gains one field:
+
+```rust
+/// Persist the instruction as a `role='user'` chat message quoting the
+/// source image turn, and hang the new image row off it. Default false —
+/// the v1 audit-only behaviour.
+#[serde(default)]
+pub persist_instruction: bool,
+```
+
+`false` (or absent) is byte-for-byte the v1 contract. Every existing caller
+is unaffected.
+
+### 2.2 Response
+
+`ImageEditResponse` gains one field, present only when a user row was
+persisted:
+
+```rust
+/// The persisted instruction message, when `persist_instruction` was set.
+#[serde(skip_serializing_if = "Option::is_none")]
+#[schema(value_type = Option<String>)]
+pub instruction_message_id: Option<Uuid>,
+```
+
+The consumer can render the user bubble without refetching history.
+
+### 2.3 Status ladder
+
+Unchanged. One 409 arm narrows: "source image turn has no originating user
+message" applies only when `persist_instruction` is false — with the switch
+on, the new user row is the anchor and the source's `user_message_id` is not
+read. (No engine path produces such a source; the arm remains for defense.)
+
+## 3. Behaviour (`persist_instruction: true`)
+
+### 3.1 Persistence
+
+Both rows are written in **one transaction**, only after the composer
+succeeds (a failed compose persists nothing — the v1 semantics; retry is
+safe):
+
+1. A `role='user'` row: `content` = trimmed instruction,
+   `metadata` = `{"reply_to_message_id": "<source message_id>"}` — the same
+   key the chat stream path writes for a quoted turn, so the history
+   endpoints hand it back unchanged and a client renders it as a quote of
+   the source picture. This is also how "this row is an edit instruction"
+   is recognized: a user row quoting an image turn, with an image-only
+   assistant row hanging off it.
+2. The assistant image row, exactly as v1 builds it (same `image` marker,
+   `edit_of`, `image_ref: "previous"`, compose-event link), except
+   `user_message_id` = the id of row 1 instead of the source's.
+
+`last_active_at` bumps once, as `insert_assistant_batch` does today.
+
+The assistant-side marker is unchanged — no new keys on the image row.
+
+### 3.2 Downstream visibility
+
+The persisted user row is an ordinary user message. Deliberately:
+
+- it enters the history window, so subsequent turns' companion context,
+  memory extraction, and affinity evaluation see it as something the user
+  said — no filtering marker of any kind;
+- the edit call itself still runs nothing else: no PDE verdict, no affinity
+  movement, no insight or memory extraction, no queue. The row is visible
+  to later pipelines, not a trigger of any.
+
+After this change a persisted edit turn is shape-identical to a chat-path
+image turn (real user row → empty-content assistant row with an `image`
+marker), so history rendering, turn pairing, and the recovery endpoint need
+no special casing.
+
+### 3.3 Audit
+
+Unchanged. The instruction is still recorded in the compose-event `inputs`;
+the audit row does not reference the new user row.
+
+## 4. Implementation shape
+
+- `eros-engine-store/src/chat.rs`: one new `ChatRepo` method,
+  `insert_instruction_turn(session_id, instruction, source_message_id,
+  AssistantInsert) -> Result<Uuid, _>` — inserts the user row and the
+  assistant row in one transaction, bumps `last_active_at`, returns the user
+  row's id. The assistant insert reuses the same column set as
+  `insert_assistant_batch`.
+- `eros-engine-server/src/routes/image_edit.rs`: branch at persistence time —
+  `false` → `insert_assistant_batch` keyed to the source's `user_message_id`
+  (v1 path, untouched); `true` → `insert_instruction_turn`, and
+  `instruction_message_id` in the response.
+- OpenAPI regenerated; `docs/api-reference.md` / `.zh.md` image-edit sections
+  updated (the "never persisted as conversation" claim becomes conditional).
+
+## 5. Not in scope
+
+- No idempotency key for the persisted user row (the endpoint itself has
+  none; a double-click makes two edits in v1 already).
+- No change to which pipelines the edit call triggers.
+- Web-side composer UX (chip copy, default for the switch) — the consumer
+  decides policy; the engine default preserves v1.
+
+## 6. Testing
+
+Extend `image_edit.rs` tests:
+
+1. `persist_instruction: true` → user row exists with trimmed content and
+   `metadata.reply_to_message_id` = source id; assistant row's
+   `user_message_id` = the new user row; response carries
+   `instruction_message_id`; history replays both rows in order, with the
+   quote handed back on the user entry.
+2. `persist_instruction` absent/false → v1 behaviour byte-for-byte (existing
+   tests already lock this; add an explicit `false` probe on the response:
+   no `instruction_message_id` key).
+3. Composer exhausted with `persist_instruction: true` → no rows persisted
+   (extends the existing 502 test).
+4. An edit of an edit with the switch on anchors to its own new user row.


### PR DESCRIPTION
## What

`POST /v2/comp/session/{sid}/message/{mid}/image/edit` gains an opt-in `persist_instruction: bool`. When set, the edit instruction is persisted as an ordinary `role='user'` chat message quoting the source image turn (the existing `metadata.reply_to_message_id` key), and the new image row hangs off it instead of inheriting the source's `user_message_id`. History then replays the whole exchange: user instruction → assistant picture. The response gains an optional `instruction_message_id`.

Default `false` is the v1 audit-only contract, byte-for-byte.

## Why

v1 records the instruction only on the audit row, so a web client's user sees their own words vanish from the thread after a refresh. The design intent: although the endpoint is named "edit", the interaction is the user *asking* the character for a revision — the persisted row is a real user message, visible to companion context, memory extraction and later affinity evaluation. The edit call itself still triggers no pipelines.

## How

- `ChatRepo::insert_instruction_turn` — user row + assistant row in one transaction (an instruction with no picture never exists); the shared single-row assistant INSERT is extracted into `insert_assistant_row_in_tx`, also used by `insert_assistant_batch`. The picture row is stamped `sent_at = clock_timestamp()` — one transaction has one `now()`, and history orders by `sent_at` alone, so without it the pair would tie and replay order would be arbitrary.
- Handler branches at persistence time only; the "source has no originating user message" 409 now applies only to the inheriting path, which is the only one that reads it.
- Composer failure persists nothing, as before; retry is safe.
- Spec: `docs/superpowers/specs/2026-09-02-image-edit-persist-instruction-design.md`. Docs: `api-reference.md` / `.zh.md`; OpenAPI snapshot regenerated.

## Testing

- New: persist path lands the trimmed user row with the quote key, anchors the image row to it, returns `instruction_message_id`, and history replays instruction directly before picture with the quote handed back.
- Extended: explicit `persist_instruction: false` keeps the v1 response shape; exhausted composer with the switch on persists neither row; an edit of an edit with the switch on anchors to its own new user row.
- `cargo fmt` / `clippy -D warnings` / full workspace test suite green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179bM2qXv8RYMVgsYxsb4b9
