### PR TITLE
ci: drop push-to-main trigger; pull requests are the only gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
+# Pull requests are the only gate: promotes to main are fast-forwards of
+# commits already tested on their PR, so no push trigger is needed.
 on:
-  push:
-    branches: [main]
   pull_request:
 
 # All jobs here are read-only checks (fmt / clippy / test / openapi snapshot).


### PR DESCRIPTION
## What

Removes the `push: [main]` trigger from `ci.yml`, leaving `pull_request` as the only CI trigger.

## Why

Promotes to main are always fast-forwards of commits already tested green on their PR, so the push-to-main run re-tested the same commit objects and carried zero new information. Pull requests into dev remain the single gate: green before merge.

Known cosmetic side effect: the README CI badge (no `branch=` param) will freeze on the last main run; every merge is still PR-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199kXtBz72F4ghDrMMTJF6g