### PR TITLE
fix: stream-path duplicate detection distinguishes terminally failed turns

### DIFF
--- a/crates/eros-engine-server/src/routes/companion_stream.rs
+++ b/crates/eros-engine-server/src/routes/companion_stream.rs
@@ -711,6 +711,17 @@ pub async fn send_message_stream(
                     original_user_message_id: Some(user_message_id),
                 }));
             }
+            ClaimedEnqueueOutcome::DuplicateFailed { user_message_id } => {
+                return Err(AppError::StreamPre(StreamPreError {
+                    status: StatusCode::CONFLICT,
+                    code: "duplicate_failed",
+                    message: "same (session_id, client_msg_id) terminally failed; \
+                              a same-id retry can never succeed"
+                        .into(),
+                    user_message: "这条消息发送失败，请重新发送".into(),
+                    original_user_message_id: Some(user_message_id),
+                }));
+            }
             ClaimedEnqueueOutcome::Replay {
                 ghost,
                 assistant_chain,

--- a/crates/eros-engine-store/src/chat_queue.rs
+++ b/crates/eros-engine-store/src/chat_queue.rs
@@ -34,8 +34,9 @@ pub enum EnqueueOutcome {
 }
 
 /// Outcome of a born-claimed (stream-path) enqueue. Mirrors
-/// `UpsertUserOutcome` so the stream handler keeps its existing replay /
-/// duplicate responses; only `Inserted` grows a queue row (spec §4).
+/// `UpsertUserOutcome` — with the duplicate case split by the queue row's
+/// status, like `EnqueueOutcome` — so the stream handler keeps its existing
+/// replay / duplicate responses; only `Inserted` grows a queue row (spec §4).
 #[derive(Debug)]
 pub enum ClaimedEnqueueOutcome {
     Claimed {
@@ -48,6 +49,13 @@ pub enum ClaimedEnqueueOutcome {
         assistant_chain: Vec<ReplayMessage>,
     },
     DuplicateInProgress {
+        user_message_id: Uuid,
+    },
+    /// The duplicate's queue row is terminally `failed` — nothing re-opens it,
+    /// so a same-id retry can never succeed. Distinct from
+    /// `DuplicateInProgress` so the client can mint a fresh `client_msg_id`
+    /// instead of backing off forever.
+    DuplicateFailed {
         user_message_id: Uuid,
     },
 }
@@ -181,8 +189,21 @@ impl<'a> ChatQueueRepo<'a> {
                 })
             }
             UpsertUserOutcome::DuplicateInProgress { user_message_id } => {
+                let status: Option<String> = sqlx::query_scalar(
+                    "SELECT status FROM engine.chat_turn_queue WHERE user_message_id = $1",
+                )
+                .bind(user_message_id)
+                .fetch_optional(&mut *tx)
+                .await?;
                 tx.commit().await?;
-                Ok(ClaimedEnqueueOutcome::DuplicateInProgress { user_message_id })
+                Ok(match status.as_deref() {
+                    Some("failed") => ClaimedEnqueueOutcome::DuplicateFailed { user_message_id },
+                    // pending / claimed → still generating. A missing queue row
+                    // is a turn persisted before stream turns rode the queue
+                    // (legacy rows) — same "being handled" answer is still the
+                    // safe reply.
+                    _ => ClaimedEnqueueOutcome::DuplicateInProgress { user_message_id },
+                })
             }
         }
     }
