### PR TITLE
fix: image-edit reply_with_text text half gets quote, caption hint, and grade-mapped style

### DIFF
--- a/crates/eros-engine-core/src/types.rs
+++ b/crates/eros-engine-core/src/types.rs
@@ -94,6 +94,12 @@ pub struct QuotedMessage {
     /// When the quoted line was sent. Renders as a relative age ("3 天前") so
     /// the model can tell a callback to an old message from a same-breath one.
     pub sent_at: DateTime<Utc>,
+    /// The user line the quoted message answered, when the quote should carry
+    /// the exchange that produced it — a quoted picture on an image-edit full
+    /// turn arrives with the message that asked for it. Rendered as a `用户：`
+    /// line above the quoted one; `None` leaves the block a single line.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trigger: Option<String>,
 }
 
 /// Which reference image an image turn should build on. `Face` = the static
@@ -368,8 +374,12 @@ mod tests {
             role: "assistant".into(),
             content: "那我们礼拜六去看展".into(),
             sent_at: chrono::DateTime::<chrono::Utc>::from_timestamp(0, 0).unwrap(),
+            trigger: None,
         };
         let s = serde_json::to_string(&q).unwrap();
+        // `trigger: None` serializes without the key, so this also proves a
+        // pre-`trigger` payload (the queue may hold old events) still parses.
+        assert!(!s.contains("trigger"), "got {s}");
         assert_eq!(serde_json::from_str::<QuotedMessage>(&s).unwrap(), q);
     }
 }

--- a/crates/eros-engine-server/src/pipeline/chat_queue.rs
+++ b/crates/eros-engine-server/src/pipeline/chat_queue.rs
@@ -306,20 +306,15 @@ async fn drive_turn(
     // Spec §9: an older-than-latest driving message must see everything that
     // landed after it, so history is always the most recent window. A quote
     // only adds the [quote] block on top of it.
-    let quote = match params.reply_to_message_id {
-        None => None,
-        Some(id) => match chat_repo
-            .message_by_id_in_session(turn.session_id, id)
-            .await
-        {
-            Ok(row) => row.map(|m| eros_engine_core::types::QuotedMessage {
-                message_id: m.id,
-                role: m.role,
-                content: m.content,
-                sent_at: m.sent_at,
-            }),
-            Err(e) => return TurnOutcome::Failure(format!("quote resolve failed: {e}")),
-        },
+    let quote = match crate::routes::companion_stream::resolve_quote(
+        &chat_repo,
+        turn.session_id,
+        params.reply_to_message_id,
+    )
+    .await
+    {
+        Ok(q) => q,
+        Err(e) => return TurnOutcome::Failure(format!("quote resolve failed: {e}")),
     };
 
     let user_msg = PersistedUserMessage {

--- a/crates/eros-engine-server/src/pipeline/stream.rs
+++ b/crates/eros-engine-server/src/pipeline/stream.rs
@@ -14401,6 +14401,7 @@ data: [DONE]\n\n";
                     role: "assistant".into(),
                     content: "那我们礼拜六去看展".into(),
                     sent_at: chrono::Utc::now(),
+                    trigger: None,
                 }),
             },
             None,

--- a/crates/eros-engine-server/src/prompt.rs
+++ b/crates/eros-engine-server/src/prompt.rs
@@ -872,12 +872,28 @@ pub fn build_prompt(
             } else {
                 "用户"
             };
-            format!(
-                "\n[quote]（用户这一轮回复的是下面这句话，{age}的，不是最后一条消息；\
-                 先接住它，再往下说）\n{speaker}：{}",
-                q.content.trim(),
-                age = relative_age(q.sent_at),
-            )
+            // A quote with a `trigger` carries the exchange that produced the
+            // quoted line — the trigger is always the user's side, so the
+            // quoted line is rendered as the answer to it.
+            match q
+                .trigger
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+            {
+                Some(t) => format!(
+                    "\n[quote]（用户这一轮回复的是下面这段对话，{age}的，不是最后一条消息；\
+                     先接住它，再往下说）\n用户：{t}\n{speaker}：{}",
+                    q.content.trim(),
+                    age = relative_age(q.sent_at),
+                ),
+                None => format!(
+                    "\n[quote]（用户这一轮回复的是下面这句话，{age}的，不是最后一条消息；\
+                     先接住它，再往下说）\n{speaker}：{}",
+                    q.content.trim(),
+                    age = relative_age(q.sent_at),
+                ),
+            }
         }
         None => String::new(),
     };
