### PR TITLE
feat: opt-in per-turn affinity evaluation on image edit

### DIFF
--- a/crates/eros-engine-server/openapi.json
+++ b/crates/eros-engine-server/openapi.json
@@ -2625,6 +2625,10 @@
             ],
             "description": "Same allow-list as the chat path. Defaults to the source turn's\n`aspect_ratio`."
           },
+          "evaluate_affinity": {
+            "type": "boolean",
+            "description": "Run this edit through the per-turn affinity judge: the instruction is\nwhat the user said, the new picture's caption is what the character\nanswered. Detached — the response never waits on the judge. Orthogonal\nto `persist_instruction`; when an instruction row was persisted it\nanchors the affinity event. Default false: an edit does not move\naffinity unless the consumer says so."
+          },
           "instruction": {
             "type": "string",
             "description": "What to change, in the user's words (\"换套衣服\"). Required, non-blank."

--- a/crates/eros-engine-server/src/pipeline/post_process.rs
+++ b/crates/eros-engine-server/src/pipeline/post_process.rs
@@ -114,7 +114,6 @@ pub async fn run(
         Event::UserMessage { affinity_scope, .. } => *affinity_scope,
         _ => eros_engine_core::scope::AffinityScope::default(),
     };
-    let scope_has_axes = affinity_scope.active_count() > 0;
     let client_id = client_id_from_event(&event);
 
     let fut_insight = async {
@@ -160,107 +159,20 @@ pub async fn run(
             plan.image_caption.as_deref(),
         );
 
-        // Semantic eval gate: Reply turns only, with a non-trivial user message
-        // and a non-empty produced assistant message (or image_caption proxy for
-        // reply_image). Other actions (Proactive / Ghost) keep rule-only deltas
-        // in v1. `pre_skip == None` ⇒ the gate passes and an eval call is
-        // attempted; otherwise it carries the reason the trio will be NULL
-        // (stamped into `context`).
-        let pre_skip = eval_skip_reason(
-            plan.action_type,
-            user_msg.chars().count(),
-            eval_text.trim().is_empty(),
-        );
-
-        let (persona_name, (grades, levels, reason, affinity_gen_id, skip_reason, eval_failures)) =
-            if pre_skip.is_none() {
-                let persona_repo = PersonaRepo { pool: &state.pool };
-                let affinity_repo = AffinityRepo { pool: &state.pool };
-                let persona_name = match persona_repo.load_companion(instance_id).await {
-                    Ok(Some(p)) => p.genome.name,
-                    _ => String::new(),
-                };
-                // Snapshot the current vector for prompt context only; the
-                // authoritative value is re-read under lock in persist_with_event.
-                let outcome = match affinity_repo.load(session_id).await {
-                    Ok(Some(current)) if !persona_name.is_empty() => {
-                        evaluate_affinity(
-                            &state,
-                            session_id,
-                            &persona_name,
-                            &current,
-                            &user_msg,
-                            &eval_text,
-                            client_id.as_deref(),
-                        )
-                        .await
-                    }
-                    _ => (
-                        eros_engine_core::affinity::AxisGrades::default(),
-                        eros_engine_core::affinity::EndpointLevelReads::default(),
-                        String::new(),
-                        None,
-                        Some("no_persona_or_affinity"),
-                        Vec::new(),
-                    ),
-                };
-                (persona_name, outcome)
-            } else {
-                (
-                    String::new(),
-                    (
-                        eros_engine_core::affinity::AxisGrades::default(),
-                        eros_engine_core::affinity::EndpointLevelReads::default(),
-                        String::new(),
-                        None,
-                        pre_skip,
-                        Vec::new(),
-                    ),
-                )
-            };
-
-        // Grades, rule deltas and endpoint levels travel separately into the
-        // store, which runs the 4.0 pipeline (convert → decay → penalty →
-        // gate, then the endpoint derivation) under the row lock so the tier
-        // lookups always read committed state. On a skipped/failed eval the
-        // levels are `None` and the stored levels hold.
-        let rule_deltas = plan.affinity_deltas.clone();
-        let context = build_affinity_context(&reason, skip_reason);
-
-        persist_affinity(
+        run_affinity_turn(
             &state,
             session_id,
             user_id,
             instance_id,
             plan.action_type,
-            grades,
-            rule_deltas,
-            context,
-            affinity_gen_id,
-            levels,
-            &eval_failures,
+            &user_msg,
+            &eval_text,
+            plan.affinity_deltas.clone(),
+            affinity_scope,
             user_message_id,
+            client_id.as_deref(),
         )
         .await;
-
-        // Feeling-clause summarizer (spec 2026-09-03): movement turns only,
-        // gated on the [tasks.affinity_summary] section being present at
-        // all (absent = feature off, clause stays NULL) and on the request
-        // actually injecting affinity (zero-axis scope ⇒ nothing would
-        // render the clause).
-        if movement_turn(&grades, &levels)
-            && scope_has_axes
-            && state.model_config.tasks.contains_key(SUMMARY_TASK)
-        {
-            summarize_feeling(
-                &state,
-                session_id,
-                &persona_name,
-                affinity_scope,
-                client_id.as_deref(),
-            )
-            .await;
-        }
     };
 
     let fut_character_insight = async {
@@ -307,6 +219,120 @@ pub async fn run(
 }
 
 // ─── Affinity persistence ──────────────────────────────────────────
+
+/// One turn's whole affinity pass: eval gate, judge call, persist, and — on
+/// movement turns whose scope actually injects affinity — the feeling-clause
+/// rewrite. Shared by the chat pipeline's `run` above and the image-edit
+/// endpoint's opt-in `evaluate_affinity`; the caller owns building
+/// `eval_text` (see `affinity_eval_text`) and choosing the scope.
+#[allow(clippy::too_many_arguments)] // each arg is a distinct per-turn concern
+pub(crate) async fn run_affinity_turn(
+    state: &AppState,
+    session_id: Uuid,
+    user_id: Uuid,
+    instance_id: Uuid,
+    action: ActionType,
+    user_msg: &str,
+    eval_text: &str,
+    rule_deltas: eros_engine_core::affinity::AffinityDeltas,
+    affinity_scope: eros_engine_core::scope::AffinityScope,
+    user_message_id: Option<Uuid>,
+    client_id: Option<&str>,
+) {
+    // Semantic eval gate: Reply turns only, with a non-trivial user message
+    // and a non-empty produced assistant message (or image_caption proxy for
+    // reply_image). Other actions (Proactive / Ghost) keep rule-only deltas
+    // in v1. `pre_skip == None` ⇒ the gate passes and an eval call is
+    // attempted; otherwise it carries the reason the trio will be NULL
+    // (stamped into `context`).
+    let pre_skip = eval_skip_reason(
+        action,
+        user_msg.chars().count(),
+        eval_text.trim().is_empty(),
+    );
+
+    let (persona_name, (grades, levels, reason, affinity_gen_id, skip_reason, eval_failures)) =
+        if pre_skip.is_none() {
+            let persona_repo = PersonaRepo { pool: &state.pool };
+            let affinity_repo = AffinityRepo { pool: &state.pool };
+            let persona_name = match persona_repo.load_companion(instance_id).await {
+                Ok(Some(p)) => p.genome.name,
+                _ => String::new(),
+            };
+            // Snapshot the current vector for prompt context only; the
+            // authoritative value is re-read under lock in persist_with_event.
+            let outcome = match affinity_repo.load(session_id).await {
+                Ok(Some(current)) if !persona_name.is_empty() => {
+                    evaluate_affinity(
+                        state,
+                        session_id,
+                        &persona_name,
+                        &current,
+                        user_msg,
+                        eval_text,
+                        client_id,
+                    )
+                    .await
+                }
+                _ => (
+                    eros_engine_core::affinity::AxisGrades::default(),
+                    eros_engine_core::affinity::EndpointLevelReads::default(),
+                    String::new(),
+                    None,
+                    Some("no_persona_or_affinity"),
+                    Vec::new(),
+                ),
+            };
+            (persona_name, outcome)
+        } else {
+            (
+                String::new(),
+                (
+                    eros_engine_core::affinity::AxisGrades::default(),
+                    eros_engine_core::affinity::EndpointLevelReads::default(),
+                    String::new(),
+                    None,
+                    pre_skip,
+                    Vec::new(),
+                ),
+            )
+        };
+
+    // Grades, rule deltas and endpoint levels travel separately into the
+    // store, which runs the 4.0 pipeline (convert → decay → penalty →
+    // gate, then the endpoint derivation) under the row lock so the tier
+    // lookups always read committed state. On a skipped/failed eval the
+    // levels are `None` and the stored levels hold.
+    let context = build_affinity_context(&reason, skip_reason);
+
+    persist_affinity(
+        state,
+        session_id,
+        user_id,
+        instance_id,
+        action,
+        grades,
+        rule_deltas,
+        context,
+        affinity_gen_id,
+        levels,
+        &eval_failures,
+        user_message_id,
+    )
+    .await;
+
+    // Feeling-clause summarizer (spec 2026-09-03): movement turns only,
+    // gated on the [tasks.affinity_summary] section being present at
+    // all (absent = feature off, clause stays NULL) and on the request
+    // actually injecting affinity (zero-axis scope ⇒ nothing would
+    // render the clause).
+    if movement_turn(&grades, &levels)
+        && affinity_scope.active_count() > 0
+        && state.model_config.tasks.contains_key(SUMMARY_TASK)
+    {
+        summarize_feeling(state, session_id, &persona_name, affinity_scope, client_id).await;
+    }
+}
 
 /// Run the graded turn through the 4.0 pipeline (or ghost counters) and write
 /// to DB.
@@ -670,7 +696,7 @@ const AFFINITY_EVAL_TIMEOUT: std::time::Duration = std::time::Duration::from_sec
 /// language, which is exactly the register the first-person evaluator reads.
 /// Captionless image turns (legacy rows, `raw` variant, failed compose) fall
 /// back to a generic photo marker so they are still evaluated.
-fn affinity_eval_text(
+pub(crate) fn affinity_eval_text(
     action: ActionType,
     assistant_msg: &str,
     image_caption: Option<&str>,

--- a/crates/eros-engine-server/src/routes/image_edit.rs
+++ b/crates/eros-engine-server/src/routes/image_edit.rs
@@ -1405,7 +1405,17 @@ mod tests {
         assert_eq!(status, StatusCode::OK);
 
         // Best-effort negative: give a wrongly spawned task time to land.
+        // A wrongly spawned judge must hit the mock BEFORE it can write, so
+        // checking both narrows the false-pass window to "spawned but never
+        // even issued its HTTP call within the sleep".
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        let judged = mock
+            .received_requests()
+            .await
+            .unwrap()
+            .iter()
+            .any(|r| String::from_utf8_lossy(&r.body).contains("当前档位"));
+        assert!(!judged, "no affinity judge call may be made by default");
         let n: i64 = sqlx::query_scalar(
             "SELECT count(*) FROM engine.companion_affinity WHERE session_id = $1",
         )

--- a/crates/eros-engine-server/src/routes/image_edit.rs
+++ b/crates/eros-engine-server/src/routes/image_edit.rs
@@ -13,10 +13,13 @@
 //! hangs off it — after which the whole turn is shape-identical to a chat-path
 //! image turn.
 //!
-//! Nothing else about a turn runs here: no PDE verdict, no affinity, no
-//! insight or memory extraction, no queue. A persisted instruction row is
-//! visible to later turns' pipelines like any user message; this call
-//! triggers none of them.
+//! Nothing else about a turn runs here by default: no PDE verdict, no
+//! affinity, no insight or memory extraction, no queue. A persisted
+//! instruction row is visible to later turns' pipelines like any user
+//! message; this call triggers none of them. The one opt-in exception is
+//! `evaluate_affinity`: the turn (instruction vs. the new picture's caption)
+//! goes through the standard per-turn affinity judge, detached — and nothing
+//! else.
 
 use axum::extract::{Extension, Path, State};
 use axum::Json;
@@ -74,6 +77,14 @@ pub struct ImageEditRequest {
     /// audit-only contract, byte-for-byte.
     #[serde(default)]
     pub persist_instruction: bool,
+    /// Run this edit through the per-turn affinity judge: the instruction is
+    /// what the user said, the new picture's caption is what the character
+    /// answered. Detached — the response never waits on the judge. Orthogonal
+    /// to `persist_instruction`; when an instruction row was persisted it
+    /// anchors the affinity event. Default false: an edit does not move
+    /// affinity unless the consumer says so.
+    #[serde(default)]
+    pub evaluate_affinity: bool,
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
@@ -523,6 +534,36 @@ async fn edit_image(
                 .await?,
         ),
     };
+
+    // Opt-in affinity: judge (instruction, new caption) as one turn, detached
+    // like post_process — the response never waits on the judge. Zero rule
+    // deltas (no PDE ran) and a zero-axis scope (this request injects no
+    // affinity, so no feeling-clause rewrite).
+    if req.evaluate_affinity {
+        let eval_text = crate::pipeline::post_process::affinity_eval_text(
+            eros_engine_core::types::ActionType::ReplyImage,
+            "",
+            outcome.caption.as_deref(),
+        );
+        let task_state = state.clone();
+        let instruction = instruction.clone();
+        tokio::spawn(async move {
+            crate::pipeline::post_process::run_affinity_turn(
+                &task_state,
+                session_id,
+                user_id,
+                instance_id,
+                eros_engine_core::types::ActionType::ReplyImage,
+                &instruction,
+                &eval_text,
+                eros_engine_core::affinity::AffinityDeltas::default(),
+                eros_engine_core::scope::AffinityScope::none(),
+                instruction_message_id,
+                None,
+            )
+            .await;
+        });
+    }
 
     Ok(Json(ImageEditResponse {
         message_id: new_id,
@@ -1209,6 +1250,213 @@ mod tests {
                 .await
                 .unwrap();
         assert_eq!(row_umid, Some(instruction_id));
+    }
+
+    /// Edit-composer config plus an affinity judge, for the
+    /// `evaluate_affinity` tests.
+    const EDIT_PLUS_AFFINITY_TOML: &str = "[tasks.chat_image_edit_compose]\nmodel = \"editor\"\n\
+         [tasks.affinity_evaluation]\nmodel = \"affinity-judge\"\n";
+
+    /// Editor + affinity-judge mocks with disjoint body matchers, so the two
+    /// LLM calls this endpoint can now make never swallow each other's
+    /// canned response.
+    async fn mount_editor_and_judge(mock: &MockServer) {
+        use wiremock::matchers::body_string_contains;
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("[修改要求]"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "gen-edit",
+                "model": "served/editor",
+                "choices": [{"message": {"content":
+                    r#"{"prompt":"EDITED SUBJECT","caption":"换了条裙子"}"#}}],
+            })))
+            .mount(mock)
+            .await;
+        Mock::given(wm_path("/api/v1/chat/completions"))
+            .and(body_string_contains("当前档位"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "gen-affinity",
+                "model": "served/affinity-judge",
+                "choices": [{"message": {"content":
+                    r#"{"warmth": 2, "trust": {"grade": 1, "direction": "up"}, "intrigue": {"grade": 0, "direction": "up"}, "intimacy": {"grade": 0, "direction": "up"}, "tension": {"grade": 0, "direction": "up"}, "patience": 2, "reason": "他想再看一张，我有点得意"}"#}}],
+            })))
+            .mount(mock)
+            .await;
+    }
+
+    /// The judge needs an existing `companion_affinity` row — in real usage it
+    /// exists after the first chat turn.
+    async fn seed_affinity(pool: &PgPool, session_id: Uuid, user_id: Uuid, instance_id: Uuid) {
+        sqlx::query(
+            "INSERT INTO engine.companion_affinity (session_id, user_id, instance_id) \
+             VALUES ($1, $2, $3)",
+        )
+        .bind(session_id)
+        .bind(user_id)
+        .bind(instance_id)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    /// Poll for the detached affinity task's event row (the handler returns
+    /// before it finishes). Panics after ~5s.
+    async fn wait_for_affinity_event(
+        pool: &PgPool,
+        session_id: Uuid,
+    ) -> (String, Option<Uuid>, serde_json::Value) {
+        for _ in 0..100 {
+            if let Some(row) = sqlx::query_as::<_, (String, Option<Uuid>, serde_json::Value)>(
+                "SELECT e.event_type, e.user_message_id, e.context \
+                 FROM engine.companion_affinity_events e \
+                 JOIN engine.companion_affinity a ON a.id = e.affinity_id \
+                 WHERE a.session_id = $1",
+            )
+            .bind(session_id)
+            .fetch_optional(pool)
+            .await
+            .unwrap()
+            {
+                return row;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        panic!("no affinity event appeared within 5s");
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn evaluate_affinity_judges_the_instruction_against_the_new_caption(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+        let (_, mid) = seed_image_turn(&pool, session_id).await;
+        seed_affinity(&pool, session_id, user_id, instance_id).await;
+
+        let mock = MockServer::start().await;
+        mount_editor_and_judge(&mock).await;
+        let state = with_composer(
+            test_state(pool.clone()),
+            &mock.uri(),
+            EDIT_PLUS_AFFINITY_TOML,
+        );
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        let (status, _) = send_request(
+            &mut app,
+            edit_req(
+                session_id,
+                mid,
+                &token,
+                json!({"instruction": "换套衣服", "evaluate_affinity": true}),
+            ),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+
+        let (event_type, event_umid, context) = wait_for_affinity_event(&pool, session_id).await;
+        assert_eq!(event_type, "message");
+        assert_eq!(
+            event_umid, None,
+            "no instruction row was persisted, so the event has no user message"
+        );
+        assert_eq!(
+            context["affinity_reason"],
+            json!("他想再看一张，我有点得意"),
+            "got {context}"
+        );
+
+        // The judge scored (instruction, new caption) — user side is the
+        // instruction whether or not it was persisted.
+        let reqs = mock.received_requests().await.unwrap();
+        let eval = reqs
+            .iter()
+            .map(|r| String::from_utf8_lossy(&r.body).into_owned())
+            .find(|b| b.contains("当前档位"))
+            .expect("an affinity eval call was made");
+        assert!(eval.contains("对方：换套衣服"), "got {eval}");
+        assert!(eval.contains("换了条裙子"), "got {eval}");
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn image_edit_default_still_leaves_affinity_untouched(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+        let (_, mid) = seed_image_turn(&pool, session_id).await;
+
+        let mock = MockServer::start().await;
+        mount_editor_and_judge(&mock).await;
+        let state = with_composer(
+            test_state(pool.clone()),
+            &mock.uri(),
+            EDIT_PLUS_AFFINITY_TOML,
+        );
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        let (status, _) = send_request(
+            &mut app,
+            edit_req(session_id, mid, &token, json!({"instruction": "换套衣服"})),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+
+        // Best-effort negative: give a wrongly spawned task time to land.
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        let n: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM engine.companion_affinity WHERE session_id = $1",
+        )
+        .bind(session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(n, 0, "the default contract stays affinity-free");
+    }
+
+    #[sqlx::test(migrations = "../eros-engine-store/migrations")]
+    async fn evaluate_affinity_links_the_event_to_the_persisted_instruction(pool: PgPool) {
+        let user_id = Uuid::new_v4();
+        let genome_id = seed_genome(&pool, "Aria").await;
+        let instance_id = seed_instance(&pool, genome_id, user_id).await;
+        let session_id = seed_session(&pool, user_id, instance_id).await;
+        let (_, mid) = seed_image_turn(&pool, session_id).await;
+        seed_affinity(&pool, session_id, user_id, instance_id).await;
+
+        let mock = MockServer::start().await;
+        mount_editor_and_judge(&mock).await;
+        let state = with_composer(
+            test_state(pool.clone()),
+            &mock.uri(),
+            EDIT_PLUS_AFFINITY_TOML,
+        );
+        let mut app = build_router(state);
+        let token = mint_test_jwt(user_id);
+
+        let (status, body) = send_request(
+            &mut app,
+            edit_req(
+                session_id,
+                mid,
+                &token,
+                json!({"instruction": "换套衣服",
+                       "persist_instruction": true,
+                       "evaluate_affinity": true}),
+            ),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "body={body}");
+        let instruction_id =
+            Uuid::parse_str(body["instruction_message_id"].as_str().unwrap()).unwrap();
+
+        let (_, event_umid, _) = wait_for_affinity_event(&pool, session_id).await;
+        assert_eq!(
+            event_umid,
+            Some(instruction_id),
+            "the event anchors to the instruction row when one exists"
+        );
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -530,7 +530,8 @@ consumer draws it, exactly as for a chat image turn.
   "style": "realistic",
   "aspect_ratio": "3:4",
   "prompt_variant": "a",
-  "persist_instruction": true
+  "persist_instruction": true,
+  "evaluate_affinity": true
 }
 ```
 
@@ -551,6 +552,12 @@ consumer draws it, exactly as for a chat image turn.
   then replays the exchange: user instruction → assistant picture. The row is
   a real user message — visible to companion context, memory extraction and
   later affinity evaluation like anything else the user said.
+- `evaluate_affinity` — default `false`. When set, the turn goes through the
+  standard per-turn affinity judge: the instruction is what the user said, the
+  new picture's caption is what the character answered. Detached — the response
+  never waits on the judge. Orthogonal to `persist_instruction` (the judge
+  reads the instruction either way); when an instruction row was persisted it
+  anchors the affinity event's `user_message_id`.
 
 ```json
 {
@@ -579,8 +586,10 @@ The new message is an ordinary image turn: it appears in history with
 `GET /comp/chat/{session_id}/messages/{message_id}/image-request`. Its
 `metadata.image` additionally carries `edit_of`. An edit can itself be edited.
 
-Nothing else about a turn runs on this call: no PDE decision, no affinity
-movement, no insight or memory extraction. Without `persist_instruction` the
+Nothing else about a turn runs on this call by default: no PDE decision, no
+affinity movement, no insight or memory extraction. The one opt-in exception
+is `evaluate_affinity` — and it runs the affinity pass alone, nothing else.
+Without `persist_instruction` the
 new row inherits the source's `user_message_id` — the edit belongs to the turn
 the original picture answered; with it, the new row's `user_message_id` is the
 persisted instruction message.

--- a/docs/api-reference.zh.md
+++ b/docs/api-reference.zh.md
@@ -458,7 +458,8 @@ curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json"
   "style": "realistic",
   "aspect_ratio": "3:4",
   "prompt_variant": "a",
-  "persist_instruction": true
+  "persist_instruction": true,
+  "evaluate_affinity": true
 }
 ```
 
@@ -475,6 +476,10 @@ curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json"
   与聊天路径写的是同一个键），新图片行挂在它上面，不再沿用原图的回合。
   历史自然回放整轮：用户指令 → 角色新图。这条 user row 是真实的用户消息 ——
   和用户说的其他话一样，进 companion context、记忆抽取和之后的好感度评估。
+- `evaluate_affinity` —— 缺省 `false`。设上时，这一轮走标准的逐轮好感度判官：
+  用户说的是这条指令，角色答的是新图的 caption。判官是脱管跑的 —— 响应不等它。
+  与 `persist_instruction` 正交（判官读的都是指令本身）；落了指令行时，
+  好感度事件的 `user_message_id` 锚到那条指令消息。
 
 ```json
 {
@@ -499,8 +504,9 @@ curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json"
 `GET /comp/chat/{session_id}/messages/{message_id}/image-request` 恢复。它的
 `metadata.image` 另外带一个 `edit_of`。编辑出来的图还可以再编辑。
 
-这次调用里回合的其余部分一概不跑：不做 PDE 判定、不动好感度、不抽 insight
-与记忆。不带 `persist_instruction` 时新行沿用原图行的 `user_message_id` ——
+这次调用里回合的其余部分默认一概不跑：不做 PDE 判定、不动好感度、不抽 insight
+与记忆。唯一的可选例外是 `evaluate_affinity` —— 它也只跑好感度这一段，
+别的照旧不跑。不带 `persist_instruction` 时新行沿用原图行的 `user_message_id` ——
 这次编辑属于原图所回应的那个回合；带上时，新行的 `user_message_id`
 就是落库的那条指令消息。
 


### PR DESCRIPTION
## What

The image-edit endpoint gains an opt-in `evaluate_affinity` request flag (default `false`). When set, the turn goes through the standard per-turn affinity judge, detached — the response never waits on it:

- **User side = the instruction**, whether or not `persist_instruction` is set (the two flags are orthogonal).
- **Assistant side = the new picture's caption**, with the generic photo marker as the captionless fallback — same proxy rule as chat-path `reply_image`.
- Zero rule deltas (no PDE ran this turn) and a zero-axis scope, so the feeling-clause summarizer never fires.
- When an instruction row was persisted, it anchors the affinity event's `user_message_id`; otherwise the event carries none.
- Default `false` keeps the existing contract byte-for-byte: an edit does not move affinity unless the consumer says so.

## How

The chat pipeline's whole affinity pass (eval gate → judge call → persist → feeling-clause gate) moves out of `post_process::run`'s inline `fut_affinity` block into a shared `run_affinity_turn`; the chat path calls it in place (pure move, no behavior change) and the image-edit handler `tokio::spawn`s it after the turn is persisted.

## Tests

Three new integration tests (written first, watched fail):

- switch on ⇒ affinity event row lands, and the judge's payload carries the instruction and the new caption
- default off ⇒ affinity stays untouched
- switch on + `persist_instruction` ⇒ the event anchors to the instruction row

Full workspace suite green locally (fmt / clippy / test / openapi all pass); `docs/api-reference{,.zh}.md` updated and the OpenAPI snapshot regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