@@ -1114,5 +1135,70 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(rows, 0);
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn enqueue_claimed_splits_duplicate_by_queue_status(pool: PgPool) {
+        let (user_id, session_id) = seed_session(&pool).await;
+        let repo = ChatQueueRepo { pool: &pool };
+        let ClaimedEnqueueOutcome::Claimed {
+            user_message_id: mid,
+            queue_id,
+        } = repo
+            .enqueue_user_message_claimed(
+                session_id,
+                "hello",
+                "01JW00000000000000000000DF",
+                "user",
+                None,
+                user_id,
+                &serde_json::json!({}),
+            )
+            .await
+            .unwrap()
+        else {
+            panic!("expected Claimed");
+        };
+
+        // Still claimed → the duplicate is genuinely in progress.
+        let out = repo
+            .enqueue_user_message_claimed(
+                session_id,
+                "hello",
+                "01JW00000000000000000000DF",
+                "user",
+                None,
+                user_id,
+                &serde_json::json!({}),
+            )
+            .await
+            .unwrap();
+        assert!(matches!(
+            out,
+            ClaimedEnqueueOutcome::DuplicateInProgress { user_message_id } if user_message_id == mid
+        ));
+
+        // Terminally failed → the duplicate must surface as dead, not busy.
+        sqlx::query("UPDATE engine.chat_turn_queue SET status = 'failed' WHERE id = $1")
+            .bind(queue_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+        let out = repo
+            .enqueue_user_message_claimed(
+                session_id,
+                "hello",
+                "01JW00000000000000000000DF",
+                "user",
+                None,
+                user_id,
+                &serde_json::json!({}),
+            )
+            .await
+            .unwrap();
+        assert!(matches!(
+            out,
+            ClaimedEnqueueOutcome::DuplicateFailed { user_message_id } if user_message_id == mid
+        ));
     }
 }

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -157,7 +157,11 @@ idle connection.
 
 Pre-stream errors (HTTP 4xx/5xx before the first SSE byte) carry a JSON
 body with `code`, `message`, `user_message` and — for