@@ -1427,6 +1443,7 @@ mod tests {
             role: role.into(),
             content: content.into(),
             sent_at: Utc::now() - chrono::Duration::minutes(minutes_ago),
+            trigger: None,
         }
     }
 
@@ -1486,6 +1503,61 @@ mod tests {
             p.contains("用户：我上次说的那个地方"),
             "a user row is attributed to the user: {p}"
         );
+    }
+
+    #[test]
+    fn build_prompt_renders_quote_trigger_as_the_exchange() {
+        // A quote carrying its trigger renders as the two-line exchange —
+        // user line first, quoted line as the answer — under the dialogue
+        // intro. A blank trigger falls back to the single-line form.
+        let mut q = quoted("assistant", "[你的照片：在天台看夕阳]", 60);
+        q.trigger = Some("拍张照".into());
+        let p = build_prompt(
+            &fixture_persona(),
+            &[],
+            &[],
+            None,
+            ReplyStyle::Neutral,
+            &[],
+            None,
+            &[],
+            AffinityScope::default(),
+            &[],
+            None,
+            None,
+            Some(&q),
+            None,
+            TurnNudges::default(),
+        );
+        assert!(p.contains("下面这段对话"), "dialogue intro: {p}");
+        assert!(
+            p.contains("用户：拍张照\nAria：[你的照片：在天台看夕阳]"),
+            "trigger line renders above the quoted line: {p}"
+        );
+
+        q.trigger = Some("  ".into());
+        let p = build_prompt(
+            &fixture_persona(),
+            &[],
+            &[],
+            None,
+            ReplyStyle::Neutral,
+            &[],
+            None,
+            &[],
+            AffinityScope::default(),
+            &[],
+            None,
+            None,
+            Some(&q),
+            None,
+            TurnNudges::default(),
+        );
+        assert!(
+            p.contains("下面这句话"),
+            "blank trigger ⇒ single-line form: {p}"
+        );
+        assert!(!p.contains("用户："), "no trigger line: {p}");
     }
 
     #[test]

--- a/crates/eros-engine-server/src/routes/companion_stream.rs
+++ b/crates/eros-engine-server/src/routes/companion_stream.rs
@@ -405,9 +405,12 @@ pub(crate) async fn resolve_quote(
         .await?
         .map(|m| QuotedMessage {
             message_id: m.id,
+            // Model-facing text, not raw content: a quoted image turn reads as
+            // its `[你的照片：…]` marker instead of an empty line.
+            content: crate::pipeline::handlers::model_facing_assistant_text(&m, false),
             role: m.role,
-            content: m.content,
             sent_at: m.sent_at,
+            trigger: None,
         }))
 }
 
@@ -1760,6 +1763,25 @@ data: [DONE]\n\n";
         assert_eq!(q.message_id, msg);
         assert_eq!(q.role, "assistant");
         assert_eq!(q.content, "那我们礼拜六去看展");