-`409 duplicate_in_progress` — an `original_user_message_id`. See the
+`409 duplicate_in_progress` / `409 duplicate_failed` — an
+`original_user_message_id`. `duplicate_in_progress` means the same
+`(session_id, client_msg_id)` is still generating (back off and re-POST);
+`duplicate_failed` means that turn terminally failed and a same-id retry can
+never succeed — send a fresh `client_msg_id`. See the
 [spec](superpowers/specs/2026-05-19-sse-streaming-chat-0.2-design.md#13-pre-stream-errors-http-status-json-body)
 for the full code table.
 

--- a/docs/api-reference.zh.md
+++ b/docs/api-reference.zh.md
@@ -141,8 +141,11 @@ data: {"type":"final","filtered":false,"prompt_injected":null,"tier":null,"retri
 防止反向代理因空闲超时断开连接。
 
 流前错误（第一个 SSE 字节写出之前的 HTTP 4xx/5xx）携带含 `code`、
-`message`、`user_message` 字段的 JSON 响应体；`409 duplicate_in_progress`
-时还会带 `original_user_message_id`。完整错误码表见
+`message`、`user_message` 字段的 JSON 响应体；`409 duplicate_in_progress` /
+`409 duplicate_failed` 时还会带 `original_user_message_id`。
+`duplicate_in_progress` 表示同一 `(session_id, client_msg_id)` 仍在生成中
+（稍候重发即可）；`duplicate_failed` 表示那一轮已终态失败，同 id 重试永远
+不会成功——换一个新的 `client_msg_id` 再发。完整错误码表见
 [设计文档](superpowers/specs/2026-05-19-sse-streaming-chat-0.2-design.md#13-pre-stream-errors-http-status-json-body)。
 
 **该端点仅限文本频道。** 传入语音频道 session 的 `session_id` 会在落库任何

--- a/docs/superpowers/specs/2026-05-19-sse-streaming-chat-0.2-design.md
+++ b/docs/superpowers/specs/2026-05-19-sse-streaming-chat-0.2-design.md
@@ -68,6 +68,7 @@ Before the first SSE byte is written, these errors return a normal HTTP error re
 |    403 | `session_forbidden`     | JWT user does not own the `session_id`                             |
 |    404 | `session_not_found`     | `session_id` does not exist                                        |
 |    409 | `duplicate_in_progress` | Same `(session_id, client_msg_id)` is still generating. Response body carries `original_user_message_id`. |
+|    409 | `duplicate_failed`      | Same `(session_id, client_msg_id)` terminally failed; a same-id retry can never succeed — send a fresh `client_msg_id`. Response body carries `original_user_message_id`. |
 |    422 | `unprocessable`         | content length 0 or > 4096, content-policy violation               |
 |    429 | `rate_limited`          | Per-user concurrent stream cap (3) or per-minute cap hit           |
 |    500 | `internal`              | Unexpected server error                                            |
@@ -227,6 +228,7 @@ The dedup key is `(session_id, client_msg_id)` within a 24 h window.
 | Replay: original request finished (all assistant messages persisted)                      | `200 text/event-stream`, **replay** from DB. For each persisted assistant message (in original order), synthesize: `meta` (with original `action_type`, `model`, and `continues_from` chain) + a single `delta` carrying the full text + `done` (with original `truncated` flag, persisted `usage`, persisted `generation_id`). Conclude with one `final` computed from **current** session state (not snapshotted). No OpenRouter call is made. |
 | Replay: original was a **ghost** (no assistant rows persisted)                            | `200 text/event-stream`. Synthesize `meta(action_type="ghost", message_id=<new ULID, not persisted>)` + `done(truncated:false, usage:null, generation_id:null)` + one `final`. To distinguish ghost-replay from "duplicate user_msg row exists but has no linked assistant yet" (= 409 race), the persistence layer MUST mark the user message row with a `ghost_decision` flag when ghost was chosen — see §2.5. |
 | Race: original request still generating                                                   | `409 duplicate_in_progress` pre-stream JSON with `original_user_message_id`. Client should poll history.                                                                                                                                                                     |
+| Duplicate of a terminally **failed** turn (queue row `failed`, no assistant rows)         | `409 duplicate_failed` pre-stream JSON with `original_user_message_id`. The turn is dead — nothing re-opens the failed row; the client must send a fresh `client_msg_id` to retry.                                                                                            |
 
 The persistence layer must support this — see §2.5.
 


### PR DESCRIPTION
Fixes #339.

## Problem

`ChatQueueRepo::enqueue_user_message_claimed` mapped `UpsertUserOutcome::DuplicateInProgress` to `ClaimedEnqueueOutcome::DuplicateInProgress` unconditionally — it never read the queue row's `status`. The stream handler turned that into `409 duplicate_in_progress` both when the turn was genuinely still generating and when it had terminally failed. A turn that failed without persisting an assistant row (e.g. the generation-timeout path) made every same-id re-POST 409 forever: the `Replay` branch requires an assistant chain, and nothing re-opens a `failed` row.

## Fix

Mirror the async variant (`enqueue_user_message`): read `engine.chat_turn_queue.status` for the duplicate inside the same transaction.

- `status = 'failed'` → new `ClaimedEnqueueOutcome::DuplicateFailed`, which the stream handler maps to **`409 duplicate_failed`** (body still carries `original_user_message_id`) — "this turn is dead, retry needs a fresh `client_msg_id`".
- `pending` / `claimed` / missing row (legacy pre-queue stream turns) → unchanged `409 duplicate_in_progress`.

Two deliberate non-changes:

- No re-claim/re-drive of the failed row — stream turns are single-attempt by design (spec §6: no background retry); the client-visible split is the load-bearing part.
- `done` is not in the failed arm: a `done` row with neither assistant rows nor `ghost_decision` would be an invariant violation ("a done turn is either served or deliberately ghosted" — pinned by an existing pipeline test), and the async path answers the same way for it.

## Tests

- New store test `enqueue_claimed_splits_duplicate_by_queue_status`: same-id re-POST answers `DuplicateInProgress` while the row is `claimed`, `DuplicateFailed` once it is `failed`.
- Docs: pre-stream error table (spec §1.3), idempotency table (§1.10), and both api-reference languages gain the `duplicate_failed` code.

All four gates green locally: fmt, clippy `-D warnings`, workspace tests (1670 passed), openapi snapshot no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)