+
+        // A quoted image turn resolves to its model-facing marker, not the
+        // row's empty content.
+        let img: Uuid = sqlx::query_scalar(
+            "INSERT INTO engine.chat_messages \
+               (session_id, role, content, assistant_action_type, metadata) \
+             VALUES ($1, 'assistant', '', 'reply', \
+                     '{\"image\": {\"prompt\": \"p\", \"caption\": \"在天台看夕阳\"}}'::jsonb) \
+             RETURNING id",
+        )
+        .bind(sessions[0])
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let q = resolve_quote(&chat_repo, sessions[0], Some(img))
+            .await
+            .unwrap()
+            .expect("image turn resolves");
+        assert_eq!(q.content, "[你的照片：在天台看夕阳]");
 
         // Real id, wrong session → None (never leaks another session's text).
         assert!(resolve_quote(&chat_repo, sessions[1], Some(msg))

--- a/crates/eros-engine-server/src/routes/image_edit.rs
+++ b/crates/eros-engine-server/src/routes/image_edit.rs
@@ -37,7 +37,9 @@ use utoipa_axum::{router::OpenApiRouter, routes};
 use uuid::Uuid;
 
 use eros_engine_core::persona::CompanionPersona;
-use eros_engine_core::types::{ActionPlan, ActionType, DecisionInput, Event, ImageRef, ReplyStyle};
+use eros_engine_core::types::{
+    ActionPlan, ActionType, DecisionInput, Event, ImageRef, QuotedMessage, ReplyStyle,
+};
 use eros_engine_llm::model_config::StyleKey;
 use eros_engine_store::affinity::AffinityRepo;
 use eros_engine_store::chat::{AssistantInsert, ChatRepo};
@@ -46,7 +48,9 @@ use eros_engine_store::persona::PersonaRepo;
 
 use crate::auth::middleware::AuthUser;
 use crate::error::AppError;
-use crate::pipeline::handlers::{build_reply_request, compose_image_prompt, CHAT_TASK};
+use crate::pipeline::handlers::{
+    build_reply_request, compose_image_prompt, model_facing_assistant_text, CHAT_TASK,
+};
 use crate::pipeline::post_process::ProducedMessage;
 use crate::pipeline::stream::{
     build_delegated_image_marker, record_compose_event, run_image_prompt_compose, split_failures,
@@ -259,8 +263,13 @@ struct TextOutcome {
 }
 
 /// The full-turn Event: the persisted instruction row is the driving user
-/// message; everything else is what an ordinary chat request defaults to.
-fn edit_turn_event(instruction: String, instruction_row_id: Uuid) -> Event {
+/// message and the quote is the picture being revised (with the exchange that
+/// produced it); everything else is what an ordinary chat request defaults to.
+fn edit_turn_event(
+    instruction: String,
+    instruction_row_id: Uuid,
+    quote: Option<QuotedMessage>,
+) -> Event {
     Event::UserMessage {
         content: instruction,
         message_id: instruction_row_id,
@@ -270,7 +279,7 @@ fn edit_turn_event(instruction: String, instruction_row_id: Uuid) -> Event {
         memory_scope: Default::default(),
         affinity_scope: Default::default(),
         tips_amount_usd: None,
-        quote: None,
+        quote,
     }
 }
 
@@ -291,10 +300,14 @@ fn edit_turn_plan(action: ActionType) -> ActionPlan {
 }
 
 /// Run the companion chain once, non-streaming, off the persisted instruction
-/// row — the rolled text half of a full-turn edit. Fail-open everywhere: any
-/// failure (affinity load, request build, LLM error, blank reply) returns a
-/// text-less outcome and the turn degrades to `reply_image` — the picture is
-/// the turn's substance.
+/// row — the rolled text half of a full-turn edit. `quote` is the picture
+/// being revised (the prompt's `[quote]` block) and `caption` the new
+/// picture's, folded in as a context hint — the text half is generated before
+/// the image row lands, so this is the only way it sees either side of the
+/// revision. Fail-open everywhere: any failure (affinity load, request build,
+/// LLM error, blank reply) returns a text-less outcome and the turn degrades
+/// to `reply_image` — the picture is the turn's substance.
+#[allow(clippy::too_many_arguments)]
 async fn generate_reply_text(
     state: &AppState,
     persona: &CompanionPersona,
@@ -303,6 +316,8 @@ async fn generate_reply_text(
     instance_id: Uuid,
     instruction_row_id: Uuid,
     instruction: &str,
+    quote: Option<QuotedMessage>,
+    caption: Option<&str>,
 ) -> TextOutcome {
     let affinity = match (AffinityRepo { pool: &state.pool })
         .load_or_create(session_id, user_id, instance_id)
@@ -328,12 +343,19 @@ async fn generate_reply_text(
         }
     };
     let input = DecisionInput {
-        event: edit_turn_event(instruction.to_string(), instruction_row_id),
+        event: edit_turn_event(instruction.to_string(), instruction_row_id, quote),
         affinity,
         persona: persona.clone(),
         signals,
     };
-    let plan = edit_turn_plan(ActionType::ReplyTextImage);
+    let mut plan = edit_turn_plan(ActionType::ReplyTextImage);
+    if let Some(c) = caption.map(str::trim).filter(|s| !s.is_empty()) {
+        // The new picture rides along as an inner-state hint so the words
+        // match what the picture now shows.
+        plan.context_hints = vec![format!(
+            "你刚按对方的要求把照片改了一版，随这条回复一起发出（新照片：{c}）；说的话要贴合这张新照片"
+        )];
+    }
     let (chat_req, _tags) = match build_reply_request(
         state,
         &input,
@@ -722,6 +744,30 @@ async fn edit_image(
         let umid = chat_repo
             .insert_instruction_row(session_id, &instruction, message_id)
             .await?;
+        // The [quote] block: the picture being revised, carrying the user
+        // message that asked for it so the exchange arrives whole. Trigger
+        // fetch failure degrades to quoting the picture alone — the quote is
+        // context, never worth failing the turn over.
+        let trigger = match source.user_message_id {
+            Some(trigger_id) => match chat_repo
+                .message_by_id_in_session(session_id, trigger_id)
+                .await
+            {
+                Ok(row) => row.map(|m| m.content),
+                Err(e) => {
+                    tracing::warn!("image_edit text half: quote trigger fetch failed: {e}");
+                    None
+                }
+            },
+            None => None,
+        };
+        let quote = QuotedMessage {
+            message_id: source.id,
+            role: source.role.clone(),
+            content: model_facing_assistant_text(&source, false),
+            sent_at: source.sent_at,
+            trigger,
+        };
         let text = generate_reply_text(
             &state,
             &persona,
@@ -730,6 +776,8 @@ async fn edit_image(
             instance_id,
             umid,
             &instruction,
+            Some(quote),
+            outcome.caption.as_deref(),
         )
         .await;
         let insert = AssistantInsert {
@@ -822,7 +870,8 @@ async fn edit_image(
                 session_id,
                 user_id,
                 instance_id,
-                edit_turn_event(instruction_bg, umid_bg),
+                // post_process never reads the quote; skip rebuilding it.
+                edit_turn_event(instruction_bg, umid_bg, None),
                 plan,
                 produced,
             )
@@ -1882,6 +1931,22 @@ mod tests {
             .find(|b| b.contains("you are a companion"))
             .expect("a chat companion call was made");
         assert!(chat.contains("换套衣服"), "got {chat}");
+        // …and the revision context (#349): the [quote] block carries the
+        // source picture plus the message that asked for it, and the new
+        // picture's caption rides in as a hint.
+        assert!(chat.contains("[quote]"), "quote block present: {chat}");
+        assert!(
+            chat.contains("用户：拍张照"),
+            "the quoted exchange opens with its trigger: {chat}"
+        );
+        assert!(
+            chat.contains("[你的照片：在天台看夕阳]"),
+            "the source picture is the quoted line: {chat}"
+        );
+        assert!(
+            chat.contains("新照片：换了条裙子"),
+            "the new caption is hinted: {chat}"
+        );
     }
 
     #[sqlx::test(migrations = "../eros-engine-store/migrations")]

--- a/crates/eros-engine-server/src/routes/image_edit.rs
+++ b/crates/eros-engine-server/src/routes/image_edit.rs
@@ -283,6 +283,19 @@ fn edit_turn_event(
     }
 }
 
+/// Edit-turn tier→style mapping (#349 gap 3): no judge runs on this endpoint,
+/// so the affinity's warmth grade picks the `[turn_style]` line — cold floor
+/// at grade 1, warm at grade 3. Chosen over pinning Neutral after an A/B
+/// reading of prod-model candidates; the chat path keeps its own channel
+/// (judge-written free-text tone) and stays pinned.
+fn tier_reply_style(warmth_grade: i16) -> ReplyStyle {
+    match warmth_grade {
+        ..=1 => ReplyStyle::Cold,
+        2 => ReplyStyle::Neutral,
+        3.. => ReplyStyle::Warm,
+    }
+}
+
 /// A minimal ActionPlan for a turn no PDE decided: neutral delivery, zero
 /// rule deltas.
 fn edit_turn_plan(action: ActionType) -> ActionPlan {
@@ -349,11 +362,16 @@ async fn generate_reply_text(
         signals,
     };
     let mut plan = edit_turn_plan(ActionType::ReplyTextImage);
+    plan.reply_style = tier_reply_style(input.affinity.warmth_grade);
     if let Some(c) = caption.map(str::trim).filter(|s| !s.is_empty()) {
         // The new picture rides along as an inner-state hint so the words
-        // match what the picture now shows.
+        // match what the picture now shows. Prose-woven on purpose: a labeled
+        // "新照片：…" shape reads as a marker format and the model echoes it
+        // into the reply as a bracket block; weaving the caption into a
+        // sentence leaves nothing to echo. Present tense "already sent" —
+        // otherwise the reply narrates going off to make the edit.
         plan.context_hints = vec![format!(
-            "你刚按对方的要求把照片改了一版，随这条回复一起发出（新照片：{c}）；说的话要贴合这张新照片"
+            "你已经按对方的要求把照片改好，随这条回复一起发出——新照片里{c}。照片已经在对方眼前，直接说贴着它的话"
         )];
     }
     let (chat_req, _tags) = match build_reply_request(
@@ -426,7 +444,15 @@ async fn generate_reply_text(
 
 #[cfg(test)]
 mod payload_tests {
-    use super::compose_edit_payload;
+    use super::{compose_edit_payload, tier_reply_style};
+    use eros_engine_core::types::ReplyStyle;
+
+    #[test]
+    fn tier_reply_style_maps_cold_neutral_warm() {
+        assert_eq!(tier_reply_style(1), ReplyStyle::Cold);
+        assert_eq!(tier_reply_style(2), ReplyStyle::Neutral);
+        assert_eq!(tier_reply_style(3), ReplyStyle::Warm);
+    }
 
     #[test]
     fn edit_payload_renders_every_slot() {
@@ -1944,8 +1970,8 @@ mod tests {
             "the source picture is the quoted line: {chat}"
         );
         assert!(
-            chat.contains("新照片：换了条裙子"),
-            "the new caption is hinted: {chat}"
+            chat.contains("新照片里换了条裙子"),
+            "the new caption is hinted, prose-woven: {chat}"
         );
     }
 


### PR DESCRIPTION
Fixes #349.

The rolled text half of a `reply_with_text` edit turn now gets the revision context a chat-path turn would have:

- **`[quote]` block (gap 1).** The prompt quotes the picture being revised as its model-facing marker (`[你的照片：{caption}]`), preceded by the user message that asked for it, so the exchange arrives whole:
  ```
  [quote]（用户这一轮回复的是下面这段对话，…）
  用户：拍张照
  Aria：[你的照片：在天台看夕阳]
  ```
  `QuotedMessage` grows an optional `trigger` line; `None` renders byte-identically to before, and old serialized events still parse. Trigger fetch failure degrades to quoting the picture alone.
- **New caption visible to the text half (gap 2).** The composer's `outcome.caption` rides into the prompt as a context hint. The hint is prose-woven and states the photo already went out: a labeled `新照片：…` shape read as a marker format and prod-model candidates echoed it back as a bracket block, and a hint that doesn't say "already sent" had the reply narrating going off to make the edit.
- **Grade-mapped `[turn_style]` (gap 3).** `tier_reply_style`: warmth grade 1 → `Cold`, 2 → `Neutral`, 3 → `Warm`, applied to the edit turn's text half only — no judge runs on this endpoint, so the affinity grade picks the delivery line. Decided from an A/B reading of prod-model candidates (4 arms × 2 samples, only the `[turn_style]` line varying within a tier). The chat path is unchanged: its reply actions stay pinned `Neutral` with the judge's free-text tone channel.
- **`resolve_quote` renders model-facing text** — a chat-path quote of an image turn now reads as its marker instead of an empty line (same bug class), and the queue path reuses `resolve_quote` instead of duplicating the mapping.

Tests: full-turn test asserts the companion request carries `[quote]` + trigger + source marker + prose-woven caption hint; `tier_reply_style` mapping locked by a unit test; `resolve_quote` test covers the image-turn marker; prompt tests cover the two-line exchange rendering and the blank-trigger fallback; serde round-trip covers queue compat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)